### PR TITLE
OCRVS-118 Scroll to first error on invalid form submission

### DIFF
--- a/front/opencrvs-web-client/package.json
+++ b/front/opencrvs-web-client/package.json
@@ -90,7 +90,7 @@
     "postcss-modules-values": "^1.3.0",
     "prettier": "^1.7.0",
     "purecss": "^0.6.2",
-    "react-collapsible": "^1.4.0",
+    "react-collapsible": "^2.0.3",
     "react-css-modules": "^4.3.0",
     "react-dev-utils": "^2.0.1",
     "redux-logger": "^3.0.6",

--- a/front/opencrvs-web-client/src/components/WorkingItemForm/index.js
+++ b/front/opencrvs-web-client/src/components/WorkingItemForm/index.js
@@ -1,6 +1,6 @@
 /*
- * @Author: Euan Millar 
- * @Date: 2017-07-05 01:18:43 
+ * @Author: Euan Millar
+ * @Date: 2017-07-05 01:18:43
  * @Last Modified by: Euan Millar
  * @Last Modified time: 2017-08-15 19:44:35
  */
@@ -12,7 +12,7 @@ import Dropdown from 'react-toolbox/lib/dropdown';
 import DatePicker from 'react-toolbox/lib/date_picker';
 import Collapsible from 'react-collapsible';
 import submit from './submit';
-import { 
+import {
   genderReference,
   typesOfBirth,
   placesOfDeliveryReference,
@@ -45,16 +45,41 @@ const renderDatePicker = ({ input: { onBlur, ...inputForm }, label, source, meta
 
 const required = value => value ? undefined : 'Required';
 
+let openChild = false;
+let openMother = false;
+let openFather = false;
+let openInformant = false;
+let openNotes = false;
+
+const scrollToFirstError = (errors) => {
+  let ms = 0;
+  if (!(openChild || openMother || openFather || openInformant || openNotes)) {
+    openChild = true;
+    openMother = true;
+    openFather = true;
+    openInformant = true;
+    openNotes = true;
+    ms = 750;
+  }
+
+  // give collapsibles time to open
+  setTimeout(() => {
+    const firstErrorField = Object.keys(errors)[0];
+    const element = document.querySelectorAll(`[name="${firstErrorField}"]`)[0];
+    element.scrollIntoView();
+  }, ms);
+};
+
 class WorkingItemForm extends React.Component {
   constructor(props) {
     super(props);
   }
 
   render = () => {
-    
 
-    const { 
-      handleSubmit, 
+
+    const {
+      handleSubmit,
       error,
     } = this.props;
 
@@ -69,6 +94,7 @@ class WorkingItemForm extends React.Component {
           trigger="
             Particulars of child
           "
+          open={openChild}
         >
           <Field component={renderInput} name="firstName" placeholder="First name" label="First name" validate={[required]} />
           <Field component={renderInput} name="middleName" placeholder="Middle name" label="Middle names" validate={[required]} />
@@ -80,7 +106,7 @@ class WorkingItemForm extends React.Component {
           <Field component={renderDropdown} name="typeOfBirth" label="Type of birth" source={ typesOfBirth } />
           <Field component={renderDropdown} name="placeOfDelivery" label="Place of delivery" source={ placesOfDeliveryReference } />
           <Field component={renderDropdown} name="attendantAtBirth" label="Attendant at birth" source={ attendantsAtBirthReference } />
-          
+
           <Field component={renderInput} name="hospitalName" placeholder="Hospital name" label="Hospital name" validate={[required]}/>
           <Field component={renderInput} name="addressLine1" placeholder="Address line 1" label="Address line 1" validate={[required]} />
           <Field component={renderInput} name="addressLine2" placeholder="Address line 2" label="Address line 2" />
@@ -98,6 +124,7 @@ class WorkingItemForm extends React.Component {
           trigger="
             Particulars of mother
           "
+          open={openMother}
         >
           <Field component={renderInput} name="mother_firstName" placeholder="First name" label="First name" validate={[required]} />
           <Field component={renderInput} name="mother_middleName" placeholder="Middle name" label="Middle names" validate={[required]} />
@@ -124,7 +151,7 @@ class WorkingItemForm extends React.Component {
           <Field component={renderDropdown} name="mother_county" label="County or district" source={ districtsReference } validate={[required]}/>
           <Field component={renderInput} name="mother_postalCode" placeholder="Postal code" label="Postal code"  />
           <Field component={renderDropdown} name="mother_state" label="State or region" source={ regionsReference } validate={[required]}/>
-          
+
           <Field component={renderDropdown} name="childrenBornAlive" label="Number of children ever born alive (including this birth)" source={ numbersReference } />
           <Field component={renderDropdown} name="childrenBornLiving" label="Number of children born alive and now living" source={ numbersReference } />
           <Field component={renderDropdown} name="foetalDeaths" label="Foetal deaths to mother" source={ numbersReference } />
@@ -145,6 +172,7 @@ class WorkingItemForm extends React.Component {
             trigger="
               Particulars of father
             "
+            open={openFather}
           >
             <Field component={renderInput} name="father_firstName" placeholder="First name" label="First name" validate={[required]} />
             <Field component={renderInput} name="father_middleName" placeholder="Middle name" label="Middle names" validate={[required]} />
@@ -179,8 +207,9 @@ class WorkingItemForm extends React.Component {
             triggerOpenedClassName={styles.collapsibleOpened}
             overflowWhenOpen={styles.scroll}
             trigger="
-              Particulars of informant 
+              Particulars of informant
             "
+            open={openInformant}
           >
             <Field component={renderInput} name="informant_firstName" placeholder="First name" label="First name" validate={[required]} />
             <Field component={renderInput} name="informant_middleName" placeholder="Middle name" label="Middle names" />
@@ -205,6 +234,7 @@ class WorkingItemForm extends React.Component {
             trigger="
               Notes
             "
+            open={openNotes}
           >
             <Field component={renderTextArea} name="notes" type="text" placeholder="Notes" label="Notes" />
         </Collapsible>
@@ -216,4 +246,5 @@ class WorkingItemForm extends React.Component {
 export default reduxForm({
   form: 'activeDeclaration',
   onSubmit: submit,
+  onSubmitFail: scrollToFirstError,
 })(WorkingItemForm);


### PR DESCRIPTION
React-collapsible seems a bit buggy on how it handles its internal state
when triggered via the open prop. When trying to close or re-open the
collapsible after it has been opened the first time things don't quite
work right. For this prototype this is probably fine, but still not
perfect.