### PR TITLE
Fix Latin alphabet showing in wrong font

### DIFF
--- a/packages/login/src/common/Page.tsx
+++ b/packages/login/src/common/Page.tsx
@@ -40,6 +40,15 @@ const StyledPage = styledPage`
   }
 
   @font-face {
+    font-family: ${({ theme }) => theme.fonts.regularFont};
+    src:
+      url('/fonts/notosans-regular-webfont-en.woff')
+      format('woff');
+    font-style: normal;
+    unicode-range: U+0025-00FF;
+  }
+
+  @font-face {
     font-family: ${({ theme }) => theme.fonts.boldFont};
     src:
       url('/fonts/notosans-bold-webfont-${({ language }) => language}.woff')


### PR DESCRIPTION
Reference for this method: https://jakearchibald.com/2017/combining-fonts/

I'm not entirely sure what to use as `unicode-range`, since code points and unicode has always been my weakness. It would be awesome if one of you guys could check which ones we specifically wanna use. It works now though. 

![image](https://user-images.githubusercontent.com/1206987/41783528-f20c4d38-7634-11e8-887e-b9f9c5ea646c.png)
