### PR TITLE
Force standardized number input in numeric fields

### DIFF
--- a/packages/components/src/components/forms/TextInput.tsx
+++ b/packages/components/src/components/forms/TextInput.tsx
@@ -26,6 +26,9 @@ const StyledInput = styled.input.attrs<ITextInputProps>({})`
   &[type='text'] {
     background: ${({ theme }) => theme.colors.inputBackground};
   }
+  &[type='number'] {
+    background: ${({ theme }) => theme.colors.inputBackground};
+  }
 
   &:focus {
     border-bottom: solid 1px ${({ theme }) => theme.colors.accent};

--- a/packages/register/src/forms/index.ts
+++ b/packages/register/src/forms/index.ts
@@ -11,6 +11,7 @@ export type IFormFieldValue = string | string[] | boolean
 export interface IFormField {
   name: string
   type: string
+  step?: number
   label: FormattedMessage.MessageDescriptor
   validate: Validation[]
   required?: boolean

--- a/packages/register/src/forms/register/child-section.ts
+++ b/packages/register/src/forms/register/child-section.ts
@@ -316,7 +316,7 @@ export const childSection: IFormSection = {
     },
     {
       name: 'orderOfBirth',
-      type: 'text',
+      type: 'number',
       label: messages.orderOfBirth,
       required: true,
       initialValue: '',
@@ -324,7 +324,8 @@ export const childSection: IFormSection = {
     },
     {
       name: 'weightAtBirth',
-      type: 'text',
+      type: 'number',
+      step: 0.01,
       label: messages.weightAtBirth,
       required: true,
       initialValue: '',

--- a/packages/register/src/forms/register/father-section.ts
+++ b/packages/register/src/forms/register/father-section.ts
@@ -455,7 +455,7 @@ export const fatherSection: IFormSection = {
     },
     {
       name: 'postCode',
-      type: 'text',
+      type: 'number',
       label: addressMessages.postCode,
       required: false,
       initialValue: '',
@@ -609,7 +609,7 @@ export const fatherSection: IFormSection = {
     },
     {
       name: 'postCodePermanent',
-      type: 'text',
+      type: 'number',
       label: addressMessages.postCode,
       required: false,
       initialValue: '',

--- a/packages/register/src/forms/register/mother-section.ts
+++ b/packages/register/src/forms/register/mother-section.ts
@@ -374,7 +374,7 @@ export const motherSection: IFormSection = {
     },
     {
       name: 'postCode',
-      type: 'text',
+      type: 'number',
       label: addressMessages.postCode,
       required: false,
       initialValue: '',
@@ -488,7 +488,7 @@ export const motherSection: IFormSection = {
     },
     {
       name: 'postCodePermanent',
-      type: 'text',
+      type: 'number',
       label: addressMessages.postCode,
       required: false,
       initialValue: '',


### PR DESCRIPTION
This commit changes the HTML element type of numeric fields from
"text" to "number". This makes mobile browsers to show a numeric
keyboard with English numbers even when a Bengali keyboard layout
is selected. So numeric fields will easily accept English numbers
only.

As a side effect, date segment fields will have a grey background
like other fields.

Fixes issue OCRVS-513.