### PR TITLE
Upgrade node version to latest lts

### DIFF
--- a/Dockerfile-login
+++ b/Dockerfile-login
@@ -1,6 +1,4 @@
-# You should always specify a full version here to ensure all of your developers
-# are running the same version of Node.
-FROM node:9.2.1
+FROM node:dubnium
 WORKDIR /usr/src/app
 
 # Override the base log level (info).

--- a/Dockerfile-performance
+++ b/Dockerfile-performance
@@ -1,6 +1,4 @@
-# You should always specify a full version here to ensure all of your developers
-# are running the same version of Node.
-FROM node:9.2.1
+FROM node:dubnium
 WORKDIR /usr/src/app
 
 # Override the base log level (info).

--- a/Dockerfile-register
+++ b/Dockerfile-register
@@ -1,6 +1,4 @@
-# You should always specify a full version here to ensure all of your developers
-# are running the same version of Node.
-FROM node:9.2.1
+FROM node:dubnium
 WORKDIR /usr/src/app
 
 # Override the base log level (info).

--- a/packages/auth/Dockerfile
+++ b/packages/auth/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:carbon
+FROM node:dubnium
 WORKDIR /usr/src/app
 
 # Override the base log level (info).

--- a/packages/components/Dockerfile
+++ b/packages/components/Dockerfile
@@ -1,6 +1,4 @@
-# You should always specify a full version here to ensure all of your developers
-# are running the same version of Node.
-FROM node:9.2.1
+FROM node:dubnium
 WORKDIR /usr/src/app
 
 # Override the base log level (info).

--- a/packages/gateway/Dockerfile
+++ b/packages/gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:carbon
+FROM node:dubnium
 WORKDIR /usr/src/app
 
 # Override the base log level (info).

--- a/packages/notification/Dockerfile
+++ b/packages/notification/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:carbon
+FROM node:dubnium
 WORKDIR /usr/src/app
 
 # Override the base log level (info).

--- a/packages/user-mgnt/Dockerfile
+++ b/packages/user-mgnt/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:carbon
+FROM node:dubnium
 WORKDIR /usr/src/app
 
 # Override the base log level (info).

--- a/packages/workflow/Dockerfile
+++ b/packages/workflow/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:carbon
+FROM node:dubnium
 WORKDIR /usr/src/app
 
 # Override the base log level (info).


### PR DESCRIPTION
This should fix the current build issues we are having with the docker images.

I don't believe in locking the version we are using so that we don't get
bug fixes. We should always be using the latest lts version including
any bug fixes they may have. We were already running into build issues
where a package needed a node version that has the latest bug fixes.