### PR TITLE
Fixes the valueReference to be an object not just a string

### DIFF
--- a/packages/gateway/src/features/registration/fhir-builders.test.ts
+++ b/packages/gateway/src/features/registration/fhir-builders.test.ts
@@ -552,7 +552,7 @@ test('should update a task document as rejected', async () => {
           },
           {
             url: 'http://opencrvs.org/specs/extension/regLastUser',
-            valueReference: 'DUMMY'
+            valueReference: { reference: 'DUMMY' }
           }
         ],
         lastModified: '2018-11-28T15:13:57.492Z',

--- a/packages/gateway/src/features/registration/root-resolvers.test.ts
+++ b/packages/gateway/src/features/registration/root-resolvers.test.ts
@@ -187,7 +187,7 @@ describe('Registration root resolvers', () => {
                     },
                     {
                       url: 'http://opencrvs.org/specs/extension/regLastUser',
-                      valueReference: 'DUMMY'
+                      valueReference: { reference: 'DUMMY' }
                     }
                   ],
                   lastModified: '2018-11-28T15:13:57.492Z',
@@ -293,7 +293,7 @@ describe('Registration root resolvers', () => {
                     },
                     {
                       url: 'http://opencrvs.org/specs/extension/regLastUser',
-                      valueReference: 'DUMMY'
+                      valueReference: { reference: 'DUMMY' }
                     }
                   ],
                   lastModified: '2018-11-28T15:13:57.492Z',
@@ -403,14 +403,18 @@ describe('Registration root resolvers', () => {
                     },
                     {
                       url: 'http://opencrvs.org/specs/extension/regLastUser',
-                      valueReference:
-                        'Practitioner/34562b20-718f-4272-9596-66cb89f2fe7b'
+                      valueReference: {
+                        reference:
+                          'Practitioner/34562b20-718f-4272-9596-66cb89f2fe7b'
+                      }
                     },
                     {
                       url:
                         'http://opencrvs.org/specs/extension/regLastLocation',
-                      valueReference:
-                        'Location/71a2f856-3e6a-4bf7-97bd-145d4ab187fa'
+                      valueReference: {
+                        reference:
+                          'Location/71a2f856-3e6a-4bf7-97bd-145d4ab187fa'
+                      }
                     }
                   ],
                   lastModified: '2018-12-11T11:55:46.775Z',
@@ -611,14 +615,18 @@ describe('Registration root resolvers', () => {
                     },
                     {
                       url: 'http://opencrvs.org/specs/extension/regLastUser',
-                      valueReference:
-                        'Practitioner/34562b20-718f-4272-9596-66cb89f2fe7b'
+                      valueReference: {
+                        reference:
+                          'Practitioner/34562b20-718f-4272-9596-66cb89f2fe7b'
+                      }
                     },
                     {
                       url:
                         'http://opencrvs.org/specs/extension/regLastLocation',
-                      valueReference:
-                        'Location/71a2f856-3e6a-4bf7-97bd-145d4ab187fa'
+                      valueReference: {
+                        reference:
+                          'Location/71a2f856-3e6a-4bf7-97bd-145d4ab187fa'
+                      }
                     }
                   ],
                   lastModified: '2018-12-11T11:55:46.775Z',

--- a/packages/gateway/src/features/registration/root-resolvers.ts
+++ b/packages/gateway/src/features/registration/root-resolvers.ts
@@ -106,7 +106,7 @@ async function getCompositionsByLocation(
 ) {
   const tasksResponses = await Promise.all(
     locationIds.map(locationId => {
-      return fetchFHIR(`/Task?location=${locationId}`, authHeader)
+      return fetchFHIR(`/Task?location=Location/${locationId}`, authHeader)
     })
   )
 

--- a/packages/gateway/src/features/registration/type-resovlers.ts
+++ b/packages/gateway/src/features/registration/type-resovlers.ts
@@ -231,10 +231,10 @@ export const typeResolvers: GQLResolver = {
         `${OPENCRVS_SPECIFICATION_URL}extension/regLastUser`,
         task.extension
       )
-      if (!user) {
+      if (!user || !user.valueReference) {
         return null
       }
-      return await fetchFHIR(`/${user.valueReference}`, authHeader)
+      return await fetchFHIR(`/${user.valueReference.reference}`, authHeader)
     },
 
     timestamp: task => task.lastModified,
@@ -244,10 +244,13 @@ export const typeResolvers: GQLResolver = {
         `${OPENCRVS_SPECIFICATION_URL}extension/regLastLocation`,
         task.extension
       )
-      if (!taskLocation) {
+      if (!taskLocation || !taskLocation.valueReference) {
         return null
       }
-      return await fetchFHIR(`/${taskLocation.valueReference}`, authHeader)
+      return await fetchFHIR(
+        `/${taskLocation.valueReference.reference}`,
+        authHeader
+      )
     }
   },
   User: {

--- a/packages/gateway/src/utils/testUtils.ts
+++ b/packages/gateway/src/utils/testUtils.ts
@@ -209,11 +209,11 @@ export const mockTask = {
   extension: [
     {
       url: 'http://opencrvs.org/specs/extension/regLastUser',
-      valueReference: 'Practitioner/123'
+      valueReference: { reference: 'Practitioner/123' }
     },
     {
       url: 'http://opencrvs.org/specs/extension/regLastLocation',
-      valueReference: 'Location/123'
+      valueReference: { reference: 'Location/123' }
     },
     {
       url: 'http://opencrvs.org/specs/extension/contact-person',

--- a/packages/workflow/src/features/registration/fhir/fhir-bundle-modifier.test.ts
+++ b/packages/workflow/src/features/registration/fhir/fhir-bundle-modifier.test.ts
@@ -144,8 +144,8 @@ describe('Verify fhir bundle modifier functions', () => {
         practitioner
       )
 
-      expect(taskResource.extension[1].valueReference).toBeDefined()
-      expect(taskResource.extension[1].valueReference).toEqual(
+      expect(taskResource.extension[1].valueReference.reference).toBeDefined()
+      expect(taskResource.extension[1].valueReference.reference).toEqual(
         'Practitioner/e0daf66b-509e-4f45-86f3-f922b74f3dbf'
       )
     })
@@ -158,8 +158,8 @@ describe('Verify fhir bundle modifier functions', () => {
         practitioner
       )
 
-      expect(taskResource.extension[0].valueReference).toBeDefined()
-      expect(taskResource.extension[0].valueReference).toEqual(
+      expect(taskResource.extension[0].valueReference.reference).toBeDefined()
+      expect(taskResource.extension[0].valueReference.reference).toEqual(
         'Practitioner/e0daf66b-509e-4f45-86f3-f922b74f3dbf'
       )
     })
@@ -173,7 +173,7 @@ describe('Verify fhir bundle modifier functions', () => {
       )
 
       expect(taskResource.extension.length).toBe(lengthOfTaskExtensions)
-      expect(taskResource.extension[1].valueReference).toEqual(
+      expect(taskResource.extension[1].valueReference.reference).toEqual(
         'Practitioner/e0daf66b-509e-4f45-86f3-f922b74f3dbf'
       )
     })
@@ -401,7 +401,9 @@ describe('Verify fhir bundle modifier functions', () => {
       )
       expect(taskResource.extension[2]).toEqual({
         url: 'http://opencrvs.org/specs/extension/regLastLocation',
-        valueReference: 'Location/d33e4cb2-670e-4564-a8ed-c72baacdxxx'
+        valueReference: {
+          reference: 'Location/d33e4cb2-670e-4564-a8ed-c72baacdxxx'
+        }
       })
     })
     it('throws error if invalid practitioner is provided', async () => {

--- a/packages/workflow/src/features/registration/fhir/fhir-bundle-modifier.ts
+++ b/packages/workflow/src/features/registration/fhir/fhir-bundle-modifier.ts
@@ -215,14 +215,12 @@ export async function setupLastRegLocation(
       extension.url === `${OPENCRVS_SPECIFICATION_URL}extension/regLastLocation`
     )
   })
-  if (regUserExtension) {
-    regUserExtension.valueReference = `Location/${
-      primaryOffice.id
-    }` as fhir.Reference
+  if (regUserExtension && regUserExtension.valueReference) {
+    regUserExtension.valueReference.reference = `Location/${primaryOffice.id}`
   } else {
     taskResource.extension.push({
       url: `${OPENCRVS_SPECIFICATION_URL}extension/regLastLocation`,
-      valueReference: `Location/${primaryOffice.id}` as fhir.Reference
+      valueReference: { reference: `Location/${primaryOffice.id}` }
     })
   }
   return taskResource
@@ -240,14 +238,12 @@ export function setupLastRegUser(
       extension.url === `${OPENCRVS_SPECIFICATION_URL}extension/regLastUser`
     )
   })
-  if (regUserExtension) {
-    regUserExtension.valueReference = getPractitionerRef(
-      practitioner
-    ) as fhir.Reference
+  if (regUserExtension && regUserExtension.valueReference) {
+    regUserExtension.valueReference.reference = getPractitionerRef(practitioner)
   } else {
     taskResource.extension.push({
       url: `${OPENCRVS_SPECIFICATION_URL}extension/regLastUser`,
-      valueReference: getPractitionerRef(practitioner) as fhir.Reference
+      valueReference: { reference: getPractitionerRef(practitioner) }
     })
   }
   return taskResource

--- a/packages/workflow/src/test/utils.ts
+++ b/packages/workflow/src/test/utils.ts
@@ -361,7 +361,7 @@ export const testFhirTaskBundle = {
           },
           {
             url: 'http://opencrvs.org/specs/extension/regLastUser',
-            valueReference: 'DUMMY'
+            valueReference: { reference: 'DUMMY' }
           }
         ],
         note: [


### PR DESCRIPTION
valueReferences should be an object according to the FHIR spec and the
way it was currently broke certian queryies in Hearth and prevented ids
to be correctly resovled when resoruces are saved.

OCRVS-910