### PR TITLE
Ensure main.xyz.js is cached in service worker

### DIFF
--- a/packages/register/workbox-config.js
+++ b/packages/register/workbox-config.js
@@ -1,6 +1,7 @@
 module.exports = {
   globDirectory: 'build/',
   globPatterns: ['**/*.{json,ico,ttf,html,js}'],
+  maximumFileSizeToCacheInBytes: 10 * 1024 * 1024,
   swDest: 'build/service-worker.js',
   swSrc: 'src/src-sw.js'
 }


### PR DESCRIPTION
It had stopped being cached as the 2mb default limit was reached.