### PR TITLE
Ocrvs 1491 Remove placeholder for phone number input

### DIFF
--- a/packages/login/src/views/StepOne/StepOneForm.tsx
+++ b/packages/login/src/views/StepOne/StepOneForm.tsx
@@ -179,7 +179,6 @@ const MobileInput = injectIntl((props: Props) => {
         touched={Boolean(meta.touched)}
         error={Boolean(meta.error)}
         type="tel"
-        placeholder={intl.formatMessage(mobileField.placeholder)}
         ignoreMediaQuery
       />
     </InputField>

--- a/packages/login/src/views/StepOne/stepOneFields.ts
+++ b/packages/login/src/views/StepOne/stepOneFields.ts
@@ -29,8 +29,7 @@ export const stepOneFields = {
     disabled: false,
     type: 'tel',
     focusInput: false,
-    label: messages.mobileLabel,
-    placeholder: messages.mobilePlaceholder
+    label: messages.mobileLabel
   },
   password: {
     id: 'password',


### PR DESCRIPTION
In the login step one form, placeholder for input (phone number) has now been removed.

![placeholder_removed1](https://user-images.githubusercontent.com/42269993/56803858-a615f600-6845-11e9-9fe5-7fe15561d804.png)

