### PR TITLE
Set a min-width on the SearchTool form

### DIFF
--- a/packages/components/src/components/interface/SearchTool/SearchTool.tsx
+++ b/packages/components/src/components/interface/SearchTool/SearchTool.tsx
@@ -10,6 +10,7 @@ const Wrapper = styled.form`
   ${({ theme }) => theme.fonts.bodyStyle};
   padding: 0px 10px;
   margin-bottom: 1px;
+  min-width: 400px;
   position: relative;
 `
 const SearchTextInput = styled.input`


### PR DESCRIPTION
Prior to this change,
The form expanded when a user starts typing
This change
Sets the min-width based on Jonathans feedback that it should accept minimum width of the BRN 18 characters