### PR TITLE
Fix Component Library hosting error

### DIFF
--- a/packages/components/styleguide.config.js
+++ b/packages/components/styleguide.config.js
@@ -2,13 +2,22 @@ const { styles, theme } = require('./styleguide.styles')
 
 const path = require('path')
 
+function getWebpackConfig() {
+  const webpackConfig = require('react-scripts-ts/config/webpack.config.dev.js')
+  if (!webpackConfig.devServer) {
+    webpackConfig.devServer = {}
+  }
+  webpackConfig.devServer.disableHostCheck = true
+  return webpackConfig
+}
+
 module.exports = {
   components: 'src/components/**/*.{ts,tsx}',
   propsParser: require('react-docgen-typescript').parse,
   styleguideDir: './lib',
   assetsDir: './static',
   skipComponentsWithoutExample: true,
-  webpackConfig: require('react-scripts-ts/config/webpack.config.dev.js'),
+  webpackConfig: getWebpackConfig(),
   styleguideComponents: {
     Wrapper: path.join(__dirname, 'src/components/styleguide/ThemeWrapper')
   },


### PR DESCRIPTION
Hopefully fix the Invalid Host Header error when the styleguide is deployed

Prior to this change,
![Screenshot 2019-05-21 at 12 37 41](https://user-images.githubusercontent.com/3169954/58092976-579a1400-7bc5-11e9-8c90-c647f939d831.png)

The styleguide is not accessible from staging
This change
Overrides the webpack config by setting disableHostCheck