### PR TITLE
 OCRVS-1466: Unlock screen issues

### DIFF
--- a/packages/register/src/views/Unlock/ComparePINs.test.ts
+++ b/packages/register/src/views/Unlock/ComparePINs.test.ts
@@ -1,0 +1,19 @@
+import { pinOps } from './ComparePINs'
+import * as bcrypt from 'bcryptjs'
+
+describe('Compare two PINs', () => {
+  const pin = '1212'
+  const salt = bcrypt.genSaltSync(10)
+  const hash = bcrypt.hashSync(pin, salt)
+
+  it('should return true when PINs match', async () => {
+    const result = await pinOps.comparePins(pin, hash)
+    expect(result).toBe(true)
+  })
+
+  it('should return false when PINs do not match', async () => {
+    const pin2 = '2121'
+    const result = await pinOps.comparePins(pin2, hash)
+    expect(result).toBe(false)
+  })
+})

--- a/packages/register/src/views/Unlock/ComparePINs.ts
+++ b/packages/register/src/views/Unlock/ComparePINs.ts
@@ -1,0 +1,11 @@
+import * as bcrypt from 'bcryptjs'
+
+// wrapping bcrypt.compare in a separate file
+// and exporting this function for tests
+async function comparePins(pin1: string, pin2: string) {
+  return await bcrypt.compare(pin1, pin2)
+}
+
+export const pinOps = {
+  comparePins
+}

--- a/packages/register/src/views/Unlock/Unlock.tsx
+++ b/packages/register/src/views/Unlock/Unlock.tsx
@@ -10,7 +10,6 @@ import { IUserDetails } from '../../utils/userUtils'
 import { GQLHumanName } from '@opencrvs/gateway/src/graphql/schema'
 import { defineMessages, injectIntl, InjectedIntlProps } from 'react-intl'
 import { storage } from 'src/storage'
-import * as bcrypt from 'bcryptjs'
 import {
   SECURITY_PIN_INDEX,
   SECURITY_PIN_EXPIRED_AT
@@ -18,6 +17,7 @@ import {
 import * as moment from 'moment'
 import { SCREEN_LOCK } from 'src/components/ProtectedPage'
 import { ErrorMessage } from '@opencrvs/components/lib/forms'
+import { pinOps } from './ComparePINs'
 
 const messages = defineMessages({
   incorrect: {
@@ -153,7 +153,7 @@ class UnlockView extends React.Component<IFullProps, IFullState> {
     this.setState({
       showSpinner: true
     })
-    const pinMatched = await bcrypt.compare(pin, userPin)
+    const pinMatched = await pinOps.comparePins(pin, userPin)
     this.setState({
       showSpinner: false
     })
@@ -235,7 +235,11 @@ class UnlockView extends React.Component<IFullProps, IFullState> {
     this.props.redirectToAuthentication()
   }
   render() {
-    return this.state.showSpinner ? <SpinnerWrapper><Spinner id="hashingSpinner" /></SpinnerWrapper> : (
+    return this.state.showSpinner ? (
+      <SpinnerWrapper>
+        <Spinner id="hashingSpinner" />
+      </SpinnerWrapper>
+    ) : (
       <PageWrapper id="unlockPage">
         <LogoutHeader onClick={this.logout} id="logout">
           <span>Logout</span>


### PR DESCRIPTION
Prior to this change,
- the unlock screen used to be slow and unresponsive when the 4th digit of PIN was inputted
- if the unlock screen is timed-out due to a certain number of failed attempts, it remained that way even after logout-login.

This change will
- add a spinner while browser is busy hashing the inputted PIN
- remove `screenLock` entry from indexed-db upon logout, so that when the user logs in, there is no timed-out screen.

Issue closed by this PR: OCRVS-1466