### PR TITLE
OCRVS-1453:  Birth Certificate → Mother Details → Date of Birth cannot be today's date 	

### DIFF
--- a/packages/register/src/forms/register/fieldDefinitions/birth/father-section.ts
+++ b/packages/register/src/forms/register/fieldDefinitions/birth/father-section.ts
@@ -30,7 +30,8 @@ import {
   dateNotInFuture,
   dateFormatIsCorrect,
   maxLength,
-  numeric
+  numeric,
+  dateInPast
 } from 'src/utils/validate'
 
 export interface IFatherSectionFormData {
@@ -403,7 +404,7 @@ export const fatherSection: IFormSection = {
             dependencies: []
           },
           {
-            validator: dateNotInFuture,
+            validator: dateInPast,
             dependencies: []
           },
           {

--- a/packages/register/src/forms/register/fieldDefinitions/birth/mother-section.ts
+++ b/packages/register/src/forms/register/fieldDefinitions/birth/mother-section.ts
@@ -31,7 +31,8 @@ import {
   dateNotInFuture,
   dateFormatIsCorrect,
   numeric,
-  maxLength
+  maxLength,
+  dateInPast
 } from 'src/utils/validate'
 
 export interface IMotherSectionFormData {
@@ -360,7 +361,7 @@ export const motherSection: IFormSection = {
             dependencies: []
           },
           {
-            validator: dateNotInFuture,
+            validator: dateInPast,
             dependencies: []
           },
           {

--- a/packages/register/src/forms/register/fieldDefinitions/death/application-section.ts
+++ b/packages/register/src/forms/register/fieldDefinitions/death/application-section.ts
@@ -18,7 +18,8 @@ import {
   isValidBirthDate,
   validIDNumber,
   numeric,
-  maxLength
+  maxLength,
+  isDateInPast
 } from 'src/utils/validate'
 import { countries } from 'src/forms/countries'
 import {
@@ -446,7 +447,7 @@ export const applicantsSection: IFormSection = {
       label: messages.applicantsDateOfBirth,
       required: false,
       initialValue: '',
-      validate: [isValidBirthDate],
+      validate: [isValidBirthDate, isDateInPast],
       mapping: {
         mutation: fieldValueNestingTransformer(
           NESTED_SECTION,

--- a/packages/register/src/utils/validate.test.ts
+++ b/packages/register/src/utils/validate.test.ts
@@ -21,7 +21,8 @@ import {
   dateGreaterThan,
   dateLessThan,
   dateNotInFuture,
-  dateFormatIsCorrect
+  dateFormatIsCorrect,
+  dateInPast
 } from './validate'
 
 describe('validate', () => {
@@ -424,6 +425,32 @@ describe('validate', () => {
       const validDate = '2011-08-12'
       const response = undefined
       expect(isValidBirthDate(validDate)).toEqual(response)
+    })
+  })
+
+  describe('dateInPast. Checks if a given birth date is in the past', () => {
+    it('should not give an error message if the birth date is in the past', () => {
+      const todaysDate = new Date('1999-12-31')
+      todaysDate.setHours(0, 0, 0)
+      const today = todaysDate.toDateString()
+      expect(dateInPast()(today)).toEqual(undefined)
+    })
+    it("should give an error message if the date is today's date", () => {
+      const todaysDate = new Date()
+      todaysDate.setHours(0, 0, 0)
+      const today = todaysDate.toDateString()
+      expect(dateInPast()(today)).toEqual({
+        message: messages.isValidBirthDate
+      })
+    })
+
+    it('should give an error message if the date is in the future', () => {
+      const todaysDate = new Date(2040, 12, 12)
+      todaysDate.setHours(0, 0, 0)
+      const today = todaysDate.toDateString()
+      expect(dateInPast()(today)).toEqual({
+        message: messages.isValidBirthDate
+      })
     })
   })
 

--- a/packages/register/src/utils/validate.ts
+++ b/packages/register/src/utils/validate.ts
@@ -390,6 +390,24 @@ export const dateNotInFuture: ValidationInitializer = (): Validation => (
   }
 }
 
+export const dateInPast: ValidationInitializer = (): Validation => (
+  value: string
+) => isDateInPast(value)
+
+export const isDateInPast: Validation = (value: string) => {
+  if (isDateNotInFuture(value) && dateNotToday(value)) {
+    return undefined
+  } else {
+    return { message: messages.isValidBirthDate } // specific to DOB of parent/applicant
+  }
+}
+
+export const dateNotToday = (date: string): boolean => {
+  const today = new Date().setHours(0, 0, 0, 0)
+  const day = new Date(date).setHours(0, 0, 0, 0)
+  return day !== today
+}
+
 export const dateFormatIsCorrect: ValidationInitializer = (): Validation => (
   value: string
 ) => dateFormat(value)


### PR DESCRIPTION
Prior to this change, while registering a birth event, applicant could input the date of application creation as the birth date of mother and/or father.

This change will enforce the applicant to use a date from the past for the DOB of mother and father.
Additionally, this validation is also added to applicant's DOB while registering a death event.

Issue fixed by this PR: OCRVS-1453