### PR TITLE
Fix nginx config for webapps

### DIFF
--- a/infrastructure/nginx-default.conf
+++ b/infrastructure/nginx-default.conf
@@ -1,0 +1,17 @@
+server {
+    listen       80;
+    server_name  localhost;
+
+    location / {
+        root   /usr/share/nginx/html;
+        # allows fallback to /index.html so SPAs work
+        try_files $uri $uri/ /index.html;
+    }
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}

--- a/packages/login/Dockerfile
+++ b/packages/login/Dockerfile
@@ -32,4 +32,5 @@ RUN cd packages/components; yarn build && cd ../login; yarn build --production
 
 # Add nginx build stage that only copies out the built webapp
 FROM nginx
+COPY infrastructure/nginx-default.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /usr/src/app/packages/login/build /usr/share/nginx/html

--- a/packages/performance/Dockerfile
+++ b/packages/performance/Dockerfile
@@ -32,4 +32,5 @@ RUN cd packages/components; yarn build && cd ../performance; yarn build --produc
 
 # Add nginx build stage that only copies out the built webapp
 FROM nginx
+COPY infrastructure/nginx-default.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /usr/src/app/packages/performance/build /usr/share/nginx/html

--- a/packages/register/Dockerfile
+++ b/packages/register/Dockerfile
@@ -33,4 +33,5 @@ RUN cd packages/components; yarn build && cd ../register; yarn build --productio
 
 # Add nginx build stage that only copies out the built webapp
 FROM nginx
+COPY infrastructure/nginx-default.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /usr/src/app/packages/register/build /usr/share/nginx/html


### PR DESCRIPTION
I was dumb and forgot that SPAs need a fallback to index.html to work as
they serve the entire application from index.html but must still
work when we try link to a particular location from an external place.
(like login does).