### PR TITLE
Fix for CI Docker build

### DIFF
--- a/packages/login/Dockerfile
+++ b/packages/login/Dockerfile
@@ -15,6 +15,8 @@ ENV REACT_APP_LANGUAGE=bn
 COPY package.json package.json
 COPY packages/login/package.json packages/login/package.json
 COPY packages/components/package.json packages/components/package.json
+# Copy any relevant patches
+COPY patches patches
 # TODO remove the following two once components dependency on gateway is removed
 COPY packages/gateway/package.json packages/gateway/package.json
 COPY packages/commons/package.json packages/commons/package.json

--- a/packages/performance/Dockerfile
+++ b/packages/performance/Dockerfile
@@ -15,6 +15,8 @@ ENV REACT_APP_LANGUAGE=en
 COPY package.json package.json
 COPY packages/performance/package.json packages/performance/package.json
 COPY packages/components/package.json packages/components/package.json
+# Copy any relevant patches
+COPY patches patches
 # TODO remove the following two once compoennts dependency on gateway is removed
 COPY packages/gateway/package.json packages/gateway/package.json
 COPY packages/commons/package.json packages/commons/package.json

--- a/packages/register/Dockerfile
+++ b/packages/register/Dockerfile
@@ -16,6 +16,8 @@ ENV REACT_APP_LANGUAGE=en
 COPY package.json package.json
 COPY packages/register/package.json packages/register/package.json
 COPY packages/components/package.json packages/components/package.json
+# Copy any relevant patches
+COPY patches patches
 # TODO remove the following two once compoennts dependency on gateway is removed
 COPY packages/gateway/package.json packages/gateway/package.json
 COPY packages/commons/package.json packages/commons/package.json


### PR DESCRIPTION
The CI Docker build was failing because it couldnt find the patches.  These need to be copied over into the container before yarn install.