### PR TITLE
Attempt to resolve prettier error in craco production build

### DIFF
--- a/packages/login/.eslintrc.js
+++ b/packages/login/.eslintrc.js
@@ -16,7 +16,17 @@ module.exports = {
     jest: true
   },
   rules: {
-    'prettier/prettier': ['error', { singleQuote: true }],
+    'prettier/prettier': [
+      'error',
+      {
+        printWidth: 80,
+        singleQuote: true,
+        useTabs: false,
+        tabWidth: 2,
+        trailingComma: 'none',
+        semi: false
+      }
+    ],
     'no-console': 'off',
     'no-return-assign': 'off',
     'no-unreachable': 2,

--- a/packages/performance/.eslintrc.js
+++ b/packages/performance/.eslintrc.js
@@ -16,7 +16,17 @@ module.exports = {
     jest: true
   },
   rules: {
-    'prettier/prettier': ['error', { singleQuote: true }],
+    'prettier/prettier': [
+      'error',
+      {
+        printWidth: 80,
+        singleQuote: true,
+        useTabs: false,
+        tabWidth: 2,
+        trailingComma: 'none',
+        semi: false
+      }
+    ],
     'no-console': 'off',
     'no-return-assign': 'off',
     'no-unreachable': 2,

--- a/packages/register/.eslintrc.js
+++ b/packages/register/.eslintrc.js
@@ -16,7 +16,17 @@ module.exports = {
     jest: true
   },
   rules: {
-    'prettier/prettier': ['error', { singleQuote: true }],
+    'prettier/prettier': [
+      'error',
+      {
+        printWidth: 80,
+        singleQuote: true,
+        useTabs: false,
+        tabWidth: 2,
+        trailingComma: 'none',
+        semi: false
+      }
+    ],
     'no-console': 'off',
     'no-return-assign': 'off',
     'no-unreachable': 2,


### PR DESCRIPTION
Prior to this change,
Prettier errors stopped production build in docker
This change
duplicates the prettier rules into the eslintrc that craco uses to build production.  In development lerna uses the .prettierrc file in the root of the project but in Docker this is not working after the craco update which seems to look for prettier rules in eslint