### PR TITLE
Attempt to resolve javascript memory issue building performance and l…

### DIFF
--- a/packages/login/package.json
+++ b/packages/login/package.json
@@ -43,7 +43,7 @@
     "postinstall": "patch-package",
     "precommit": "lint-staged",
     "start": "BROWSER=none PORT=3020 craco start",
-    "build": "craco build && yarn gen:sw",
+    "build": "craco --max_old_space_size=4096 build && yarn gen:sw",
     "gen:sw": "workbox generateSW --config workbox-config.js",
     "docker:build": "docker build ../../ -f ../../Dockerfile-login -t ocrvs-login",
     "docker:run": "docker run -it --rm -p 5000:80 --name ocrvs-login ocrvs-login",

--- a/packages/performance/package.json
+++ b/packages/performance/package.json
@@ -42,7 +42,7 @@
     "postinstall": "patch-package",
     "precommit": "lint-staged",
     "start": "BROWSER=none PORT=3001 craco start",
-    "build": "craco build",
+    "build": "craco --max_old_space_size=4096 build",
     "docker:build": "docker build ../../ -f ../../Dockerfile-register -t ocrvs-register",
     "docker:run": "docker run -it --rm -p 5000:80 --name ocrvs-register ocrvs-register",
     "test": "PORT=3001 craco test --watchAll=false --coverage --silent --noStackTrace --env=jsdom --modulePaths=src/ && yarn test:compilation",


### PR DESCRIPTION
…ogin app in Docker

Prior to this change,
Docker build fails with Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory error on performance app
This change
Increases the memory allocation to the build task on performance and login apps to be the same as that successfully passing for register app