### PR TITLE
OCRVS-1556 & 1543 - Mobile style for the keypad and hides keypad on desktop

### DIFF
--- a/packages/components/src/components/interface/PINKeypad.tsx
+++ b/packages/components/src/components/interface/PINKeypad.tsx
@@ -17,6 +17,7 @@ const Container = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
+  outline: none;
 `
 
 const DotFilled = styled.span`
@@ -26,6 +27,11 @@ const DotFilled = styled.span`
   border-radius: 50%;
   display: inline-block;
   margin: 24px;
+  @media (max-width: ${({ theme }) => theme.grid.breakpoints.md}px) {
+    height: 14px;
+    width: 14px;
+    margin: 14px;
+  }
 `
 
 const DotUnfilled = styled.span`
@@ -35,11 +41,21 @@ const DotUnfilled = styled.span`
   border-radius: 50%;
   display: inline-block;
   margin: 24px;
+
+  @media (max-width: ${({ theme }) => theme.grid.breakpoints.md}px) {
+    height: 14px;
+    width: 14px;
+    margin: 14px;
+  }
 `
 
 const NumberContainer = styled.div`
   display: grid;
   grid-template-columns: auto auto auto;
+
+  @media (min-width: ${({ theme }) => theme.grid.breakpoints.lg}px) {
+    display: none;
+  }
 `
 
 const Key = styled.span`
@@ -47,6 +63,10 @@ const Key = styled.span`
   ${({ theme }) => theme.fonts.h2Style};
   padding: 24px 48px;
   text-align: center;
+  @media (max-width: ${({ theme }) => theme.grid.breakpoints.md}px) {
+    padding: 20px 40px;
+    ${({ theme }) => theme.fonts.h3Style};
+  }
 `
 
 export class PINKeypad extends React.Component<IProps, IState> {

--- a/packages/register/src/components/ProtectedPage.tsx
+++ b/packages/register/src/components/ProtectedPage.tsx
@@ -78,7 +78,6 @@ class ProtectedPageComponent extends React.Component<
   onIdle() {
     this.setState({ secured: false })
   }
-
   render() {
     const { pendingUser, secured, pinExists } = this.state
     return (

--- a/packages/register/src/views/Unlock/Unlock.tsx
+++ b/packages/register/src/views/Unlock/Unlock.tsx
@@ -264,7 +264,7 @@ class UnlockView extends React.Component<IFullProps, IFullState> {
           <span>Logout</span>
           <Logout />
         </LogoutHeader>
-        <Container>
+        <Container onClick={this.focusKeypad}>
           <Logo />
           {this.showName()}
 


### PR DESCRIPTION
Prior to this change,
Hiding keypad on desktop would not be possible because focus changes away from the keypad if the user clicks on the page
This change
Adds a click handler to the Unlock container sending focus back to the PIN component.  Also introduces mobile style.