### PR TITLE
Add an icon column into GridTable to support duplicate icons

### DIFF
--- a/packages/components/src/components/interface/GridTable/GridTable.tsx
+++ b/packages/components/src/components/interface/GridTable/GridTable.tsx
@@ -68,6 +68,10 @@ const ActionWrapper = styled(ContentWrapper)`
   padding-right: 0px;
 `
 
+const IconWrapper = styled(ContentWrapper)`
+  padding-top: 5px;
+`
+
 const ExpandedSectionContainer = styled.div.attrs<{ expanded: boolean }>({})`
   margin-top: 5px;
   overflow: hidden;
@@ -235,7 +239,7 @@ export class GridTable extends React.Component<
                 width={preference.width}
                 alignment={preference.alignment}
               >
-                {preference.label}
+                {preference.label && preference.label}
               </ContentWrapper>
             ))}
           </TableHeader>
@@ -266,6 +270,19 @@ export class GridTable extends React.Component<
                         preference.width,
                         indx,
                         preference.alignment
+                      )
+                    } else if (preference.isIconColumn) {
+                      return (
+                        <IconWrapper
+                          key={indx}
+                          width={preference.width}
+                          alignment={preference.alignment}
+                          color={preference.color}
+                        >
+                          {(item.icon as JSX.Element) || (
+                            <Error>{preference.errorValue}</Error>
+                          )}
+                        </IconWrapper>
                       )
                     } else {
                       return (

--- a/packages/components/src/components/interface/GridTable/types.ts
+++ b/packages/components/src/components/interface/GridTable/types.ts
@@ -18,12 +18,13 @@ export interface IStatus {
 }
 
 export interface IColumn {
-  label: string
+  label?: string
   width: number
   key: string
   errorValue?: string
   alignment?: ColumnContentAlignment
   isActionColumn?: boolean
+  isIconColumn?: boolean
   color?: string
 }
 

--- a/packages/register/src/i18n/locales/bn.ts
+++ b/packages/register/src/i18n/locales/bn.ts
@@ -777,10 +777,8 @@ export const BENGALI_STATE: ILanguage = {
       'তথ্যদাতা পর্যালোচনা করেছেন এবং নিশ্চিত করেছেন যে শংসাপত্রের তথ্য সঠিক।',
     'register.workQueue.labels.results.duplicate':
       'সম্ভাব্য সদৃশ খুঁজে পাওয়া গেছে',
-    'register.registrarHome.results.reviewDuplicates':
-      'সদৃশগুলো পর্যালোচনা করুন',
-    'register.searchResult.results.reviewDuplicates':
-      'সদৃশগুলো পর্যালোচনা করুন',
+    'register.registrarHome.results.reviewDuplicates': 'পর্যালোচনা',
+    'register.searchResult.results.reviewDuplicates': 'পর্যালোচনা',
     'register.workQueue.buttons.printCertificate': 'সার্টিফিকেট মুদ্রণ',
     'review.edit.modal.preview': 'প্রিভিউতে ফেরত যান',
     'review.edit.modal.editButton': 'সম্পাদন',

--- a/packages/register/src/i18n/locales/en.ts
+++ b/packages/register/src/i18n/locales/en.ts
@@ -779,8 +779,8 @@ export const ENGLISH_STATE: ILanguage = {
     'print.certificate.userReviewed':
       'The informant has reviewed and confirmed that the information on the certificate is correct.',
     'register.workQueue.labels.results.duplicate': 'Possible duplicate found',
-    'register.registrarHome.results.reviewDuplicates': 'Review Duplicates',
-    'register.searchResult.results.reviewDuplicates': 'Review Duplicates',
+    'register.registrarHome.results.reviewDuplicates': 'Review',
+    'register.searchResult.results.reviewDuplicates': 'Review',
     'register.workQueue.buttons.printCertificate': 'Print Certificate',
     'review.edit.modal.preview': 'Back to Preview',
     'review.edit.modal.editButton': 'Edit',

--- a/packages/register/src/views/RegistrarHome/RegistrarHome.tsx
+++ b/packages/register/src/views/RegistrarHome/RegistrarHome.tsx
@@ -7,7 +7,8 @@ import {
   StatusOrange,
   StatusProgress,
   StatusGreen,
-  StatusRejected
+  StatusRejected,
+  Duplicate
 } from '@opencrvs/components/lib/icons'
 import {
   ISearchInputProps,
@@ -190,7 +191,7 @@ const messages: {
   },
   reviewDuplicates: {
     id: 'register.registrarHome.results.reviewDuplicates',
-    defaultMessage: 'Review Duplicates',
+    defaultMessage: 'Review',
     description:
       'The title of review duplicates button in expanded area of list item'
   },
@@ -299,12 +300,14 @@ export class RegistrarHomeView extends React.Component<
 
     return transformedData.map(reg => {
       const actions = [] as IAction[]
+      let icon: JSX.Element = <div />
       if (this.userHasRegisterScope()) {
         if (reg.duplicates && reg.duplicates.length > 0) {
           actions.push({
             label: this.props.intl.formatMessage(messages.reviewDuplicates),
             handler: () => this.props.goToReviewDuplicate(reg.id)
           })
+          icon = <Duplicate />
         } else {
           actions.push({
             label: this.props.intl.formatMessage(messages.review),
@@ -332,7 +335,8 @@ export class RegistrarHomeView extends React.Component<
               'YYYY-MM-DD HH:mm:ss'
             ).fromNow()) ||
           '',
-        actions
+        actions,
+        icon
       }
     })
   }
@@ -716,20 +720,22 @@ export class RegistrarHomeView extends React.Component<
                         label: this.props.intl.formatMessage(
                           messages.listItemApplicationDate
                         ),
-                        width: 23,
+                        width: 20,
                         key: 'applicationTimeElapsed'
                       },
                       {
                         label: this.props.intl.formatMessage(
                           messages.listItemEventDate
                         ),
-                        width: 23,
+                        width: 20,
                         key: 'eventTimeElapsed'
                       },
                       {
-                        label: this.props.intl.formatMessage(
-                          messages.listItemAction
-                        ),
+                        width: 6,
+                        key: 'icons',
+                        isIconColumn: true
+                      },
+                      {
                         width: 20,
                         key: 'actions',
                         isActionColumn: true,


### PR DESCRIPTION
Prior to this change,
No icon column existed in GridTable
This change
Adds an optional icon column and also sets label as optional as some labels are not required. Removes the word duplicates from action button Review duplicates so that the button simply says Review as per the request OCRVS-1759

![Screenshot 2019-07-11 at 12 28 12](https://user-images.githubusercontent.com/3169954/61047434-63d96b00-a3d7-11e9-8c71-15711694718c.png)
