### PR TITLE
Add travis_wait commands while wait for services

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ jobs:
         - sudo chmod 775 data/elasticsearch
         - sleep 10
         - yarn start:prod &
-        - wait-on http://localhost:3000 http://localhost:3020
+        - travis_wait wait-on http://localhost:3000 http://localhost:3020
         - yarn db:backup:restore
         - cd packages/resources && yarn save:testData && cd ../..
         - cd packages/e2e && yarn start --record false


### PR DESCRIPTION
This is so that we can wait for more that 10mins before the build times
out.