### PR TITLE
Only run e2e tests on travis on the pullrequest test type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jobs:
       after_success:
         - npm install codecov -g
         - codecov
-    - if: type = push
+    - if: type = pull_request
       before_install: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
       addons:
         apt:


### PR DESCRIPTION
This is to ease presssure on travis as the e2e builds take a really long
time. We are really only interested in if the e2e tests run against
master so this change should be fine.