### PR TITLE
Fix QA being broken after v2 version of Traefik was released

### DIFF
--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -5,7 +5,7 @@ services:
   # Note: these published port will override UFW rules as Docker manages it's own iptables
   # Only publish the exact ports that are required for OpenCRVS to work
   traefik:
-    image: traefik
+    image: traefik:1.7.16
     ports:
       - '80:80'
       - '443:443'


### PR DESCRIPTION
It seems we hadn't defined the version of Traefik we use explicitly when we first added it to our compose file. v2.0 was released last night and as we deployed a new version of our app we also got the new version, which wasn't 100% compatible with our `traefik.toml` configuration.