### PR TITLE
OCRVS-2011 Certificate covering buttons

### DIFF
--- a/packages/components/src/components/forms/PDFViewer/PDFViewer.tsx
+++ b/packages/components/src/components/forms/PDFViewer/PDFViewer.tsx
@@ -8,6 +8,10 @@ const Container = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
+  @media (max-height: 900px) {
+    margin-top: 30%;
+    margin-bottom: 5%;
+  }
   background: ${({ theme }) => theme.colors.white};
 `
 

--- a/packages/register/src/views/PrintCertificate/ReviewCertificateAction.tsx
+++ b/packages/register/src/views/PrintCertificate/ReviewCertificateAction.tsx
@@ -75,6 +75,7 @@ const PdfWrapper = styled.div`
   align-items: center;
   justify-content: center;
   margin-bottom: 32px;
+  overflow: scroll;
 `
 
 const Info = styled.div`


### PR DESCRIPTION
Adjusting CSS of pdfviewer and pdfwrapper to stop certificate covering buttons

![Screenshot 2019-09-18 at 16 37 53](https://user-images.githubusercontent.com/3169954/65163377-bae06980-da32-11e9-8a44-83de6a9ff17a.png)
