### PR TITLE
Unify the way we send GraphQL query errors to Sentry

### DIFF
--- a/packages/register/.eslintrc.js
+++ b/packages/register/.eslintrc.js
@@ -30,6 +30,23 @@ module.exports = {
     ],
     'no-console': 'off',
     'no-return-assign': 'off',
+    'no-restricted-imports': [
+      'error',
+      {
+        paths: [
+          {
+            name: '@sentry/browser',
+            message: `Errors should be sent to Sentry from few centralised places of our codebase.
+Query component now sends errors automatically to Sentry.`
+          },
+          {
+            name: 'react-apollo',
+            importNames: ['Query'],
+            message: `Please use our own <Query /> component instead from components/Query.tsx`
+          }
+        ]
+      }
+    ],
     'no-unreachable': 2,
     'import/no-extraneous-dependencies': 'off',
     'import/no-unresolved': 'off',

--- a/packages/register/src/SubmissionController.ts
+++ b/packages/register/src/SubmissionController.ts
@@ -1,4 +1,5 @@
 import ApolloClient, { ApolloError } from 'apollo-client'
+// eslint-disable-next-line no-restricted-imports
 import * as Sentry from '@sentry/browser'
 import {
   IApplication,

--- a/packages/register/src/components/ErrorBoundary.tsx
+++ b/packages/register/src/components/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+// eslint-disable-next-line no-restricted-imports
 import * as Sentry from '@sentry/browser'
 import styled from '@register/styledComponents'
 

--- a/packages/register/src/components/Query.tsx
+++ b/packages/register/src/components/Query.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react'
+import { ComponentProps } from '@register/utils/react'
+// eslint-disable-next-line no-restricted-imports
+import { Query as ApolloQuery } from 'react-apollo'
+// eslint-disable-next-line no-restricted-imports
+import * as Sentry from '@sentry/browser'
+
+type Props = ComponentProps<ApolloQuery>
+
+export function Query(props: Props) {
+  return (
+    <ApolloQuery
+      onError={(error: Error) => {
+        Sentry.captureException(error)
+      }}
+      {...props}
+    />
+  )
+}

--- a/packages/register/src/components/StyledErrorBoundary.tsx
+++ b/packages/register/src/components/StyledErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+// eslint-disable-next-line no-restricted-imports
 import * as Sentry from '@sentry/browser'
 import styled from '@register/styledComponents'
 import { injectIntl, WrappedComponentProps as IntlShapeProps } from 'react-intl'

--- a/packages/register/src/components/form/FetchButton.tsx
+++ b/packages/register/src/components/form/FetchButton.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import styled from '@register/styledComponents'
 import { ApolloQueryResult } from 'apollo-client'
 import { ApolloConsumer } from 'react-apollo'
+// eslint-disable-next-line no-restricted-imports
 import * as Sentry from '@sentry/browser'
 import { GQLQuery } from '@opencrvs/gateway/src/graphql/schema.d'
 import {

--- a/packages/register/src/components/form/SearchField.tsx
+++ b/packages/register/src/components/form/SearchField.tsx
@@ -19,7 +19,6 @@ import { TextInput, InputLabel } from '@opencrvs/components/lib/forms'
 import {
   buttonMessages,
   formMessages,
-  errorMessages,
   constantsMessages
 } from '@register/i18n/messages'
 import { IOfflineData, ILocation } from '@register/offline/reducer'

--- a/packages/register/src/forms/register/fieldMappings/birth/mutation/child-mappings.ts
+++ b/packages/register/src/forms/register/fieldMappings/birth/mutation/child-mappings.ts
@@ -2,9 +2,7 @@ import {
   IFormField,
   IFormData,
   TransformedData,
-  SEARCH_FIELD,
-  ISearchFormField,
-  IDynamicFormField
+  SEARCH_FIELD
 } from '@register/forms'
 import { IDynamicValues } from '@opencrvs/components/lib/interface/GridTable/types'
 

--- a/packages/register/src/forms/utils.ts
+++ b/packages/register/src/forms/utils.ts
@@ -26,9 +26,7 @@ import {
   DATE,
   IDateFormField,
   IFormSectionGroup,
-  DOCUMENT_UPLOADER_WITH_OPTION,
-  SEARCH_FIELD,
-  ISearchFormField
+  DOCUMENT_UPLOADER_WITH_OPTION
 } from '@register/forms'
 import { IntlShape, MessageDescriptor } from 'react-intl'
 import { getValidationErrorsForForm } from '@register/forms/validation'

--- a/packages/register/src/index.tsx
+++ b/packages/register/src/index.tsx
@@ -6,6 +6,7 @@ import registerServiceWorker from '@register/registerServiceWorker'
 import { createStore } from '@register/store'
 import * as actions from '@register/notification/actions'
 import { storage } from '@register/storage'
+// eslint-disable-next-line no-restricted-imports
 import * as Sentry from '@sentry/browser'
 import * as LogRocket from 'logrocket'
 import { SubmissionController } from '@register/SubmissionController'

--- a/packages/register/src/store.ts
+++ b/packages/register/src/store.ts
@@ -42,6 +42,7 @@ import {
   IPrintFormState,
   printReducer
 } from '@register/forms/certificate/printReducer'
+// eslint-disable-next-line no-restricted-imports
 import * as Sentry from '@sentry/browser'
 import createSentryMiddleware from 'redux-sentry-middleware'
 import {

--- a/packages/register/src/utils/apolloClient.ts
+++ b/packages/register/src/utils/apolloClient.ts
@@ -12,6 +12,7 @@ import { showSessionExpireConfirmation } from '@register/notification/actions'
 
 import { IStoreState } from '@register/store'
 import { AnyAction, Store } from 'redux'
+// eslint-disable-next-line no-restricted-imports
 import * as Sentry from '@sentry/browser'
 import TimeoutLink from '@register/utils/timeoutLink'
 

--- a/packages/register/src/utils/authUtils.ts
+++ b/packages/register/src/utils/authUtils.ts
@@ -1,5 +1,6 @@
 import * as queryString from 'querystring'
 import decode from 'jwt-decode'
+// eslint-disable-next-line no-restricted-imports
 import * as Sentry from '@sentry/browser'
 
 export interface IURLParams {

--- a/packages/register/src/utils/react.ts
+++ b/packages/register/src/utils/react.ts
@@ -1,0 +1,3 @@
+export type ComponentProps<C> = C extends React.Component<infer P, any>
+  ? P
+  : never

--- a/packages/register/src/views/DataProvider/QueryProvider.tsx
+++ b/packages/register/src/views/DataProvider/QueryProvider.tsx
@@ -3,8 +3,7 @@ import { WrappedComponentProps as IntlShapeProps, injectIntl } from 'react-intl'
 import { Event, Action } from '@register/forms'
 import { getBirthQueryMappings } from '@register/views/DataProvider/birth/queries'
 import { getDeathQueryMappings } from '@register/views/DataProvider/death/queries'
-import { Query } from 'react-apollo'
-import * as Sentry from '@sentry/browser'
+import { Query } from '@register/components/Query'
 
 interface IQueryProviderProps {
   event: Event
@@ -49,10 +48,6 @@ class QueryProviderComponent extends React.Component<IProps> {
           error?: any
           data: any
         }) => {
-          if (error) {
-            Sentry.captureException(error)
-          }
-
           return (
             <QueryContext.Provider
               value={{

--- a/packages/register/src/views/Duplicates/ReviewDuplicates.tsx
+++ b/packages/register/src/views/Duplicates/ReviewDuplicates.tsx
@@ -7,7 +7,7 @@ import {
 } from '@opencrvs/components/lib/interface'
 import { PrimaryButton } from '@opencrvs/components/lib/buttons'
 import { Duplicate } from '@opencrvs/components/lib/icons'
-import { Mutation, Query } from 'react-apollo'
+import { Mutation } from 'react-apollo'
 import styled from '@register/styledComponents'
 import {
   injectIntl,
@@ -38,7 +38,7 @@ import {
   GQLComment
 } from '@opencrvs/gateway/src/graphql/schema'
 import { formatLongDate } from '@register/utils/date-formatting'
-import * as Sentry from '@sentry/browser'
+
 import {
   userMessages,
   buttonMessages,
@@ -46,6 +46,7 @@ import {
   dynamicConstantsMessages
 } from '@register/i18n/messages'
 import { messages } from '@register/i18n/messages/views/duplicates'
+import { Query } from '@register/components/Query'
 
 interface IMatchParams {
   applicationId: string
@@ -399,8 +400,6 @@ class ReviewDuplicatesClass extends React.Component<Props, IState> {
               !data.fetchBirthRegistration ||
               !data.fetchBirthRegistration.registration
             ) {
-              Sentry.captureException(error)
-
               return (
                 <ErrorText id="duplicates-error-text">
                   {this.props.intl.formatMessage(
@@ -450,9 +449,6 @@ class ReviewDuplicatesClass extends React.Component<Props, IState> {
                   }
 
                   if (errorDetails) {
-                    Sentry.captureException(errorDetails)
-                    console.error(errorDetails)
-
                     return (
                       <ErrorText id="duplicates-error-text">
                         {this.props.intl.formatMessage(

--- a/packages/register/src/views/FieldAgentHome/FieldAgentHome.tsx
+++ b/packages/register/src/views/FieldAgentHome/FieldAgentHome.tsx
@@ -47,13 +47,13 @@ import {
   PlusTransparentWhite,
   ApplicationsOrangeAmber
 } from '@opencrvs/components/lib/icons'
-import { Query } from 'react-apollo'
+import { Query } from '@register/components/Query'
 import {
   SEARCH_APPLICATIONS_USER_WISE,
   COUNT_USER_WISE_APPLICATIONS
 } from '@register/search/queries'
 import { EVENT_STATUS } from '@register/views/RegistrationHome/RegistrationHome'
-import * as Sentry from '@sentry/browser'
+
 import { HomeContent } from '@opencrvs/components/lib/layout'
 
 import {
@@ -335,7 +335,6 @@ class FieldAgentHomeView extends React.Component<
                   )
                 }
                 if (error) {
-                  Sentry.captureException(error)
                   return (
                     <ErrorText id="field-agent-home_error">
                       {intl.formatMessage(errorMessages.fieldAgentQueryError)}
@@ -444,7 +443,6 @@ class FieldAgentHomeView extends React.Component<
                     )
                   }
                   if (error) {
-                    Sentry.captureException(error)
                     return (
                       <ErrorText id="require_updates_loading_error">
                         {intl.formatMessage(errorMessages.fieldAgentQueryError)}

--- a/packages/register/src/views/Home/Details.tsx
+++ b/packages/register/src/views/Home/Details.tsx
@@ -41,9 +41,9 @@ import {
   DRAFT_DEATH_FORM_PAGE,
   REVIEW_EVENT_PARENT_FORM_PAGE
 } from '@register/navigation/routes'
-import { Query } from 'react-apollo'
+import { Query } from '@register/components/Query'
 import { FETCH_REGISTRATION_BY_COMPOSITION } from '@register/views/Home/queries'
-import * as Sentry from '@sentry/browser'
+
 import {
   userMessages,
   constantsMessages as messages,
@@ -597,10 +597,7 @@ class DetailView extends React.Component<IDetailProps & IntlShapeProps> {
               error?: any
               data: any
             }) => {
-              if (error) {
-                Sentry.captureException(error)
-                throw error
-              } else if (loading) {
+              if (loading) {
                 return (
                   <SpinnerContainer>
                     <QuerySpinner

--- a/packages/register/src/views/PrintCertificate/ReviewCertificateAction.tsx
+++ b/packages/register/src/views/PrintCertificate/ReviewCertificateAction.tsx
@@ -14,7 +14,7 @@ import {
   storeApplication,
   SUBMISSION_STATUS
 } from '@opencrvs/register/src/applications'
-import { Action, Event, IForm, ICertificate } from '@register/forms'
+import { Action, Event, IForm } from '@register/forms'
 import { constantsMessages } from '@register/i18n/messages'
 import { buttonMessages } from '@register/i18n/messages/buttons'
 import { messages as certificateMessages } from '@register/i18n/messages/views/certificate'

--- a/packages/register/src/views/PrintCertificate/collectorForm/CollectorForm.tsx
+++ b/packages/register/src/views/PrintCertificate/collectorForm/CollectorForm.tsx
@@ -53,6 +53,7 @@ import {
   isFreeOfCost
 } from '@register/views/PrintCertificate/utils'
 import { StyledSpinner } from '@register/views/RegistrationHome/RegistrationHome'
+// eslint-disable-next-line no-restricted-imports
 import * as Sentry from '@sentry/browser'
 import { debounce, flatten, cloneDeep } from 'lodash'
 import * as React from 'react'

--- a/packages/register/src/views/RegisterForm/PreviewForm.test.tsx
+++ b/packages/register/src/views/RegisterForm/PreviewForm.test.tsx
@@ -23,6 +23,7 @@ import { Store } from 'redux'
 
 import { Event } from '@register/forms'
 import { v4 as uuid } from 'uuid'
+// eslint-disable-next-line no-restricted-imports
 import * as ReactApollo from 'react-apollo'
 import { checkAuth } from '@opencrvs/register/src/profile/profileActions'
 

--- a/packages/register/src/views/RegisterForm/ReviewForm.tsx
+++ b/packages/register/src/views/RegisterForm/ReviewForm.tsx
@@ -25,7 +25,7 @@ import {
   QueryProvider,
   QueryContext
 } from '@register/views/DataProvider/QueryProvider'
-import * as Sentry from '@sentry/browser'
+
 import { REVIEW_EVENT_PARENT_FORM_PAGE } from '@register/navigation/routes'
 import { errorMessages } from '@register/i18n/messages'
 
@@ -97,8 +97,6 @@ export class ReviewFormView extends React.Component<IProps> {
                 )
               }
               if (error) {
-                Sentry.captureException(error)
-
                 return (
                   <ErrorText id="review-error-text">
                     {intl.formatMessage(errorMessages.registrationQueryError)}

--- a/packages/register/src/views/RegistrationHome/RegistrationHome.tsx
+++ b/packages/register/src/views/RegistrationHome/RegistrationHome.tsx
@@ -41,9 +41,8 @@ import { getUserLocation, IUserDetails } from '@register/utils/userUtils'
 import NotificationToast from '@register/views/RegistrationHome/NotificationToast'
 import { REGISTRATION_HOME_QUERY } from '@register/views/RegistrationHome/queries'
 import { RowHistoryView } from '@register/views/RegistrationHome/RowHistoryView'
-import * as Sentry from '@sentry/browser'
 import * as React from 'react'
-import { Query } from 'react-apollo'
+import { Query } from '@register/components/Query'
 import { WrappedComponentProps as IntlShapeProps, injectIntl } from 'react-intl'
 import { connect } from 'react-redux'
 import { RouteComponentProps } from 'react-router'
@@ -284,7 +283,6 @@ export class RegistrationHomeView extends React.Component<
               )
             }
             if (error) {
-              Sentry.captureException(error)
               return (
                 <ErrorText id="search-result-error-text-count">
                   {intl.formatMessage(errorMessages.queryError)}

--- a/packages/register/src/views/RegistrationHome/RowHistoryView.tsx
+++ b/packages/register/src/views/RegistrationHome/RowHistoryView.tsx
@@ -3,8 +3,8 @@ import styled, { withTheme } from 'styled-components'
 import { injectIntl, WrappedComponentProps as IntlShapeProps } from 'react-intl'
 import { Spinner } from '@opencrvs/components/lib/interface'
 import { FETCH_REGISTRATION_BY_COMPOSITION } from './queries'
-import { Query } from 'react-apollo'
-import * as Sentry from '@sentry/browser'
+import { Query } from '@register/components/Query'
+
 import { ITheme } from '@opencrvs/components/lib/theme'
 import {
   GQLDeathRegistration,
@@ -309,7 +309,6 @@ export class RowHistoryViewComponent extends React.Component<IProps> {
             data?: any
           }) => {
             if (error) {
-              Sentry.captureException(error)
               return (
                 <ErrorText id="search-result-error-text-expanded">
                   {intl.formatMessage(errorMessages.queryError)}

--- a/packages/register/src/views/RegistrationHome/tabs/inProgress/remoteInProgressDataDetails.tsx
+++ b/packages/register/src/views/RegistrationHome/tabs/inProgress/remoteInProgressDataDetails.tsx
@@ -16,10 +16,9 @@ import {
   dynamicConstantsMessages
 } from '@register/i18n/messages'
 import { FETCH_REGISTRATION_BY_COMPOSITION } from '@register/views/RegistrationHome/queries'
-import * as Sentry from '@sentry/browser'
 import moment from 'moment'
 import * as React from 'react'
-import { Query } from 'react-apollo'
+import { Query } from '@register/components/Query'
 import { WrappedComponentProps as IntlShapeProps, injectIntl } from 'react-intl'
 import styled, { withTheme } from 'styled-components'
 
@@ -189,7 +188,6 @@ class RemoteInProgressDataDetailsComponent extends React.Component<IProps> {
             data?: any
           }) => {
             if (error) {
-              Sentry.captureException(error)
               return (
                 <ErrorText id="search-result-error-text-expanded">
                   {intl.formatMessage(errorMessages.queryError)}

--- a/packages/register/src/views/SearchResult/SearchResult.tsx
+++ b/packages/register/src/views/SearchResult/SearchResult.tsx
@@ -24,10 +24,9 @@ import {
   GQLHumanName,
   GQLQuery
 } from '@opencrvs/gateway/src/graphql/schema.d'
-import * as Sentry from '@sentry/browser'
 import moment from 'moment'
 import * as React from 'react'
-import { Query } from 'react-apollo'
+import { Query } from '@register/components/Query'
 import { WrappedComponentProps as IntlShapeProps, injectIntl } from 'react-intl'
 import { connect } from 'react-redux'
 import { RouteComponentProps } from 'react-router'
@@ -425,9 +424,7 @@ export class SearchResultView extends React.Component<ISearchResultProps> {
           }) => {
             const { intl, language } = this.props
             moment.locale(language)
-            if (error) {
-              Sentry.captureException(error)
-            } else if (loading) {
+            if (loading) {
               return (
                 <ExpansionSpinnerContainer>
                   <ListItemExpansionSpinner
@@ -750,8 +747,6 @@ export class SearchResultView extends React.Component<ISearchResultProps> {
                     )
                   }
                   if (error || !data.searchEvents) {
-                    Sentry.captureException(error)
-
                     return (
                       <ErrorText id="search-result-error-text">
                         {intl.formatMessage(errorMessages.queryError)}

--- a/packages/register/src/views/SysAdmin/forms/fieldDefinitions/user-section.ts
+++ b/packages/register/src/views/SysAdmin/forms/fieldDefinitions/user-section.ts
@@ -12,8 +12,7 @@ import {
 import { NATIONAL_ID } from '@register/forms/identity'
 import {
   constantsMessages,
-  formMessages as messages,
-  formMessages
+  formMessages as messages
 } from '@register/i18n/messages'
 import { conditionals } from '@register/forms/utils'
 

--- a/packages/register/src/views/SysAdmin/user/userTab.tsx
+++ b/packages/register/src/views/SysAdmin/user/userTab.tsx
@@ -14,9 +14,8 @@ import {
 import { SEARCH_USERS } from '@register/sysadmin/user/queries'
 import { LANG_EN } from '@register/utils/constants'
 import { createNamesMap } from '@register/utils/data-formatting'
-import * as Sentry from '@sentry/browser'
 import * as React from 'react'
-import { Query } from 'react-apollo'
+import { Query } from '@register/components/Query'
 import { WrappedComponentProps as IntlShapeProps, injectIntl } from 'react-intl'
 import styled from 'styled-components'
 import { UserStatus } from './utils'
@@ -194,7 +193,6 @@ class UserTabComponent extends React.Component<IProps, IState> {
       >
         {({ error, data }: { error?: any; data: any }) => {
           if (error) {
-            Sentry.captureException(error)
             return (
               <ErrorText id="user_loading_error">
                 {intl.formatMessage(errorMessages.userQueryError)}

--- a/packages/register/src/views/SysAdmin/views/CreateNewUser.tsx
+++ b/packages/register/src/views/SysAdmin/views/CreateNewUser.tsx
@@ -18,6 +18,7 @@ import styled from '@register/styledComponents'
 import { goBack } from '@register/navigation'
 import { getRolesQuery } from '@register/views/SysAdmin/user/queries'
 import { updateUserFormFieldDefinitions } from '@register/views/SysAdmin/forms/userReducer'
+// eslint-disable-next-line no-restricted-imports
 import * as Sentry from '@sentry/browser'
 import { formMessages } from '@register/i18n/messages'
 import { getVisibleSectionGroupsBasedOnConditions } from '@register/forms/utils'


### PR DESCRIPTION
The query error handling was a bit all over the place, so I created a new
wrapper component for Query, that handles the error cases automatically.

In the future this could also be used as the base for a more refined Query component,
that would also provide the correct return types based on the submitted query.

I added few new eslint rules to prevent people from directly importing Sentry or Query from react-apollo

**Related:**

https://github.com/jembi/OpenCRVS/issues/1092

---

There are still some modules / components that are directly using the two dependencies tho and we need to take care of them at some point as well.

For example `packages/register/src/views/PrintCertificate/collectorForm/CollectorForm.tsx`

is creating the query like this

```ts
<QueryProvider
  event={event}
  action={Action.LOAD_CERTIFICATE_APPLICATION}
  payload={{ id: applicationId }}
>
  <QueryContext.Consumer>
    {({ loading, error, data, dataKey }) => {
      if (loading) {
        return <StyledSpinner id="print-certificate-spinner" />
      }
```

and I wasn't entirely sure if that can be refactored into the `<Query />` component without breaking something. @Sadman-Ilham can you remember if that's just a regular GraphQL query or if there's something special involved? We can refactor that bit the next time work needs to be done there