### PR TITLE
Fixed message key

### DIFF
--- a/packages/resources/src/bgd/features/forms/register.json
+++ b/packages/resources/src/bgd/features/forms/register.json
@@ -693,7 +693,7 @@
                   "label": {
                     "defaultMessage": "Health institution",
                     "description": "Label for form field: Health Institution",
-                    "id": "form.field.label.healdInstitution"
+                    "id": "form.field.label.healthInstitution"
                   },
                   "previewGroup": "placeOfBirth",
                   "required": true,

--- a/packages/resources/src/zmb/features/forms/register.json
+++ b/packages/resources/src/zmb/features/forms/register.json
@@ -647,9 +647,9 @@
                   "name": "birthLocation",
                   "type": "SEARCH_FIELD",
                   "label": {
-                    "defaultMessage": "Health instition",
+                    "defaultMessage": "Health institution",
                     "description": "Label for form field: Health Institution",
-                    "id": "form.field.label.healdInstitution"
+                    "id": "form.field.label.healthInstitution"
                   },
                   "previewGroup": "placeOfBirth",
                   "required": true,


### PR DESCRIPTION
Due to spelling mistake in  message key,
the error message was showing
incorrect field name.