### PR TITLE
Child document will be loaded by default

### DIFF
--- a/packages/register/src/views/RegisterForm/review/ReviewSection.tsx
+++ b/packages/register/src/views/RegisterForm/review/ReviewSection.tsx
@@ -914,7 +914,7 @@ class ReviewSectionComp extends React.Component<FullProps, State> {
                 key={'Document_section_' + this.state.activeSection}
                 options={this.prepSectionDocuments(
                   application,
-                  this.state.activeSection || formSections[0].id
+                  this.state.activeSection || this.docSections[0].id
                 )}
               >
                 <ZeroDocument>


### PR DESCRIPTION
Previously the child section was the first section
so, it was loading as default but now the registration
section is in the zero index. Took docSections instead
of formSections to make sure the child document is loaded
as default.

https://jembiprojects.jira.com/browse/OCRVS-2115