### PR TITLE
Fixed navigation problem for groups

### DIFF
--- a/packages/register/src/App.tsx
+++ b/packages/register/src/App.tsx
@@ -164,6 +164,13 @@ export class App extends React.Component<IAppProps> {
                                           />
                                           <ProtectedRoute
                                             exact
+                                            path={
+                                              routes.REVIEW_EVENT_PARENT_FORM_PAGE_GROUP
+                                            }
+                                            component={ReviewForm}
+                                          />
+                                          <ProtectedRoute
+                                            exact
                                             path={routes.REGISTRAR_HOME}
                                             component={RegistrationHome}
                                           />

--- a/packages/register/src/components/TransitionWrapper.tsx
+++ b/packages/register/src/components/TransitionWrapper.tsx
@@ -39,7 +39,8 @@ function isFormPage(pathname: string): boolean {
     isPathExactmatch(pathname, routes.DRAFT_DEATH_FORM) ||
     isPathExactmatch(pathname, routes.DRAFT_DEATH_FORM_PAGE) ||
     isPathExactmatch(pathname, routes.DRAFT_DEATH_FORM_PAGE_GROUP) ||
-    isPathExactmatch(pathname, routes.REVIEW_EVENT_PARENT_FORM_PAGE)
+    isPathExactmatch(pathname, routes.REVIEW_EVENT_PARENT_FORM_PAGE) ||
+    isPathExactmatch(pathname, routes.REVIEW_EVENT_PARENT_FORM_PAGE_GROUP)
   ) {
     return true
   }

--- a/packages/register/src/forms/register/reviewReducer.ts
+++ b/packages/register/src/forms/register/reviewReducer.ts
@@ -44,7 +44,7 @@ export const reviewReducer: LoopReducer<IReviewFormState, Action> = (
         title: messages.reviewTitle,
         groups: [
           {
-            id: 'review-group',
+            id: 'review-view-group',
             fields: []
           }
         ]

--- a/packages/register/src/navigation/routes.ts
+++ b/packages/register/src/navigation/routes.ts
@@ -21,6 +21,8 @@ export const DRAFT_DEATH_FORM_PAGE_GROUP = `/drafts/:applicationId/events/${Even
 
 export const REVIEW_EVENT_PARENT_FORM_PAGE =
   '/reviews/:applicationId/events/:event/parent/:pageId'
+export const REVIEW_EVENT_PARENT_FORM_PAGE_GROUP =
+  '/reviews/:applicationId/events/:event/parent/:pageId/group/:groupId'
 
 export const SAVED_REGISTRATION = '/saved'
 export const REJECTED_REGISTRATION = '/rejected'

--- a/packages/register/src/views/RegisterForm/ReviewForm.tsx
+++ b/packages/register/src/views/RegisterForm/ReviewForm.tsx
@@ -26,7 +26,7 @@ import {
   QueryContext
 } from '@register/views/DataProvider/QueryProvider'
 
-import { REVIEW_EVENT_PARENT_FORM_PAGE } from '@register/navigation/routes'
+import { REVIEW_EVENT_PARENT_FORM_PAGE_GROUP } from '@register/navigation/routes'
 import { errorMessages } from '@register/i18n/messages'
 
 interface IReviewProps {
@@ -153,6 +153,7 @@ function mapStatetoProps(
   props: RouteComponentProps<{
     pageRoute: string
     pageId: string
+    groupId: string
     applicationId: string
     event: string
   }>
@@ -175,7 +176,7 @@ function mapStatetoProps(
     applicationId: match.params.applicationId,
     event: getEvent(match.params.event),
     registerForm: form,
-    pageRoute: REVIEW_EVENT_PARENT_FORM_PAGE,
+    pageRoute: REVIEW_EVENT_PARENT_FORM_PAGE_GROUP,
     duplicate: history.location.state && history.location.state.duplicate
   }
 }


### PR DESCRIPTION
Due to wrong review URL, back and continue
buttons were not working for section groups.

Now reviewer can navigate specially death event groups.

https://jembiprojects.jira.com/browse/OCRVS-2147