### PR TITLE
Ocrvs 1990 searchinput style

### DIFF
--- a/packages/components/src/components/interface/SearchTool/SearchTool.tsx
+++ b/packages/components/src/components/interface/SearchTool/SearchTool.tsx
@@ -10,7 +10,6 @@ const Wrapper = styled.form`
   ${({ theme }) => theme.fonts.bodyStyle};
   padding: 0px 10px;
   margin-bottom: 1px;
-  min-width: 150px;
   position: relative;
 `
 const SearchTextInput = styled.input`


### PR DESCRIPTION
Fixed the width of searchinput for mobile layout. The the search criteria dropdown is showing now-

![1990-search](https://user-images.githubusercontent.com/35958228/66815600-60b3c500-ef5a-11e9-97e2-215d03fccdb3.png)
