### PR TITLE
Ocrvs 2126 Permission unlimitedStorage

### DIFF
--- a/packages/register/public/manifest.json
+++ b/packages/register/public/manifest.json
@@ -47,5 +47,8 @@
       "sizes": "512x512",
       "type": "image/png"
     }
+  ],
+  "permissions": [
+    "unlimitedStorage"
   ]
 }


### PR DESCRIPTION
According to the [docs](https://developer.chrome.com/apps/offline_storage#table) when the first install the user should be informed but I did not see any prompt. 

Seems [Firefox](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) grants the premission without prompting.

I also could not reproduce the storage quota limit exceeded case, so could not check the whether the permission is working or not. Any suggestions would be highly appreciated.