### PR TITLE
Add missing FHIR_URL environment variable for metrics service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,8 @@ services:
       - INFLUX_DB=ocrvs
       - AUTH_URL=http://auth:4040
       - CHECK_INVALID_TOKEN=true
+      - FHIR_URL=http://openhim-core:5001/fhir
+
   # END User facing services
 
   auth:


### PR DESCRIPTION
This was why `metrics` service was responding with a 500 error

```
FHIR request failed: request to http://localhost:5001/fhir/Task/9d93ef27-c44a-4641-a25e-29d332f99ca0/_history failed, reason: connect ECONNREFUSED 127.0.0.1:5001
```