### PR TITLE
Fix typo in mongo replica address

### DIFF
--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -185,7 +185,7 @@ services:
       - jwt-public-key.{{ts}}
     environment:
       - CERT_PUBLIC_KEY_PATH=/run/secrets/jwt-public-key.{{ts}}
-      - MONGO_URL=mongodb://mongo1,mongo2,mogno3/user-mgnt?replicaSet=rs0
+      - MONGO_URL=mongodb://mongo1,mongo2,mongo3/user-mgnt?replicaSet=rs0
     deploy:
       replicas: 2
     networks:
@@ -241,7 +241,7 @@ services:
       - jwt-public-key.{{ts}}
     environment:
       - CERT_PUBLIC_KEY_PATH=/run/secrets/jwt-public-key.{{ts}}
-      - MONGO_URL=mongodb://mongo1,mongo2,mogno3/user-mgnt?replicaSet=rs0
+      - MONGO_URL=mongodb://mongo1,mongo2,mongo3/user-mgnt?replicaSet=rs0
       - TEST_USER_PASSWORD=test
     deploy:
       labels:
@@ -266,7 +266,7 @@ services:
   # Configure other dependencies with deployment specifc details
   hearth:
     environment:
-      - mongodb__url=mongodb://mongo1,mongo2,mogno3/hearth-dev?replicaSet=rs0
+      - mongodb__url=mongodb://mongo1,mongo2,mongo3/hearth-dev?replicaSet=rs0
     depends_on:
       - mongo1
       - mongo2
@@ -285,8 +285,8 @@ services:
 
   openhim-core:
     environment:
-      - mongo_url=mongodb://mongo1,mongo2,mogno3/openhim-dev?replicaSet=rs0
-      - mongo_atnaUrl=mongodb://mongo1,mongo2,mogno3/openhim-dev?replicaSet=rs0
+      - mongo_url=mongodb://mongo1,mongo2,mongo3/openhim-dev?replicaSet=rs0
+      - mongo_atnaUrl=mongodb://mongo1,mongo2,mongo3/openhim-dev?replicaSet=rs0
     depends_on:
       - mongo1
       - mongo2


### PR DESCRIPTION
Noticed this while working on some other stuff:

```
opencrvs_openhim-core.1.ufjsotfpafsh@opencrvs-qa3    | (node:1) UnhandledPromiseRejectionWarning: Error: getaddrinfo ENOTFOUND mogno3 mogno3:27017
opencrvs_openhim-core.1.ufjsotfpafsh@opencrvs-qa3    |     at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:57:26)
opencrvs_openhim-core.1.ufjsotfpafsh@opencrvs-qa3    | (node:1) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
opencrvs_openhim-core.1.ufjsotfpafsh@opencrvs-qa3    | (node:1) UnhandledPromiseRejectionWarning: Error: getaddrinfo ENOTFOUND mogno3 mogno3:27017
opencrvs_openhim-core.1.ufjsotfpafsh@opencrvs-qa3    |     at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:57:26)
opencrvs_openhim-core.1.ufjsotfpafsh@opencrvs-qa3    | (node:1) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 3)
opencrvs_openhim-core.1.ufjsotfpafsh@opencrvs-qa3    | winston-mongodb: error initialising logger { MongoNetworkError: failed to connect to server [mogno3:27017] on first connect [MongoNetworkError: getaddrinfo ENOTFOUND mogno3 mogno3:27017]
opencrvs_openhim-core.1.ufjsotfpafsh@opencrvs-qa3    |     at Pool.<anonymous> (/usr/src/app/node_modules/winston-mongodb/node_modules/mongodb/lib/core/topologies/server.js:431:11)
opencrvs_openhim-core.1.ufjsotfpafsh@opencrvs-qa3    |     at Pool.emit (events.js:182:13)
opencrvs_openhim-core.1.ufjsotfpafsh@opencrvs-qa3    |     at connect (/usr/src/app/node_modules/winston-mongodb/node_modules/mongodb/lib/core/connection/pool.js:580:14)
opencrvs_openhim-core.1.ufjsotfpafsh@opencrvs-qa3    |     at makeConnection (/usr/src/app/node_modules/winston-mongodb/node_modules/mongodb/lib/core/connection/connect.js:39:11)
opencrvs_openhim-core.1.ufjsotfpafsh@opencrvs-qa3    |     at callback (/usr/src/app/node_modules/winston-mongodb/node_modules/mongodb/lib/core/connection/connect.js:261:5)
opencrvs_openhim-core.1.ufjsotfpafsh@opencrvs-qa3    |     at Socket.err (/usr/src/app/node_modules/winston-mongodb/node_modules/mongodb/lib/core/connection/connect.js:286:7)
opencrvs_openhim-core.1.ufjsotfpafsh@opencrvs-qa3    |     at Object.onceWrapper (events.js:273:13)
opencrvs_openhim-core.1.ufjsotfpafsh@opencrvs-qa3    |     at Socket.emit (events.js:182:13)
opencrvs_openhim-core.1.ufjsotfpafsh@opencrvs-qa3    |     at emitErrorNT (internal/streams/destroy.js:82:8)
opencrvs_openhim-core.1.ufjsotfpafsh@opencrvs-qa3    |     at emitErrorAndCloseNT (internal/streams/destroy.js:50:3)
opencrvs_openhim-core.1.ufjsotfpafsh@opencrvs-qa3    |     at process._tickCallback (internal/process/next_tick.js:63:19)
opencrvs_openhim-core.1.ufjsotfpafsh@opencrvs-qa3    |   name: 'MongoNetworkError',
opencrvs_openhim-core.1.ufjsotfpafsh@opencrvs-qa3    |   errorLabels: [ 'TransientTransactionError' ],
opencrvs_openhim-core.1.ufjsotfpafsh@opencrvs-qa3    |   [Symbol(mongoErrorContextSymbol)]: {} }
opencrvs_openhim-core.1.ufjsotfpafsh@opencrvs-qa3    | (node:1) UnhandledPromiseRejectionWarning: Error: getaddrinfo ENOTFOUND mogno3 mogno3:27017
opencrvs_openhim-core.1.ufjsotfpafsh@opencrvs-qa3    |     at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:57:26)
opencrvs_openhim-core.1.ufjsotfpafsh@opencrvs-qa3    | (node:1) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 4)
```

I'm not sure if this is relatedd to metrics service searching from task history before the previous task is moved there, but I think this is still good to get fixed.