### PR TITLE
Fix metrics service responding with 500 and previous task not found

### DIFF
--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@opencrvs/commons": "^1.0.0-alpha.1.1",
+    "@types/url-join": "^4.0.0",
     "app-module-path": "^2.2.0",
     "boom": "^7.2.0",
     "hapi": "^17.5.1",
@@ -31,6 +32,7 @@
     "moment": "^2.22.2",
     "node-fetch": "^2.6.0",
     "typescript": "^3.0.1",
+    "url-join": "^4.0.1",
     "winston": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/metrics/src/api.ts
+++ b/packages/metrics/src/api.ts
@@ -1,6 +1,7 @@
 import fetch from 'node-fetch'
 import { IAuthHeader } from '@metrics/features/registration'
 import { fhirUrl } from '@metrics/constants'
+import urlJoin from 'url-join'
 
 export function fetchFHIR<T = any>(
   suffix: string,
@@ -8,7 +9,7 @@ export function fetchFHIR<T = any>(
   method: string = 'GET',
   body?: string
 ) {
-  return fetch(`${fhirUrl}${suffix}`, {
+  return fetch(urlJoin(fhirUrl, suffix), {
     method,
     headers: {
       'Content-Type': 'application/fhir+json',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2444,6 +2444,11 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
 
+"@types/url-join@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/url-join/-/url-join-4.0.0.tgz#72eff71648a429c7d4acf94e03780e06671369bd"
+  integrity sha512-awrJu8yML4E/xTwr2EMatC+HBnHGoDxc2+ImA9QyeUELI1S7dOCIZcyjki1rkwoA8P2D2NVgLAJLjnclkdLtAw==
+
 "@types/uuid@^3.4.3", "@types/uuid@^3.4.4":
   version "3.4.4"
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-3.4.4.tgz#7af69360fa65ef0decb41fd150bf4ca5c0cefdf5"
@@ -21345,6 +21350,11 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
+
+url-join@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/url-join/-/url-join-4.0.1.tgz#b642e21a2646808ffa178c4c5fda39844e12cde7"
+  integrity sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==
 
 url-loader@0.6.2:
   version "0.6.2"


### PR DESCRIPTION
Apparently an invalid url format caused Hearth to return 404