### PR TITLE
Removes the unwanted asterisk above the field

### DIFF
--- a/packages/resources/src/bgd/features/forms/register.json
+++ b/packages/resources/src/bgd/features/forms/register.json
@@ -373,11 +373,12 @@
                   "label": {
                     "defaultMessage": " ",
                     "description": "Form section title for contact point",
-                    "id": "register.SelectContactPoint.headings"
+                    "id": "register.SelectContactPoint.heading"
                   },
                   "conditionals": [],
                   "previewGroup": "contactPointGroup",
                   "required": true,
+                  "hideHeader":true,
                   "initialValue": "",
                   "validate": [],
                   "size": "large",


### PR DESCRIPTION
Corrected the label id and added hideHeader property to hide the asterisk along with the redundant label. The ui looks like this now -

![Screenshot from 2019-11-06 12 39 19](https://user-images.githubusercontent.com/35958228/68274135-78cac000-0092-11ea-8e4d-a42812f44c3d.png)
