### PR TITLE
Make sure collector selection gets stored to application before user clicks Continue

### DIFF
--- a/packages/register/src/views/PrintCertificate/collectorForm/CollectorForm.tsx
+++ b/packages/register/src/views/PrintCertificate/collectorForm/CollectorForm.tsx
@@ -69,7 +69,7 @@ import {
 import { StyledSpinner } from '@register/views/RegistrationHome/RegistrationHome'
 // eslint-disable-next-line no-restricted-imports
 import * as Sentry from '@sentry/browser'
-import { debounce, flatten, cloneDeep } from 'lodash'
+import { flatten, cloneDeep } from 'lodash'
 import * as React from 'react'
 import { WrappedComponentProps as IntlShapeProps, injectIntl } from 'react-intl'
 import { connect } from 'react-redux'
@@ -310,8 +310,6 @@ class CollectorFormComponent extends React.Component<IProps, IState> {
 
     const { showError, showModalForNoSignedAffidavit } = this.state
 
-    const debouncedModifyApplication = debounce(this.modifyApplication, 500)
-
     const nextSectionGroup = getNextSectionIds(
       formSection,
       formGroup,
@@ -393,7 +391,7 @@ class CollectorFormComponent extends React.Component<IProps, IState> {
           <FormFieldGenerator
             id={formGroup.id}
             onChange={values => {
-              debouncedModifyApplication(values, applicationToBeCertified)
+              this.modifyApplication(values, applicationToBeCertified)
             }}
             setAllFieldsDirty={false}
             fields={formGroup.fields}


### PR DESCRIPTION
So it seems the problem was that there was a debounce in between user selecting the radio button option and the value registering to the application. If user clicked Continue in between, the error message was shown as the value wasnt there yet.

![image](https://user-images.githubusercontent.com/1206987/68297959-e382f800-00a0-11ea-8c7b-afbcb415e4da.png)

@Sadman-Ilham you've seem to be the last one whose worked on this. What is the debounce used here for?