### PR TITLE
[OCRVS-2366] Adds no-cache fetchPolicy in query

### DIFF
--- a/packages/client/src/views/Home/Details.tsx
+++ b/packages/client/src/views/Home/Details.tsx
@@ -601,6 +601,7 @@ class DetailView extends React.Component<IDetailProps & IntlShapeProps> {
             variables={{
               id: this.props.applicationId
             }}
+            fetchPolicy="no-cache"
           >
             {({
               loading,


### PR DESCRIPTION
When registrar tried to review an application multiple times they used to face error -

https://drive.google.com/file/d/15C3A5BL8BscUy2AzuV6YOJtcRDZTm-Zl/view

After fixing it, 

![secon-time-reciew](https://user-images.githubusercontent.com/35958228/69520522-22f98180-0f87-11ea-9a37-bd8200d533bf.gif)
