### PR TITLE
Fix birth query mapping and death query and mutation mapping

### DIFF
--- a/packages/client/src/forms/register/fieldMappings/birth/query/documents-mappings.ts
+++ b/packages/client/src/forms/register/fieldMappings/birth/query/documents-mappings.ts
@@ -27,7 +27,9 @@ const fieldNameMapping = {
   [birthDocumentForWhomFhirMapping.AssignedResponsibilityProof]:
     'uploadDocForProofOfAssignedResponsibility',
   [birthDocumentForWhomFhirMapping.LegalGuardianProof]:
-    'uploadDocForProofOfLegarGuardian'
+    'uploadDocForProofOfLegarGuardian',
+  [birthDocumentForWhomFhirMapping.WardCouncillorProof]:
+    'uploadDocFromCounsilor'
 }
 
 export function birthAttachmentToFieldTransformer(

--- a/packages/client/src/forms/register/fieldMappings/death/mutation/documents-mappings.ts
+++ b/packages/client/src/forms/register/fieldMappings/death/mutation/documents-mappings.ts
@@ -23,7 +23,9 @@ export const deathDocumentForWhomFhirMapping = {
   'Proof of Death of Deceased': 'DECEASED_DEATH_PROOF',
   'Proof of Date of Birth of Deceased': 'DECEASED_BIRTH_PROOF',
   "Proof of Applicant's ID": 'APPLICANT_ID_PROOF',
-  "Proof of applicant's authority to apply": 'APPLICANT_ATHORITY_TO_APPLY_PROOF'
+  "Proof of applicant's authority to apply":
+    'APPLICANT_ATHORITY_TO_APPLY_PROOF',
+  'Letter from ward councillor': 'WARD_COUNCILLOR_PROOF'
 }
 
 export const deathSectionMapping = {
@@ -31,7 +33,8 @@ export const deathSectionMapping = {
     deathDocumentForWhomFhirMapping["Proof of Deceased's ID"],
     deathDocumentForWhomFhirMapping['Proof Deceased Permanent Address'],
     deathDocumentForWhomFhirMapping['Proof of Death of Deceased'],
-    deathDocumentForWhomFhirMapping['Proof of Date of Birth of Deceased']
+    deathDocumentForWhomFhirMapping['Proof of Date of Birth of Deceased'],
+    deathDocumentForWhomFhirMapping['Letter from ward councillor']
   ],
   [DeathSection.Applicants]: [
     deathDocumentForWhomFhirMapping["Proof of Applicant's ID"],
@@ -59,6 +62,7 @@ export const deathDocumentTypeFhirMapping = {
   'Coroners Report': 'CORONERS_REPORT',
   'Signed Affidavit': 'SIGNED_AFFIDAVIT',
   'Proof of Date of Birth of Deceased': 'DECEASED_BIRTH_PROOF_PAPER',
+  'Letter from ward councillor': 'WARD_COUNCILLOR_PROOF',
   Other: 'OTHER'
 }
 

--- a/packages/client/src/forms/register/fieldMappings/death/query/documents-mappings.ts
+++ b/packages/client/src/forms/register/fieldMappings/death/query/documents-mappings.ts
@@ -30,7 +30,9 @@ const fieldNameMapping = {
   [deathDocumentForWhomFhirMapping['Proof of Date of Birth of Deceased']]:
     'uploadDocForDeceasedDOB',
   [deathDocumentForWhomFhirMapping['Proof of Death of Deceased']]:
-    'uploadDocForDeceasedDeath'
+    'uploadDocForDeceasedDeath',
+  [deathDocumentForWhomFhirMapping['Letter from ward councillor']]:
+    'uploadDocFromCounsilor'
 }
 
 export function deathAttachmentToFieldTransformer(


### PR DESCRIPTION
Issue - https://jembiprojects.jira.com/browse/OCRVS-2226?atlOrigin=eyJpIjoiYWQwMTMzYjQ3MGI5NDE3OWFjNzhlYTM4OTdiMWUzZjgiLCJwIjoiaiJ9

This pr fixes 2 issues mentioned in the comment section - 

Fixed the mappings for birth query.

and fixed the mappings for death query and mutation.

Now, all users can see the "ward counsilor's acknowledgement attachment" when they add or review documents.

![2226 at](https://user-images.githubusercontent.com/35958228/69710465-a8b53280-1129-11ea-8b2e-a3942c9b9e1b.png)
