### PR TITLE
ocrvs-2454-user-can-attach-without-selecting-document-type

### DIFF
--- a/packages/components/src/components/forms/ImageUploader.tsx
+++ b/packages/components/src/components/forms/ImageUploader.tsx
@@ -47,13 +47,19 @@ export class ImageUploader extends React.Component<IImagePickerProps, {}> {
     const { files } = event.target
     return files && this.props.handleFileChange(files[0])
   }
-  clickOnFileUploader = () => {
-    this.fileUploader.current!.click()
-  }
+
   render() {
-    const { icon, title, ...otherProps } = this.props
+    const { icon, title, onClick, ...otherProps } = this.props
     return (
-      <ImageBase {...otherProps} onClick={this.clickOnFileUploader}>
+      <ImageBase
+        {...otherProps}
+        onClick={event => {
+          if (onClick !== undefined) {
+            this.fileUploader.current!.click()
+            onClick(event)
+          }
+        }}
+      >
         {title}
         {icon && <Icon>{icon()}</Icon>}
         <HiddenInput


### PR DESCRIPTION
Attach document | user can attach document without selecting the document type

Issue link: https://jembiprojects.jira.com/browse/OCRVS-2454