### PR TITLE
ocrvs-2481 document-preview-image-load-fullscreen 

### DIFF
--- a/packages/client/src/components/form/DocumentUploadfield/DocumentPreview.tsx
+++ b/packages/client/src/components/form/DocumentUploadfield/DocumentPreview.tsx
@@ -44,11 +44,8 @@ const ImageHolder = styled.div`
   overflow: hidden;
   display: flex;
   & img {
-    display: block;
-    margin-left: auto;
-    margin-right: auto;
-    max-height: 90vh;
-    max-width: 90vw;
+    max-height: 80vh;
+    max-width: 80vw;
     width: auto;
   }
 `


### PR DESCRIPTION
- Scaled the document preview image to 80% screen

**Current Version :** 
![current_image](https://user-images.githubusercontent.com/25863651/71348560-fe4cf580-2596-11ea-836a-a6a0471f869b.png)

**Previous Version :**
![previous_image](https://user-images.githubusercontent.com/25863651/71348583-0f960200-2597-11ea-8d76-0280f29469cb.png)
