### PR TITLE
ocrvs-2281-FIX-space-in-language-modal

### DIFF
--- a/packages/client/src/views/Settings/SettingsPage.tsx
+++ b/packages/client/src/views/Settings/SettingsPage.tsx
@@ -359,7 +359,7 @@ class SettingsView extends React.Component<IProps, IState> {
           ]}
           handleClose={this.cancelLanguageSettings}
           contentHeight={175}
-          contentVisible={true}
+          contentScrollableY={true}
         >
           <Message>
             {intl.formatMessage(messages.changeLanguageMessege)}

--- a/packages/components/src/components/interface/ResponsiveModal.tsx
+++ b/packages/components/src/components/interface/ResponsiveModal.tsx
@@ -63,10 +63,10 @@ const Header = styled.div`
 const Title = styled.h1`
   ${({ theme }) => theme.fonts.h4Style};
 `
-const Body = styled.div<{ height?: number; visible?: boolean }>`
+const Body = styled.div<{ height?: number; scrollableY?: boolean }>`
   ${({ theme }) => theme.fonts.bodyStyle};
   height: ${({ height }) => (height ? height : 250)}px;
-  overflow-y: ${({ visible }) => (visible ? 'visible' : 'auto')};
+  overflow-y: ${({ scrollableY }) => (scrollableY ? 'visible' : 'auto')};
   padding: 0 24px 16px;
   display: flex;
   flex-direction: column;
@@ -110,7 +110,7 @@ interface IProps {
   show: boolean
   width?: number
   contentHeight?: number
-  contentVisible?: boolean
+  contentScrollableY?: boolean
   actions: JSX.Element[]
   handleClose?: () => void
 }
@@ -137,7 +137,7 @@ export class ResponsiveModal extends React.Component<IProps> {
       actions,
       width,
       contentHeight,
-      contentVisible
+      contentScrollableY
     } = this.props
 
     this.toggleScroll()
@@ -155,7 +155,7 @@ export class ResponsiveModal extends React.Component<IProps> {
               <Cross color="currentColor" />
             </CircleButton>
           </Header>
-          <Body height={contentHeight} visible={contentVisible}>
+          <Body height={contentHeight} scrollableY={contentScrollableY}>
             {this.props.children}
           </Body>
           <Footer>


### PR DESCRIPTION
Fixed modal body height to reduce unnecessary space between language selector and linebar.
Added overflow-y parameter to keep the language selector visible over linebar.
Passed tests locally.

### BEFORE:
![image](https://user-images.githubusercontent.com/11446347/71403644-8cd67b00-265a-11ea-8626-f04454274a1d.png)

### AFTER:
![image](https://user-images.githubusercontent.com/11446347/71403571-57ca2880-265a-11ea-9c1c-b4b78434eec9.png)
![image](https://user-images.githubusercontent.com/11446347/71403587-63b5ea80-265a-11ea-9407-ab4012f588cc.png)

