### PR TITLE
ocrvs-2282-FIX-selected-dropdown-font-color-to-white

### DIFF
--- a/packages/components/src/components/forms/Select.tsx
+++ b/packages/components/src/components/forms/Select.tsx
@@ -65,10 +65,6 @@ const StyledSelect = styled(ReactSelect)<IStyledSelectProps>`
     }
   }
 
-  .react-select__option {
-    color: ${({ theme }) => theme.colors.copy};
-  }
-
   .react-select__indicator-separator {
     display: none;
   }


### PR DESCRIPTION
Deleted color theme copy lines to make the selected option in dropdown font white.

### BEFORE:
![image](https://user-images.githubusercontent.com/11446347/71411401-578a5700-2673-11ea-802a-66679bcbcbee.png)


### AFTER:
![image](https://user-images.githubusercontent.com/11446347/71411430-6e30ae00-2673-11ea-8694-5f521c7ec7eb.png)
