### PR TITLE
Ocrvs 2532 Convert time spent working on drafts to seconds

### DIFF
--- a/packages/metrics/src/features/registration/pointGenerator.ts
+++ b/packages/metrics/src/features/registration/pointGenerator.ts
@@ -284,8 +284,11 @@ export function generateTimeLoggedPoint(payload: fhir.Bundle): IPoints {
     throw new Error('Current task not found')
   }
 
+  const timeLoggedInMS = getTimeLoggedFromTask(currentTask)
+  const timeLoggedInSeconds = timeLoggedInMS / 1000
+
   const fields: ITimeLoggedFields = {
-    timeSpentEditing: getTimeLoggedFromTask(currentTask),
+    timeSpentEditing: timeLoggedInSeconds,
     compositionId: composition.id
   }
 


### PR DESCRIPTION
Prior to this change data from csv used to look like below

![image](https://user-images.githubusercontent.com/42269993/71475639-53913d00-280b-11ea-89bf-cbf92650da21.png)

Now data from csv looks like below

![image](https://user-images.githubusercontent.com/42269993/71475680-876c6280-280b-11ea-9495-09c49ccb9c66.png)




