### PR TITLE
ocrvs-2503-searchUsers-and-createUser-doesnt-check-if-the-user-role-is-sys-admin

### DIFF
--- a/packages/gateway/src/features/user/root-resolvers.ts
+++ b/packages/gateway/src/features/user/root-resolvers.ts
@@ -55,9 +55,10 @@ export const resolvers: GQLResolver = {
       // Only sysadmin should be able to search user
       if (!hasScope(authHeader, 'sysadmin')) {
         return await Promise.reject(
-          new Error(`Search user is only allowed for sysadmin`)
+          new Error('Search user is only allowed for sysadmin')
         )
       }
+
       let payload: IUserSearchPayload = {
         count,
         skip,
@@ -98,9 +99,10 @@ export const resolvers: GQLResolver = {
       // Only sysadmin should be able to create user
       if (!hasScope(authHeader, 'sysadmin')) {
         return await Promise.reject(
-          new Error(`Create user is only allowed for sysadmin`)
+          new Error('Create user is only allowed for sysadmin')
         )
       }
+
       const res = await fetch(`${USER_MANAGEMENT_URL}createUser`, {
         method: 'POST',
         body: JSON.stringify(createUserPayload(user)),


### PR DESCRIPTION
searchUsers and createUser doesnt check if the user role is sys admin

Issue link: https://jembiprojects.jira.com/browse/OCRVS-2503

Locally e2e passed successfully.
![e2emaruf](https://user-images.githubusercontent.com/23413083/71579367-6c109880-2b26-11ea-9a74-ceeeb7cdb8ed.png)
