### PR TITLE
ocrvs-2504-field-agent-restrict-for-empty-location-Id

### DIFF
--- a/packages/gateway/src/features/search/root-resolvers.ts
+++ b/packages/gateway/src/features/search/root-resolvers.ts
@@ -12,6 +12,7 @@
 import { GQLResolver } from '@gateway/graphql/schema'
 import { postSearch } from '@gateway/features/fhir/utils'
 import { ISearchCriteria } from '@gateway/features/search/type-resolvers'
+import { hasScope } from '@gateway/features/user/utils'
 
 export const resolvers: GQLResolver = {
   Query: {
@@ -37,11 +38,12 @@ export const resolvers: GQLResolver = {
       }
       if (locationIds) {
         if (locationIds.length <= 0 || locationIds.includes('')) {
-          return await Promise.reject(
-            new Error('User includes wrong location id')
-          )
+          return await Promise.reject(new Error('Invalid location id'))
         }
         searchCriteria.applicationLocationId = locationIds.join(',')
+      } else if (authHeader && !hasScope(authHeader, 'register')) {
+        // Only register scope user can search without locationIds
+        return await Promise.reject(new Error('User does not have permission'))
       }
       if (trackingId) {
         searchCriteria.trackingId = trackingId


### PR DESCRIPTION
Field Agents can forge requests to the search by forging the request location parameters and receive registrations

Issue link: https://jembiprojects.jira.com/browse/OCRVS-2504

Locally e2e pased successfully.

![image](https://user-images.githubusercontent.com/23413083/71616556-0af9cb00-2be1-11ea-8773-fd883371f760.png)

