### PR TITLE
Removed extra padding

### DIFF
--- a/packages/components/src/components/forms/RadioGroup/RadioGroup.tsx
+++ b/packages/components/src/components/forms/RadioGroup/RadioGroup.tsx
@@ -39,10 +39,6 @@ const NestedChildren = styled.div`
   padding-left: 33px;
   border-left: 4px solid ${({ theme }) => theme.colors.copy};
   padding-top: 0px !important;
-
-  > div {
-    padding: 16px 0;
-  }
 `
 
 export enum RadioSize {


### PR DESCRIPTION
https://jembiprojects.jira.com/browse/OCRVS-2280

Current:
<img width="697" alt="Screen Shot 2020-01-02 at 3 09 05 PM" src="https://user-images.githubusercontent.com/8521992/71659603-61e2da00-2d72-11ea-97f7-681576b285e8.png">

After change:
<img width="638" alt="Screen Shot 2020-01-02 at 3 08 09 PM" src="https://user-images.githubusercontent.com/8521992/71659634-80e16c00-2d72-11ea-982d-c5b7452319b6.png">
