### PR TITLE
Add the environment setting to Sentry config in client

### DIFF
--- a/packages/client/src/index.tsx
+++ b/packages/client/src/index.tsx
@@ -36,6 +36,7 @@ if (
   // setup error reporting using sentry
   Sentry.init({
     release: process.env.REACT_APP_VERSION,
+    environment: process.env.NODE_ENV,
     dsn: window.config.SENTRY
   })
 

--- a/packages/login/src/index.tsx
+++ b/packages/login/src/index.tsx
@@ -26,6 +26,7 @@ if (
 ) {
   // setup error reporting using sentry
   Sentry.init({
+    environment: process.env.NODE_ENV,
     dsn: window.config.SENTRY
   })
 


### PR DESCRIPTION
Prior to this change,
All errors even from localhost could not be filtered in Sentry.  Now we can filter out notifications to only send production issues from the client.
This change
Passes NODE_ENV from the client to the Sentry init function