### PR TITLE
Fixed some spelling and grammatical mistakes in erros.ts

### DIFF
--- a/packages/client/src/i18n/messages/errors.ts
+++ b/packages/client/src/i18n/messages/errors.ts
@@ -54,7 +54,7 @@ const messagesToDefine: IErrorMessages = {
     id: 'error.somethingWentWrong'
   },
   unknownErrorDescription: {
-    defaultMessage: "It's not you, it us. This is our fault.",
+    defaultMessage: "It's not you, it's us. This is our fault.",
     description: 'Error description',
     id: 'error.weAreTryingToFixThisError'
   },
@@ -81,7 +81,7 @@ const messagesToDefine: IErrorMessages = {
   },
   printQueryError: {
     defaultMessage:
-      'An error occurred while quering for birth registration data',
+      'An error occurred while querying for birth registration data',
     description: 'The error message shown when a query fails',
     id: 'print.certificate.queryError'
   },


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11446347/71821798-4141b980-30bd-11ea-8016-856ed87d97d8.png)
This is fixed as ''...It's us..."
Also, the spelling of "querying" is fixed. 