### PR TITLE
Removed record prop to bypass Cypress cost

### DIFF
--- a/build-and-test-e2e.sh
+++ b/build-and-test-e2e.sh
@@ -20,4 +20,4 @@ yarn compose:all &
 wait-on tcp:4040 tcp:3030 tcp:2020 tcp:7070 tcp:5050 tcp:9090 tcp:3040 tcp:1050 http://localhost:3000 http://localhost:3001 http://localhost:3020 tcp:27017 tcp:6379 tcp:9200 http://localhost:9200 tcp:8086 http://localhost:8086/ping tcp:3447 tcp:5001
 cd packages/resources && yarn db:clear:all && yarn db:backup:restore bgd
 yarn save:testData && cd ../..
-cd packages/e2e && yarn start --record
+cd packages/e2e && yarn start


### PR DESCRIPTION
I think that this should resolve the 500 recordings going over the Cypress limit and fix our integration tests