### PR TITLE
ocrvs-2591-formfield radiogroup bottom padding changed to 32px

### DIFF
--- a/packages/client/src/components/form/FormFieldGenerator.tsx
+++ b/packages/client/src/components/form/FormFieldGenerator.tsx
@@ -119,7 +119,7 @@ const fadeIn = keyframes`
 
 const FormItem = styled.div`
   animation: ${fadeIn} 500ms;
-  margin-bottom: 24px;
+  margin-bottom: 32px;
 `
 const LinkFormField = styled(Link)`
   ${({ theme }) => theme.fonts.bodyStyle};


### PR DESCRIPTION
radiogroup form field bottom padding changed to 32px
![image](https://user-images.githubusercontent.com/11446347/72322612-f9c8b800-36d0-11ea-812b-0f5c6a4793e7.png)
