### PR TITLE
Fixes for in-progress submission issues in prod env

### DIFF
--- a/packages/client/src/views/SelectInformant/SelectInformant.tsx
+++ b/packages/client/src/views/SelectInformant/SelectInformant.tsx
@@ -322,7 +322,15 @@ export class SelectInformantView extends React.Component<IFullProps, IState> {
             ...{
               presentAtBirthRegistration: this.state.informant,
               applicant: {
-                value: this.state.informant,
+                value:
+                  (this.props.application &&
+                    this.props.application.data &&
+                    this.props.application.data[registrationSection.id] &&
+                    this.props.application.data[registrationSection.id]
+                      .applicant &&
+                    (this.props.application.data[registrationSection.id]
+                      .applicant as IFormSectionData).value) ||
+                  '',
                 nestedFields: {}
               }
             }

--- a/packages/gateway/src/features/registration/type-resolvers.ts
+++ b/packages/gateway/src/features/registration/type-resolvers.ts
@@ -196,6 +196,13 @@ export const typeResolvers: GQLResolver = {
       )
     },
     individual: async (relatedPerson, _, authHeader) => {
+      if (
+        !relatedPerson ||
+        !relatedPerson.patient ||
+        !relatedPerson.patient.reference
+      ) {
+        return
+      }
       if (relatedPerson.patient.reference.startsWith('RelatedPerson')) {
         // tslint:disable-next-line
         relatedPerson = await fetchFHIR(

--- a/packages/resources/src/bgd/features/forms/register.json
+++ b/packages/resources/src/bgd/features/forms/register.json
@@ -235,6 +235,7 @@
                   "expression": "(!draftData || !draftData.registration || draftData.registration.presentAtBirthRegistration !== \"BOTH_PARENTS\" || draftData.registration.presentAtBirthRegistration === \"OTHER\")"
                 }
               ],
+              "preventContinueIfError": true,
               "fields": [
                 {
                   "name": "paragraph",

--- a/packages/search/src/features/registration/birth/service.ts
+++ b/packages/search/src/features/registration/birth/service.ts
@@ -269,7 +269,7 @@ function createInformantIndex(
     bundleEntries
   ) as fhir.RelatedPerson
 
-  if (!informantRef) {
+  if (!informantRef || !informantRef.patient) {
     return
   }
 

--- a/packages/search/src/features/registration/death/service.ts
+++ b/packages/search/src/features/registration/death/service.ts
@@ -280,7 +280,7 @@ function createInformantIndex(
     bundleEntries
   ) as fhir.RelatedPerson
 
-  if (!informantRef) {
+  if (!informantRef || !informantRef.patient) {
     return
   }
 


### PR DESCRIPTION
Current issues with in-progress application submissions:

1. For Death events, if you submit an in-progress application with just deceased name then it's getting lost
2. For Birth events, if you select "Mother and Father" as informant and then select either "Mother" or "Father" as primary applicant then it's getting lost.

This PR should resolve above issues including [OCRVS-2512](https://jembiprojects.jira.com/browse/OCRVS-2512)