### PR TITLE
ocrvs-2597-added pseudo selection to fix sentence case

### DIFF
--- a/packages/client/src/views/RegisterForm/review/ReviewSection.tsx
+++ b/packages/client/src/views/RegisterForm/review/ReviewSection.tsx
@@ -119,7 +119,11 @@ import { ReviewHeader } from './ReviewHeader'
 
 const RequiredField = styled.span`
   color: ${({ theme }) => theme.colors.error};
+  display: inline-block;
   text-transform: lowercase;
+  &::first-letter {
+    text-transform: uppercase;
+  }
 `
 const Row = styled.div`
   display: flex;


### PR DESCRIPTION
The required validation error messages were lower case. They are now specified as sentence case. (The first letter of every message is capital.)
![image](https://user-images.githubusercontent.com/11446347/72426326-b72bdc00-37b3-11ea-905a-963eb7582da0.png)
