### PR TITLE
Fixes OCRVS-2590 and issue with no external validation setup

### DIFF
--- a/packages/workflow/src/constants.ts
+++ b/packages/workflow/src/constants.ts
@@ -13,6 +13,7 @@ export const HOST = process.env.HOST || '0.0.0.0'
 export const PORT = process.env.PORT || 5050
 export const HEARTH_URL = process.env.HEARTH_URL || 'http://localhost:3447/fhir'
 export const OPENHIM_URL = process.env.OPENHIM_URL || 'http://localhost:5001'
+export const VALIDATING_EXTERNALLY = process.env.VALIDATING_EXTERNALLY || false
 export const NOTIFICATION_SERVICE_URL =
   process.env.NOTIFICATION_SERVICE_URL || 'http://localhost:2020/'
 

--- a/packages/workflow/src/features/registration/fhir/fhir-bundle-modifier.ts
+++ b/packages/workflow/src/features/registration/fhir/fhir-bundle-modifier.ts
@@ -114,7 +114,10 @@ export async function markBundleAsValidated(
   return bundle
 }
 
-export async function validateRegistration(bundle: fhir.Bundle, token: string) {
+async function invokeRegistrationValidation(
+  bundle: fhir.Bundle,
+  token: string
+) {
   try {
     fetch(`${RESOURCE_SERVICE_URL}validate/registration`, {
       method: 'POST',
@@ -149,6 +152,9 @@ export async function markBundleAsWaitingValidation(
 
   /* setting lastRegUser here */
   setupLastRegUser(taskResource, practitioner)
+
+  // validate registration with resource service and set resulting registration number
+  invokeRegistrationValidation(bundle, token)
 
   return bundle
 }

--- a/packages/workflow/src/features/registration/fhir/fhir-bundle-modifier.ts
+++ b/packages/workflow/src/features/registration/fhir/fhir-bundle-modifier.ts
@@ -114,7 +114,7 @@ export async function markBundleAsValidated(
   return bundle
 }
 
-async function validateRegistration(bundle: fhir.Bundle, token: string) {
+export async function validateRegistration(bundle: fhir.Bundle, token: string) {
   try {
     fetch(`${RESOURCE_SERVICE_URL}validate/registration`, {
       method: 'POST',
@@ -149,9 +149,6 @@ export async function markBundleAsWaitingValidation(
 
   /* setting lastRegUser here */
   setupLastRegUser(taskResource, practitioner)
-
-  // validate registration with resource service and set resulting registration number
-  validateRegistration(bundle, token)
 
   return bundle
 }

--- a/packages/workflow/src/features/registration/handler.ts
+++ b/packages/workflow/src/features/registration/handler.ts
@@ -17,8 +17,7 @@ import {
   markEventAsRegistered,
   modifyRegistrationBundle,
   setTrackingId,
-  markBundleAsWaitingValidation,
-  validateRegistration
+  markBundleAsWaitingValidation
 } from '@workflow/features/registration/fhir/fhir-bundle-modifier'
 import {
   getEventInformantName,
@@ -119,13 +118,6 @@ export async function createRegistrationHandler(
       )
     }
     const resBundle = await sendBundleToHearth(payload)
-    if (
-      event === Events.BIRTH_NEW_WAITING_VALIDATION ||
-      event === Events.DEATH_NEW_WAITING_VALIDATION
-    ) {
-      // validate registration with resource service and set resulting registration number now that bundle exists in Hearth
-      validateRegistration(payload, getToken(request))
-    }
     populateCompositionWithID(payload, resBundle)
 
     if (isEventNonNotifiable(event)) {


### PR DESCRIPTION
Resolves 3 issues.

1. This is a potential fix for https://jembiprojects.jira.com/browse/OCRVS-2590. The error occurs because FS Cache takes time to spin up for elastic search. I reckon that could happen at periods of inactivity when the server might be saving resources. The only solution I could come up with is forcing a delay into the workflow > resources > workflow loop. Perhaps there is a better way to resolve this.

2. This PR also contains a necessity for countries that do not have external validation of BRNs. Zambia BRN generation is instantaneous, so the loop from workflow > resources and back to workflow happens too fast before workflow saves the Task into hearth. So I moved the call to resources so it happens after the Task is saved. Hopefully this doesn't cause any issues but needs to be tested thoroughly in QA.  If ```validateRegistration``` is called too early, then the Task with the TrackingID doesn't exist in Hearth. This caused an error further down in ```markEventAsRegisteredCallbackHandler``` .  The Task for tracking id ${trackingId} could not be found during markEventAsRegisteredCallbackHandler.  We never noticed this before because the BRN generation for Bangladesh takes a relatively long time by comparison.

3. Primary caregiver's document section property was incorrectly set in register.json

