### PR TITLE
[ocrvs 2682 & 2683] added timeLogged type resolver and adjusted export query

### DIFF
--- a/packages/gateway/src/features/fhir/utils.ts
+++ b/packages/gateway/src/features/fhir/utils.ts
@@ -762,6 +762,13 @@ export function findExtension(
   return extension
 }
 
+export function getStatusFromTask(task: fhir.Task) {
+  const statusType = task.businessStatus?.coding?.find(
+    (coding: fhir.Coding) =>
+      coding.system === `${OPENCRVS_SPECIFICATION_URL}reg-status`
+  )
+  return (statusType && statusType.code) || null
+}
 export function getMaritalStatusCode(fieldValue: string) {
   switch (fieldValue) {
     case 'SINGLE':
@@ -864,6 +871,28 @@ export const getMetrics = (
     .catch(error => {
       return Promise.reject(
         new Error(`Metrics request failed: ${error.message}`)
+      )
+    })
+}
+
+export const getTimeLoggedByStatusFromMetrics = async (
+  authHeader: IAuthHeader,
+  compositionId: string,
+  status: string
+) => {
+  const params = new URLSearchParams({ compositionId, status })
+  return fetch(`${METRICS_URL}/timeLogged?` + params, {
+    method: 'GET',
+    headers: {
+      ...authHeader
+    }
+  })
+    .then(response => {
+      return response.json()
+    })
+    .catch(error => {
+      return Promise.reject(
+        new Error(`Time logged from metrics request failed: ${error.message}`)
       )
     })
 }

--- a/packages/gateway/src/features/registration/schema.graphql
+++ b/packages/gateway/src/features/registration/schema.graphql
@@ -230,6 +230,7 @@ type RegWorkflow { # Task
   comments: [Comment] # -> .note
   location: Location # -> extension(url='http://opencrvs.org/specs/extension/regLastLocation').valueReference
   office: Location # -> extension(url='http://opencrvs.org/specs/extension/regLastOffice').valueReference
+  timeLogged: Int # -> from metrics
 }
 
 interface EventRegistration {

--- a/packages/gateway/src/features/registration/type-resolvers.test.ts
+++ b/packages/gateway/src/features/registration/type-resolvers.test.ts
@@ -993,6 +993,13 @@ describe('Registration type resolvers', () => {
       expect(time).toBe('2016-10-31T09:45:05+10:00')
     })
 
+    it('returns timeLogged of the task', async () => {
+      fetch.mockResponseOnce(JSON.stringify({ timeSpentEditing: 0 }))
+      const timeLogged = await typeResolvers.RegWorkflow.timeLogged(mockTask)
+
+      expect(timeLogged).toBe(0)
+    })
+
     it('returns user of the task', async () => {
       const mock = fetch.mockResponseOnce(JSON.stringify({ _id: '1' }))
       // @ts-ignore

--- a/packages/gateway/src/features/registration/type-resolvers.ts
+++ b/packages/gateway/src/features/registration/type-resolvers.ts
@@ -12,7 +12,9 @@
 import {
   findCompositionSection,
   findExtension,
-  fetchFHIR
+  fetchFHIR,
+  getTimeLoggedByStatusFromMetrics,
+  getStatusFromTask
 } from '@gateway/features/fhir/utils'
 import {
   MOTHER_CODE,
@@ -435,16 +437,7 @@ export const typeResolvers: GQLResolver = {
   },
   RegWorkflow: {
     type: (task: fhir.Task) => {
-      const taskStatus = task.businessStatus
-      const taskStatusCoding = taskStatus && taskStatus.coding
-      const statusType =
-        taskStatusCoding &&
-        taskStatusCoding.find(
-          (coding: fhir.Coding) =>
-            coding.system === `${OPENCRVS_SPECIFICATION_URL}reg-status`
-        )
-
-      return (statusType && statusType.code) || null
+      return getStatusFromTask(task)
     },
     user: async (task, _, authHeader) => {
       const user = findExtension(
@@ -494,6 +487,16 @@ export const typeResolvers: GQLResolver = {
         `/${taskLocation.valueReference.reference}`,
         authHeader
       )
+    },
+    timeLogged: async (task, _, authHeader) => {
+      const compositionId =
+        (task.focus.reference && task.focus.reference.split('/')[1]) || ''
+      const timeLoggedResponse = await getTimeLoggedByStatusFromMetrics(
+        authHeader,
+        compositionId,
+        getStatusFromTask(task) || ''
+      )
+      return (timeLoggedResponse && timeLoggedResponse.timeSpentEditing) || 0
     }
   },
   Comment: {

--- a/packages/gateway/src/graphql/schema.d.ts
+++ b/packages/gateway/src/graphql/schema.d.ts
@@ -333,6 +333,7 @@ export interface GQLRegWorkflow {
   comments?: Array<GQLComment | null>
   location?: GQLLocation
   office?: GQLLocation
+  timeLogged?: number
 }
 
 export enum GQLRegStatus {
@@ -2084,6 +2085,7 @@ export interface GQLRegWorkflowTypeResolver<TParent = any> {
   comments?: RegWorkflowToCommentsResolver<TParent>
   location?: RegWorkflowToLocationResolver<TParent>
   office?: RegWorkflowToOfficeResolver<TParent>
+  timeLogged?: RegWorkflowToTimeLoggedResolver<TParent>
 }
 
 export interface RegWorkflowToIdResolver<TParent = any, TResult = any> {
@@ -2111,6 +2113,10 @@ export interface RegWorkflowToLocationResolver<TParent = any, TResult = any> {
 }
 
 export interface RegWorkflowToOfficeResolver<TParent = any, TResult = any> {
+  (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult
+}
+
+export interface RegWorkflowToTimeLoggedResolver<TParent = any, TResult = any> {
   (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult
 }
 

--- a/packages/gateway/src/routes/registrations/export-route.ts
+++ b/packages/gateway/src/routes/registrations/export-route.ts
@@ -179,6 +179,15 @@ export default {
                   name
                   alias
                 }
+                user {
+                  name {
+                    use
+                    firstNames
+                    familyName
+                  }
+                  role
+                }
+                timeLogged
                 office {
                   name
                   alias
@@ -302,8 +311,32 @@ export default {
                 subject
               }
               status {
+                comments {
+                  comment
+                }
                 type
                 timestamp
+                location {
+                  name
+                  alias
+                }
+                user {
+                  name {
+                    use
+                    firstNames
+                    familyName
+                  }
+                  role
+                }
+                timeLogged
+                office {
+                  name
+                  alias
+                  address {
+                    districtName
+                    stateName
+                  }
+                }
               }
               type
               trackingId
@@ -337,7 +370,6 @@ export default {
     if (response.errors?.length) {
       throw response.errors[0]
     }
-
     const birthRows =
       response?.data?.searchBirthRegistrations?.map(flatten) ?? []
 

--- a/packages/metrics/src/config/routes.ts
+++ b/packages/metrics/src/config/routes.ts
@@ -21,6 +21,7 @@ import {
   newDeathRegistrationHandler
 } from '@metrics/features/registration/handler'
 import { metricsHandler } from '@metrics/features/metrics/handler'
+import { getTimeLoggedHandler } from '@metrics/features/getTimeLogged/handler'
 import { exportHandler } from '@metrics/features/export/handler'
 
 export const getRoutes = () => {
@@ -177,6 +178,22 @@ export const getRoutes = () => {
             timeEnd: Joi.string().required(),
             locationId: Joi.string().required(),
             event: Joi.string().required()
+          })
+        },
+        tags: ['api']
+      }
+    },
+
+    // Time logged query by application status API
+    {
+      method: 'GET',
+      path: '/timeLogged',
+      handler: getTimeLoggedHandler,
+      config: {
+        validate: {
+          query: Joi.object({
+            compositionId: Joi.string().required(),
+            status: Joi.string().required()
           })
         },
         tags: ['api']

--- a/packages/metrics/src/features/getTimeLogged/constants.ts
+++ b/packages/metrics/src/features/getTimeLogged/constants.ts
@@ -1,0 +1,13 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors. OpenCRVS and the OpenCRVS
+ * graphic logo are (registered/a) trademark(s) of Plan International.
+ */
+export const COMPOSITION_ID = 'compositionId'
+export const STATUS = 'status'

--- a/packages/metrics/src/features/getTimeLogged/handler.test.ts
+++ b/packages/metrics/src/features/getTimeLogged/handler.test.ts
@@ -1,0 +1,79 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors. OpenCRVS and the OpenCRVS
+ * graphic logo are (registered/a) trademark(s) of Plan International.
+ */
+import { createServer } from '@metrics/index'
+import * as influx from '@metrics/influxdb/client'
+import { readFileSync } from 'fs'
+import * as jwt from 'jsonwebtoken'
+const readPoints = influx.query as jest.Mock
+
+describe('verify time logged handler', () => {
+  let server: any
+  const token = jwt.sign(
+    { scope: ['declare'] },
+    readFileSync('../auth/test/cert.key'),
+    {
+      algorithm: 'RS256',
+      issuer: 'opencrvs:auth-service',
+      audience: 'opencrvs:metrics-user'
+    }
+  )
+
+  beforeEach(async () => {
+    server = await createServer()
+  })
+
+  it('returns ok for valid request', async () => {
+    readPoints.mockResolvedValueOnce([
+      {
+        timeSpentEditing: 70
+      }
+    ])
+
+    const res = await server.server.inject({
+      method: 'GET',
+      url:
+        '/timeLogged?compositionId=94429795-0a09-4de8-8e1e-27dab01877d2&status=REGISTERED',
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    })
+
+    expect(res.statusCode).toBe(200)
+  })
+
+  it('returns 200 even if no time logged data found for given status', async () => {
+    readPoints.mockResolvedValueOnce([])
+
+    const res = await server.server.inject({
+      method: 'GET',
+      url:
+        '/timeLogged?compositionId=94429795-0a09-4de8-8e1e-27dab01877d2&status=REGISTERED',
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    })
+
+    expect(res.statusCode).toBe(200)
+  })
+
+  it('returns 400 for required params', async () => {
+    const res = await server.server.inject({
+      method: 'GET',
+      url: '/timeLogged',
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    })
+
+    expect(res.statusCode).toBe(400)
+  })
+})

--- a/packages/metrics/src/features/getTimeLogged/handler.ts
+++ b/packages/metrics/src/features/getTimeLogged/handler.ts
@@ -1,0 +1,37 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors. OpenCRVS and the OpenCRVS
+ * graphic logo are (registered/a) trademark(s) of Plan International.
+ */
+import * as Hapi from 'hapi'
+import {
+  COMPOSITION_ID,
+  STATUS
+} from '@metrics/features/getTimeLogged/constants'
+import {
+  getTimeLoggedByStatus,
+  ITimeLoggedData
+} from '@metrics/features/getTimeLogged/utils'
+
+export async function getTimeLoggedHandler(
+  request: Hapi.Request,
+  h: Hapi.ResponseToolkit
+) {
+  const compositionId = request.query[COMPOSITION_ID]
+  const status = request.query[STATUS].toUpperCase()
+
+  const timeLoggedData: ITimeLoggedData[] = await getTimeLoggedByStatus(
+    compositionId,
+    status
+  )
+  return timeLoggedData && timeLoggedData.length > 0
+    ? timeLoggedData[0]
+    : // Send 0 if no logged data found for given status
+      { timeSpentEditing: 0 }
+}

--- a/packages/metrics/src/features/getTimeLogged/utils.ts
+++ b/packages/metrics/src/features/getTimeLogged/utils.ts
@@ -1,0 +1,28 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors. OpenCRVS and the OpenCRVS
+ * graphic logo are (registered/a) trademark(s) of Plan International.
+ */
+import { query } from '@metrics/influxdb/client'
+
+export interface ITimeLoggedData {
+  timeSpentEditing: number
+}
+
+export async function getTimeLoggedByStatus(
+  compositionId: string,
+  status: string
+): Promise<ITimeLoggedData[]> {
+  return await query(
+    `SELECT timeSpentEditing
+          FROM application_time_logged
+        WHERE compositionId = '${compositionId}'
+        AND currentStatus = '${status}'`
+  )
+}


### PR DESCRIPTION
- Added a new end point on metrics service to get timeLogged for a given status of an application
- Added type resolver for timeLogged property under RegWorkFlow in gateway
- Adjusted birth and death export registration query to include time logged, practitioner name and role 