### PR TITLE
Ocrvs 2371 save confirmation modal

### DIFF
--- a/packages/client/src/i18n/messages/buttons.ts
+++ b/packages/client/src/i18n/messages/buttons.ts
@@ -36,6 +36,7 @@ interface IButtonsMessages {
   rejectApplication: MessageDescriptor
   retry: MessageDescriptor
   review: MessageDescriptor
+  save: MessageDescriptor
   saveExitButton: MessageDescriptor
   deleteApplication: MessageDescriptor
   closeApplication: MessageDescriptor
@@ -179,6 +180,11 @@ const messagesToDefine: IButtonsMessages = {
     defaultMessage: 'Review',
     description: 'Review button text',
     id: 'buttons.review'
+  },
+  save: {
+    defaultMessage: 'Save',
+    description: 'Save Button Text',
+    id: 'buttons.save'
   },
   saveExitButton: {
     defaultMessage: 'Save & Exit',

--- a/packages/client/src/i18n/messages/views/register.ts
+++ b/packages/client/src/i18n/messages/views/register.ts
@@ -18,6 +18,8 @@ interface IRegisterMessages {
   submitDescription: MessageDescriptor
   registerFormQueryError: MessageDescriptor
   backToReviewButton: MessageDescriptor
+  saveApplicationConfirmModalTitle: MessageDescriptor
+  saveApplicationConfirmModalDescription: MessageDescriptor
 }
 
 const messagesToDefine: IRegisterMessages = {
@@ -54,6 +56,17 @@ const messagesToDefine: IRegisterMessages = {
   backToReviewButton: {
     id: 'register.selectVitalEvent.backToReviewButton',
     defaultMessage: 'Back to review'
+  },
+  saveApplicationConfirmModalTitle: {
+    id: 'register.form.saveApplicationConfirmModalTitle',
+    defaultMessage: 'Save your changes?',
+    description: 'Title for save application confirmation modal'
+  },
+  saveApplicationConfirmModalDescription: {
+    id: 'register.form.saveApplicationConfirmModalDescription',
+    defaultMessage:
+      'By clicking save the old information will be deleted and new information will be saved',
+    description: 'Description for save application confirmation modal'
   }
 }
 

--- a/packages/client/src/i18n/messages/views/register.ts
+++ b/packages/client/src/i18n/messages/views/register.ts
@@ -58,12 +58,12 @@ const messagesToDefine: IRegisterMessages = {
     defaultMessage: 'Back to review'
   },
   saveApplicationConfirmModalTitle: {
-    id: 'register.form.saveApplicationConfirmModalTitle',
+    id: 'register.form.modal.title.saveApplicationConfirm',
     defaultMessage: 'Save your changes?',
     description: 'Title for save application confirmation modal'
   },
   saveApplicationConfirmModalDescription: {
-    id: 'register.form.saveApplicationConfirmModalDescription',
+    id: 'register.form.modal.desc.saveApplicationConfirm',
     defaultMessage:
       'By clicking save the old information will be deleted and new information will be saved',
     description: 'Description for save application confirmation modal'

--- a/packages/client/src/views/RegisterForm/RegisterForm.tsx
+++ b/packages/client/src/views/RegisterForm/RegisterForm.tsx
@@ -26,7 +26,8 @@ import { BackArrow } from '@opencrvs/components/lib/icons'
 import {
   EventTopBar,
   IEventTopBarProps,
-  IEventTopBarMenuAction
+  IEventTopBarMenuAction,
+  ResponsiveModal
 } from '@opencrvs/components/lib/interface'
 import { BodyContent, Container } from '@opencrvs/components/lib/layout'
 import {
@@ -76,7 +77,9 @@ import {
   PAGE_TRANSITIONS_ENTER_TIME,
   PAGE_TRANSITIONS_CLASSNAME,
   PAGE_TRANSITIONS_TIMING_FUNC_N_FILL_MODE,
-  PAGE_TRANSITIONS_EXIT_TIME
+  PAGE_TRANSITIONS_EXIT_TIME,
+  DECLARED,
+  REJECTED
 } from '@client/utils/constants'
 import { TimeMounted } from '@client/components/TimeMounted'
 import { getValueFromApplicationDataByKey } from '@client/pdfRenderer/transformer/utils'
@@ -218,6 +221,7 @@ type State = {
   isDataAltered: boolean
   rejectFormOpen: boolean
   hasError: boolean
+  showConfirmationModal: boolean
 }
 
 const fadeFromTop = keyframes`
@@ -244,7 +248,8 @@ class RegisterFormView extends React.Component<FullProps, State> {
     this.state = {
       isDataAltered: false,
       rejectFormOpen: false,
-      hasError: false
+      hasError: false,
+      showConfirmationModal: false
     }
   }
   setAllFormFieldsTouched!: (touched: FormikTouched<FormikValues>) => void
@@ -274,6 +279,10 @@ class RegisterFormView extends React.Component<FullProps, State> {
 
   userHasRegisterScope() {
     return this.props.scope && this.props.scope.includes('register')
+  }
+
+  userHasValidateScope() {
+    return this.props.scope && this.props.scope.includes('validate')
   }
 
   modifyApplication = (
@@ -341,6 +350,12 @@ class RegisterFormView extends React.Component<FullProps, State> {
     }))
   }
 
+  toggleConfirmationModal = () => {
+    this.setState(prevState => ({
+      showConfirmationModal: !prevState.showConfirmationModal
+    }))
+  }
+
   getEvent() {
     const eventType = this.props.application.event || 'BIRTH'
     switch (eventType.toLocaleLowerCase()) {
@@ -354,7 +369,21 @@ class RegisterFormView extends React.Component<FullProps, State> {
   }
 
   onSaveAsDraftClicked = async () => {
-    await this.props.writeApplication(this.props.application)
+    const { application } = this.props
+    const isRegistrarOrRegistrationAgent =
+      this.userHasRegisterScope() || this.userHasValidateScope()
+    const isApplicationDeclaredOrRejected =
+      application.registrationStatus === DECLARED ||
+      application.registrationStatus === REJECTED
+    if (isRegistrarOrRegistrationAgent && isApplicationDeclaredOrRejected) {
+      this.toggleConfirmationModal()
+    } else {
+      this.writeApplicationAndGoToHome()
+    }
+  }
+
+  writeApplicationAndGoToHome = () => {
+    this.props.writeApplication(this.props.application)
     this.props.goToHomeTab(this.getRedirectionTabOnSaveOrExit())
   }
 
@@ -730,6 +759,36 @@ class RegisterFormView extends React.Component<FullProps, State> {
               application={application}
             />
           )}
+          <ResponsiveModal
+            id="save_application_confirmation"
+            title={intl.formatMessage(
+              messages.saveApplicationConfirmModalTitle
+            )}
+            show={this.state.showConfirmationModal}
+            handleClose={this.toggleConfirmationModal}
+            responsive={false}
+            contentHeight={80}
+            actions={[
+              <TertiaryButton
+                id="cancel_save"
+                key="cancel_save"
+                onClick={this.toggleConfirmationModal}
+              >
+                {intl.formatMessage(buttonMessages.cancel)}
+              </TertiaryButton>,
+              <PrimaryButton
+                id="confirm_save"
+                key="confirm_save"
+                onClick={this.writeApplicationAndGoToHome}
+              >
+                {intl.formatMessage(buttonMessages.save)}
+              </PrimaryButton>
+            ]}
+          >
+            {intl.formatMessage(
+              messages.saveApplicationConfirmModalDescription
+            )}
+          </ResponsiveModal>
         </StyledContainer>
       </>
     )

--- a/packages/client/src/views/RegisterForm/RegisterForm.tsx
+++ b/packages/client/src/views/RegisterForm/RegisterForm.tsx
@@ -79,7 +79,8 @@ import {
   PAGE_TRANSITIONS_TIMING_FUNC_N_FILL_MODE,
   PAGE_TRANSITIONS_EXIT_TIME,
   DECLARED,
-  REJECTED
+  REJECTED,
+  VALIDATED
 } from '@client/utils/constants'
 import { TimeMounted } from '@client/components/TimeMounted'
 import { getValueFromApplicationDataByKey } from '@client/pdfRenderer/transformer/utils'
@@ -372,10 +373,11 @@ class RegisterFormView extends React.Component<FullProps, State> {
     const { application } = this.props
     const isRegistrarOrRegistrationAgent =
       this.userHasRegisterScope() || this.userHasValidateScope()
-    const isApplicationDeclaredOrRejected =
+    const isConfirmationModalApplicable =
       application.registrationStatus === DECLARED ||
+      application.registrationStatus === VALIDATED ||
       application.registrationStatus === REJECTED
-    if (isRegistrarOrRegistrationAgent && isApplicationDeclaredOrRejected) {
+    if (isRegistrarOrRegistrationAgent && isConfirmationModalApplicable) {
       this.toggleConfirmationModal()
     } else {
       this.writeApplicationAndGoToHome()


### PR DESCRIPTION
Modal shows up only when both of the below conditions are met
- User has `register` or `validate` scope
- `registrationStatus` is either `DECLARED` or `REJECTED`

![save_confirmation_modal](https://user-images.githubusercontent.com/42269993/75133439-06472400-5705-11ea-9a38-9a9d83868fc2.png)
