### PR TITLE
Ocrvs 1716 Operational dashboard style amends

### DIFF
--- a/packages/client/src/views/Performance/OperationalReport.tsx
+++ b/packages/client/src/views/Performance/OperationalReport.tsx
@@ -118,13 +118,13 @@ interface State {
 const Header = styled.h1`
   color: ${({ theme }) => theme.colors.copy};
   ${({ theme }) => theme.fonts.h2Style};
+  margin: 0;
 `
 
 const HeaderContainer = styled.div`
   display: flex;
   align-items: baseline;
   flex-wrap: wrap;
-  margin-top: -32px;
 
   & > :first-child {
     margin-right: 24px;

--- a/packages/client/src/views/Performance/PerformanceContentWrapper.tsx
+++ b/packages/client/src/views/Performance/PerformanceContentWrapper.tsx
@@ -17,7 +17,7 @@ import styled from 'styled-components'
 import { BackArrowDeepBlue } from '@opencrvs/components/lib/icons'
 
 const Content = styled(BodyContent)`
-  padding: 0px;
+  padding: 0px 24px;
   margin: 32px auto 0;
   @media (max-width: ${({ theme }) => theme.grid.breakpoints.lg}px) {
     padding: 0px 16px;

--- a/packages/client/src/views/Performance/reports/operational/RegistrationRatesReport.tsx
+++ b/packages/client/src/views/Performance/reports/operational/RegistrationRatesReport.tsx
@@ -23,7 +23,7 @@ import { injectIntl, WrappedComponentProps } from 'react-intl'
 import styled from 'styled-components'
 
 const ReportHeader = styled.div`
-  margin: 24px 0px;
+  margin: 32px 0px;
 `
 
 const Report = styled.div`

--- a/packages/client/src/views/Performance/utils.ts
+++ b/packages/client/src/views/Performance/utils.ts
@@ -31,7 +31,7 @@ export function getMonthDateRange(year: number, month: number) {
   }
 }
 export const ReportHeader = styled.div`
-  margin: 24px 0px;
+  margin: 32px 0 24px 0;
 `
 
 export const SubHeader = styled.div`
@@ -50,8 +50,8 @@ export const ActionContainer = styled.div`
   justify-content: space-between;
   align-items: flex-end;
   flex-wrap: wrap;
-  margin: 0 -40px 0 -40px;
-  padding: 0 40px 16px 40px;
+  margin: 0 -24px 0 -24px;
+  padding: 12px 24px 11px 24px;
   border-bottom: 1px solid ${({ theme }) => theme.colors.dividerDark};
 `
 


### PR DESCRIPTION
Closes #1716 UI - OpsDash - page padding and filter bar

![op-dashboard-style-amends](https://user-images.githubusercontent.com/42269993/83662228-0d75ac00-a5e9-11ea-9c64-3a053c8ffc96.png)

1. paddingtop = 32px
2. H2 page title - 54px
3. filterBar div = 56px. pT: 12px, pB=11px
4. Divider line = 1140px wide
5. MarginBottom = 32px

**1**
![image](https://user-images.githubusercontent.com/42269993/83662451-4dd52a00-a5e9-11ea-8dd6-c128f288528f.png)

**2**
![image (1)](https://user-images.githubusercontent.com/42269993/83662548-72c99d00-a5e9-11ea-8b8e-a81fc3d233b9.png)

**3,4**
![image (2)](https://user-images.githubusercontent.com/42269993/83663061-2763be80-a5ea-11ea-95a4-9d1cf94dc69e.png)

**5**
![image (3)](https://user-images.githubusercontent.com/42269993/83663187-567a3000-a5ea-11ea-9e2a-4551ba8de0a5.png)



