### PR TITLE
Ocrvs 1913 Fix for review duplicate issue

### DIFF
--- a/packages/client/src/views/RegistrationHome/tabs/review/reviewTab.test.tsx
+++ b/packages/client/src/views/RegistrationHome/tabs/review/reviewTab.test.tsx
@@ -155,6 +155,27 @@ const mockReviewTabData = {
     {
       id: '9a55d213-ad9f-4dcd-9418-340f3a7f6269',
       type: 'Birth',
+      operationHistories: [
+        {
+          operationType: 'DECLARED',
+          operatedOn: new Date(1544188309380).toISOString(),
+          operatorOfficeName: 'Baniajan Union Parishad',
+          operatorRole: 'FIELD_AGENT',
+          operatorName: [
+            {
+              familyName: 'Al Hasan',
+              firstNames: 'Shakib',
+              use: 'en'
+            },
+            {
+              familyName: null,
+              firstNames: '',
+              use: 'bn'
+            }
+          ],
+          operatorOfficeAlias: ['বানিয়াজান ইউনিয়ন পরিষদ']
+        }
+      ],
       registration: {
         status: 'DECLARED',
         contactNumber: '01622688231',
@@ -246,8 +267,7 @@ describe('RegistrationHome sent for review tab related tests', () => {
 
     const data = gridTable.prop('content')
     const EXPECTED_DATE_OF_APPLICATION = moment(
-      moment(TIME_STAMP, 'x').format('YYYY-MM-DD HH:mm:ss'),
-      'YYYY-MM-DD HH:mm:ss'
+      new Date(Number.parseInt(TIME_STAMP))
     ).fromNow()
 
     expect(data.length).toBe(2)

--- a/packages/client/src/views/RegistrationHome/tabs/review/reviewTab.tsx
+++ b/packages/client/src/views/RegistrationHome/tabs/review/reviewTab.tsx
@@ -190,12 +190,7 @@ class ReviewTabComponent extends React.Component<
             moment(reg.dateOfEvent.toString(), 'YYYY-MM-DD').fromNow()) ||
           '',
         applicationTimeElapsed:
-          (reg.modifiedAt &&
-            moment(
-              moment(reg.modifiedAt, 'x').format('YYYY-MM-DD HH:mm:ss'),
-              'YYYY-MM-DD HH:mm:ss'
-            ).fromNow()) ||
-          '',
+          (reg.createdAt && moment(reg.createdAt).fromNow()) || '',
         actions,
         icon,
         rowClickHandler: [

--- a/packages/client/src/views/SearchResult/SearchResult.tsx
+++ b/packages/client/src/views/SearchResult/SearchResult.tsx
@@ -371,7 +371,7 @@ export class SearchResultView extends React.Component<
       }
 
       let icon: JSX.Element = <div />
-      if (isDuplicate) {
+      if (isDuplicate && !applicationIsRegistered && !applicationIsCertified) {
         icon = <Duplicate />
       } else if (applicationIsValidated) {
         icon = <Validate data-tip data-for="validateTooltip" />

--- a/packages/gateway/src/features/registration/root-resolvers.test.ts
+++ b/packages/gateway/src/features/registration/root-resolvers.test.ts
@@ -2036,6 +2036,24 @@ describe('Registration root resolvers', () => {
         ],
         [
           JSON.stringify({
+            id: '1648b1fb-bad4-4b98-b8a3-bd7ceee496b6',
+            resourceType: 'Composition',
+            identifier: {
+              system: 'urn:ietf:rfc:3986',
+              value: 'DewpkiM'
+            },
+            relatesTo: [
+              {
+                code: 'duplicate',
+                targetReference: {
+                  reference: 'Composition/5e3815d1-d039-4399-b47d-af9a9f51993b'
+                }
+              }
+            ]
+          })
+        ],
+        [
+          JSON.stringify({
             resourceType: 'Bundle',
             entry: [
               {

--- a/packages/gateway/src/features/registration/root-resolvers.ts
+++ b/packages/gateway/src/features/registration/root-resolvers.ts
@@ -356,18 +356,32 @@ export const resolvers: GQLResolver = {
           'GET'
         )
         removeDuplicatesFromComposition(composition, id, duplicateId)
-        await fetch(`${FHIR_URL}/Composition/${id}`, {
-          method: 'PUT',
-          headers: {
-            'Content-Type': 'application/fhir+json',
-            ...authHeader
-          },
-          body: JSON.stringify(composition)
-        }).catch(error => {
-          return Promise.reject(
-            new Error(`FHIR request failed: ${error.message}`)
-          )
-        })
+        await Promise.all([
+          fetch(`${SEARCH_URL}/events/not-duplicate`, {
+            method: 'PUT',
+            headers: {
+              'Content-Type': 'application/fhir+json',
+              ...authHeader
+            },
+            body: JSON.stringify(composition)
+          }).catch(error => {
+            return Promise.reject(
+              new Error(`Search request failed: ${error.message}`)
+            )
+          }),
+          fetch(`${FHIR_URL}/Composition/${id}`, {
+            method: 'PUT',
+            headers: {
+              'Content-Type': 'application/fhir+json',
+              ...authHeader
+            },
+            body: JSON.stringify(composition)
+          }).catch(error => {
+            return Promise.reject(
+              new Error(`FHIR request failed: ${error.message}`)
+            )
+          })
+        ])
         return composition.id
       } else {
         return await Promise.reject(

--- a/packages/gateway/src/features/registration/root-resolvers.ts
+++ b/packages/gateway/src/features/registration/root-resolvers.ts
@@ -356,32 +356,33 @@ export const resolvers: GQLResolver = {
           'GET'
         )
         removeDuplicatesFromComposition(composition, id, duplicateId)
-        await Promise.all([
-          fetch(`${SEARCH_URL}/events/not-duplicate`, {
-            method: 'PUT',
-            headers: {
-              'Content-Type': 'application/fhir+json',
-              ...authHeader
-            },
-            body: JSON.stringify(composition)
-          }).catch(error => {
-            return Promise.reject(
-              new Error(`Search request failed: ${error.message}`)
-            )
-          }),
-          fetch(`${FHIR_URL}/Composition/${id}`, {
-            method: 'PUT',
-            headers: {
-              'Content-Type': 'application/fhir+json',
-              ...authHeader
-            },
-            body: JSON.stringify(composition)
-          }).catch(error => {
-            return Promise.reject(
-              new Error(`FHIR request failed: ${error.message}`)
-            )
-          })
-        ])
+
+        await fetch(`${SEARCH_URL}/events/not-duplicate`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/fhir+json',
+            ...authHeader
+          },
+          body: JSON.stringify(composition)
+        }).catch(error => {
+          return Promise.reject(
+            new Error(`Search request failed: ${error.message}`)
+          )
+        })
+
+        await fetch(`${FHIR_URL}/Composition/${id}`, {
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/fhir+json',
+            ...authHeader
+          },
+          body: JSON.stringify(composition)
+        }).catch(error => {
+          return Promise.reject(
+            new Error(`FHIR request failed: ${error.message}`)
+          )
+        })
+
         return composition.id
       } else {
         return await Promise.reject(

--- a/packages/search/src/elasticsearch/utils.ts
+++ b/packages/search/src/elasticsearch/utils.ts
@@ -290,7 +290,7 @@ export function buildQuery(body: IBirthCompositionBody) {
   if (body.motherDoB) {
     should.push({
       term: {
-        childDoB: body.motherDoB
+        motherDoB: body.motherDoB
       }
     })
   }

--- a/packages/search/src/features/registration/deduplicate/service.ts
+++ b/packages/search/src/features/registration/deduplicate/service.ts
@@ -24,7 +24,7 @@ export const removeDuplicate = async (bundle: fhir.Bundle) => {
     throw new Error('No Composition ID found')
   }
   const composition = await searchByCompositionId(compositionId)
-  const body = get(composition, 'hits.hits[0]._source') as ICompositionBody
+  const body = get(composition, 'body.hits.hits[0]._source') as ICompositionBody
   body.relatesTo = extractRelatesToIDs(bundle)
   await updateComposition(compositionId, body)
 }


### PR DESCRIPTION
fixes #1913 

Prior to this change, after calling `notADuplicate` resolver used to update hearth composition but did not update the search service. As a result, in spite of calling the resolver, the duplicate flag did not go and produce the above mentioned issue.

After this change, the duplicate flag goes after calling the `notADuplicate` resolver which keeps hearth and search service synchronized. 

![review-duplicate](https://user-images.githubusercontent.com/42269993/96274110-f791e200-0ff1-11eb-8cee-9c1ce1a46f14.gif)
