### PR TITLE
Ocrvs 2033 Fix for validation issue

### DIFF
--- a/packages/client/src/utils/validate.test.ts
+++ b/packages/client/src/utils/validate.test.ts
@@ -478,6 +478,18 @@ describe('validate', () => {
       })
     })
 
+    it('should error when input a date after birth event', () => {
+      const drafts = {
+        child: {
+          childBirthDate: '1992-08-18'
+        }
+      }
+      const invalidDate = '1994-10-22'
+      expect(isValidBirthDate(invalidDate, drafts)).toEqual({
+        message: messages.isValidBirthDate
+      })
+    })
+
     it('should pass when supplied a valid birth date with single digit', () => {
       const validDate = '2011-8-12'
       const response = undefined

--- a/packages/client/src/utils/validate.ts
+++ b/packages/client/src/utils/validate.ts
@@ -230,6 +230,13 @@ export const isDateNotBeforeBirth = (date: string, drafts: IFormData) => {
     : true
 }
 
+export const isDateNotAfterBirthEvent = (date: string, drafts?: IFormData) => {
+  const dateOfBirth = drafts && drafts.child && drafts.child.childBirthDate
+  return dateOfBirth
+    ? new Date(date) <= new Date(JSON.stringify(dateOfBirth))
+    : true
+}
+
 export const isDateNotAfterDeath = (date: string, drafts?: IFormData) => {
   const deathDate = drafts && drafts.deathEvent && drafts.deathEvent.deathDate
   return deathDate
@@ -261,7 +268,10 @@ export const isValidBirthDate: Validation = (
   const cast = value as string
   return !cast
     ? { message: messages.required }
-    : cast && isDateNotInFuture(cast) && isAValidDateFormat(cast)
+    : cast &&
+      isDateNotInFuture(cast) &&
+      isAValidDateFormat(cast) &&
+      isDateNotAfterBirthEvent(cast, drafts as IFormData)
     ? isDateNotAfterDeath(cast, drafts as IFormData)
       ? undefined
       : {


### PR DESCRIPTION
fixes #2033 

Note: In case of death, there is already a validation that shows error if the birth date of applicant is after death date. Birth date of applicant can be after birth date of the deceased and not a bug, considering the applicant is a descendant. 

![validation-2033](https://user-images.githubusercontent.com/42269993/97423094-f0939980-1938-11eb-8adb-a3259680a29f.gif)
