### PR TITLE
IndexedDB usage optimization

### DIFF
--- a/packages/client/src/SubmissionController.ts
+++ b/packages/client/src/SubmissionController.ts
@@ -240,7 +240,11 @@ export class SubmissionController {
       application.submissionStatus === SUBMISSION_STATUS.REGISTERED ||
       application.submissionStatus === SUBMISSION_STATUS.REJECTED
     ) {
-      this.store.dispatch(deleteApplication(application))
+      this.store.dispatch(
+        deleteApplication(application, {
+          shouldUpdateFieldAgentHome: scopes.includes('declare')
+        })
+      )
     } else {
       await this.store.dispatch(writeApplication(application))
     }

--- a/packages/client/src/SubmissionController.ts
+++ b/packages/client/src/SubmissionController.ts
@@ -17,7 +17,8 @@ import {
   modifyApplication,
   writeApplication,
   SUBMISSION_STATUS,
-  updateRegistrarWorkqueue
+  updateRegistrarWorkqueue,
+  deleteApplication
 } from '@client/applications'
 import { Action } from '@client/forms'
 import { getRegisterForm } from '@client/forms/register/application-selectors'
@@ -232,7 +233,17 @@ export class SubmissionController {
     }
     await this.store.dispatch(updateRegistrarWorkqueue())
     await this.store.dispatch(modifyApplication(application))
-    await this.store.dispatch(writeApplication(application))
+
+    if (
+      application.submissionStatus === SUBMISSION_STATUS.SUBMITTED ||
+      application.submissionStatus === SUBMISSION_STATUS.APPROVED ||
+      application.submissionStatus === SUBMISSION_STATUS.REGISTERED ||
+      application.submissionStatus === SUBMISSION_STATUS.REJECTED
+    ) {
+      this.store.dispatch(deleteApplication(application))
+    } else {
+      await this.store.dispatch(writeApplication(application))
+    }
   }
 
   private onError = async (application: IApplication, error: ApolloError) => {

--- a/packages/client/src/applications/index.ts
+++ b/packages/client/src/applications/index.ts
@@ -274,12 +274,14 @@ interface ISetInitialApplicationsAction {
   type: typeof SET_INITIAL_APPLICATION
 }
 
-type DeleteApplicationOptions = Partial<{ shouldUpdateFieldAgentHome: boolean }>
+type OnSuccessDeleteApplicationOptions = Partial<{
+  shouldUpdateFieldAgentHome: boolean
+}>
 interface IDeleteApplicationAction {
   type: typeof DELETE_APPLICATION
   payload: {
     application: IApplication | IPrintableApplication
-  } & DeleteApplicationOptions
+  } & OnSuccessDeleteApplicationOptions
 }
 
 interface IGetStorageApplicationsSuccessAction {
@@ -501,7 +503,7 @@ export const getStorageApplicationsFailed = (): IGetStorageApplicationsFailedAct
 
 export function deleteApplication(
   application: IApplication | IPrintableApplication,
-  options?: DeleteApplicationOptions
+  options?: OnSuccessDeleteApplicationOptions
 ): IDeleteApplicationAction {
   return { type: DELETE_APPLICATION, payload: { application, ...options } }
 }

--- a/packages/client/src/applications/index.ts
+++ b/packages/client/src/applications/index.ts
@@ -274,11 +274,12 @@ interface ISetInitialApplicationsAction {
   type: typeof SET_INITIAL_APPLICATION
 }
 
+type DeleteApplicationOptions = Partial<{ shouldUpdateFieldAgentHome: boolean }>
 interface IDeleteApplicationAction {
   type: typeof DELETE_APPLICATION
   payload: {
     application: IApplication | IPrintableApplication
-  }
+  } & DeleteApplicationOptions
 }
 
 interface IGetStorageApplicationsSuccessAction {
@@ -499,9 +500,10 @@ export const getStorageApplicationsFailed = (): IGetStorageApplicationsFailedAct
 })
 
 export function deleteApplication(
-  application: IApplication | IPrintableApplication
+  application: IApplication | IPrintableApplication,
+  options?: DeleteApplicationOptions
 ): IDeleteApplicationAction {
-  return { type: DELETE_APPLICATION, payload: { application } }
+  return { type: DELETE_APPLICATION, payload: { application, ...options } }
 }
 
 export function writeApplication(
@@ -1112,7 +1114,9 @@ export const applicationsReducer: LoopReducer<IApplicationsState, Action> = (
           ...state
         },
         Cmd.run(deleteApplicationByUser, {
-          successActionCreator: getStorageApplicationsSuccess,
+          successActionCreator: action.payload.shouldUpdateFieldAgentHome
+            ? updateFieldAgentDeclaredApplications
+            : getStorageApplicationsSuccess,
           failActionCreator: getStorageApplicationsFailed,
           args: [state.userID, action.payload.application]
         })

--- a/packages/client/src/views/DataProvider/birth/queries.ts
+++ b/packages/client/src/views/DataProvider/birth/queries.ts
@@ -313,12 +313,6 @@ export const GET_BIRTH_REGISTRATION_FOR_CERTIFICATE = gql`
         id
         contact
         contactPhoneNumber
-        attachments {
-          data
-          type
-          contentType
-          subject
-        }
         status {
           comments {
             comment

--- a/packages/client/src/views/DataProvider/death/queries.ts
+++ b/packages/client/src/views/DataProvider/death/queries.ts
@@ -239,12 +239,6 @@ export const GET_DEATH_REGISTRATION_FOR_CERTIFICATION = gql`
         contact
         contactRelationship
         contactPhoneNumber
-        attachments {
-          data
-          type
-          contentType
-          subject
-        }
         status {
           comments {
             comment

--- a/packages/client/src/views/FieldAgentHome/SentForReview.tsx
+++ b/packages/client/src/views/FieldAgentHome/SentForReview.tsx
@@ -138,7 +138,9 @@ class SentForReviewComponent extends React.Component<IFullProps, IState> {
             new Date(application.modifiedOn).toISOString().split('T')[0]
           ) > APPLICATIONS_DAY_LIMIT
       )
-      .forEach(this.props.deleteApplication)
+      .forEach(application => {
+        this.props.deleteApplication(application)
+      })
   }
 
   transformApplicationsReadyToSend = () => {

--- a/packages/client/src/views/Home/Details.tsx
+++ b/packages/client/src/views/Home/Details.tsx
@@ -306,11 +306,15 @@ class DetailView extends React.Component<IDetailProps & IntlShapeProps> {
   }
 
   userHasRegisterOrValidateScope() {
-    return (
-      this.props.scope &&
-      (this.props.scope.includes('register') ||
-        this.props.scope.includes('validate'))
-    )
+    return this.userHasRegisterScope() || this.userHasValidateScope()
+  }
+
+  userHasRegisterScope() {
+    return this.props.scope && this.props.scope.includes('register')
+  }
+
+  userHasValidateScope() {
+    return this.props.scope && this.props.scope.includes('validate')
   }
 
   generateDeclaredApplicationHistorData = (
@@ -514,11 +518,11 @@ class DetailView extends React.Component<IDetailProps & IntlShapeProps> {
         </ActionButton>
       )
     } else if (
-      (applicationState === IN_PROGRESS ||
+      ((applicationState === IN_PROGRESS ||
         applicationState === DECLARED ||
-        applicationState === VALIDATED ||
         applicationState === REJECTED) &&
-      this.userHasRegisterOrValidateScope()
+        this.userHasRegisterOrValidateScope()) ||
+      (applicationState === VALIDATED && this.userHasRegisterScope())
     ) {
       if (downloadStatus !== DOWNLOAD_STATUS.DOWNLOADED) {
         return (


### PR DESCRIPTION
This change deletes application when submitted, validated, registered, or rejected to optimize usage of indexedDB. Also, it fixes an unaddressed bug, in which a registration agent can download a validated application from details page on small devices but we restrict the user on desktop. After this change, a registration agent cannot download a validated application.

Notice the usage decrease after every submit action

![optimize-indexedDB](https://user-images.githubusercontent.com/42269993/99377820-e4c04500-28f0-11eb-85fd-9194040e50f7.gif)
 