### PR TITLE
Fix for duplicate history issue

### DIFF
--- a/packages/search/src/elasticsearch/utils.test.ts
+++ b/packages/search/src/elasticsearch/utils.test.ts
@@ -66,4 +66,38 @@ describe('elastic search utils', () => {
     )
     expect(mockNotificationBody.operationHistories.length).toEqual(1)
   })
+
+  it('should throw error when going to create duplicate history', async () => {
+    const mockNotificationBody = {
+      compositionId: '9c0dde8d-65b2-49dd-8b7e-5dd0c7c63779',
+      compositionType: 'birth-notification',
+      type: 'REGISTERED',
+      updatedBy: '489b76cf-6b58-4b0d-96ba-caa1271f787b',
+      eventLocationId: '489b76cf-6b58-4b0d-96ba-caa1271f787c',
+      operationHistories: [
+        {
+          operatedOn: '2020-11-23T12:01:15.600Z',
+          operatorFirstNames: 'Mohammad',
+          operatorFamilyNameLocale: '',
+          operatorFamilyName: 'Ashraful',
+          operatorFirstNamesLocale: '',
+          operatorOfficeName: 'Baniajan Union Parishad',
+          operatorOfficeAlias: ['বানিয়াজান ইউনিয়ন পরিষদ'],
+          operationType: 'REGISTERED',
+          operatorRole: 'LOCAL_REGISTRAR'
+        }
+      ]
+    }
+    let error: Error
+    try {
+      await createStatusHistory(
+        mockNotificationBody,
+        mockBirthFhirBundle.entry[1].resource as fhir.Task,
+        'Bearer abc'
+      )
+    } catch (e) {
+      error = e
+      expect(error.message).toBe('Duplicate operation history not allowed')
+    }
+  })
 })

--- a/packages/search/src/elasticsearch/utils.test.ts
+++ b/packages/search/src/elasticsearch/utils.test.ts
@@ -67,7 +67,7 @@ describe('elastic search utils', () => {
     expect(mockNotificationBody.operationHistories.length).toEqual(1)
   })
 
-  it('should throw error when going to create duplicate history', async () => {
+  it('should ignore when going to create invalid history', async () => {
     const mockNotificationBody = {
       compositionId: '9c0dde8d-65b2-49dd-8b7e-5dd0c7c63779',
       compositionType: 'birth-notification',
@@ -88,16 +88,12 @@ describe('elastic search utils', () => {
         }
       ]
     }
-    let error: Error
-    try {
-      await createStatusHistory(
-        mockNotificationBody,
-        mockBirthFhirBundle.entry[1].resource as fhir.Task,
-        'Bearer abc'
-      )
-    } catch (e) {
-      error = e
-      expect(error.message).toBe('Duplicate operation history not allowed')
-    }
+
+    await createStatusHistory(
+      mockNotificationBody,
+      mockBirthFhirBundle.entry[1].resource as fhir.Task,
+      'Bearer abc'
+    )
+    expect(mockNotificationBody.operationHistories.length).toEqual(1)
   })
 })

--- a/packages/search/src/elasticsearch/utils.ts
+++ b/packages/search/src/elasticsearch/utils.ts
@@ -160,6 +160,16 @@ export const createStatusHistory = async (
   task: fhir.Task | undefined,
   authHeader: string
 ) => {
+  if (
+    body.operationHistories &&
+    body.operationHistories.length > 0 &&
+    body.operationHistories.some(
+      history => history.operationType && history.operationType === body.type
+    )
+  ) {
+    throw new Error('Duplicate operation history not allowed')
+  }
+
   const user: IUserModelData = await getUser(body.updatedBy || '', authHeader)
   const operatorName = user && findName(NAME_EN, user.name)
   const operatorNameLocale = user && findNameLocale(user.name)

--- a/packages/search/src/elasticsearch/utils.ts
+++ b/packages/search/src/elasticsearch/utils.ts
@@ -30,6 +30,13 @@ export const enum EVENT {
 }
 
 export const IN_PROGRESS_STATUS = 'IN_PROGRESS'
+const DECLARED_STATUS = 'DECLARED'
+const REJECTED_STATUS = 'REJECTED'
+const VALIDATED_STATUS = 'VALIDATED'
+const WAITING_VALIDATION_STATUS = 'WAITING_VALIDATION'
+const REGISTERED_STATUS = 'REGISTERED'
+const CERTIFIED_STATUS = 'CERTIFIED'
+
 export const NOTIFICATION_TYPES = ['birth-notification', 'death-notification']
 export const NAME_EN = 'en'
 
@@ -160,14 +167,8 @@ export const createStatusHistory = async (
   task: fhir.Task | undefined,
   authHeader: string
 ) => {
-  if (
-    body.operationHistories &&
-    body.operationHistories.length > 0 &&
-    body.operationHistories.some(
-      history => history.operationType && history.operationType === body.type
-    )
-  ) {
-    throw new Error('Duplicate operation history not allowed')
+  if (!isValidOperationHistory(body)) {
+    return
   }
 
   const user: IUserModelData = await getUser(body.updatedBy || '', authHeader)
@@ -371,4 +372,60 @@ export async function getUser(practitionerId: string, authHeader: any) {
     }
   })
   return await res.json()
+}
+
+function getPreviousStatus(body: IBirthCompositionBody) {
+  if (body.operationHistories && body.operationHistories.length > 0) {
+    return body.operationHistories[body.operationHistories.length - 1]
+      .operationType
+  }
+
+  return null
+}
+
+export function isValidOperationHistory(body: IBirthCompositionBody) {
+  const validStatusMapping = {
+    [IN_PROGRESS_STATUS]: [null],
+    [DECLARED_STATUS]: [null],
+    [REJECTED_STATUS]: [DECLARED_STATUS, IN_PROGRESS_STATUS, VALIDATED_STATUS],
+    [VALIDATED_STATUS]: [
+      DECLARED_STATUS,
+      IN_PROGRESS_STATUS,
+      REJECTED_STATUS,
+      null
+    ],
+    [WAITING_VALIDATION_STATUS]: [
+      null,
+      DECLARED_STATUS,
+      IN_PROGRESS_STATUS,
+      REJECTED_STATUS,
+      VALIDATED_STATUS
+    ],
+    [REGISTERED_STATUS]: [
+      null,
+      DECLARED_STATUS,
+      IN_PROGRESS_STATUS,
+      REJECTED_STATUS,
+      VALIDATED_STATUS,
+      WAITING_VALIDATION_STATUS
+    ],
+    [CERTIFIED_STATUS]: [REGISTERED_STATUS, CERTIFIED_STATUS]
+  }
+
+  const previousStatus = getPreviousStatus(body)
+  const currentStatus = body.type
+
+  // tslint:disable-next-line:no-console
+  console.log('----------CURRENT-STATUS-----------', currentStatus)
+  // tslint:disable-next-line:no-console
+  console.log('----------PREVIOUS-STATUS----------', previousStatus)
+
+  if (
+    currentStatus &&
+    !validStatusMapping[currentStatus].includes(previousStatus)
+  ) {
+    return false
+  }
+
+  return true
 }

--- a/packages/search/src/elasticsearch/utils.ts
+++ b/packages/search/src/elasticsearch/utils.ts
@@ -415,11 +415,6 @@ export function isValidOperationHistory(body: IBirthCompositionBody) {
   const previousStatus = getPreviousStatus(body)
   const currentStatus = body.type
 
-  // tslint:disable-next-line:no-console
-  console.log('----------CURRENT-STATUS-----------', currentStatus)
-  // tslint:disable-next-line:no-console
-  console.log('----------PREVIOUS-STATUS----------', previousStatus)
-
   if (
     currentStatus &&
     !validStatusMapping[currentStatus].includes(previousStatus)


### PR DESCRIPTION
Add checking and throw an error if going to create duplicate operation history in search service

This change passes all unit test cases

![image](https://user-images.githubusercontent.com/42269993/101479044-c55e8a00-397b-11eb-875a-f99f21b2d618.png)

This change also passes all e2e tests

![image](https://user-images.githubusercontent.com/42269993/101483405-546ea080-3982-11eb-8ba6-ade619243d89.png)
