### PR TITLE
Change language code used for extract translations

### DIFF
--- a/packages/notification/src/extract-translations.ts
+++ b/packages/notification/src/extract-translations.ts
@@ -56,7 +56,7 @@ async function extractMessages() {
   )
 
   const englishTranslations = notification.data.find(
-    (obj: ILanguage) => obj.lang === 'en-US'
+    (obj: ILanguage) => obj.lang === 'en'
   ).messages
   try {
     // tslint:disable-next-line:no-console


### PR DESCRIPTION
OpenCRVS core is set up to use [ISO 639-1 language codes](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) like this:

English = "en"

In December 2020 we configured OpenCRVS to optionally use a CMS like [Contentful](https://www.contentful.com/).

Contentful is set up to use an ISO 639-1 language code followed by a hyphen then an [Alpha-2 country code](https://www.iban.com/country-codes) like this:

U.S. English = "en-US"

When writing the import process to Contentful, we temporarily changed the language codes in the fallback langauge JSON files to the COntentful style and forgot to change it back.  This caused a bug where languages were not loading properly.  

This change in core is to resolve the check for new language keys and is not a breaking change.