### PR TITLE
[ocrvs-2202] Incorrect statistics on performance data

### DIFF
--- a/packages/client/src/components/DateRangePicker.tsx
+++ b/packages/client/src/components/DateRangePicker.tsx
@@ -720,7 +720,7 @@ function DateRangePickerComponent(props: IDateRangePickerProps) {
                 onClick={() => {
                   props.onDatesChange({
                     startDate: startDate.toDate(),
-                    endDate: endDate.toDate()
+                    endDate: endDate.endOf('month').toDate()
                   })
                   setModalVisible(false)
                 }}


### PR DESCRIPTION
Fixed incorrect statistics data showing on **performance operational** tab while use custom date picker.