### PR TITLE
Ocrvs 1794

### DIFF
--- a/packages/client/src/views/Performance/FieldAgentList.tsx
+++ b/packages/client/src/views/Performance/FieldAgentList.tsx
@@ -64,7 +64,7 @@ const INITIAL_SORT_MAP = {
   totalApplications: SORT_ORDER.DESCENDING,
   name: SORT_ORDER.ASCENDING,
   startMonth: SORT_ORDER.ASCENDING,
-  avgCompleteApplicationTime: SORT_ORDER.DESCENDING
+  avgCompleteApplicationTime: SORT_ORDER.ASCENDING
 }
 
 interface ISearchParams {
@@ -172,7 +172,7 @@ function FieldAgentListComponent(props: IProps) {
         width: 20,
         isSortable: true,
         sortFunction: () => toggleSort('name'),
-        icon: <ArrowDownBlue />
+        icon: columnToBeSort === 'name' ? <ArrowDownBlue /> : <></>
       },
       {
         key: 'type',
@@ -190,7 +190,7 @@ function FieldAgentListComponent(props: IProps) {
         width: 12,
         isSortable: true,
         sortFunction: () => toggleSort('startMonth'),
-        icon: <ArrowDownBlue />
+        icon: columnToBeSort === 'startMonth' ? <ArrowDownBlue /> : <></>
       },
       {
         key: 'totalApplications',
@@ -200,7 +200,7 @@ function FieldAgentListComponent(props: IProps) {
         width: 12,
         isSortable: true,
         sortFunction: () => toggleSort('totalApplications'),
-        icon: <ArrowDownBlue />
+        icon: columnToBeSort === 'totalApplications' ? <ArrowDownBlue /> : <></>
       },
       {
         key: 'inProgressApplications',
@@ -216,8 +216,13 @@ function FieldAgentListComponent(props: IProps) {
         }),
         width: 15,
         isSortable: true,
-        sortFunction: () => toggleSort('totalApplications'),
-        icon: <ArrowDownBlue />
+        sortFunction: () => toggleSort('avgCompleteApplicationTime'),
+        icon:
+          columnToBeSort === 'avgCompleteApplicationTime' ? (
+            <ArrowDownBlue />
+          ) : (
+            <></>
+          )
       },
       {
         key: 'rejectedApplications',
@@ -260,10 +265,7 @@ function FieldAgentListComponent(props: IProps) {
             row.totalNumberOfApplicationStarted,
             row.totalNumberOfInProgressAppStarted
           )}%)`,
-          avgCompleteApplicationTime: getAverageCompletionTimeComponent(
-            row.averageTimeForDeclaredApplications,
-            idx
-          ),
+          avgCompleteApplicationTime: row.averageTimeForDeclaredApplications,
           rejectedApplications: `${
             row.totalNumberOfRejectedApplications
           } (${getPercentage(
@@ -275,13 +277,17 @@ function FieldAgentListComponent(props: IProps) {
     return (
       (content &&
         orderBy(content, [columnToBeSort], [sortOrder[columnToBeSort]]).map(
-          row => {
+          (row, idx) => {
             return {
               ...row,
               startMonth:
                 (row.startMonth &&
                   moment(Number(row.startMonth)).format('MMMM YYYY')) ||
-                ''
+                '',
+              avgCompleteApplicationTime: getAverageCompletionTimeComponent(
+                Number(row.avgCompleteApplicationTime),
+                idx
+              )
             }
           }
         )) ||

--- a/packages/components/src/components/forms/DateField.tsx
+++ b/packages/components/src/components/forms/DateField.tsx
@@ -40,15 +40,15 @@ export interface IState {
 export type IDateFieldProps = IProps & Omit<ITextInputProps, 'onChange'>
 
 const DateSegment = styled(TextInput)`
-  width: 4em;
-  margin: 0 9px;
+  width: 3.375em;
+  margin: 0 4px;
 
   &:first-of-type {
     margin-left: 0;
   }
   &:last-of-type {
     margin-right: 0;
-    width: 5em;
+    width: 4.875em;
   }
 `
 


### PR DESCRIPTION
![field-agent-sort](https://user-images.githubusercontent.com/43314141/143861862-c04c07b2-df62-4d4f-aa2e-783e677becfe.gif)

Sorting implemented for "Field agents", "Start month", "Avg. time to send complete application" columns in Field agents detailed view.

As it looke quite messy, as arrow sign are showing on all columns those are sortable, I change, now arrow sign is showing only on that columns by which rows are sorted
![arrow-sign-organized-field-agent-sort](https://user-images.githubusercontent.com/43314141/143871576-be77f2f8-5a53-4ad1-900b-14afd2343b33.gif)
.