### PR TITLE
ocrvs-1618 Replaced default svg with ui-avatars

### DIFF
--- a/packages/client/src/components/Avatar/Avatar.tsx
+++ b/packages/client/src/components/Avatar/Avatar.tsx
@@ -1,0 +1,35 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors. OpenCRVS and the OpenCRVS
+ * graphic logo are (registered/a) trademark(s) of Plan International.
+ */
+import * as React from 'react'
+import { Avatar as DefaultAvatar } from '@opencrvs/components/lib/icons'
+import { AVATAR_API } from '@client/utils/constants'
+
+interface IProps extends React.HTMLAttributes<Element> {
+  name?: string
+}
+
+export function Avatar(props: IProps) {
+  const [error, setError] = React.useState<boolean>(false)
+
+  if (!error && props.name) {
+    return (
+      <img
+        width={64}
+        height={64}
+        src={`${AVATAR_API}${props.name.replaceAll(' ', '+')}`}
+        onError={() => setError(true)}
+        {...props}
+      />
+    )
+  }
+  return <DefaultAvatar {...props} />
+}

--- a/packages/client/src/components/Avatar/AvatarLarge.tsx
+++ b/packages/client/src/components/Avatar/AvatarLarge.tsx
@@ -1,0 +1,35 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors. OpenCRVS and the OpenCRVS
+ * graphic logo are (registered/a) trademark(s) of Plan International.
+ */
+import * as React from 'react'
+import { AvatarLarge as DefaultAvatar } from '@opencrvs/components/lib/icons'
+import { AVATAR_API } from '@client/utils/constants'
+
+interface IProps extends React.HTMLAttributes<Element> {
+  name?: string
+}
+
+export function AvatarLarge(props: IProps) {
+  const [error, setError] = React.useState<boolean>(false)
+
+  if (!error && props.name) {
+    return (
+      <img
+        width={132}
+        height={132}
+        src={`${AVATAR_API}&name=${props.name.replaceAll(' ', '+')}`}
+        onError={() => setError(true)}
+        {...props}
+      />
+    )
+  }
+  return <DefaultAvatar {...props} />
+}

--- a/packages/client/src/components/Avatar/AvatarSmall.tsx
+++ b/packages/client/src/components/Avatar/AvatarSmall.tsx
@@ -1,0 +1,35 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors. OpenCRVS and the OpenCRVS
+ * graphic logo are (registered/a) trademark(s) of Plan International.
+ */
+import * as React from 'react'
+import { AvatarSmall as DefaultAvatar } from '@opencrvs/components/lib/icons'
+import { AVATAR_API } from '@client/utils/constants'
+
+interface IProps extends React.HTMLAttributes<Element> {
+  name?: string
+}
+
+export function AvatarSmall(props: IProps) {
+  const [error, setError] = React.useState<boolean>(false)
+
+  if (!error && props.name) {
+    return (
+      <img
+        width={40}
+        height={40}
+        src={`${AVATAR_API}${props.name.replaceAll(' ', '+')}`}
+        onError={() => setError(true)}
+        {...props}
+      />
+    )
+  }
+  return <DefaultAvatar {...props} />
+}

--- a/packages/client/src/components/Avatar/index.ts
+++ b/packages/client/src/components/Avatar/index.ts
@@ -1,0 +1,15 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors. OpenCRVS and the OpenCRVS
+ * graphic logo are (registered/a) trademark(s) of Plan International.
+ */
+
+export * from './Avatar'
+export * from './AvatarSmall'
+export * from './AvatarLarge'

--- a/packages/client/src/components/ProfileMenu.tsx
+++ b/packages/client/src/components/ProfileMenu.tsx
@@ -18,11 +18,8 @@ import {
   IntlShape
 } from 'react-intl'
 import { IToggleMenuItem, ToggleMenu } from '@opencrvs/components/lib/interface'
-import {
-  SettingsBlack,
-  LogoutBlack,
-  AvatarSmall
-} from '@opencrvs/components/lib/icons'
+import { SettingsBlack, LogoutBlack } from '@opencrvs/components/lib/icons'
+import { AvatarSmall } from '@client/components/Avatar'
 import { IStoreState } from '@client/store'
 import { IUserDetails, getIndividualNameObj } from '@client/utils/userUtils'
 import { getLanguage } from '@client/i18n/selectors'
@@ -72,13 +69,11 @@ class ProfileMenuComponent extends React.Component<FullProps, IState> {
     return items
   }
 
-  getMenuHeader = (
-    intl: IntlShape,
+  getUserName = (
     language: string,
     userDetails: IUserDetails | null
-  ): JSX.Element => {
-    let userName
-    let userRole
+  ): string => {
+    let userName = ''
 
     if (userDetails && userDetails.name) {
       const nameObj = getIndividualNameObj(userDetails.name, language)
@@ -86,14 +81,28 @@ class ProfileMenuComponent extends React.Component<FullProps, IState> {
       if (nameObj) {
         userName = `${String(nameObj.firstNames)} ${String(nameObj.familyName)}`
       }
-
-      userRole =
-        userDetails.role &&
-        intl.formatMessage(userMessages[userDetails.role as string])
-    } else {
-      userName = ''
-      userRole = ''
     }
+
+    return userName
+  }
+
+  getUserRole = (intl: IntlShape, userDetails: IUserDetails | null): string => {
+    let userRole = ''
+
+    if (userDetails && userDetails.role) {
+      userRole = intl.formatMessage(userMessages[userDetails.role as string])
+    }
+
+    return userRole
+  }
+
+  getMenuHeader = (
+    intl: IntlShape,
+    language: string,
+    userDetails: IUserDetails | null
+  ): JSX.Element => {
+    let userName = this.getUserName(language, userDetails)
+    let userRole = this.getUserRole(intl, userDetails)
 
     return (
       <>
@@ -110,7 +119,9 @@ class ProfileMenuComponent extends React.Component<FullProps, IState> {
       <>
         <ToggleMenu
           id="ProfileMenu"
-          toggleButton={<AvatarSmall />}
+          toggleButton={
+            <AvatarSmall name={this.getUserName(language, userDetails)} />
+          }
           menuHeader={this.getMenuHeader(intl, language, userDetails)}
           menuItems={this.getMenuItems(intl)}
           hasFocusRing={true}

--- a/packages/client/src/utils/constants.ts
+++ b/packages/client/src/utils/constants.ts
@@ -103,3 +103,5 @@ export const MONTHS_IN_YEAR = 12
 
 export const DECLARED_APPLICATION_SEARCH_QUERY_COUNT =
   process.env.DECLARED_APPLICATION_SEARCH_QUERY_COUNT || 100
+
+export const AVATAR_API = 'https:/eu.ui-avatars.com/api/?rounded=true&name='

--- a/packages/client/src/views/Settings/SettingsPage.tsx
+++ b/packages/client/src/views/Settings/SettingsPage.tsx
@@ -22,7 +22,7 @@ import { IUserDetails } from '@client/utils/userUtils'
 import { GQLHumanName } from '@opencrvs/gateway/src/graphql/schema'
 import styled from '@client/styledComponents'
 import { Header } from '@client/components/interface/Header/Header'
-import { AvatarLarge, Avatar } from '@opencrvs/components/lib/icons'
+import { AvatarLarge, Avatar } from '@client/components/Avatar'
 import { DataSection } from '@opencrvs/components/lib/interface/ViewData'
 import {
   ResponsiveModal,
@@ -332,8 +332,8 @@ class SettingsView extends React.Component<IProps, IState> {
               </Version>
             </Left>
             <Right>
-              <Avatar className="tablet" />
-              <AvatarLarge className="desktop" />
+              <Avatar className="tablet" name={englishName} />
+              <AvatarLarge className="desktop" name={englishName} />
             </Right>
           </Content>
         </Container>

--- a/packages/client/src/views/SysAdmin/Team/user/UserList.tsx
+++ b/packages/client/src/views/SysAdmin/Team/user/UserList.tsx
@@ -36,10 +36,10 @@ import { UserStatus } from '@client/views/SysAdmin/Team/utils'
 import { LinkButton } from '@opencrvs/components/lib/buttons'
 import {
   AddUser,
-  AvatarSmall,
   VerticalThreeDots,
   SearchRed
 } from '@opencrvs/components/lib/icons'
+import { AvatarSmall } from '@client/components/Avatar'
 import {
   ColumnContentAlignment,
   ListTable,
@@ -402,7 +402,7 @@ function UserListComponent(props: IProps) {
             (user.type && intl.formatMessage(userMessages[user.type])) || '-'
 
           return {
-            photo: <AvatarSmall />,
+            photo: <AvatarSmall name={name} />,
             name: (
               <LinkButton
                 id={`name-link-${user.id}`}

--- a/packages/client/src/views/SysAdmin/Team/user/userProfilie/UserProfile.tsx
+++ b/packages/client/src/views/SysAdmin/Team/user/userProfilie/UserProfile.tsx
@@ -24,11 +24,8 @@ import {
 } from '@client/views/SysAdmin/SysAdminContentWrapper'
 import { GQLUser, GQLHumanName } from '@opencrvs/gateway/src/graphql/schema'
 import { createNamesMap } from '@client/utils/data-formatting'
-import {
-  SearchRed,
-  Avatar,
-  VerticalThreeDots
-} from '@opencrvs/components/lib/icons'
+import { SearchRed, VerticalThreeDots } from '@opencrvs/components/lib/icons'
+import { Avatar } from '@client/components/Avatar'
 import styled from 'styled-components'
 import { LinkButton } from '@opencrvs/components/lib/buttons'
 import moment from 'moment'
@@ -359,7 +356,7 @@ class UserProfileComponent extends React.Component<Props, State> {
                   }
                 >
                   <ContentWrapper>
-                    <UserAvatar />
+                    <UserAvatar name={user.name} />
                     <NameHolder>{user.name}</NameHolder>
                     <InformationHolder>
                       <InformationTitle paddingRight={70}>


### PR DESCRIPTION
The default svg is still used as a fallback
![1618-ui-avatar](https://user-images.githubusercontent.com/29002716/144408974-17ed6900-95bd-4dd1-8df8-f35316a3909f.gif)
.
