### PR TITLE
ocrvs-1908 NID validation moved from core to contry-wise config

### DIFF
--- a/packages/client/src/utils/validate.ts
+++ b/packages/client/src/utils/validate.ts
@@ -525,6 +525,11 @@ export const range: RangeValidation = (min: number, max: number) => (
 const hasValidLength = (value: string, length: number): boolean =>
   !value || value.length === length
 
+export const isAValidNIDNumberFormat = (value: string): boolean => {
+  const { pattern } = window.config.NID_NUMBER_PATTERN
+  return pattern.test(value)
+}
+
 export const validIDNumber = (typeOfID: string): Validation => (value: any) => {
   const validNationalIDLengths = [10, 17]
   const validBirthRegistrationNumberLength = 17
@@ -534,19 +539,22 @@ export const validIDNumber = (typeOfID: string): Validation => (value: any) => {
   value = (value && value.toString()) || ''
   switch (typeOfID) {
     case NATIONAL_ID:
-      const containsOnlyNumbers = value.match(/^[0-9]+$/)
+      const { num } = window.config.NID_NUMBER_PATTERN
 
-      if (
-        validNationalIDLengths.includes(value.length) &&
-        containsOnlyNumbers
-      ) {
+      const cast = value as string
+      const trimmedValue =
+        cast === undefined || cast === null ? '' : cast.trim()
+
+      if (isAValidNIDNumberFormat(trimmedValue) || !trimmedValue) {
         return undefined
       }
+
       return {
         message: messages.validNationalId,
         props: {
           min: validNationalIDLengths[0],
-          max: validNationalIDLengths[1]
+          max: validNationalIDLengths[1],
+          validLength: num
         }
       }
 

--- a/packages/client/typings/window.d.ts
+++ b/packages/client/typings/window.d.ts
@@ -43,6 +43,11 @@ interface Window {
         endBefore: number
       }
     }
+    NID_NUMBER_PATTERN: {
+      pattern: RegExp
+      example: string
+      num: string
+    }
     LOGROCKET: string
     SENTRY: string
   }


### PR DESCRIPTION
![nid-validation](https://user-images.githubusercontent.com/43314141/144424719-90f45f65-f475-47db-9c90-118edb385295.gif)
