### PR TITLE
ocrvs-1963: newfont created, pill fontStyle changed as 12px semibold, padding: 4px 8px, border-radius: 2px

### DIFF
--- a/packages/client/src/views/SysAdmin/Team/user/UserList.tsx
+++ b/packages/client/src/views/SysAdmin/Team/user/UserList.tsx
@@ -99,7 +99,7 @@ const ErrorText = styled.div`
 
 const StatusBox = styled.span`
   padding: 4px 8px;
-  ${({ theme }) => theme.fonts.smallPillStyle};
+  ${({ theme }) => theme.fonts.captionBold};
   border-radius: 2px;
   height: 30px;
   text-align: center;

--- a/packages/client/src/views/SysAdmin/Team/user/UserList.tsx
+++ b/packages/client/src/views/SysAdmin/Team/user/UserList.tsx
@@ -98,8 +98,9 @@ const ErrorText = styled.div`
 `
 
 const StatusBox = styled.span`
-  padding: 2px 6px 4px 6px;
-  border-radius: 4px;
+  padding: 4px 8px;
+  ${({ theme }) => theme.fonts.smallPillStyle};
+  border-radius: 2px;
   height: 30px;
   text-align: center;
   margin-left: 4px;

--- a/packages/components/src/components/fonts.ts
+++ b/packages/components/src/components/fonts.ts
@@ -29,6 +29,7 @@ export interface IFonts {
   smallButtonStyle: string
   smallButtonStyleNoCapitalize: string
   chartLegendStyle: string
+  smallPillStyle: string
 }
 
 // TODO: we need a way to load fonts for other languages without recompiling
@@ -122,12 +123,17 @@ export const fonts = (language: string): IFonts => {
       font-weight: normal;
       text-transform: capitalize;`,
     smallButtonStyleNoCapitalize: `font-family: ${semiBoldFont};
-        font-size: 14px;
-        font-weight: 600;
-        line-height: 150%;`,
+      font-size: 14px;
+      font-weight: 600;
+      line-height: 150%;`,
     chartLegendStyle: `font-family: ${regularFont};
       font-size: 14px;
       font-weight: 400;
-      line-height: 21px;`
+      line-height: 21px;`,
+    smallPillStyle: `font-family: ${semiBoldFont};
+      font-size: 12px;
+      font-weight: 400;
+      line-height: 21px;
+    `
   }
 }

--- a/packages/components/src/components/fonts.ts
+++ b/packages/components/src/components/fonts.ts
@@ -29,7 +29,7 @@ export interface IFonts {
   smallButtonStyle: string
   smallButtonStyleNoCapitalize: string
   chartLegendStyle: string
-  smallPillStyle: string
+  captionBold: string
 }
 
 // TODO: we need a way to load fonts for other languages without recompiling
@@ -130,7 +130,7 @@ export const fonts = (language: string): IFonts => {
       font-size: 14px;
       font-weight: 400;
       line-height: 21px;`,
-    smallPillStyle: `font-family: ${semiBoldFont};
+    captionBold: `font-family: ${semiBoldFont};
       font-size: 12px;
       font-weight: 400;
       line-height: 21px;


### PR DESCRIPTION
newfont created, pill fontStyle changed as 12px semibold, padding: 4px 8px, border-radius: 2px
![Screenshot from 2021-12-08 16-29-13](https://user-images.githubusercontent.com/43314141/145193742-200a8dfb-b52c-476c-859c-f0bd211bea40.png)

