### PR TITLE
ocrvs-1962: hover and active state on download button made circle same as expand button.

### DIFF
--- a/packages/client/src/components/interface/DownloadButton.tsx
+++ b/packages/client/src/components/interface/DownloadButton.tsx
@@ -58,6 +58,11 @@ const DownloadAction = styled(TertiaryButton)<{
   isFullHeight?: boolean
 }>`
   ${({ isFullHeight }) => isFullHeight && `height: 100%;`}
+  border-radius: 50%;
+  height: 40px;
+  & > div {
+    padding: 0px 0px;
+  }
 `
 
 function DownloadButtonComponent(props: DownloadButtonProps & HOCProps) {


### PR DESCRIPTION
![Screenshot from 2021-12-20 15-07-44](https://user-images.githubusercontent.com/43314141/146743624-90cae5b4-e462-45bd-9893-8e1f560ee4a4.png)
