### PR TITLE
ocrvs-1936: time period represented using '-'

### DIFF
--- a/packages/client/src/i18n/messages/constants.ts
+++ b/packages/client/src/i18n/messages/constants.ts
@@ -682,7 +682,7 @@ const messagesToDefine: IConstantsMessages = {
     id: 'constants.within45DaysTo1Year'
   },
   within1YearTo5Years: {
-    defaultMessage: '1 year to 5 years',
+    defaultMessage: '1 year - 5 years',
     description: 'Label for registrations within 1 year to 5 years',
     id: 'constants.within1YearTo5Years'
   },


### PR DESCRIPTION
![Screenshot from 2021-12-22 14-12-24](https://user-images.githubusercontent.com/43314141/147190311-80723171-c670-4f42-94a6-b91b8f750954.png)
