### PR TITLE
Commons build issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "postinstall": "patch-package",
-    "start": "lerna run build --scope @opencrvs/components && lerna run --parallel --ignore @opencrvs/mobile-proxy --ignore @opencrvs/integration $OTHER_LERNA_FLAGS start",
+    "start": "lerna run build --scope @opencrvs/commons && lerna run build --scope @opencrvs/components && lerna run --parallel --ignore @opencrvs/mobile-proxy --ignore @opencrvs/integration $OTHER_LERNA_FLAGS start",
     "start:prod": "yarn build && lerna run --parallel --ignore @opencrvs/mobile-proxy --ignore @opencrvs/integration $OTHER_LERNA_FLAGS start:prod",
     "dev": "bash dev.sh",
     "dev:secrets:gen": "openssl genrsa -out .secrets/private-key.pem 2048 && openssl rsa -pubout -in .secrets/private-key.pem -out .secrets/public-key.pem",


### PR DESCRIPTION
Commons must be built before other modules when running yarn dev.  Otherwise Mac will not generate Typescript files in time and cannot start up