### PR TITLE
Make sure schema and types are generated before the server starts

### DIFF
--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -4,19 +4,20 @@
   "description": "OpenCRVS API Gateway with GraphQL",
   "license": "MPL-2.0",
   "scripts": {
-    "start": "concurrently \"nodemon --exec ts-node -r tsconfig-paths/register src/index.ts\" \"yarn gen:types:watch\" ",
+    "start": "yarn gen:schema && yarn gen:types && concurrently \"nodemon --exec ts-node -r tsconfig-paths/register src/index.ts\" \"yarn gen:types:watch\" \"yarn gen:schema:watch\"",
     "start:prod": "node build/dist/src/index.js",
     "test": "jest --coverage --silent --noStackTrace && yarn test:compilation",
     "test:watch": "jest --watch",
-    "open:cov": "yarn test && opener coverage/index.html",
-    "precommit": "tslint --project ./tsconfig.json && lint-staged",
-    "gen:full-schema": "node -e \"const importSchema = require('graphql-import').importSchema; console.log(importSchema('src/graphql/index.graphql'))\"",
-    "gen:types": "yarn -s gen:full-schema > src/graphql/schema.graphql && graphql-schema-typescript generate-ts src/graphql/schema.graphql --output src/graphql/schema.d.ts && yarn prettier --write src/graphql/schema.d.ts src/graphql/schema.graphql && echo Done",
-    "gen:types:watch": "nodemon -e graphql -i src/graphql/schema.graphql -x 'yarn gen:types'",
     "test:compilation": "tsc --noEmit",
     "build": "tsc && copyfiles 'src/**/*.graphql' build/dist",
     "postbuild": "ef-tspm",
-    "build:clean": "rm -rf build"
+    "build:clean": "rm -rf build",
+    "gen:schema": "node -e \"const importSchema = require('graphql-import').importSchema; console.log(importSchema('src/graphql/index.graphql'))\" > src/graphql/schema.graphql && yarn prettier --write src/graphql/schema.graphql",
+    "gen:types": "graphql-schema-typescript generate-ts src/graphql/schema.graphql --output src/graphql/schema.d.ts && yarn prettier --write src/graphql/schema.d.ts",
+    "gen:schema:watch": "nodemon --on-change-only -e graphql -i src/graphql/schema.graphql -x 'yarn gen:schema'",
+    "gen:types:watch": "nodemon --on-change-only -w src/graphql/schema.graphql -x 'yarn gen:types'",
+    "open:cov": "yarn test && opener coverage/index.html",
+    "precommit": "tslint --project ./tsconfig.json && lint-staged"
   },
   "dependencies": {
     "@elastic/elasticsearch": "6",


### PR DESCRIPTION
Make sure schema and types are generated before the server starts and not rewritten while the server is reading the files. I also reorganised the scripts a little