### PR TITLE
Allow setting declarations 'created at' value from outside (#2537)

### DIFF
--- a/packages/gateway/src/features/registration/death-fhir-builders.test.ts
+++ b/packages/gateway/src/features/registration/death-fhir-builders.test.ts
@@ -112,10 +112,11 @@ test('should build a minimal FHIR registration document without error', async ()
             comments: [
               {
                 comment: 'This is just a test data',
-                createdAt: '2018-10-31T09:45:05+10:00'
+                createdAt: '2018-10-31T09:40:05+10:00'
               }
             ],
-            timestamp: '2018-10-31T09:45:05+10:00'
+            timestamp: '2018-10-31T09:40:05+10:00',
+            timeLoggedMS: 1234
           }
         ],
         attachments: [
@@ -188,7 +189,7 @@ test('should build a minimal FHIR registration document without error', async ()
       causeOfDeath: 'age',
       maleDependentsOfDeceased: 1,
       femaleDependentsOfDeceased: 1,
-      createdAt: new Date(),
+      createdAt: '2018-10-31T09:45:05+10:00',
       _fhirIDMap: {
         composition: '8f18a6ea-89d1-4b03-80b3-57509a7eebcedsd',
         encounter: '8f18a6ea-89d1-4b03-80b3-57509a7eebce-dsakelske'

--- a/packages/gateway/src/features/registration/fhir-builders.test.ts
+++ b/packages/gateway/src/features/registration/fhir-builders.test.ts
@@ -127,10 +127,10 @@ test('should build a minimal FHIR registration document without error', async ()
             comments: [
               {
                 comment: 'This is just a test data',
-                createdAt: '2018-10-31T09:45:05+10:00'
+                createdAt: '2018-10-31T09:40:05+10:00'
               }
             ],
-            timestamp: '2018-10-31T09:45:05+10:00',
+            timestamp: '2018-10-31T09:40:05+10:00',
             timeLoggedMS: 1234
           }
         ],
@@ -211,7 +211,7 @@ test('should build a minimal FHIR registration document without error', async ()
       childrenBornAliveToMother: 2,
       foetalDeathsToMother: 0,
       lastPreviousLiveBirth: '2014-01-28',
-      createdAt: new Date(),
+      createdAt: '2018-10-31T09:45:05+10:00',
       _fhirIDMap: {
         composition: '8f18a6ea-89d1-4b03-80b3-57509a7eebcedsd',
         encounter: '8f18a6ea-89d1-4b03-80b3-57509a7eebce-dsakelske',
@@ -387,7 +387,7 @@ test('should build a minimal FHIR registration document without error', async ()
   )
   expect(fhir.entry[5].resource.note[0]).toEqual({
     text: 'This is just a test data',
-    time: '2018-10-31T09:45:05+10:00'
+    time: '2018-10-31T09:40:05+10:00'
   })
   expect(fhir.entry[5].resource.identifier).toEqual([
     { system: 'http://opencrvs.org/specs/id/paper-form-id', value: '12345678' },
@@ -809,10 +809,10 @@ test('creates task with contact other relationship', async () => {
             comments: [
               {
                 comment: 'This is just a test data',
-                createdAt: '2018-10-31T09:45:05+10:00'
+                createdAt: '2018-10-31T09:40:05+10:00'
               }
             ],
-            timestamp: '2018-10-31T09:45:05+10:00',
+            timestamp: '2018-10-31T09:40:05+10:00',
             timeLoggedMS: 1234
           }
         ],
@@ -873,13 +873,15 @@ test('creates task with contact other relationship', async () => {
 
   expect(simpleFhir).toBeDefined()
 
-  const taskResource = (simpleFhir.entry.find(
-    ({ resource }) => resource.resourceType === 'Task'
-  ) as fhir.BundleEntry).resource as fhir.Task
+  const taskResource = (
+    simpleFhir.entry.find(
+      ({ resource }) => resource.resourceType === 'Task'
+    ) as fhir.BundleEntry
+  ).resource as fhir.Task
 
   expect(taskResource).toBeDefined()
   expect(
-    taskResource.extension.some(taskExtension =>
+    taskResource.extension.some((taskExtension) =>
       _.isEqual(taskExtension, {
         url: 'http://opencrvs.org/specs/extension/contact-person',
         valueString: 'OTHER'
@@ -888,7 +890,7 @@ test('creates task with contact other relationship', async () => {
   ).toBe(true)
 
   expect(
-    taskResource.extension.some(taskExtension =>
+    taskResource.extension.some((taskExtension) =>
       _.isEqual(taskExtension, {
         url: 'http://opencrvs.org/specs/extension/contact-relationship',
         valueString: 'Friend'

--- a/packages/gateway/src/features/registration/fhir-builders.ts
+++ b/packages/gateway/src/features/registration/fhir-builders.ts
@@ -870,12 +870,16 @@ const builders: IFieldBuilders = {
       }
     }
   },
-  createdAt: (fhirBundle, fieldValue) => {
+  createdAt: (fhirBundle, fieldValue, context) => {
     if (!fhirBundle.meta) {
       fhirBundle.meta = {}
     }
     fhirBundle.meta.lastUpdated = fieldValue
     fhirBundle.entry[0].resource.date = fieldValue
+
+    const taskResource = selectOrCreateTaskRefResource(fhirBundle, context)
+    taskResource.lastModified = fieldValue as string
+    return
   },
   mother: {
     _fhirID: (fhirBundle, fieldValue) => {
@@ -1841,13 +1845,7 @@ const builders: IFieldBuilders = {
           )
         }
       },
-      timestamp: (
-        fhirBundle: ITemplatedBundle,
-        fieldValue: string,
-        context: any
-      ) => {
-        const taskResource = selectOrCreateTaskRefResource(fhirBundle, context)
-        taskResource.lastModified = fieldValue
+      timestamp: () => {
         return
       },
       timeLoggedMS: (

--- a/packages/gateway/src/features/transformation/index.ts
+++ b/packages/gateway/src/features/transformation/index.ts
@@ -35,7 +35,8 @@ async function transformField(
   sourceVal: any,
   targetObj: any,
   fieldBuilderForVal: IFieldBuilderFunction | IFieldBuilders,
-  context: any
+  context: any,
+  currentPropName: string
 ) {
   if (!(sourceVal instanceof Date) && typeof sourceVal === 'object') {
     if (isFieldBuilder(fieldBuilderForVal)) {
@@ -46,7 +47,7 @@ async function transformField(
     throw new Error(
       `Expected ${JSON.stringify(
         fieldBuilderForVal
-      )} to be a FieldBuilder object. The current field value is ${JSON.stringify(
+      )} to be a FieldBuilder object for field name ${currentPropName}. The current field value is ${JSON.stringify(
         sourceVal
       )}.`
     )
@@ -61,7 +62,7 @@ async function transformField(
   throw new Error(
     `Expected ${JSON.stringify(
       fieldBuilderForVal
-    )} to be a FieldBuilderFunction. The current field value is ${JSON.stringify(
+    )} to be a FieldBuilderFunction for field name ${currentPropName}. The current field value is ${JSON.stringify(
       sourceVal
     )}.`
   )
@@ -86,11 +87,13 @@ export default async function transformObj(
           /* context._index = {
             [currentPropName]: index
           } */
+
           await transformField(
             arrayVal,
             targetObj,
             fieldBuilders[currentPropName],
-            context
+            context,
+            currentPropName
           )
         }
 
@@ -101,7 +104,8 @@ export default async function transformObj(
         sourceObj[currentPropName],
         targetObj,
         fieldBuilders[currentPropName],
-        context
+        context,
+        currentPropName
       )
     }
   }

--- a/packages/gateway/src/features/user/root-resolvers.test.ts
+++ b/packages/gateway/src/features/user/root-resolvers.test.ts
@@ -504,10 +504,10 @@ describe('User root resolvers', () => {
         }
       ])
     })
-    it('should return error if invalid data received from user-mgnt endpoint', async () => {
+    it('returns empty results if invalid data received from user-mgnt endpoint', () => {
       fetch.mockResponseOnce(JSON.stringify({}))
 
-      expect(
+      return expect(
         resolvers.Query.searchFieldAgents(
           {},
           {
@@ -517,12 +517,15 @@ describe('User root resolvers', () => {
           },
           authHeaderSysAdmin
         )
-      ).rejects.toThrow('Invalid result found from search user endpoint')
+      ).resolves.toStrictEqual({
+        totalItems: 0,
+        results: []
+      })
     })
-    it('should return error if no locationId or primaryOfficeId is provided', async () => {
+    it('returns empty results if no locationId or primaryOfficeId is provided', () => {
       fetch.mockResponseOnce(JSON.stringify({}))
 
-      expect(
+      return expect(
         resolvers.Query.searchFieldAgents(
           {},
           {
@@ -531,7 +534,10 @@ describe('User root resolvers', () => {
           },
           authHeaderSysAdmin
         )
-      ).rejects.toThrow('No location provided')
+      ).resolves.toStrictEqual({
+        totalItems: 0,
+        results: []
+      })
     })
   })
 

--- a/packages/metrics/src/features/registration/__snapshots__/handler.test.ts.snap
+++ b/packages/metrics/src/features/registration/__snapshots__/handler.test.ts.snap
@@ -12,6 +12,7 @@ Object {
     "locationLevel5": "Location/fb5b7377-0c00-407d-97a1-0a7f08ed727b",
     "officeLocation": "Location/fb5b7377-0c00-407d-97a1-0a7f08ed727b",
   },
+  "timestamp": undefined,
 }
 `;
 
@@ -29,6 +30,7 @@ Object {
     "eventType": "DEATH",
     "previousStatus": "REGISTERED",
   },
+  "timestamp": 1574083515546000000,
 }
 `;
 
@@ -46,6 +48,7 @@ Object {
     "eventType": "BIRTH",
     "previousStatus": "REGISTERED",
   },
+  "timestamp": 1570613507666000000,
 }
 `;
 
@@ -63,6 +66,7 @@ Object {
     "eventType": "DEATH",
     "previousStatus": "DECLARED",
   },
+  "timestamp": 1574074172990000000,
 }
 `;
 
@@ -80,6 +84,7 @@ Object {
     "eventType": "BIRTH",
     "previousStatus": "DECLARED",
   },
+  "timestamp": 1570516927666000000,
 }
 `;
 
@@ -97,6 +102,7 @@ Object {
     "eventType": "BIRTH",
     "previousStatus": "DECLARED",
   },
+  "timestamp": 1570516927666000000,
 }
 `;
 
@@ -114,6 +120,7 @@ Object {
     "eventType": "BIRTH",
     "previousStatus": "VALIDATED",
   },
+  "timestamp": 1570516927666000000,
 }
 `;
 
@@ -131,6 +138,7 @@ Object {
     "eventType": "BIRTH",
     "previousStatus": "VALIDATED",
   },
+  "timestamp": 1570516927666000000,
 }
 `;
 
@@ -148,6 +156,7 @@ Object {
     "missingFieldSectionId": "child",
     "regStatus": "IN_PROGESS",
   },
+  "timestamp": 1551785895844000000,
 }
 `;
 
@@ -163,5 +172,6 @@ Object {
     "officeLocation": "Location/2a520dc1-0a9a-48a1-a4b8-66f3075a9155",
     "startedBy": "4bb03541-116e-4ce2-8ea4-407f307f7579",
   },
+  "timestamp": 1589199329739000000,
 }
 `;

--- a/packages/metrics/src/features/registration/index.ts
+++ b/packages/metrics/src/features/registration/index.ts
@@ -117,36 +117,42 @@ export interface IDurationPoints {
   measurement: string
   tags: IDurationTags
   fields: IDurationFields
+  timestamp: number | undefined
 }
 
 export interface ITimeLoggedPoints {
   measurement: string
   tags: ITimeLoggedTags
   fields: ITimeLoggedFields
+  timestamp: number | undefined
 }
 
 export interface IInProgressApplicationPoints {
   measurement: string
   tags: IInProgressApplicationTags
   fields: IInProgressApplicationFields
+  timestamp: number | undefined
 }
 
 export interface IDeathRegistrationPoints {
   measurement: string
   tags: IDeathRegistrationTags
   fields: IDeathRegistrationFields
+  timestamp: number | undefined
 }
 
 export interface IBirthRegistrationPoints {
   measurement: string
   tags: IBirthRegistrationTags
   fields: IBirthRegistrationFields
+  timestamp: number | undefined
 }
 
 export interface IPaymentPoints {
   measurement: string
   tags: ILocationTags
   fields: IPaymentFields
+  timestamp: number | undefined
 }
 
 export interface IPaymentFields {
@@ -158,6 +164,7 @@ export interface IApplicationsStartedPoints {
   measurement: string
   tags: ILocationTags
   fields: IApplicationsStartedFields
+  timestamp: number | undefined
 }
 
 export interface IApplicationsStartedFields {
@@ -174,6 +181,7 @@ export interface IRejectedPoints {
   measurement: string
   tags: ILocationTags
   fields: IRejectedFields
+  timestamp: number | undefined
 }
 
 export type IPoints =

--- a/packages/metrics/src/features/registration/pointGenerator.test.ts
+++ b/packages/metrics/src/features/registration/pointGenerator.test.ts
@@ -48,7 +48,7 @@ describe('Verify point generation', () => {
       'mark-existing-application-registered',
       AUTH_HEADER
     )
-    expect(point).toEqual({
+    expect(point).toMatchObject({
       measurement: 'birth_reg',
       tags: {
         regStatus: 'mark-existing-application-registered',
@@ -90,7 +90,7 @@ describe('Verify point generation', () => {
       'mark-existing-application-registered',
       AUTH_HEADER
     )
-    expect(point).toEqual({
+    expect(point).toMatchObject({
       measurement: 'birth_reg',
       tags: {
         regStatus: 'mark-existing-application-registered',
@@ -115,7 +115,7 @@ describe('Verify point generation', () => {
       'mark-existing-application-registered',
       AUTH_HEADER
     )
-    expect(point).toEqual({
+    expect(point).toMatchObject({
       measurement: 'birth_reg',
       tags: {
         regStatus: 'mark-existing-application-registered',
@@ -156,7 +156,7 @@ describe('Verify point generation', () => {
       'mark-existing-application-registered',
       AUTH_HEADER
     )
-    expect(point).toEqual({
+    expect(point).toMatchObject({
       measurement: 'death_reg',
       tags: {
         regStatus: 'mark-existing-application-registered',
@@ -193,7 +193,7 @@ describe('Verify point generation', () => {
       cloneDeep(testDeathCertPayload),
       AUTH_HEADER
     )
-    expect(point).toEqual({
+    expect(point).toMatchObject({
       measurement: 'certification_payment',
       tags: {
         eventType: 'DEATH',
@@ -233,7 +233,7 @@ describe('Verify point generation', () => {
       AUTH_HEADER,
       Events.NEW_DEC
     )
-    expect(point).toEqual({
+    expect(point).toMatchObject({
       measurement: 'applications_started',
       tags: {
         eventType: 'BIRTH',
@@ -262,7 +262,7 @@ describe('Verify point generation', () => {
       AUTH_HEADER,
       Events.NEW_VALIDATE
     )
-    expect(point).toEqual({
+    expect(point).toMatchObject({
       measurement: 'applications_started',
       tags: {
         eventType: 'BIRTH',
@@ -291,7 +291,7 @@ describe('Verify point generation', () => {
       AUTH_HEADER,
       Events.NEW_WAITING_VALIDATION
     )
-    expect(point).toEqual({
+    expect(point).toMatchObject({
       measurement: 'applications_started',
       tags: {
         eventType: 'BIRTH',
@@ -320,7 +320,7 @@ describe('Verify point generation', () => {
       AUTH_HEADER,
       Events.IN_PROGRESS_DEC
     )
-    expect(point).toEqual({
+    expect(point).toMatchObject({
       measurement: 'applications_started',
       tags: {
         eventType: 'BIRTH',
@@ -352,7 +352,7 @@ describe('Verify point generation', () => {
       AUTH_HEADER,
       Events.IN_PROGRESS_DEC
     )
-    expect(point).toEqual({
+    expect(point).toMatchObject({
       measurement: 'applications_started',
       tags: {
         eventType: 'BIRTH',
@@ -381,7 +381,7 @@ describe('Verify point generation', () => {
       .mockResolvedValueOnce('Location/3')
       .mockResolvedValueOnce('Location/2')
     const point = await generateRejectedPoints(payload, AUTH_HEADER)
-    expect(point).toEqual({
+    expect(point).toMatchObject({
       measurement: 'applications_rejected',
       tags: {
         eventType: 'BIRTH',

--- a/packages/metrics/src/features/registration/pointGenerator.ts
+++ b/packages/metrics/src/features/registration/pointGenerator.ts
@@ -117,9 +117,17 @@ export const generateInCompleteFieldPoints = async (
       return {
         measurement: 'in_complete_fields',
         tags,
-        fields
+        fields,
+        timestamp: toInfluxTimestamp(task.lastModified)
       }
     })
+}
+
+function toInfluxTimestamp(date?: Date | string) {
+  if (!date) {
+    return undefined
+  }
+  return new Date(date).valueOf() * 1000000
 }
 
 export const generateBirthRegPoint = async (
@@ -152,7 +160,8 @@ export const generateBirthRegPoint = async (
   const point = {
     measurement: 'birth_reg',
     tags,
-    fields
+    fields,
+    timestamp: toInfluxTimestamp(composition.date)
   }
 
   return point
@@ -198,7 +207,8 @@ export const generateDeathRegPoint = async (
   const point = {
     measurement: 'death_reg',
     tags,
-    fields
+    fields,
+    timestamp: new Date(composition.date).valueOf() * 1000000
   }
 
   return point
@@ -261,7 +271,8 @@ export async function generatePaymentPoint(
   return {
     measurement: 'certification_payment',
     tags,
-    fields
+    fields,
+    timestamp: toInfluxTimestamp(reconciliation.created)
   }
 }
 
@@ -319,7 +330,8 @@ export async function generateEventDurationPoint(
   return {
     measurement: 'application_event_duration',
     tags,
-    fields
+    fields,
+    timestamp: toInfluxTimestamp(currentTask.lastModified)
   }
 }
 
@@ -330,15 +342,18 @@ export async function generateTimeLoggedPoint(
 ): Promise<IPoints> {
   const currentTask = getTask(payload)
   let compositionId
+  let timestamp
   if (!fromTask) {
     const composition = getComposition(payload)
     if (!composition) {
       throw new Error('composition not found')
     }
     compositionId = composition.id
+    timestamp = composition.date
   } else {
     if (currentTask && currentTask.focus && currentTask.focus.reference) {
       compositionId = currentTask.focus.reference.split('/')[1]
+      timestamp = currentTask.meta?.lastUpdated
     }
   }
 
@@ -370,7 +385,8 @@ export async function generateTimeLoggedPoint(
   return {
     measurement: 'application_time_logged',
     tags,
-    fields
+    fields,
+    timestamp: toInfluxTimestamp(timestamp)
   }
 }
 
@@ -424,7 +440,8 @@ export async function generateApplicationStartedPoint(
   return {
     measurement: 'applications_started',
     tags,
-    fields
+    fields,
+    timestamp: toInfluxTimestamp(task.lastModified)
   }
 }
 
@@ -459,6 +476,7 @@ export async function generateRejectedPoints(
   return {
     measurement: 'applications_rejected',
     tags,
-    fields
+    fields,
+    timestamp: toInfluxTimestamp(task.lastModified)
   }
 }

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -29,6 +29,7 @@
     "hapi-pino": "^8.5.0",
     "hapi-sentry": "^3.1.0",
     "joi": "^17.3.0",
+    "dotenv": "^6.1.0",
     "jsonwebtoken": "^8.3.0",
     "jwt-decode": "^2.2.0",
     "node-fetch": "^2.6.7",

--- a/packages/workflow/src/features/registration/fhir/fhir-bundle-modifier.ts
+++ b/packages/workflow/src/features/registration/fhir/fhir-bundle-modifier.ts
@@ -386,7 +386,8 @@ export function setupLastRegUser(
       valueReference: { reference: getPractitionerRef(practitioner) }
     })
   }
-  taskResource.lastModified = new Date().toISOString()
+  taskResource.lastModified =
+    taskResource.lastModified || new Date().toISOString()
   return taskResource
 }
 

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -11,6 +11,10 @@
  */
 // tslint:disable-next-line no-var-requires
 require('app-module-path').addPath(require('path').join(__dirname, '../'))
+// tslint:disable-next-line no-var-requires
+require('dotenv').config({
+  path: `${process.cwd()}/.env`
+})
 
 import * as Hapi from '@hapi/hapi'
 import {
@@ -77,5 +81,5 @@ export async function createServer() {
 }
 
 if (require.main === module) {
-  createServer().then(server => server.start())
+  createServer().then((server) => server.start())
 }


### PR DESCRIPTION
* allow setting declarations 'created at' value from outside

this is needed so mass data generator can create declarations retrospectively

* remove console.log from component file

* fix linting error

* fix broken tests

* fix other tests that were not being run properly

* use fhir data also for influxdb creation timestamps

* update tests