### PR TITLE
[OCRVS-2522] Make age calculation functions use composition date, not current timestamp

### DIFF
--- a/packages/metrics/src/features/registration/pointGenerator.ts
+++ b/packages/metrics/src/features/registration/pointGenerator.ts
@@ -147,7 +147,10 @@ export const generateBirthRegPoint = async (
 
   const fields: IBirthRegistrationFields = {
     compositionId: composition.id,
-    ageInDays: (child.birthDate && getAgeInDays(child.birthDate)) || undefined
+    ageInDays:
+      (child.birthDate &&
+        getAgeInDays(child.birthDate, new Date(composition.date))) ||
+      undefined
   }
 
   const tags: IBirthRegistrationTags = {
@@ -185,7 +188,9 @@ export const generateDeathRegPoint = async (
   const fields: IDeathRegistrationFields = {
     compositionId: composition.id,
     ageInYears:
-      (deceased.birthDate && getAgeInYears(deceased.birthDate)) || undefined,
+      (deceased.birthDate &&
+        getAgeInYears(deceased.birthDate, new Date(composition.date))) ||
+      undefined,
     deathDays:
       (deceased.deceasedDateTime &&
         getDurationInDays(

--- a/packages/metrics/src/features/registration/utils.test.ts
+++ b/packages/metrics/src/features/registration/utils.test.ts
@@ -17,10 +17,12 @@ import { fetchFHIR } from '@metrics/api'
 
 describe('Verify age in days conversion', () => {
   it('Return valid age in days', () => {
-    Date.prototype.toISOString = jest.fn(() => '2019-03-12T07:35:42.043Z')
     const birthDate = '2019-02-28'
 
-    const ageInDays = getAgeInDays(birthDate)
+    const ageInDays = getAgeInDays(
+      birthDate,
+      new Date('2019-03-12T07:35:42.043Z')
+    )
     expect(ageInDays).toEqual(12)
   })
 })

--- a/packages/metrics/src/features/registration/utils.ts
+++ b/packages/metrics/src/features/registration/utils.ts
@@ -19,12 +19,12 @@ import { fetchFHIR } from '@metrics/api'
 type YYYY_MM_DD = string
 type ISO_DATE = string
 
-export function getAgeInDays(dateOfBirth: YYYY_MM_DD) {
-  return getDurationInDays(dateOfBirth, new Date().toISOString())
+export function getAgeInDays(dateOfBirth: YYYY_MM_DD, fromDate: Date) {
+  return getDurationInDays(dateOfBirth, fromDate.toISOString())
 }
 
-export function getAgeInYears(dateOfBirth: YYYY_MM_DD) {
-  return getDurationInYears(dateOfBirth, new Date().toISOString())
+export function getAgeInYears(dateOfBirth: YYYY_MM_DD, fromDate: Date) {
+  return getDurationInYears(dateOfBirth, fromDate.toISOString())
 }
 
 export function getDurationInDays(from: ISO_DATE, to: ISO_DATE) {


### PR DESCRIPTION
Without this, all births sent with a creation date more than 45 days ago (think data generator) would be registered as late declarations