### PR TITLE
Add workflow to publish Docker images from any branch

### DIFF
--- a/.github/workflows/build-images-from-branch.yml
+++ b/.github/workflows/build-images-from-branch.yml
@@ -1,0 +1,33 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# OpenCRVS is also distributed under the terms of the Civil Registration
+# & Healthcare Disclaimer located at http://opencrvs.org/license.
+#
+# Copyright (C) The OpenCRVS Authors. OpenCRVS and the OpenCRVS
+# graphic logo are (registered/a) trademark(s) of Plan International.
+name: Publish images to Dockerhub from any branch
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch_name:
+        description: Branch to build from
+        default: develop
+        required: true
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    steps:
+      - uses: actions/checkout@v2
+        ref: '${{ github.event.inputs.farajaland }}'
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Push image
+        run: |
+          export COUNTRY_CONFIG_VERSION=`git log -1 --pretty=format:%h` && bash build-and-push.sh && unset COUNTRY_CONFIG_VERSION


### PR DESCRIPTION
I realised I cannot build images locally as I'm on ARM architecture 🤦  something like this would be often useful