### PR TITLE
removes messaging at top of Review Section

### DIFF
--- a/packages/client/src/i18n/messages/views/review.ts
+++ b/packages/client/src/i18n/messages/views/review.ts
@@ -18,7 +18,6 @@ interface IReviewMessages
   editDeclarationConfirmationTitle: MessageDescriptor
   editDeclarationConfirmation: MessageDescriptor
   editDocuments: MessageDescriptor
-  formDataHeader: MessageDescriptor
   headerSubjectWithName: MessageDescriptor
   headerSubjectWithoutName: MessageDescriptor
   previewName: MessageDescriptor
@@ -93,12 +92,6 @@ const messagesToDefine: IReviewMessages = {
     defaultMessage: 'Add attachement',
     description: 'Edit documents text',
     id: 'review.documents.editDocuments'
-  },
-  formDataHeader: {
-    defaultMessage:
-      '{isDraft, select, true {Check responses with the informant before sending for review} false {Review the answers with the supporting documents}}',
-    description: 'Label for form data header text',
-    id: 'review.formData.header'
   },
   headerSubjectWithName: {
     defaultMessage:

--- a/packages/client/src/tests/languages.json
+++ b/packages/client/src/tests/languages.json
@@ -1044,7 +1044,6 @@
         "review.error.unauthorized": "We are unable to display this page to you",
         "review.form.section.review.name": "Review",
         "review.form.section.review.title": "Review",
-        "review.formData.header": "{isDraft, select, true {Check responses with the informant before sending for review} false {Review the answers with the supporting documents}}",
         "review.header.subject.subjectWithoutName": "{eventType, select, birth {Birth} death {Death} other {Birth}} Declaration",
         "review.header.subject.subjectWitName": "{eventType, select, birth {Birth} death {Death} other {Birth}} Declaration for {name}",
         "review.header.title.govtName": "Government of the peoples republic of Bangladesh",

--- a/packages/client/src/views/RegisterForm/review/ReviewSection.tsx
+++ b/packages/client/src/views/RegisterForm/review/ReviewSection.tsx
@@ -1494,13 +1494,6 @@ class ReviewSectionComp extends React.Component<FullProps, State> {
               }
             />
             <FormData>
-              {!isCorrection(declaration) && (
-                <FormDataHeader>
-                  {intl.formatMessage(messages.formDataHeader, {
-                    isDraft: draft
-                  })}
-                </FormDataHeader>
-              )}
               {transformedSectionData.map((sec, index) => {
                 const { uploadedDocuments, selectOptions } =
                   this.prepSectionDocuments(declaration, sec.id)


### PR DESCRIPTION
- removes the messaging "Check responses with the informant before sending for review" and "Review the answers with the supporting documents"
<img width="890" alt="image" src="https://user-images.githubusercontent.com/46478402/161775473-ad70c7a7-f6bf-4b8d-9398-fcd54d0d6ea6.png">



- these reminders should be handle in dialog prompt onClick of register and send for review
- unable to test as there is a bug when navigating to Review page 
<img width="1019" alt="image" src="https://user-images.githubusercontent.com/46478402/161775065-ba2b665a-0d7c-45a9-85c8-6f23a548dba6.png">
