### PR TITLE
[OCRVS-2807] Setup basic credentials and authentication for ElasticSearch and applications using it

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -244,7 +244,12 @@ if [ $1 == "--clear-data=yes" ] ; then
     echo
     echo "Clearing all existing data..."
     echo
-    ssh $SSH_USER@$SSH_HOST /tmp/compose/infrastructure/clear-all-data.sh $REPLICAS $ENV
+    ssh $SSH_USER@$SSH_HOST "
+        ELASTICSEARCH_ADMIN_USER=elastic \
+        ELASTICSEARCH_ADMIN_PASSWORD=$ELASTICSEARCH_SUPERUSER_PASSWORD \
+        MONGODB_ADMIN_USER=$MONGODB_ADMIN_USER \
+        MONGODB_ADMIN_PASSWORD=$MONGODB_ADMIN_PASSWORD \
+        /tmp/compose/infrastructure/clear-all-data.sh $REPLICAS $ENV"
 fi
 
 if [ $2 == "--restore-metadata=yes" ] ; then

--- a/deploy.sh
+++ b/deploy.sh
@@ -104,15 +104,25 @@ SSH_HOST=${SSH_HOST:-$HOST}
 LOG_LOCATION=${LOG_LOCATION:-/var/log}
 
 
+#
+# Elasticsearch credentials
+#
+# Notice that all of these passwords change on each deployment.
 
-# Rotate ElasticSearch credentials
+# This is the root ElasticSearch password meant to be used internally by Kibana,
+# Metricbeat and other applications that require admin-level access for managing indices etc.
 ROTATING_ELASTIC_PASSWORD=`generate_password`
-# Used for Metricsbeat -> ElasticSearch communication
-ROTATING_METRICBEAT_ELASTIC_PASSWORD=`generate_password`
-# Used for APM -> ElasticSearch communication
-ROTATING_APM_ELASTIC_PASSWORD=`generate_password`
-# Application password
+
+# Application password for OpenCRVS Search
 ROTATING_SEARCH_ELASTIC_PASSWORD=`generate_password`
+# If new applications require access to ElasticSearch, new passwords should be generated here.
+# Remember to add the user to infrastructure/elasticsearch/setup-users.sh so it is created when you deploy.
+
+# Used by Metricsbeat when writing data to ElasticSearch
+ROTATING_METRICBEAT_ELASTIC_PASSWORD=`generate_password`
+
+# Used by APM for writing data to ElasticSearch
+ROTATING_APM_ELASTIC_PASSWORD=`generate_password`
 
 echo
 echo "Deploying VERSION $VERSION to $SSH_HOST..."

--- a/deploy.sh
+++ b/deploy.sh
@@ -103,6 +103,17 @@ SSH_USER=${SSH_USER:-root}
 SSH_HOST=${SSH_HOST:-$HOST}
 LOG_LOCATION=${LOG_LOCATION:-/var/log}
 
+# Create new passwords for all MongoDB users created in
+# infrastructure/mongodb/docker-entrypoint-initdb.d/create-mongo-users.sh
+#
+# If you're adding a new MongoDB user, you'll need to also create a new update statement in
+# infrastructure/mongodb/on-deploy.sh
+
+USER_MGNT_MONGODB_PASSWORD=`generate_password`
+HEARTH_MONGODB_PASSWORD=`generate_password`
+CONFIG_MONGODB_PASSWORD=`generate_password`
+OPENHIM_MONGODB_PASSWORD=`generate_password`
+WEBHOOKS_MONGODB_PASSWORD=`generate_password`
 
 #
 # Elasticsearch credentials

--- a/deploy.sh
+++ b/deploy.sh
@@ -104,6 +104,16 @@ SSH_HOST=${SSH_HOST:-$HOST}
 LOG_LOCATION=${LOG_LOCATION:-/var/log}
 
 
+
+# Rotate ElasticSearch credentials
+ROTATING_ELASTIC_PASSWORD=`generate_password`
+# Used for Metricsbeat -> ElasticSearch communication
+ROTATING_METRICBEAT_ELASTIC_PASSWORD=`generate_password`
+# Used for APM -> ElasticSearch communication
+ROTATING_APM_ELASTIC_PASSWORD=`generate_password`
+# Application password
+ROTATING_SEARCH_ELASTIC_PASSWORD=`generate_password`
+
 echo
 echo "Deploying VERSION $VERSION to $SSH_HOST..."
 echo

--- a/deploy.sh
+++ b/deploy.sh
@@ -159,7 +159,31 @@ else
 fi
 
 # Setup configuration files and compose file for the deployment domain
-ssh $SSH_USER@$SSH_HOST "KIBANA_USERNAME=$KIBANA_USERNAME KIBANA_PASSWORD=$KIBANA_PASSWORD SLACK_WEBHOOK_URL=$SLACK_WEBHOOK_URL /tmp/compose/infrastructure/setup-deploy-config.sh $HOST | tee -a $LOG_LOCATION/setup-deploy-config.log"
+ssh $SSH_USER@$SSH_HOST "SLACK_WEBHOOK_URL=$SLACK_WEBHOOK_URL /tmp/compose/infrastructure/setup-deploy-config.sh $HOST | tee -a $LOG_LOCATION/setup-deploy-config.log"
+
+docker_stack_deploy() {
+  local environment_compose=${1}
+  ssh $SSH_USER@$SSH_HOST 'cd /tmp/compose && \
+    HOSTNAME='$HOST' \
+    VERSION='$VERSION' \
+    COUNTRY_CONFIG_VERSION='$COUNTRY_CONFIG_VERSION' \
+    PAPERTRAIL='$PAPERTRAIL' \
+    USER_MGNT_MONGODB_PASSWORD='$USER_MGNT_MONGODB_PASSWORD' \
+    HEARTH_MONGODB_PASSWORD='$HEARTH_MONGODB_PASSWORD' \
+    CONFIG_MONGODB_PASSWORD='$CONFIG_MONGODB_PASSWORD' \
+    OPENHIM_MONGODB_PASSWORD='$OPENHIM_MONGODB_PASSWORD' \
+    WEBHOOKS_MONGODB_PASSWORD='$WEBHOOKS_MONGODB_PASSWORD' \
+    MONGODB_ADMIN_USER='$MONGODB_ADMIN_USER' \
+    MONGODB_ADMIN_PASSWORD='$MONGODB_ADMIN_PASSWORD' \
+    ROTATING_ELASTIC_PASSWORD='$ROTATING_ELASTIC_PASSWORD' \
+    ROTATING_METRICBEAT_ELASTIC_PASSWORD='$ROTATING_METRICBEAT_ELASTIC_PASSWORD' \
+    ROTATING_APM_ELASTIC_PASSWORD='$ROTATING_APM_ELASTIC_PASSWORD' \
+    ROTATING_SEARCH_ELASTIC_PASSWORD='$ROTATING_SEARCH_ELASTIC_PASSWORD' \
+    KIBANA_USERNAME='$KIBANA_USERNAME' \
+    KIBANA_PASSWORD='$KIBANA_PASSWORD' \
+    docker stack deploy -c docker-compose.deps.yml -c docker-compose.yml -c docker-compose.deploy.yml -c '$environment_compose' --with-registry-auth opencrvs'
+}
+
 
 # Deploy the OpenCRVS stack onto the swarm
 if [[ "$ENV" = "development" ]]; then

--- a/deploy.sh
+++ b/deploy.sh
@@ -93,6 +93,21 @@ if [ -z "$KIBANA_PASSWORD" ] ; then
     print_usage_and_exit
 fi
 
+if [ -z "$ELASTICSEARCH_SUPERUSER_PASSWORD" ] ; then
+    echo 'Error: Missing environment variable ELASTICSEARCH_SUPERUSER_PASSWORD.'
+    print_usage_and_exit
+fi
+
+if [ -z "$MONGODB_ADMIN_USER" ] ; then
+    echo 'Error: Missing environment variable MONGODB_ADMIN_USER.'
+    print_usage_and_exit
+fi
+
+if [ -z "$MONGODB_ADMIN_PASSWORD" ] ; then
+    echo 'Error: Missing environment variable MONGODB_ADMIN_PASSWORD.'
+    print_usage_and_exit
+fi
+
 ENV=$4
 HOST=$5
 VERSION=$6
@@ -119,10 +134,6 @@ WEBHOOKS_MONGODB_PASSWORD=`generate_password`
 # Elasticsearch credentials
 #
 # Notice that all of these passwords change on each deployment.
-
-# This is the root ElasticSearch password meant to be used internally by Kibana,
-# Metricbeat and other applications that require admin-level access for managing indices etc.
-ROTATING_ELASTIC_PASSWORD=`generate_password`
 
 # Application password for OpenCRVS Search
 ROTATING_SEARCH_ELASTIC_PASSWORD=`generate_password`
@@ -196,7 +207,7 @@ docker_stack_deploy() {
     WEBHOOKS_MONGODB_PASSWORD='$WEBHOOKS_MONGODB_PASSWORD' \
     MONGODB_ADMIN_USER='$MONGODB_ADMIN_USER' \
     MONGODB_ADMIN_PASSWORD='$MONGODB_ADMIN_PASSWORD' \
-    ROTATING_ELASTIC_PASSWORD='$ROTATING_ELASTIC_PASSWORD' \
+    ELASTICSEARCH_SUPERUSER_PASSWORD='$ELASTICSEARCH_SUPERUSER_PASSWORD' \
     ROTATING_METRICBEAT_ELASTIC_PASSWORD='$ROTATING_METRICBEAT_ELASTIC_PASSWORD' \
     ROTATING_APM_ELASTIC_PASSWORD='$ROTATING_APM_ELASTIC_PASSWORD' \
     ROTATING_SEARCH_ELASTIC_PASSWORD='$ROTATING_SEARCH_ELASTIC_PASSWORD' \

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -44,10 +44,14 @@ services:
       - /:/hostfs:ro
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
-      - KIBANA_HOST=kibana:5601
       - ELASTICSEARCH_HOST=elasticsearch:9200
-      - ELASTICSEARCH_USERNAME=beats_system
-      - ELASTICSEARCH_PASSWORD=${ROTATING_METRICBEAT_ELASTIC_PASSWORD}
+      - ELASTICSEARCH_USERNAME=elastic
+      - ELASTICSEARCH_PASSWORD=${ROTATING_ELASTIC_PASSWORD}
+      - KIBANA_HOST=kibana:5601
+      - KIBANA_USERNAME=${KIBANA_USERNAME}
+      - KIBANA_PASSWORD=${KIBANA_PASSWORD}
+      - BEATS_USERNAME=beats_system
+      - BEATS_PASSWORD=${ROTATING_METRICBEAT_ELASTIC_PASSWORD}
     command: ['--strict.perms=false', '-system.hostfs=/hostfs']
     hostname: 'metricbeat-{{.Node.Hostname}}'
     restart: always
@@ -68,6 +72,8 @@ services:
     depends_on:
       - kibana
     environment:
+      - KIBANA_USERNAME=${KIBANA_USERNAME}
+      - KIBANA_PASSWORD=${KIBANA_PASSWORD}
       - KIBANA_HOST=kibana
       - KIBANA_PORT=5601
     volumes:
@@ -166,7 +172,7 @@ services:
       - KIBANA_USERNAME=${KIBANA_USERNAME}
       - KIBANA_PASSWORD=${KIBANA_PASSWORD}
     volumes:
-      - './infrastructure/elasticsearch:/usr/app'
+      - '/tmp/compose/infrastructure/elasticsearch:/usr/app'
     networks:
       - overlay_net
     deploy:
@@ -200,9 +206,22 @@ services:
     networks:
       - overlay_net
     deploy:
-      replicas: 3
-    command: >
-      apm-server -e -c apm-server.yml
+      replicas: 1
+    command:
+      [
+        'apm-server',
+        '-e',
+        '-c',
+        'apm-server.yml',
+        '-E',
+        'output.elasticsearch.username=elastic',
+        '-E',
+        'output.elasticsearch.password=${ROTATING_ELASTIC_PASSWORD}',
+        '-E',
+        'kibana.username=${KIBANA_USERNAME}',
+        '-E',
+        'kibana.password=${KIBANA_PASSWORD}'
+      ]
     configs:
       - source: apm.{{ts}}
         target: /usr/share/apm-server/apm-server.yml
@@ -350,6 +369,7 @@ services:
     secrets:
       - jwt-public-key.{{ts}}
     environment:
+      - ES_HOST=search-user:${ROTATING_SEARCH_ELASTIC_PASSWORD}@elasticsearch:9200
       - APN_SERVICE_URL=http://apm-server:8200
       - CERT_PUBLIC_KEY_PATH=/run/secrets/jwt-public-key.{{ts}}
     deploy:

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -46,7 +46,7 @@ services:
     environment:
       - ELASTICSEARCH_HOST=elasticsearch:9200
       - ELASTICSEARCH_USERNAME=elastic
-      - ELASTICSEARCH_PASSWORD=${ROTATING_ELASTIC_PASSWORD}
+      - ELASTICSEARCH_PASSWORD=${ELASTICSEARCH_SUPERUSER_PASSWORD}
       - KIBANA_HOST=kibana:5601
       - KIBANA_USERNAME=${KIBANA_USERNAME}
       - KIBANA_PASSWORD=${KIBANA_PASSWORD}
@@ -97,12 +97,15 @@ services:
         - 'traefik.docker.network=opencrvs_overlay_net'
     networks:
       - overlay_net
+    environment:
+      - ELASTICSEARCH_USERNAME=elastic
+      - ELASTICSEARCH_PASSWORD=${ELASTICSEARCH_SUPERUSER_PASSWORD}
     configs:
       - source: kibana.{{ts}}
         target: /usr/share/kibana/config/kibana.yml
     environment:
       - ELASTICSEARCH_USERNAME=elastic
-      - ELASTICSEARCH_PASSWORD=${ROTATING_ELASTIC_PASSWORD}
+      - ELASTICSEARCH_PASSWORD=${ELASTICSEARCH_SUPERUSER_PASSWORD}
     depends_on:
       - elasticsearch
 
@@ -152,7 +155,7 @@ services:
     ports:
       - 9200:9200
     environment:
-      - ELASTIC_PASSWORD=${ROTATING_ELASTIC_PASSWORD}
+      - ELASTIC_PASSWORD=${ELASTICSEARCH_SUPERUSER_PASSWORD}
     networks:
       - overlay_net
 
@@ -164,7 +167,7 @@ services:
       - elasticsearch
     environment:
       - ELASTICSEARCH_HOST=elasticsearch
-      - ELASTIC_PASSWORD=${ROTATING_ELASTIC_PASSWORD}
+      - ELASTIC_PASSWORD=${ELASTICSEARCH_SUPERUSER_PASSWORD}
       - METRICBEAT_ELASTIC_PASSWORD=${ROTATING_METRICBEAT_ELASTIC_PASSWORD}
       - APM_ELASTIC_PASSWORD=${ROTATING_APM_ELASTIC_PASSWORD}
       - SEARCH_ELASTIC_USERNAME=search-user
@@ -216,7 +219,7 @@ services:
         '-E',
         'output.elasticsearch.username=elastic',
         '-E',
-        'output.elasticsearch.password=${ROTATING_ELASTIC_PASSWORD}',
+        'output.elasticsearch.password=${ELASTICSEARCH_SUPERUSER_PASSWORD}',
         '-E',
         'kibana.username=${KIBANA_USERNAME}',
         '-E',

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -46,8 +46,8 @@ services:
     environment:
       - KIBANA_HOST=kibana:5601
       - ELASTICSEARCH_HOST=elasticsearch:9200
-      - ELASTICSEARCH_USERNAME=elastic
-      - ELASTICSEARCH_PASSWORD=changeme
+      - ELASTICSEARCH_USERNAME=beats_system
+      - ELASTICSEARCH_PASSWORD=${ROTATING_METRICBEAT_ELASTIC_PASSWORD}
     command: ['--strict.perms=false', '-system.hostfs=/hostfs']
     hostname: 'metricbeat-{{.Node.Hostname}}'
     restart: always
@@ -77,6 +77,9 @@ services:
       - overlay_net
     deploy:
       replicas: 1
+      placement:
+        constraints:
+          - node.role == manager
   kibana:
     restart: always
     deploy:
@@ -84,7 +87,6 @@ services:
         # https://doc.traefik.io/traefik/v1.7/configuration/backends/docker/#labels-overriding-default-behavior
         - 'traefik.enable=true'
         - 'traefik.frontend.rule=Host: kibana.{{hostname}}'
-        - 'traefik.frontend.auth.basic.usersFile=/run/secrets/kibana-htpasswd'
         - 'traefik.port=5601'
         - 'traefik.docker.network=opencrvs_overlay_net'
     networks:
@@ -92,6 +94,9 @@ services:
     configs:
       - source: kibana.{{ts}}
         target: /usr/share/kibana/config/kibana.yml
+    environment:
+      - ELASTICSEARCH_USERNAME=elastic
+      - ELASTICSEARCH_PASSWORD=${ROTATING_ELASTIC_PASSWORD}
     depends_on:
       - elasticsearch
 
@@ -129,18 +134,46 @@ services:
   # Configure elasticsearch
   elasticsearch:
     volumes:
-      - '/data/elasticsearch:/usr/share/elasticsearch/data'
-      - '/data/backups/elasticsearch:/data/backups/elasticsearch'
-      - '/tmp/compose/infrastructure/elasticsearch/elasticsearch.yml:/config/elasticsearch.yml'
-      - '/tmp/compose/infrastructure/elasticsearch/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml'
+      - './data/elasticsearch:/usr/share/elasticsearch/data'
+      - './data/backups/elasticsearch:/data/backups/elasticsearch'
+      - './infrastructure/elasticsearch/elasticsearch.yml:/config/elasticsearch.yml'
+      - './infrastructure/elasticsearch/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml'
     deploy:
       replicas: 1
       placement:
         constraints:
           - node.labels.data1 == true
+    ports:
+      - 9200:9200
+    environment:
+      - ELASTIC_PASSWORD=${ROTATING_ELASTIC_PASSWORD}
     networks:
       - overlay_net
 
+  setup-elasticsearch-users:
+    image: ubuntu:bionic
+    entrypoint: ['bash', '/usr/app/setup-users.sh']
+    restart: on-failure
+    depends_on:
+      - elasticsearch
+    environment:
+      - ELASTICSEARCH_HOST=elasticsearch
+      - ELASTIC_PASSWORD=${ROTATING_ELASTIC_PASSWORD}
+      - METRICBEAT_ELASTIC_PASSWORD=${ROTATING_METRICBEAT_ELASTIC_PASSWORD}
+      - APM_ELASTIC_PASSWORD=${ROTATING_APM_ELASTIC_PASSWORD}
+      - SEARCH_ELASTIC_USERNAME=search-user
+      - SEARCH_ELASTIC_PASSWORD=${ROTATING_SEARCH_ELASTIC_PASSWORD}
+      - KIBANA_USERNAME=${KIBANA_USERNAME}
+      - KIBANA_PASSWORD=${KIBANA_PASSWORD}
+    volumes:
+      - './infrastructure/elasticsearch:/usr/app'
+    networks:
+      - overlay_net
+    deploy:
+      replicas: 1
+      placement:
+        constraints:
+          - node.role == manager
   elastalert:
     image: jertel/elastalert2:2.3.0
     restart: unless-stopped

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -140,10 +140,10 @@ services:
   # Configure elasticsearch
   elasticsearch:
     volumes:
-      - './data/elasticsearch:/usr/share/elasticsearch/data'
-      - './data/backups/elasticsearch:/data/backups/elasticsearch'
-      - './infrastructure/elasticsearch/elasticsearch.yml:/config/elasticsearch.yml'
-      - './infrastructure/elasticsearch/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml'
+      - '/data/elasticsearch:/usr/share/elasticsearch/data'
+      - '/data/backups/elasticsearch:/data/backups/elasticsearch'
+      - '/tmp/compose/infrastructure/elasticsearch/elasticsearch.yml:/config/elasticsearch.yml'
+      - '/tmp/compose/infrastructure/elasticsearch/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml'
     deploy:
       replicas: 1
       placement:
@@ -511,13 +511,16 @@ configs:
     file: ./infrastructure/hearth-queryparam-extensions.json
   metricbeat-conf.{{ts}}:
     file: ./infrastructure/monitoring/beats/metricbeat.yml
+  mongo-init.{{ts}}:
+    file: ./infrastructure/mongodb/docker-entrypoint-initdb.d/create-mongo-users.sh
+  mongo-on-deploy.{{ts}}:
+    file: ./infrastructure/mongodb/on-deploy.sh
   metricbeat-rollover-policy.{{ts}}:
     file: ./infrastructure/monitoring/beats/rollover-policy.json
   kibana.{{ts}}:
     file: ./infrastructure/monitoring/kibana/kibana.yml
   apm.{{ts}}:
     file: ./infrastructure/monitoring/apm/apm-server.yml
-
 networks:
   overlay_net:
     driver: overlay

--- a/infrastructure/clear-all-data.sh
+++ b/infrastructure/clear-all-data.sh
@@ -88,7 +88,7 @@ docker run --rm --network=$NETWORK mongo:4.4 mongo application-config --host $HO
 
 # Delete all data from elasticsearch
 #-----------------------------------
-docker run --rm --network=$NETWORK appropriate/curl curl -XDELETE 'http://$(elasticsearch_host)/*' -v
+docker run --rm --network=$NETWORK appropriate/curl curl -XDELETE "http://$(elasticsearch_host)/*" -v
 
 # Delete all data from metrics
 #-----------------------------

--- a/infrastructure/elasticsearch/elasticsearch.yml
+++ b/infrastructure/elasticsearch/elasticsearch.yml
@@ -17,3 +17,4 @@ discovery.zen.minimum_master_nodes: 1
 path.repo: ['/data/backups/elasticsearch']
 discovery.type: single-node
 xpack.security.enabled: true
+xpack.security.authc.api_key.enabled: true

--- a/infrastructure/elasticsearch/elasticsearch.yml
+++ b/infrastructure/elasticsearch/elasticsearch.yml
@@ -16,3 +16,4 @@ network.host: 0.0.0.0
 discovery.zen.minimum_master_nodes: 1
 path.repo: ['/data/backups/elasticsearch']
 discovery.type: single-node
+xpack.security.enabled: true

--- a/infrastructure/elasticsearch/roles/kibana_user.json
+++ b/infrastructure/elasticsearch/roles/kibana_user.json
@@ -1,0 +1,27 @@
+{
+  "cluster": [
+    "cluster:monitor/main",
+    "cluster:monitor/xpack/info",
+    "cluster:monitor/remote/info"
+  ],
+  "indices": [
+    {
+      "names": ["*"],
+      "privileges": [
+        "view_index_metadata",
+        "monitor",
+        "read",
+        "read_cross_cluster"
+      ],
+      "allow_restricted_indices": false
+    }
+  ],
+  "run_as": [],
+  "applications": [
+    {
+      "application": "kibana-.kibana",
+      "privileges": ["all"],
+      "resources": ["*"]
+    }
+  ]
+}

--- a/infrastructure/elasticsearch/roles/search_user.json
+++ b/infrastructure/elasticsearch/roles/search_user.json
@@ -1,0 +1,8 @@
+{
+  "indices": [
+    {
+      "names": ["ocrvs"],
+      "privileges": ["write", "create", "create_index"]
+    }
+  ]
+}

--- a/infrastructure/elasticsearch/roles/search_user.json
+++ b/infrastructure/elasticsearch/roles/search_user.json
@@ -2,7 +2,7 @@
   "indices": [
     {
       "names": ["ocrvs"],
-      "privileges": ["write", "create", "create_index"]
+      "privileges": ["write", "create", "create_index", "delete", "read"]
     }
   ]
 }

--- a/infrastructure/elasticsearch/setup-helpers.sh
+++ b/infrastructure/elasticsearch/setup-helpers.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# OpenCRVS is also distributed under the terms of the Civil Registration
+# & Healthcare Disclaimer located at http://opencrvs.org/license.
+#
+# Copyright (C) The OpenCRVS Authors. OpenCRVS and the OpenCRVS
+# graphic logo are (registered/a) trademark(s) of Plan International.
+
+# Log a message.
+function log {
+	echo "[+] $1"
+}
+
+# Log a message at a sub-level.
+function sublog {
+	echo "   ⠿ $1"
+}
+
+# Log an error.
+function err {
+	echo "[x] $1" >&2
+}
+
+# Poll the 'elasticsearch' service until it responds with HTTP code 200.
+function wait_for_elasticsearch {
+	local elasticsearch_host="${ELASTICSEARCH_HOST:-elasticsearch}"
+
+	local -a args=( '-s' '-D-' '-m15' '-w' '%{http_code}' "http://${elasticsearch_host}:9200/" )
+
+	if [[ -n "${ELASTIC_PASSWORD:-}" ]]; then
+		args+=( '-u' "elastic:${ELASTIC_PASSWORD}" )
+	fi
+
+	local -i result=1
+	local output
+
+	# retry for max 300s (60*5s)
+	for _ in $(seq 1 60); do
+		output="$(curl "${args[@]}" || true)"
+		if [[ "${output: -3}" -eq 200 ]]; then
+			result=0
+			break
+		fi
+
+		sleep 5
+	done
+
+	if ((result)); then
+		echo -e "\n${output::-3}"
+	fi
+
+	return $result
+}
+
+# Verify that the given Elasticsearch user exists.
+function check_user_exists {
+	local username=$1
+
+	local elasticsearch_host="${ELASTICSEARCH_HOST:-elasticsearch}"
+
+	local -a args=( '-s' '-D-' '-m15' '-w' '%{http_code}'
+		"http://${elasticsearch_host}:9200/_security/user/${username}"
+		)
+
+	if [[ -n "${ELASTIC_PASSWORD:-}" ]]; then
+		args+=( '-u' "elastic:${ELASTIC_PASSWORD}" )
+	fi
+
+	local -i result=1
+	local -i exists=0
+	local output
+
+	output="$(curl "${args[@]}")"
+	if [[ "${output: -3}" -eq 200 || "${output: -3}" -eq 404 ]]; then
+		result=0
+	fi
+	if [[ "${output: -3}" -eq 200 ]]; then
+		exists=1
+	fi
+
+	if ((result)); then
+		echo -e "\n${output::-3}"
+	else
+		echo "$exists"
+	fi
+
+	return $result
+}
+
+# Set password of a given Elasticsearch user.
+function set_user_password {
+	local username=$1
+	local password=$2
+
+	local elasticsearch_host="${ELASTICSEARCH_HOST:-elasticsearch}"
+
+	local -a args=( '-s' '-D-' '-m15' '-w' '%{http_code}'
+		"http://${elasticsearch_host}:9200/_security/user/${username}/_password"
+		'-X' 'POST'
+		'-H' 'Content-Type: application/json'
+		'-d' "{\"password\" : \"${password}\"}"
+		)
+
+	if [[ -n "${ELASTIC_PASSWORD:-}" ]]; then
+		args+=( '-u' "elastic:${ELASTIC_PASSWORD}" )
+	fi
+
+	local -i result=1
+	local output
+
+	output="$(curl "${args[@]}")"
+	if [[ "${output: -3}" -eq 200 ]]; then
+		result=0
+	fi
+
+	if ((result)); then
+		echo -e "\n${output::-3}\n"
+	fi
+
+	return $result
+}
+
+# Create the given Elasticsearch user.
+function create_user {
+	local username=$1
+	local password=$2
+	local role=$3
+
+	local elasticsearch_host="${ELASTICSEARCH_HOST:-elasticsearch}"
+
+	local -a args=( '-s' '-D-' '-m15' '-w' '%{http_code}'
+		"http://${elasticsearch_host}:9200/_security/user/${username}"
+		'-X' 'POST'
+		'-H' 'Content-Type: application/json'
+		'-d' "{\"password\":\"${password}\",\"roles\":[\"${role}\"]}"
+		)
+
+	if [[ -n "${ELASTIC_PASSWORD:-}" ]]; then
+		args+=( '-u' "elastic:${ELASTIC_PASSWORD}" )
+	fi
+
+	local -i result=1
+	local output
+
+	output="$(curl "${args[@]}")"
+	if [[ "${output: -3}" -eq 200 ]]; then
+		result=0
+	fi
+
+	if ((result)); then
+		echo -e "\n${output::-3}\n"
+	fi
+
+	return $result
+}
+
+# Ensure that the given Elasticsearch role is up-to-date, create it if required.
+function ensure_role {
+	local name=$1
+	local body=$2
+
+	local elasticsearch_host="${ELASTICSEARCH_HOST:-elasticsearch}"
+
+	local -a args=( '-s' '-D-' '-m15' '-w' '%{http_code}'
+		"http://${elasticsearch_host}:9200/_security/role/${name}"
+		'-X' 'POST'
+		'-H' 'Content-Type: application/json'
+		'-d' "$body"
+		)
+
+	if [[ -n "${ELASTIC_PASSWORD:-}" ]]; then
+		args+=( '-u' "elastic:${ELASTIC_PASSWORD}" )
+	fi
+
+	local -i result=1
+	local output
+
+	output="$(curl "${args[@]}")"
+	if [[ "${output: -3}" -eq 200 ]]; then
+		result=0
+	fi
+
+	if ((result)); then
+		echo -e "\n${output::-3}\n"
+	fi
+
+	return $result
+}

--- a/infrastructure/elasticsearch/setup-helpers.sh
+++ b/infrastructure/elasticsearch/setup-helpers.sh
@@ -12,191 +12,191 @@
 
 # Log a message.
 function log {
-	echo "[+] $1"
+  echo "[+] $1"
 }
 
 # Log a message at a sub-level.
 function sublog {
-	echo "   ⠿ $1"
+  echo "   ⠿ $1"
 }
 
 # Log an error.
 function err {
-	echo "[x] $1" >&2
+  echo "[x] $1" >&2
 }
 
 # Poll the 'elasticsearch' service until it responds with HTTP code 200.
 function wait_for_elasticsearch {
-	local elasticsearch_host="${ELASTICSEARCH_HOST:-elasticsearch}"
+  local elasticsearch_host="${ELASTICSEARCH_HOST:-elasticsearch}"
 
-	local -a args=( '-s' '-D-' '-m15' '-w' '%{http_code}' "http://${elasticsearch_host}:9200/" )
+  local -a args=( '-s' '-D-' '-m15' '-w' '%{http_code}' "http://${elasticsearch_host}:9200/" )
 
-	if [[ -n "${ELASTIC_PASSWORD:-}" ]]; then
-		args+=( '-u' "elastic:${ELASTIC_PASSWORD}" )
-	fi
+  if [[ -n "${ELASTIC_PASSWORD:-}" ]]; then
+    args+=( '-u' "elastic:${ELASTIC_PASSWORD}" )
+  fi
 
-	local -i result=1
-	local output
+  local -i result=1
+  local output
 
-	# retry for max 300s (60*5s)
-	for _ in $(seq 1 60); do
-		output="$(curl "${args[@]}" || true)"
-		if [[ "${output: -3}" -eq 200 ]]; then
-			result=0
-			break
-		fi
+  # retry for max 300s (60*5s)
+  for _ in $(seq 1 60); do
+    output="$(curl "${args[@]}" || true)"
+    if [[ "${output: -3}" -eq 200 ]]; then
+      result=0
+      break
+    fi
 
-		sleep 5
-	done
+    sleep 5
+  done
 
-	if ((result)); then
-		echo -e "\n${output::-3}"
-	fi
+  if ((result)); then
+    echo -e "\n${output::-3}"
+  fi
 
-	return $result
+  return $result
 }
 
 # Verify that the given Elasticsearch user exists.
 function check_user_exists {
-	local username=$1
+  local username=$1
 
-	local elasticsearch_host="${ELASTICSEARCH_HOST:-elasticsearch}"
+  local elasticsearch_host="${ELASTICSEARCH_HOST:-elasticsearch}"
 
-	local -a args=( '-s' '-D-' '-m15' '-w' '%{http_code}'
-		"http://${elasticsearch_host}:9200/_security/user/${username}"
-		)
+  local -a args=( '-s' '-D-' '-m15' '-w' '%{http_code}'
+    "http://${elasticsearch_host}:9200/_security/user/${username}"
+    )
 
-	if [[ -n "${ELASTIC_PASSWORD:-}" ]]; then
-		args+=( '-u' "elastic:${ELASTIC_PASSWORD}" )
-	fi
+  if [[ -n "${ELASTIC_PASSWORD:-}" ]]; then
+    args+=( '-u' "elastic:${ELASTIC_PASSWORD}" )
+  fi
 
-	local -i result=1
-	local -i exists=0
-	local output
+  local -i result=1
+  local -i exists=0
+  local output
 
-	output="$(curl "${args[@]}")"
-	if [[ "${output: -3}" -eq 200 || "${output: -3}" -eq 404 ]]; then
-		result=0
-	fi
-	if [[ "${output: -3}" -eq 200 ]]; then
-		exists=1
-	fi
+  output="$(curl "${args[@]}")"
+  if [[ "${output: -3}" -eq 200 || "${output: -3}" -eq 404 ]]; then
+    result=0
+  fi
+  if [[ "${output: -3}" -eq 200 ]]; then
+    exists=1
+  fi
 
-	if ((result)); then
-		echo -e "\n${output::-3}"
-	else
-		echo "$exists"
-	fi
+  if ((result)); then
+    echo -e "\n${output::-3}"
+  else
+    echo "$exists"
+  fi
 
-	return $result
+  return $result
 }
 
 # Set password of a given Elasticsearch user.
 function update_user {
-	local username=$1
-	local password=$2
-	local role=${3:-}
+  local username=$1
+  local password=$2
+  local role=${3:-}
 
-	local elasticsearch_host="${ELASTICSEARCH_HOST:-elasticsearch}"
+  local elasticsearch_host="${ELASTICSEARCH_HOST:-elasticsearch}"
 
-	if [[ -n "${role:-}" ]]; then
-		local -a args=( '-s' '-D-' '-m15' '-w' '%{http_code}'
-			"http://${elasticsearch_host}:9200/_security/user/${username}"
-			'-X' 'PUT'
-			'-H' 'Content-Type: application/json'
-			'-d' "{\"password\" : \"${password}\",\"roles\":[\"${role}\"]}}"
-		)
-	else
-		local -a args=( '-s' '-D-' '-m15' '-w' '%{http_code}'
-			"http://${elasticsearch_host}:9200/_security/user/${username}/_password"
-			'-X' 'POST'
-			'-H' 'Content-Type: application/json'
-			'-d' "{\"password\" : \"${password}\"}"
-		)
-	fi
+  if [[ -n "${role:-}" ]]; then
+    local -a args=( '-s' '-D-' '-m15' '-w' '%{http_code}'
+      "http://${elasticsearch_host}:9200/_security/user/${username}"
+      '-X' 'PUT'
+      '-H' 'Content-Type: application/json'
+      '-d' "{\"password\" : \"${password}\",\"roles\":[\"${role}\"]}}"
+    )
+  else
+    local -a args=( '-s' '-D-' '-m15' '-w' '%{http_code}'
+      "http://${elasticsearch_host}:9200/_security/user/${username}/_password"
+      '-X' 'POST'
+      '-H' 'Content-Type: application/json'
+      '-d' "{\"password\" : \"${password}\"}"
+    )
+  fi
 
-	if [[ -n "${ELASTIC_PASSWORD:-}" ]]; then
-		args+=( '-u' "elastic:${ELASTIC_PASSWORD}" )
-	fi
+  if [[ -n "${ELASTIC_PASSWORD:-}" ]]; then
+    args+=( '-u' "elastic:${ELASTIC_PASSWORD}" )
+  fi
 
-	local -i result=1
-	local output
+  local -i result=1
+  local output
 
-	output="$(curl "${args[@]}")"
-	if [[ "${output: -3}" -eq 200 ]]; then
-		result=0
-	fi
+  output="$(curl "${args[@]}")"
+  if [[ "${output: -3}" -eq 200 ]]; then
+    result=0
+  fi
 
-	if ((result)); then
-		echo -e "\n${output::-3}\n"
-	fi
+  if ((result)); then
+    echo -e "\n${output::-3}\n"
+  fi
 
-	return $result
+  return $result
 }
 
 # Create the given Elasticsearch user.
 function create_user {
-	local username=$1
-	local password=$2
-	local role=$3
+  local username=$1
+  local password=$2
+  local role=$3
 
-	local elasticsearch_host="${ELASTICSEARCH_HOST:-elasticsearch}"
+  local elasticsearch_host="${ELASTICSEARCH_HOST:-elasticsearch}"
 
-	local -a args=( '-s' '-D-' '-m15' '-w' '%{http_code}'
-		"http://${elasticsearch_host}:9200/_security/user/${username}"
-		'-X' 'POST'
-		'-H' 'Content-Type: application/json'
-		'-d' "{\"password\":\"${password}\",\"roles\":[\"${role}\"]}"
-		)
+  local -a args=( '-s' '-D-' '-m15' '-w' '%{http_code}'
+    "http://${elasticsearch_host}:9200/_security/user/${username}"
+    '-X' 'POST'
+    '-H' 'Content-Type: application/json'
+    '-d' "{\"password\":\"${password}\",\"roles\":[\"${role}\"]}"
+    )
 
-	if [[ -n "${ELASTIC_PASSWORD:-}" ]]; then
-		args+=( '-u' "elastic:${ELASTIC_PASSWORD}" )
-	fi
+  if [[ -n "${ELASTIC_PASSWORD:-}" ]]; then
+    args+=( '-u' "elastic:${ELASTIC_PASSWORD}" )
+  fi
 
-	local -i result=1
-	local output
+  local -i result=1
+  local output
 
-	output="$(curl "${args[@]}")"
-	if [[ "${output: -3}" -eq 200 ]]; then
-		result=0
-	fi
+  output="$(curl "${args[@]}")"
+  if [[ "${output: -3}" -eq 200 ]]; then
+    result=0
+  fi
 
-	if ((result)); then
-		echo -e "\n${output::-3}\n"
-	fi
+  if ((result)); then
+    echo -e "\n${output::-3}\n"
+  fi
 
-	return $result
+  return $result
 }
 
 # Ensure that the given Elasticsearch role is up-to-date, create it if required.
 function ensure_role {
-	local name=$1
-	local body=$2
+  local name=$1
+  local body=$2
 
-	local elasticsearch_host="${ELASTICSEARCH_HOST:-elasticsearch}"
+  local elasticsearch_host="${ELASTICSEARCH_HOST:-elasticsearch}"
 
-	local -a args=( '-s' '-D-' '-m15' '-w' '%{http_code}'
-		"http://${elasticsearch_host}:9200/_security/role/${name}"
-		'-X' 'PUT'
-		'-H' 'Content-Type: application/json'
-		'-d' "$body"
-		)
+  local -a args=( '-s' '-D-' '-m15' '-w' '%{http_code}'
+    "http://${elasticsearch_host}:9200/_security/role/${name}"
+    '-X' 'PUT'
+    '-H' 'Content-Type: application/json'
+    '-d' "$body"
+    )
 
-	if [[ -n "${ELASTIC_PASSWORD:-}" ]]; then
-		args+=( '-u' "elastic:${ELASTIC_PASSWORD}" )
-	fi
+  if [[ -n "${ELASTIC_PASSWORD:-}" ]]; then
+    args+=( '-u' "elastic:${ELASTIC_PASSWORD}" )
+  fi
 
-	local -i result=1
-	local output
+  local -i result=1
+  local output
 
-	output="$(curl "${args[@]}")"
-	if [[ "${output: -3}" -eq 200 ]]; then
-		result=0
-	fi
+  output="$(curl "${args[@]}")"
+  if [[ "${output: -3}" -eq 200 ]]; then
+    result=0
+  fi
 
-	if ((result)); then
-		echo -e "\n${output::-3}\n"
-	fi
+  if ((result)); then
+    echo -e "\n${output::-3}\n"
+  fi
 
-	return $result
+  return $result
 }

--- a/infrastructure/elasticsearch/setup-users.sh
+++ b/infrastructure/elasticsearch/setup-users.sh
@@ -21,6 +21,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/setup-helpers.sh"
 
 # --------------------------------------------------------
 # Users declarations
+# All new users should be added to this list
 
 declare -A users_passwords
 users_passwords=(
@@ -30,6 +31,9 @@ users_passwords=(
 	[$KIBANA_USERNAME]="${KIBANA_PASSWORD:-}"
 )
 
+# -------------------------------------
+# Role assignations for users
+# If you are adding a new user, remember to assign a role. You can use search_user as a template.
 declare -A users_roles
 users_roles=(
 	[$SEARCH_ELASTIC_USERNAME]='search_user'

--- a/infrastructure/elasticsearch/setup-users.sh
+++ b/infrastructure/elasticsearch/setup-users.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# OpenCRVS is also distributed under the terms of the Civil Registration
+# & Healthcare Disclaimer located at http://opencrvs.org/license.
+#
+# Copyright (C) The OpenCRVS Authors. OpenCRVS and the OpenCRVS
+# graphic logo are (registered/a) trademark(s) of Plan International.
+
+set -eu
+set -o pipefail
+
+apt-get update
+apt-get install curl -y
+
+source "$(dirname "${BASH_SOURCE[0]}")/setup-helpers.sh"
+
+
+# --------------------------------------------------------
+# Users declarations
+
+declare -A users_passwords
+users_passwords=(
+	[$SEARCH_ELASTIC_USERNAME]="${SEARCH_ELASTIC_PASSWORD:-}"
+	[beats_system]="${METRICBEAT_ELASTIC_PASSWORD:-}"
+	[apm_system]="${APM_ELASTIC_PASSWORD:-}"
+	[$KIBANA_USERNAME]="${KIBANA_PASSWORD:-}"
+)
+
+declare -A users_roles
+users_roles=(
+	[$SEARCH_ELASTIC_USERNAME]='search_user'
+	[$KIBANA_USERNAME]='kibana_admin'
+)
+
+# --------------------------------------------------------
+# Roles declarations
+
+declare -A roles_files
+roles_files=(
+	[search_user]='search_user.json'
+)
+
+# --------------------------------------------------------
+
+
+echo "-------- $(date) --------"
+
+log 'Waiting for availability of Elasticsearch'
+wait_for_elasticsearch
+sublog 'Elasticsearch is running'
+
+for role in "${!roles_files[@]}"; do
+	log "Role '$role'"
+
+	declare body_file
+	body_file="$(dirname "${BASH_SOURCE[0]}")/roles/${roles_files[$role]:-}"
+	if [[ ! -f "${body_file:-}" ]]; then
+		sublog "No role body found at '${body_file}', skipping"
+		continue
+	fi
+
+	sublog 'Creating/updating'
+	ensure_role "$role" "$(<"${body_file}")"
+done
+
+for user in "${!users_passwords[@]}"; do
+	log "User '$user'"
+	if [[ -z "${users_passwords[$user]:-}" ]]; then
+		sublog 'No password defined, skipping'
+		continue
+	fi
+
+	declare -i user_exists=0
+	user_exists="$(check_user_exists "$user")"
+
+	if ((user_exists)); then
+		sublog 'User exists, setting password'
+		set_user_password "$user" "${users_passwords[$user]}"
+	else
+		if [[ -z "${users_roles[$user]:-}" ]]; then
+			err '  No role defined, skipping creation'
+			continue
+		fi
+
+		sublog 'User does not exist, creating'
+		create_user "$user" "${users_passwords[$user]}" "${users_roles[$user]}"
+	fi
+done

--- a/infrastructure/elasticsearch/setup-users.sh
+++ b/infrastructure/elasticsearch/setup-users.sh
@@ -33,7 +33,7 @@ users_passwords=(
 declare -A users_roles
 users_roles=(
 	[$SEARCH_ELASTIC_USERNAME]='search_user'
-	[$KIBANA_USERNAME]='kibana_admin'
+	[$KIBANA_USERNAME]='kibana_admin_user'
 )
 
 # --------------------------------------------------------
@@ -42,6 +42,7 @@ users_roles=(
 declare -A roles_files
 roles_files=(
 	[search_user]='search_user.json'
+	[kibana_admin_user]='kibana_user.json'
 )
 
 # --------------------------------------------------------
@@ -78,8 +79,13 @@ for user in "${!users_passwords[@]}"; do
 	user_exists="$(check_user_exists "$user")"
 
 	if ((user_exists)); then
-		sublog 'User exists, setting password'
-		set_user_password "$user" "${users_passwords[$user]}"
+		sublog 'User exists, updating user'
+
+		if [[ -z "${users_roles[$user]:-}" ]]; then
+			update_user "$user" "${users_passwords[$user]}"
+		else
+			update_user "$user" "${users_passwords[$user]}" "${users_roles[$user]}"
+		fi
 	else
 		if [[ -z "${users_roles[$user]:-}" ]]; then
 			err '  No role defined, skipping creation'

--- a/infrastructure/elasticsearch/setup-users.sh
+++ b/infrastructure/elasticsearch/setup-users.sh
@@ -25,10 +25,10 @@ source "$(dirname "${BASH_SOURCE[0]}")/setup-helpers.sh"
 
 declare -A users_passwords
 users_passwords=(
-	[$SEARCH_ELASTIC_USERNAME]="${SEARCH_ELASTIC_PASSWORD:-}"
-	[beats_system]="${METRICBEAT_ELASTIC_PASSWORD:-}"
-	[apm_system]="${APM_ELASTIC_PASSWORD:-}"
-	[$KIBANA_USERNAME]="${KIBANA_PASSWORD:-}"
+  [$SEARCH_ELASTIC_USERNAME]="${SEARCH_ELASTIC_PASSWORD:-}"
+  [beats_system]="${METRICBEAT_ELASTIC_PASSWORD:-}"
+  [apm_system]="${APM_ELASTIC_PASSWORD:-}"
+  [$KIBANA_USERNAME]="${KIBANA_PASSWORD:-}"
 )
 
 # -------------------------------------
@@ -36,8 +36,8 @@ users_passwords=(
 # If you are adding a new user, remember to assign a role. You can use search_user as a template.
 declare -A users_roles
 users_roles=(
-	[$SEARCH_ELASTIC_USERNAME]='search_user'
-	[$KIBANA_USERNAME]='kibana_admin_user'
+  [$SEARCH_ELASTIC_USERNAME]='search_user'
+  [$KIBANA_USERNAME]='kibana_admin_user'
 )
 
 # --------------------------------------------------------
@@ -45,8 +45,8 @@ users_roles=(
 
 declare -A roles_files
 roles_files=(
-	[search_user]='search_user.json'
-	[kibana_admin_user]='kibana_user.json'
+  [search_user]='search_user.json'
+  [kibana_admin_user]='kibana_user.json'
 )
 
 # --------------------------------------------------------
@@ -59,44 +59,44 @@ wait_for_elasticsearch
 sublog 'Elasticsearch is running'
 
 for role in "${!roles_files[@]}"; do
-	log "Role '$role'"
+  log "Role '$role'"
 
-	declare body_file
-	body_file="$(dirname "${BASH_SOURCE[0]}")/roles/${roles_files[$role]:-}"
-	if [[ ! -f "${body_file:-}" ]]; then
-		sublog "No role body found at '${body_file}', skipping"
-		continue
-	fi
+  declare body_file
+  body_file="$(dirname "${BASH_SOURCE[0]}")/roles/${roles_files[$role]:-}"
+  if [[ ! -f "${body_file:-}" ]]; then
+    sublog "No role body found at '${body_file}', skipping"
+    continue
+  fi
 
-	sublog 'Creating/updating'
-	ensure_role "$role" "$(<"${body_file}")"
+  sublog 'Creating/updating'
+  ensure_role "$role" "$(<"${body_file}")"
 done
 
 for user in "${!users_passwords[@]}"; do
-	log "User '$user'"
-	if [[ -z "${users_passwords[$user]:-}" ]]; then
-		sublog 'No password defined, skipping'
-		continue
-	fi
+  log "User '$user'"
+  if [[ -z "${users_passwords[$user]:-}" ]]; then
+    sublog 'No password defined, skipping'
+    continue
+  fi
 
-	declare -i user_exists=0
-	user_exists="$(check_user_exists "$user")"
+  declare -i user_exists=0
+  user_exists="$(check_user_exists "$user")"
 
-	if ((user_exists)); then
-		sublog 'User exists, updating user'
+  if ((user_exists)); then
+    sublog 'User exists, updating user'
 
-		if [[ -z "${users_roles[$user]:-}" ]]; then
-			update_user "$user" "${users_passwords[$user]}"
-		else
-			update_user "$user" "${users_passwords[$user]}" "${users_roles[$user]}"
-		fi
-	else
-		if [[ -z "${users_roles[$user]:-}" ]]; then
-			err '  No role defined, skipping creation'
-			continue
-		fi
+    if [[ -z "${users_roles[$user]:-}" ]]; then
+      update_user "$user" "${users_passwords[$user]}"
+    else
+      update_user "$user" "${users_passwords[$user]}" "${users_roles[$user]}"
+    fi
+  else
+    if [[ -z "${users_roles[$user]:-}" ]]; then
+      err '  No role defined, skipping creation'
+      continue
+    fi
 
-		sublog 'User does not exist, creating'
-		create_user "$user" "${users_passwords[$user]}" "${users_roles[$user]}"
-	fi
+    sublog 'User does not exist, creating'
+    create_user "$user" "${users_passwords[$user]}" "${users_roles[$user]}"
+  fi
 done

--- a/infrastructure/emergency-backup-metadata.sh
+++ b/infrastructure/emergency-backup-metadata.sh
@@ -117,7 +117,7 @@ docker run --rm -v /data/backups/mongo:/data/backups/mongo --network=$NETWORK mo
 
 # Register backup folder as an Elasticsearch repository for backing up the search data
 #-------------------------------------------------------------------------------------
-docker run --rm --network=$NETWORK appropriate/curl curl -XPUT -H "Content-Type: application/json;charset=UTF-8" 'http://$(elasticsearch_host)/_snapshot/ocrvs' -d '{ "type": "fs", "settings": { "location": "/data/backups/elasticsearch", "compress": true }}'
+docker run --rm --network=$NETWORK appropriate/curl curl -XPUT -H "Content-Type: application/json;charset=UTF-8" "http://$(elasticsearch_host)/_snapshot/ocrvs" -d '{ "type": "fs", "settings": { "location": "/data/backups/elasticsearch", "compress": true }}'
 
 # Backup Elasticsearch as a set of snapshot files into an elasticsearch sub folder
 #---------------------------------------------------------------------------------

--- a/infrastructure/emergency-restore-metadata.sh
+++ b/infrastructure/emergency-restore-metadata.sh
@@ -106,7 +106,7 @@ docker run --rm --network=$NETWORK mongo:4.4 mongo application-config --host $HO
 
 # Delete all data from search
 #----------------------------
-docker run --rm --network=$NETWORK appropriate/curl curl -XDELETE 'http://$(elasticsearch_host)/*' -v
+docker run --rm --network=$NETWORK appropriate/curl curl -XDELETE "http://$(elasticsearch_host)/*" -v
 
 # Delete all data from metrics
 #-----------------------------

--- a/infrastructure/emergency-restore-metadata.sh
+++ b/infrastructure/emergency-restore-metadata.sh
@@ -20,6 +20,12 @@ print_usage_and_exit () {
     echo "The Hearth, OpenHIM User and Application-config db backup zips you would like to restore from: hearth-dev-{date}.gz, openhim-dev-{date}.gz, user-mgnt-{date}.gz and  application-config-{date}.gz must exist in /data/backups/mongo/{date} folder"
     echo "The Elasticsearch backup folder /data/backups/elasticsearch must exist with all previous snapshots and indices. All files are required"
     echo "The InfluxDB backup files must exist in the /data/backups/influxdb/{date} folder"
+    echo ""
+    echo "If your MongoDB is password protected, an admin user's credentials can be given as environment variables:"
+    echo "MONGODB_ADMIN_USER=your_user MONGODB_ADMIN_PASSWORD=your_pass"
+    echo ""
+    echo "If your Elasticsearch is password protected, an admin user's credentials can be given as environment variables:"
+    echo "ELASTICSEARCH_ADMIN_USER=your_user ELASTICSEARCH_ADMIN_PASSWORD=your_pass"
     exit 1
 }
 
@@ -75,6 +81,22 @@ else
   exit 1
 fi
 
+mongo_credentials() {
+  if [ ! -z ${MONGODB_ADMIN_USER+x} ] || [ ! -z ${MONGODB_ADMIN_PASSWORD+x} ]; then
+    echo "--username $MONGODB_ADMIN_USER --password $MONGODB_ADMIN_PASSWORD --authenticationDatabase admin";
+  else
+    echo "";
+  fi
+}
+
+elasticsearch_host() {
+  if [ ! -z ${ELASTICSEARCH_ADMIN_USER+x} ] || [ ! -z ${ELASTICSEARCH_ADMIN_PASSWORD+x} ]; then
+    echo "$ELASTICSEARCH_ADMIN_USER:$ELASTICSEARCH_ADMIN_PASSWORD@elasticsearch:9200";
+  else
+    echo "elasticsearch:9200";
+  fi
+}
+
 # Delete all data from Hearth, OpenHIM, User and Application-config and any other service related Mongo databases
 #-----------------------------------------------------------------------------------
 docker run --rm --network=$NETWORK mongo:4.4 mongo hearth-dev --host $HOST --eval "db.dropDatabase()"
@@ -84,7 +106,7 @@ docker run --rm --network=$NETWORK mongo:4.4 mongo application-config --host $HO
 
 # Delete all data from search
 #----------------------------
-docker run --rm --network=$NETWORK appropriate/curl curl -XDELETE 'http://elasticsearch:9200/*' -v
+docker run --rm --network=$NETWORK appropriate/curl curl -XDELETE 'http://$(elasticsearch_host)/*' -v
 
 # Delete all data from metrics
 #-----------------------------
@@ -104,7 +126,7 @@ docker run --rm -v /data/backups/mongo:/data/backups/mongo --network=$NETWORK mo
 
 # Restore all data from a backup into search
 #-------------------------------------------
-docker run --rm --network=$NETWORK appropriate/curl curl -X POST "http://elasticsearch:9200/_snapshot/ocrvs/snapshot_$1/_restore?pretty"
+docker run --rm --network=$NETWORK appropriate/curl curl -X POST "http://$(elasticsearch_host)/_snapshot/ocrvs/snapshot_$1/_restore?pretty"
 
 # Get the container ID and host details of any running InfluxDB container, as the only way to restore is by using the Influxd CLI inside a running opencrvs_metrics container
 #----------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/infrastructure/mongodb/on-deploy.sh
+++ b/infrastructure/mongodb/on-deploy.sh
@@ -1,0 +1,80 @@
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# OpenCRVS is also distributed under the terms of the Civil Registration
+# & Healthcare Disclaimer located at http://opencrvs.org/license.
+#
+# Copyright (C) The OpenCRVS Authors. OpenCRVS and the OpenCRVS
+# graphic logo are (registered/a) trademark(s) of Plan International.
+
+# This file is run on each deployment with the sole purpose of updating
+# passwords of MongoDB users to passwords given to this service as environment varibles
+
+apt-get update
+apt-get install curl
+
+curl -L https://github.com/ufoscout/docker-compose-wait/releases/download/2.9.0/wait --output /wait
+chmod +x /wait
+
+WAIT_TIMEOUT=240 WAIT_HOSTS=mongo1:27017,mongo2:27017,mongo3:27017 /wait
+
+mongo_credentials() {
+  if [ ! -z ${MONGODB_ADMIN_USER+x} ] || [ ! -z ${MONGODB_ADMIN_PASSWORD+x} ]; then
+    echo "--username $MONGODB_ADMIN_USER --password $MONGODB_ADMIN_PASSWORD --authenticationDatabase admin";
+  else
+    echo "";
+  fi
+}
+
+# Initialise replica sets
+if [ "$REPLICAS" = "1" ]; then
+  mongo $(mongo_credentials) --host mongo1 --eval "rs.initiate({_id:\"rs0\",members:[{_id:0,host:\"mongo1:27017\"}]})"
+  HOST=rs0/mongo1
+elif [ "$REPLICAS" = "3" ]; then
+  mongo $(mongo_credentials) --host mongo1 --eval "rs.initiate({_id:\"rs0\",members:[{_id:0,host:\"mongo1:27017\"},{_id:1,host:\"mongo2:27017\"},{_id:2,host:\"mongo3:27017\"}]})"
+  HOST=rs0/mongo1,mongo2,mongo3
+elif [ "$REPLICAS" = "5" ]; then
+  mongo $(mongo_credentials) --host mongo1 --eval "rs.initiate({_id:\"rs0\",members:[{_id:0,host:\"mongo1:27017\"},{_id:1,host:\"mongo2:27017\"},{_id:2,host:\"mongo3:27017\"},{_id:3,host:\"mongo4:27017\"},{_id:4,host:\"mongo5:27017\"}]})"
+  HOST=rs0/mongo1,mongo2,mongo3,mongo4,mongo5
+else
+  echo "Script must be passed an understandable number of replicas: 0,1,3 or 5"
+  exit 1
+fi
+
+# Rotate passwords to match the ones given to this script
+mongo $(mongo_credentials) --host $HOST <<EOF
+  use hearth-dev
+  db.updateUser('hearth', {
+    pwd: '$HEARTH_MONGODB_PASSWORD'
+  })
+EOF
+
+mongo $(mongo_credentials) --host $HOST <<EOF
+  use user-mgnt
+  db.updateUser('user-mgnt', {
+    pwd: '$USER_MGNT_MONGODB_PASSWORD'
+  })
+EOF
+
+mongo $(mongo_credentials) --host $HOST <<EOF
+  use openhim-dev
+  db.updateUser('openhim', {
+    pwd: '$OPENHIM_MONGODB_PASSWORD'
+  })
+EOF
+
+mongo $(mongo_credentials) --host $HOST <<EOF
+  use application-config
+  db.updateUser('config', {
+    pwd: '$CONFIG_MONGODB_PASSWORD'
+  })
+EOF
+
+mongo $(mongo_credentials) --host $HOST <<EOF
+  use webhooks
+  db.updateUser('webhooks', {
+    pwd: '$WEBHOOKS_MONGODB_PASSWORD'
+  })
+EOF

--- a/infrastructure/monitoring/apm/apm-server.yml
+++ b/infrastructure/monitoring/apm/apm-server.yml
@@ -15,7 +15,7 @@
 
 apm-server:
   # Defines the host and port the server is listening on. Use "unix:/path/to.sock" to listen on a unix domain socket.
-  # host: "0.0.0.0:8200"
+  host: '0.0.0.0:8200'
 
   # Maximum permitted size in bytes of a request's header accepted by the server to be processed.
   #max_header_size: 1048576
@@ -298,8 +298,11 @@ apm-server:
 
     # Optional protocol and basic auth credentials.
     #protocol: "https"
+<<<<<<< HEAD
     #username: "elastic"
     #password: "changeme"
+=======
+>>>>>>> f18982dc4 (setup basic credentials and authentication for elasticsearch and applications using it)
 
     # Optional HTTP path.
     #path: ""
@@ -565,8 +568,11 @@ output.elasticsearch:
 
   # Authentication credentials - either API key or username/password.
   #api_key: "id:api_key"
+<<<<<<< HEAD
   ####username: ${ELASTICSEARCH_USERNAME:elastic}
   ####password: ${ELASTICSEARCH_PASSWORD:pass4elastic}
+=======
+>>>>>>> f18982dc4 (setup basic credentials and authentication for elasticsearch and applications using it)
 
   # Dictionary of HTTP parameters to pass within the url with index operations.
   #parameters:

--- a/infrastructure/monitoring/apm/apm-server.yml
+++ b/infrastructure/monitoring/apm/apm-server.yml
@@ -298,11 +298,6 @@ apm-server:
 
     # Optional protocol and basic auth credentials.
     #protocol: "https"
-<<<<<<< HEAD
-    #username: "elastic"
-    #password: "changeme"
-=======
->>>>>>> f18982dc4 (setup basic credentials and authentication for elasticsearch and applications using it)
 
     # Optional HTTP path.
     #path: ""
@@ -568,11 +563,6 @@ output.elasticsearch:
 
   # Authentication credentials - either API key or username/password.
   #api_key: "id:api_key"
-<<<<<<< HEAD
-  ####username: ${ELASTICSEARCH_USERNAME:elastic}
-  ####password: ${ELASTICSEARCH_PASSWORD:pass4elastic}
-=======
->>>>>>> f18982dc4 (setup basic credentials and authentication for elasticsearch and applications using it)
 
   # Dictionary of HTTP parameters to pass within the url with index operations.
   #parameters:

--- a/infrastructure/monitoring/beats/metricbeat.yml
+++ b/infrastructure/monitoring/beats/metricbeat.yml
@@ -82,16 +82,22 @@ setup.dashboards:
 #============================== Kibana =========================================
 setup.kibana:
   host: '${KIBANA_HOST}'
-  username: '{{KIBANA_USERNAME}}'
-  password: '{{KIBANA_PASSWORD}}'
+  username: ${KIBANA_USERNAME}
+  password: ${KIBANA_PASSWORD}
 
 #============================== Xpack Monitoring ===============================
 xpack.monitoring:
   enabled: true
   elasticsearch:
-
+    username: ${BEATS_USERNAME}
+    password: ${BEATS_PASSWORD}
+#============================== Index lifecycle management ===============================
 setup.ilm.enabled: true
 setup.ilm.policy_name: 'metricbeat-opencrvs-rollover-policy'
 setup.ilm.policy_file: /usr/share/metricbeat/rollover-policy.json
 setup.ilm.check_exists: true
 setup.ilm.overwrite: true
+
+#============================== Logging ===============================
+logging.level: info
+logging.to_stderr: true

--- a/infrastructure/monitoring/kibana/alert-rules.json
+++ b/infrastructure/monitoring/kibana/alert-rules.json
@@ -75,5 +75,30 @@
         }
       }
     ]
+  },
+  {
+    "params": {
+      "threshold": 1,
+      "windowSize": 1,
+      "windowUnit": "m",
+      "environment": "ENVIRONMENT_ALL"
+    },
+    "consumer": "alerts",
+    "schedule": { "interval": "1m" },
+    "tags": [],
+    "name": "Error in service",
+    "rule_type_id": "apm.error_rate",
+    "notify_when": "onActionGroupChange",
+    "actions": [
+      {
+        "group": "threshold_met",
+        "id": "preconfigured-alert-history-es-index",
+        "params": {
+          "documents": [
+            "{\"@timestamp\":\"2022-04-18T07:05:33.819Z\",\"tags\":\"{{rule.tags}}\",\"rule\":{\"id\":\"{{rule.id}}\",\"name\":\"{{rule.name}}\",\"params\":{\"{{rule__type}}\":\"{{params}}\"},\"space\":\"{{rule.spaceId}}\",\"type\":\"{{rule.type}}\"},\"kibana\":{\"alert\":{\"id\":\"{{alert.id}}\",\"context\":{\"{{rule__type}}\":\"{{context}}\"},\"actionGroup\":\"{{alert.actionGroup}}\",\"actionGroupName\":\"{{alert.actionGroupName}}\"}},\"event\":{\"kind\":\"alert\"}}"
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/infrastructure/server-setup/README.md
+++ b/infrastructure/server-setup/README.md
@@ -96,13 +96,24 @@ Use the `-b` option if your servers require sudo to perform the ansible tasks. I
 Ansible playbooks are run like this:
 
 ```
-ansible-playbook -i <inventory_file> <playbook_file> -e "dockerhub_username=your_username dockerhub_password=your_password papertrail_token=your_papertrail_token external_backup_server_ip=your_external_backup_server_ip external_backup_server_user=your_external_backup_server_user external_backup_server_ssh_port=your_external_backup_server_ssh_port manager_production_server_ip=your_manager_production_server_ip external_backup_server_remote_directory=your_external_backup_server_remote_directory"
+ansible-playbook -i <inventory_file> <playbook_file> -e " \
+dockerhub_username=<your_username> \
+dockerhub_password=<your_password> \
+papertrail_token=<your_papertrail_token> \
+external_backup_server_ip=<your_external_backup_server_ip> \
+external_backup_server_user=<your_external_backup_server_user> \
+external_backup_server_ssh_port=<your_external_backup_server_ssh_port> \
+manager_production_server_ip=<your_manager_production_server_ip> \
+external_backup_server_remote_directory=<your_external_backup_server_remote_directory> \
+mongodb_admin_username=<opencrvs-admin> \
+mongodb_admin_password=<secure password you generated> \
+elasticsearch_superuser_password=<secure password you generated>"
 ```
 
 E.G.:
 
 ```
-ansible-playbook -i example-3.ini playbook-3.yml -e "dockerhub_username=your_username dockerhub_password=your_password"
+ansible-playbook -i example-3.ini playbook-3.yml -e "dockerhub_username=your_username dockerhub_password=your_password ..."
 ```
 
 ## Enabling encryption
@@ -110,7 +121,7 @@ ansible-playbook -i example-3.ini playbook-3.yml -e "dockerhub_username=your_use
 For production servers we offer the ability to setup an encrypted /data folder for the docker containers to use. This allows us to support encryption at rest. To do this run the ansible script with these extra variables. Note, if the server is already setup the docker stack must be stopped and ALL DATA WILL BE LOST when switching to an ecrypted folder. It is useful to set this up from the beginning.
 
 ```
-ansible-playbook -i <inventory_file> <playbook_file> -e "dockerhub_username=your_username dockerhub_password=your_password papertrail_token=your_papertrail_token encrypt_passphrase=<a_strong_passphrase> encrypt_data=True"
+ansible-playbook -i <inventory_file> <playbook_file> -e "encrypt_passphrase=<a_strong_passphrase> encrypt_data=True"
 ```
 
 Once this command is finished the servers are now prepared for an OpenCRVS deployment.

--- a/infrastructure/server-setup/playbook-1.yml
+++ b/infrastructure/server-setup/playbook-1.yml
@@ -12,6 +12,12 @@
   become: yes
   become_method: sudo
   tasks:
+    - name: 'Check mandatory variables are defined'
+      assert:
+        that:
+          - mongodb_admin_username is defined
+          - mongodb_admin_password is defined
+          - elasticsearch_superuser_password is defined
     - name: 'Add docker repository key'
       apt_key:
         url: https://download.docker.com/linux/ubuntu/gpg
@@ -59,6 +65,34 @@
         minute: '0'
         hour: '0'
         job: '/usr/bin/docker system prune -af >> /var/log/docker-prune.log'
+
+    - name: Inserts Elasticsearch super user username environment variable to crontab
+      cron:
+        name: ELASTICSEARCH_ADMIN_USER
+        env: yes
+        job: 'elastic'
+      when: elasticsearch_superuser_password is defined
+
+    - name: Inserts Elasticsearch super user password environment variable to crontab
+      cron:
+        name: ELASTICSEARCH_ADMIN_PASSWORD
+        env: yes
+        job: '{{ elasticsearch_superuser_password }}'
+      when: elasticsearch_superuser_password is defined
+
+    - name: Inserts MongoDB username environment variable to crontab
+      cron:
+        name: MONGODB_ADMIN_USER
+        env: yes
+        job: '{{ mongodb_admin_username }}'
+      when: mongodb_admin_username is defined
+
+    - name: Inserts MongoDB password environment variable to crontab
+      cron:
+        name: MONGODB_ADMIN_PASSWORD
+        env: yes
+        job: '{{ mongodb_admin_password }}'
+      when: mongodb_admin_password is defined
 
     - name: 'Setup crontab to backup the opencrvs data'
       cron:

--- a/infrastructure/server-setup/playbook-3.yml
+++ b/infrastructure/server-setup/playbook-3.yml
@@ -12,6 +12,12 @@
   become: yes
   become_method: sudo
   tasks:
+    - name: 'Check mandatory variables are defined'
+      assert:
+        that:
+          - mongodb_admin_username is defined
+          - mongodb_admin_password is defined
+          - elasticsearch_superuser_password is defined
     - name: 'Add docker repository key'
       apt_key:
         url: https://download.docker.com/linux/ubuntu/gpg
@@ -59,6 +65,34 @@
         minute: '0'
         hour: '0'
         job: '/usr/bin/docker system prune -af >> /var/log/docker-prune.log'
+
+    - name: Inserts Elasticsearch super user username environment variable to crontab
+      cron:
+        name: ELASTICSEARCH_ADMIN_USER
+        env: yes
+        job: 'elastic'
+      when: elasticsearch_superuser_password is defined
+
+    - name: Inserts Elasticsearch super user password environment variable to crontab
+      cron:
+        name: ELASTICSEARCH_ADMIN_PASSWORD
+        env: yes
+        job: '{{ elasticsearch_superuser_password }}'
+      when: elasticsearch_superuser_password is defined
+
+    - name: Inserts MongoDB username environment variable to crontab
+      cron:
+        name: MONGODB_ADMIN_USER
+        env: yes
+        job: '{{ mongodb_admin_username }}'
+      when: mongodb_admin_username is defined
+
+    - name: Inserts MongoDB password environment variable to crontab
+      cron:
+        name: MONGODB_ADMIN_PASSWORD
+        env: yes
+        job: '{{ mongodb_admin_password }}'
+      when: mongodb_admin_password is defined
 
     - name: 'Setup crontab to backup the opencrvs data'
       cron:

--- a/infrastructure/server-setup/playbook-5.yml
+++ b/infrastructure/server-setup/playbook-5.yml
@@ -12,6 +12,12 @@
   become: yes
   become_method: sudo
   tasks:
+    - name: 'Check mandatory variables are defined'
+      assert:
+        that:
+          - mongodb_admin_username is defined
+          - mongodb_admin_password is defined
+          - elasticsearch_superuser_password is defined
     - name: 'Add docker repository key'
       apt_key:
         url: https://download.docker.com/linux/ubuntu/gpg
@@ -59,6 +65,41 @@
         minute: '0'
         hour: '0'
         job: '/usr/bin/docker system prune -af >> /var/log/docker-prune.log'
+
+    - name: Inserts Elasticsearch super user username environment variable to crontab
+      cron:
+        name: ELASTICSEARCH_ADMIN_USER
+        env: yes
+        job: 'elastic'
+      when: elasticsearch_superuser_password is defined
+
+    - name: Inserts Elasticsearch super user password environment variable to crontab
+      cron:
+        name: ELASTICSEARCH_ADMIN_PASSWORD
+        env: yes
+        job: '{{ elasticsearch_superuser_password }}'
+      when: elasticsearch_superuser_password is defined
+
+    - name: Inserts Elasticsearch super user password environment variable to crontab
+      cron:
+        name: ELASTICSEARCH_SUPERUSER_PASSWORD
+        env: yes
+        job: '{{ elasticsearch_superuser_password }}'
+      when: elasticsearch_superuser_password is defined
+
+    - name: Inserts MongoDB username environment variable to crontab
+      cron:
+        name: MONGODB_ADMIN_USER
+        env: yes
+        job: '{{ mongodb_admin_username }}'
+      when: mongodb_admin_username is defined
+
+    - name: Inserts MongoDB password environment variable to crontab
+      cron:
+        name: MONGODB_ADMIN_PASSWORD
+        env: yes
+        job: '{{ mongodb_admin_password }}'
+      when: mongodb_admin_password is defined
 
     - name: 'Setup crontab to backup the opencrvs data'
       cron:

--- a/infrastructure/setup-deploy-config.sh
+++ b/infrastructure/setup-deploy-config.sh
@@ -24,8 +24,6 @@ sed -i "s/{{hostname}}/$1/g" /tmp/compose/docker-compose.deploy.yml
 KIBANA_ENCRYPTION_KEY=`uuidgen`
 sed -i "s/{{KIBANA_ENCRYPTION_KEY}}/$KIBANA_ENCRYPTION_KEY/g" /tmp/compose/infrastructure/monitoring/kibana/kibana.yml
 sed -i -e "s%{{SLACK_WEBHOOK_URL}}%$SLACK_WEBHOOK_URL%" /tmp/compose/infrastructure/monitoring/elastalert/rules/alert.yaml
-sed -i -e "s%{{KIBANA_USERNAME}}%$KIBANA_USERNAME%" /tmp/compose/infrastructure/monitoring/beats/metricbeat.yml
-sed -i -e "s%{{KIBANA_PASSWORD}}%$KIBANA_PASSWORD%" /tmp/compose/infrastructure/monitoring/beats/metricbeat.yml
 
 
 echo "DONE - `date --iso-8601=ns`"


### PR DESCRIPTION
This PR secures our data in Elasticsearch, making it writable to only one user, whose password is rotated on every deployment

Other additions:
- Super user account for Elasticsearch with credentials stored in 1password
  - It would be better to have dynamic credentials for this, but our current way of backups makes this a little difficult
- Predefined user accounts with automatically rotating passwords
  - applications using ElasticSearch (`search`)
  - for internal tools like Metricbeat, APM...
- Kibana user that uses actual ElasticSearch authentication mechanism and whose access rights are explicitly defined