### PR TITLE
[OCRVS-2886] Add payments resolver

### DIFF
--- a/packages/gateway/src/features/metrics/root-resolvers.ts
+++ b/packages/gateway/src/features/metrics/root-resolvers.ts
@@ -18,7 +18,7 @@ import {
 export interface IMetricsParam {
   timeStart: string
   timeEnd: string
-  locationId: string
+  locationId?: string
   event?: string
   practitionerIds?: string[]
   practitionerId?: string
@@ -38,6 +38,22 @@ export const resolvers: GQLResolver = {
     ) {
       return getMetrics(
         '/totalMetrics',
+        {
+          timeStart,
+          timeEnd,
+          locationId,
+          event
+        },
+        authHeader
+      )
+    },
+    async getTotalPayments(
+      _,
+      { timeStart, timeEnd, locationId, event },
+      authHeader
+    ) {
+      return getMetrics(
+        '/totalPayments',
         {
           timeStart,
           timeEnd,

--- a/packages/gateway/src/features/metrics/schema.graphql
+++ b/packages/gateway/src/features/metrics/schema.graphql
@@ -29,6 +29,11 @@ type TotalMetricsResult {
   results: [EventMetrics!]!
 }
 
+type PaymentMetric {
+  total: Float!
+  paymentType: String!
+}
+
 type DeclarationsStartedMetrics {
   fieldAgentDeclarations: Int!
   hospitalDeclarations: Int!
@@ -91,6 +96,12 @@ type Query {
     locationId: String
     event: String!
   ): TotalMetricsResult
+  getTotalPayments(
+    timeStart: String!
+    timeEnd: String!
+    locationId: String
+    event: String!
+  ): [PaymentMetric!]!
   getDeclarationsStartedMetrics(
     timeStart: String!
     timeEnd: String!

--- a/packages/gateway/src/features/metrics/schema.graphql
+++ b/packages/gateway/src/features/metrics/schema.graphql
@@ -101,7 +101,7 @@ type Query {
     timeEnd: String!
     locationId: String
     event: String!
-  ): [PaymentMetric!]!
+  ): [PaymentMetric!]
   getDeclarationsStartedMetrics(
     timeStart: String!
     timeEnd: String!

--- a/packages/gateway/src/graphql/schema.d.ts
+++ b/packages/gateway/src/graphql/schema.d.ts
@@ -32,7 +32,7 @@ export interface GQLQuery {
   searchFieldAgents?: GQLSearchFieldAgentResult
   verifyPasswordById?: GQLVerifyPasswordResult
   getTotalMetrics?: GQLTotalMetricsResult
-  getTotalPayments: Array<GQLPaymentMetric>
+  getTotalPayments?: Array<GQLPaymentMetric>
   getDeclarationsStartedMetrics?: GQLDeclarationsStartedMetrics
   fetchMonthWiseEventMetrics?: GQLMonthWiseEstimationMetrics
   fetchLocationWiseEventMetrics?: GQLLocationWiseEstimationMetrics

--- a/packages/gateway/src/graphql/schema.d.ts
+++ b/packages/gateway/src/graphql/schema.d.ts
@@ -32,6 +32,7 @@ export interface GQLQuery {
   searchFieldAgents?: GQLSearchFieldAgentResult
   verifyPasswordById?: GQLVerifyPasswordResult
   getTotalMetrics?: GQLTotalMetricsResult
+  getTotalPayments: Array<GQLPaymentMetric>
   getDeclarationsStartedMetrics?: GQLDeclarationsStartedMetrics
   fetchMonthWiseEventMetrics?: GQLMonthWiseEstimationMetrics
   fetchLocationWiseEventMetrics?: GQLLocationWiseEstimationMetrics
@@ -251,6 +252,11 @@ export interface GQLVerifyPasswordResult {
 export interface GQLTotalMetricsResult {
   estimated?: GQLEstimation
   results: Array<GQLEventMetrics>
+}
+
+export interface GQLPaymentMetric {
+  total: number
+  paymentType: string
 }
 
 export interface GQLDeclarationsStartedMetrics {
@@ -1320,6 +1326,7 @@ export interface GQLResolver {
   SearchFieldAgentResult?: GQLSearchFieldAgentResultTypeResolver
   VerifyPasswordResult?: GQLVerifyPasswordResultTypeResolver
   TotalMetricsResult?: GQLTotalMetricsResultTypeResolver
+  PaymentMetric?: GQLPaymentMetricTypeResolver
   DeclarationsStartedMetrics?: GQLDeclarationsStartedMetricsTypeResolver
   MonthWiseEstimationMetrics?: GQLMonthWiseEstimationMetricsTypeResolver
   LocationWiseEstimationMetrics?: GQLLocationWiseEstimationMetricsTypeResolver
@@ -1402,6 +1409,7 @@ export interface GQLQueryTypeResolver<TParent = any> {
   searchFieldAgents?: QueryToSearchFieldAgentsResolver<TParent>
   verifyPasswordById?: QueryToVerifyPasswordByIdResolver<TParent>
   getTotalMetrics?: QueryToGetTotalMetricsResolver<TParent>
+  getTotalPayments?: QueryToGetTotalPaymentsResolver<TParent>
   getDeclarationsStartedMetrics?: QueryToGetDeclarationsStartedMetricsResolver<TParent>
   fetchMonthWiseEventMetrics?: QueryToFetchMonthWiseEventMetricsResolver<TParent>
   fetchLocationWiseEventMetrics?: QueryToFetchLocationWiseEventMetricsResolver<TParent>
@@ -1731,6 +1739,21 @@ export interface QueryToGetTotalMetricsResolver<TParent = any, TResult = any> {
   (
     parent: TParent,
     args: QueryToGetTotalMetricsArgs,
+    context: any,
+    info: GraphQLResolveInfo
+  ): TResult
+}
+
+export interface QueryToGetTotalPaymentsArgs {
+  timeStart: string
+  timeEnd: string
+  locationId?: string
+  event: string
+}
+export interface QueryToGetTotalPaymentsResolver<TParent = any, TResult = any> {
+  (
+    parent: TParent,
+    args: QueryToGetTotalPaymentsArgs,
     context: any,
     info: GraphQLResolveInfo
   ): TResult
@@ -3184,6 +3207,22 @@ export interface TotalMetricsResultToEstimatedResolver<
 }
 
 export interface TotalMetricsResultToResultsResolver<
+  TParent = any,
+  TResult = any
+> {
+  (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult
+}
+
+export interface GQLPaymentMetricTypeResolver<TParent = any> {
+  total?: PaymentMetricToTotalResolver<TParent>
+  paymentType?: PaymentMetricToPaymentTypeResolver<TParent>
+}
+
+export interface PaymentMetricToTotalResolver<TParent = any, TResult = any> {
+  (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult
+}
+
+export interface PaymentMetricToPaymentTypeResolver<
   TParent = any,
   TResult = any
 > {

--- a/packages/gateway/src/graphql/schema.graphql
+++ b/packages/gateway/src/graphql/schema.graphql
@@ -62,6 +62,12 @@ type Query {
     locationId: String
     event: String!
   ): TotalMetricsResult
+  getTotalPayments(
+    timeStart: String!
+    timeEnd: String!
+    locationId: String
+    event: String!
+  ): [PaymentMetric!]!
   getDeclarationsStartedMetrics(
     timeStart: String!
     timeEnd: String!
@@ -357,6 +363,11 @@ type VerifyPasswordResult {
 type TotalMetricsResult {
   estimated: Estimation
   results: [EventMetrics!]!
+}
+
+type PaymentMetric {
+  total: Float!
+  paymentType: String!
 }
 
 type DeclarationsStartedMetrics {

--- a/packages/gateway/src/graphql/schema.graphql
+++ b/packages/gateway/src/graphql/schema.graphql
@@ -67,7 +67,7 @@ type Query {
     timeEnd: String!
     locationId: String
     event: String!
-  ): [PaymentMetric!]!
+  ): [PaymentMetric!]
   getDeclarationsStartedMetrics(
     timeStart: String!
     timeEnd: String!

--- a/packages/metrics/src/config/routes.ts
+++ b/packages/metrics/src/config/routes.ts
@@ -43,6 +43,7 @@ import {
 } from '@metrics/features/legacy/handler'
 import { getEventDurationHandler } from '@metrics/features/getEventDuration/handler'
 import { totalMetricsHandler } from '@metrics/features/totalMetrics/handler'
+import { totalPaymentsHandler } from '@metrics/features/payments/handler'
 
 export const getRoutes = () => {
   const routes = [
@@ -279,6 +280,22 @@ export const getRoutes = () => {
       method: 'GET',
       path: '/totalMetrics',
       handler: totalMetricsHandler,
+      config: {
+        validate: {
+          query: Joi.object({
+            timeStart: Joi.string().required(),
+            timeEnd: Joi.string().required(),
+            locationId: Joi.string(),
+            event: Joi.string().required()
+          })
+        },
+        tags: ['api']
+      }
+    },
+    {
+      method: 'GET',
+      path: '/totalPayments',
+      handler: totalPaymentsHandler,
       config: {
         validate: {
           query: Joi.object({

--- a/packages/metrics/src/features/payments/handler.ts
+++ b/packages/metrics/src/features/payments/handler.ts
@@ -1,0 +1,33 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors. OpenCRVS and the OpenCRVS
+ * graphic logo are (registered/a) trademark(s) of Plan International.
+ */
+import * as Hapi from '@hapi/hapi'
+import {
+  TIME_FROM,
+  TIME_TO,
+  LOCATION_ID,
+  EVENT
+} from '@metrics/features/metrics/constants'
+import { getTotalPayments } from './service'
+
+export async function totalPaymentsHandler(
+  request: Hapi.Request,
+  h: Hapi.ResponseToolkit
+) {
+  const timeStart = request.query[TIME_FROM]
+  const timeEnd = request.query[TIME_TO]
+  const locationId = request.query[LOCATION_ID]
+    ? 'Location/' + request.query[LOCATION_ID]
+    : undefined
+  const event = request.query[EVENT]
+
+  return getTotalPayments(timeStart, timeEnd, locationId, event)
+}

--- a/packages/metrics/src/features/payments/service.ts
+++ b/packages/metrics/src/features/payments/service.ts
@@ -1,0 +1,50 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors. OpenCRVS and the OpenCRVS
+ * graphic logo are (registered/a) trademark(s) of Plan International.
+ */
+import { EVENT_TYPE } from '@metrics/features/metrics/utils'
+
+import { query } from '@metrics/influxdb/client'
+
+export async function getTotalPayments(
+  timeFrom: string,
+  timeTo: string,
+  locationId: string | undefined,
+  eventType: EVENT_TYPE
+) {
+  const totalMetrics = await query<
+    Array<{ total: number; paymentType: string }>
+  >(
+    `SELECT SUM(total) AS total
+      FROM payment
+    WHERE eventType = $eventType
+      AND time > $timeFrom
+      AND time <= $timeTo
+      ${
+        locationId
+          ? `AND ( locationLevel2 = $locationId
+      OR locationLevel3 = $locationId
+      OR locationLevel4 = $locationId
+      OR locationLevel5 = $locationId)`
+          : ``
+      }
+    GROUP BY paymentType`,
+    {
+      placeholders: {
+        locationId,
+        timeFrom,
+        timeTo,
+        eventType
+      }
+    }
+  )
+
+  return totalMetrics
+}

--- a/packages/metrics/src/features/registration/__snapshots__/handler.test.ts.snap
+++ b/packages/metrics/src/features/registration/__snapshots__/handler.test.ts.snap
@@ -6,11 +6,12 @@ Object {
     "compositionId": "1744fc19-95be-434b-8bc9-a76d6b81551b",
     "total": 50,
   },
-  "measurement": "certification_payment",
+  "measurement": "payment",
   "tags": Object {
     "eventType": "BIRTH",
     "locationLevel5": "Location/fb5b7377-0c00-407d-97a1-0a7f08ed727b",
     "officeLocation": "Location/fb5b7377-0c00-407d-97a1-0a7f08ed727b",
+    "paymentType": "certification",
   },
   "timestamp": undefined,
 }
@@ -148,11 +149,12 @@ Object {
     "compositionId": "c41a95b6-4439-4fc7-9d56-6d3a8ea0f80b",
     "total": undefined,
   },
-  "measurement": "correction_payment",
+  "measurement": "payment",
   "tags": Object {
     "eventType": "BIRTH",
     "locationLevel5": "Location/976c4871-c4d1-46f7-b50b-09f346e05d55",
     "officeLocation": "Location/fe68d322-4d98-4cdf-a320-2db9653f781d",
+    "paymentType": "correction",
   },
   "timestamp": undefined,
 }

--- a/packages/metrics/src/features/registration/fhirUtils.ts
+++ b/packages/metrics/src/features/registration/fhirUtils.ts
@@ -155,16 +155,12 @@ export function getTrackingId(task: Task) {
   return trackingIdentifier.value
 }
 
-export function getDeclarationType(task: Task): DECLARATION_TYPE | null {
-  if (!task.code || !task.code.coding) {
-    return null
-  }
-
-  const coding = task.code.coding.find(
+export function getDeclarationType(task: Task): DECLARATION_TYPE {
+  const coding = task.code?.coding?.find(
     ({ system }) => system === 'http://opencrvs.org/specs/types'
   )
   if (!coding) {
-    return null
+    throw new Error('No declaration type found in task')
   }
   return coding.code as DECLARATION_TYPE
 }

--- a/packages/metrics/src/features/registration/handler.test.ts
+++ b/packages/metrics/src/features/registration/handler.test.ts
@@ -1329,7 +1329,7 @@ describe('When an existing declaration is marked certified', () => {
       const declarationEventPoint =
         influxClient.writePoints.mock.calls[0][0].find(
           ({ measurement }: { measurement: string }) =>
-            measurement === 'certification_payment'
+            measurement === 'payment'
         )
 
       expect(declarationEventPoint).toMatchSnapshot()
@@ -1477,7 +1477,7 @@ describe('When an existing declaration requested correction', () => {
       const declarationEventPoint =
         influxClient.writePoints.mock.calls[0][0].find(
           ({ measurement }: { measurement: string }) =>
-            measurement === 'correction_payment'
+            measurement === 'payment'
         )
 
       expect(declarationEventPoint).toMatchSnapshot()

--- a/packages/metrics/src/features/registration/handler.ts
+++ b/packages/metrics/src/features/registration/handler.ts
@@ -357,10 +357,14 @@ export async function markCertifiedHandler(
 ) {
   try {
     const points = await Promise.all([
-      generatePaymentPoint(request.payload as fhir.Bundle, {
-        Authorization: request.headers.authorization,
-        'x-correlation-id': request.headers['x-correlation-id']
-      }),
+      generatePaymentPoint(
+        request.payload as fhir.Bundle,
+        {
+          Authorization: request.headers.authorization,
+          'x-correlation-id': request.headers['x-correlation-id']
+        },
+        'certification'
+      ),
       generateEventDurationPoint(
         request.payload as fhir.Bundle,
         ['REGISTERED'],
@@ -418,7 +422,7 @@ export async function requestCorrectionHandler(
         {
           Authorization: request.headers.authorization
         },
-        'correction_payment'
+        'correction'
       ),
       generateEventDurationPoint(
         request.payload as fhir.Bundle,

--- a/packages/metrics/src/features/registration/index.ts
+++ b/packages/metrics/src/features/registration/index.ts
@@ -161,7 +161,10 @@ export interface IBirthRegistrationPoints {
 
 export interface IPaymentPoints {
   measurement: string
-  tags: ILocationTags
+  tags: ILocationTags & {
+    eventType: 'BIRTH' | 'DEATH'
+    paymentType: 'certification' | 'correction'
+  }
   fields: IPaymentFields
   timestamp: number | undefined
 }

--- a/packages/metrics/src/features/registration/pointGenerator.test.ts
+++ b/packages/metrics/src/features/registration/pointGenerator.test.ts
@@ -280,11 +280,13 @@ describe('Verify point generation', () => {
   it('returns payment point', async () => {
     const point = await generatePaymentPoint(
       cloneDeep(testDeathCertPayload),
-      AUTH_HEADER
+      AUTH_HEADER,
+      'certification'
     )
     expect(point).toMatchObject({
-      measurement: 'certification_payment',
+      measurement: 'payment',
       tags: {
+        paymentType: 'certification',
         eventType: 'DEATH',
         officeLocation: 'Location/232ed3db-6b3f-4a5c-875e-f57aacadb2d3',
         locationLevel5: 'Location/9a3c7389-bf06-4f42-b1b3-202ced23b3af'
@@ -299,17 +301,17 @@ describe('Verify point generation', () => {
     const payload = cloneDeep(testDeathCertPayload)
     // @ts-ignore
     payload.entry[1] = {}
-    expect(generatePaymentPoint(payload, AUTH_HEADER)).rejects.toThrowError(
-      'Task not found'
-    )
+    expect(
+      generatePaymentPoint(payload, AUTH_HEADER, 'certification')
+    ).rejects.toThrowError('Task not found')
   })
   it('Throw error when no reconciliation found for payment point', () => {
     const payload = cloneDeep(testDeathCertPayload)
     // @ts-ignore
     payload.entry[4] = {}
-    expect(generatePaymentPoint(payload, AUTH_HEADER)).rejects.toThrowError(
-      'Payment reconciliation not found'
-    )
+    expect(
+      generatePaymentPoint(payload, AUTH_HEADER, 'certification')
+    ).rejects.toThrowError('Payment reconciliation not found')
   })
   it('returns declarations started point for field agent', async () => {
     fetchParentLocationByLocationID

--- a/packages/metrics/src/features/registration/pointGenerator.ts
+++ b/packages/metrics/src/features/registration/pointGenerator.ts
@@ -114,7 +114,7 @@ export const generateInCompleteFieldPoints = async (
         missingFieldSectionId: missingFieldIds[0],
         missingFieldGroupId: missingFieldIds[1],
         missingFieldId: missingFieldIds[2],
-        eventType: getDeclarationType(task) as string,
+        eventType: getDeclarationType(task),
         regStatus: 'IN_PROGESS',
         ...locationTags
       }
@@ -265,7 +265,7 @@ const generatePointLocations = async (
 export async function generatePaymentPoint(
   payload: fhir.Bundle,
   authHeader: IAuthHeader,
-  measurement = 'certification_payment'
+  paymentType: 'certification' | 'correction'
 ): Promise<IPaymentPoints> {
   const reconciliation = getPaymentReconciliation(payload)
   const composition = getComposition(payload)
@@ -290,11 +290,12 @@ export async function generatePaymentPoint(
   const tags = {
     eventType: getDeclarationType(task),
     officeLocation: getRegLastOffice(payload),
+    paymentType,
     ...(await generatePointLocations(payload, authHeader))
   }
 
   return {
-    measurement,
+    measurement: 'payment',
     tags,
     fields,
     timestamp: toInfluxTimestamp(reconciliation.created)
@@ -349,7 +350,7 @@ export async function generateEventDurationPoint(
   const tags: IDurationTags = {
     currentStatus: getDeclarationStatus(currentTask) as string,
     previousStatus: getDeclarationStatus(previousTask) as string,
-    eventType: getDeclarationType(currentTask) as string
+    eventType: getDeclarationType(currentTask)
   }
 
   return {
@@ -401,7 +402,7 @@ export async function generateTimeLoggedPoint(
   const tags: ITimeLoggedTags = {
     currentStatus: getDeclarationStatus(currentTask) as string,
     trackingId: getTrackingId(currentTask) as string,
-    eventType: getDeclarationType(currentTask) as string,
+    eventType: getDeclarationType(currentTask),
     practitionerId: getPractionerIdFromTask(currentTask),
     officeLocation: getRegLastOffice(payload),
     ...(await generatePointLocations(payload, authHeader))

--- a/packages/metrics/src/influxdb/client.ts
+++ b/packages/metrics/src/influxdb/client.ts
@@ -113,28 +113,14 @@ export const influx = new Influx.InfluxDB({
       tags: ['currentStatus', 'previousStatus', 'eventType']
     },
     {
-      measurement: 'certification_payment',
+      measurement: 'payment',
       fields: {
         total: Influx.FieldType.FLOAT,
         compositionId: Influx.FieldType.STRING
       },
       tags: [
         'eventType',
-        'officeLocation',
-        'locationLevel5',
-        'locationLevel4',
-        'locationLevel3',
-        'locationLevel2'
-      ]
-    },
-    {
-      measurement: 'correction_payment',
-      fields: {
-        total: Influx.FieldType.FLOAT,
-        compositionId: Influx.FieldType.STRING
-      },
-      tags: [
-        'eventType',
+        'paymentType',
         'officeLocation',
         'locationLevel5',
         'locationLevel4',
@@ -184,9 +170,16 @@ export const writePoints = (points: IPoints[]) => {
   })
 }
 
-export const query = <T = any>(q: string): Promise<T> => {
+type InfluxQueryOptions = {
+  placeholders: Record<string, any>
+}
+
+export const query = <T = any>(
+  q: string,
+  options?: InfluxQueryOptions
+): Promise<T> => {
   try {
-    return influx.query(q)
+    return influx.query(q, options)
   } catch (err) {
     logger.error(`Error reading data from InfluxDB! ${err.stack}`)
     throw err


### PR DESCRIPTION
Querying

```graphql
query data($event: String!, $timeStart: String!, $timeEnd: String!, $locationId: String!) {
  getTotalPayments(
    timeStart: $timeStart
    timeEnd: $timeEnd
    locationId: $locationId
    event: $event
  ) {
    total
    paymentType
  }
}

```

should give you the following data

```
{
	"data": {
		"getTotalPayments": [
			{
				"total": 3792,
				"paymentType": "certification"
			},
			{
				"total": 5283,
				"paymentType": "correction"
			}
		]
	}
}
```