### PR TITLE
Create a lightweight frontend-only dev environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "start:prod": "yarn build && lerna run --parallel --ignore @opencrvs/mobile-proxy --ignore @opencrvs/integration $OTHER_LERNA_FLAGS start:prod",
     "demo": "bash demo.sh",
     "dev": "bash dev.sh",
+    "dev:frontend": "lerna run build --scope @opencrvs/components && lerna run --scope @opencrvs/client --scope @opencrvs/login start:frontend",
     "dev:secrets:gen": "openssl genrsa -out .secrets/private-key.pem 2048 && openssl rsa -pubout -in .secrets/private-key.pem -out .secrets/public-key.pem",
     "open": "opener 'http://localhost:6060/' && opener 'http://localhost:3020/'",
     "lint": "lerna run lint",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -73,6 +73,7 @@
     "postinstall": "patch-package",
     "precommit": "lint-staged",
     "start": "BROWSER=none PORT=3000 craco start",
+    "start:frontend": "PROXY=true BROWSER=none PORT=3000 craco start",
     "build": "REACT_APP_VERSION=$VERSION craco --max_old_space_size=8000 build && yarn gen:sw",
     "gen:sw": "workbox injectManifest --config workbox-config.js",
     "docker:build": "docker build ../../ -f ../../Dockerfile-register -t ocrvs-client",

--- a/packages/login/package.json
+++ b/packages/login/package.json
@@ -46,6 +46,7 @@
     "postinstall": "patch-package",
     "precommit": "lint-staged",
     "start": "BROWSER=none PORT=3020 craco start",
+    "start:frontend": "PROXY=true BROWSER=none PORT=3020 craco start",
     "build": "craco --max_old_space_size=8000 build && yarn gen:sw",
     "gen:sw": "workbox generateSW --config workbox-config.js",
     "docker:build": "docker build ../../ -f ../../Dockerfile-login -t ocrvs-login",

--- a/packages/login/src/setupProxy.js
+++ b/packages/login/src/setupProxy.js
@@ -1,0 +1,71 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors. OpenCRVS and the OpenCRVS
+ * graphic logo are (registered/a) trademark(s) of Plan International.
+ */
+
+const https = require('https')
+function makeRequest(options) {
+  return new Promise((resolve, reject) => {
+    const req = https.request(options, (res) => {
+      let data = ''
+
+      res.on('data', (d) => {
+        data += d.toString()
+      })
+
+      res.on('end', () => resolve(data))
+    })
+
+    req.on('error', reject)
+
+    req.end()
+  })
+}
+
+function replaceBody(res, transformFn) {
+  const send = res.send
+  res.send = async function (string) {
+    let body = string instanceof Buffer ? string.toString() : string
+    body = await transformFn(body)
+    send.call(this, body)
+  }
+}
+
+module.exports = function (app) {
+  if (!process.env.PROXY) {
+    return
+  }
+  app.use((req, res, next) => {
+    const isIndexHTMLPath = !req.path.includes('.')
+    if (isIndexHTMLPath) {
+      replaceBody(res, (body) => {
+        return body.replace('http://localhost:3040', '')
+      })
+    }
+    if (req.path === '/login-config.js') {
+      replaceBody(res, async () => {
+        const config = await makeRequest({
+          hostname: 'countryconfig.farajaland-qa.opencrvs.org',
+          path: '/login-config.js',
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/javascript; charset=utf-8'
+          }
+        })
+
+        return config.replace(
+          'https://register.farajaland-qa.opencrvs.org/',
+          'http://localhost:3000'
+        )
+      })
+    }
+    next()
+  })
+}


### PR DESCRIPTION
Only starts the dev environments for client and login. Uses QA as its backend (I will change this to be staging as soon as login works there). With this, you can start the local environment by installing dependencies and running `yarn dev:frontend`