### PR TITLE
removes max-width on fields

### DIFF
--- a/packages/components/src/components/forms/InputField/InputField.tsx
+++ b/packages/components/src/components/forms/InputField/InputField.tsx
@@ -20,7 +20,6 @@ const InputHeader = styled.div`
 `
 const ComponentWrapper = styled.span`
   display: flex;
-  max-width: 344px;
 `
 
 const Padding = styled.span`

--- a/packages/components/src/components/forms/TextInput.tsx
+++ b/packages/components/src/components/forms/TextInput.tsx
@@ -97,10 +97,10 @@ const StyledInput = styled.input<ITextInputProps>`
     return !ignoreMediaQuery && !inputFieldWidth
       ? isSmallSized
         ? `@media (min-width: ${theme.grid.breakpoints.md}px) {
-        width: 234px;
+        width: 344px;
       }`
         : `@media (min-width: ${theme.grid.breakpoints.md}px) {
-        width: 535px;
+        width: 344px;
       }`
       : ''
   }}


### PR DESCRIPTION
- removes max-width on Input field. That cause ui issues with radio buttons. 
- sets width of text input to 344px

<img width="828" alt="image" src="https://user-images.githubusercontent.com/46478402/168308576-2737bbe0-f34d-46b9-9a38-1945d03efe2b.png">

<img width="932" alt="image" src="https://user-images.githubusercontent.com/46478402/168308685-97875c40-85fb-43e5-a866-113785890b5d.png">

<img width="898" alt="image" src="https://user-images.githubusercontent.com/46478402/168308717-ebcce8d6-7605-46e9-b9a6-532b466ff599.png">

