### PR TITLE
use AUTOMATED as the source name for Health System notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "compose:push": "yarn compose:build && docker-compose push && yarn compose:push:version",
     "compose:push:version": "export VERSION=`git log -1 --pretty=format:%h` && yarn compose:build && docker-compose push && unset VERSION",
     "compose:push:release": "export VERSION=`git describe --tags --abbrev=0` && git checkout -b release-`git describe --tags --abbrev=0` && yarn compose:build && docker-compose push && unset VERSION",
-    "deploy:staging": "bash deploy.sh --clear-data=yes --restore-metadata=yes --update-metadata=no development",
+    "deploy:staging": "bash deploy.sh --clear-data=no --restore-metadata=no --update-metadata=no development",
     "deploy:qa": "bash deploy.sh --clear-data=no --restore-metadata=no --update-metadata=no qa",
     "deploy:prod": "bash deploy.sh --clear-data=no --restore-metadata=no --update-metadata=no production",
     "deploy": "bash deploy.sh",

--- a/packages/client/src/views/SysAdmin/Performance/ApplicationSourcesReport.tsx
+++ b/packages/client/src/views/SysAdmin/Performance/ApplicationSourcesReport.tsx
@@ -118,7 +118,7 @@ export function ApplicationSourcesReport(
               <TotalDisplayWithPercentage
                 total={calculateTotal(
                   data.results.filter(
-                    (item) => item.practitionerRole === 'HOSPITAL_NOTIFICATION'
+                    (item) => item.practitionerRole === 'AUTOMATED'
                   )
                 )}
                 ofNumber={calculateTotal(data.results)}

--- a/packages/metrics/src/features/registration/fhirUtils.ts
+++ b/packages/metrics/src/features/registration/fhirUtils.ts
@@ -382,10 +382,7 @@ export async function fetchDeclarationsBeginnerRole(
 ) {
   let startedByRole = ''
   const currentTask = getTask(fhirBundle)
-  const composition = getComposition(fhirBundle)
-  if (isNotification(composition as fhir.Composition)) {
-    return 'HOSPITAL_NOTIFICATION'
-  }
+
   if (currentTask) {
     const bundle = await fetchTaskHistory(currentTask.id, authHeader)
     const length = bundle.entry ? bundle.entry.length : 0


### PR DESCRIPTION
I noticed Health Systems source showing 0 as the number of declarations
<img width="548" alt="image" src="https://user-images.githubusercontent.com/1206987/170990124-72255943-3229-4260-8ad7-0c7a65b19299.png">

Taking a closer look in the data, it seems we get `AUTOMATED` to InfluxDB
<img width="1249" alt="image" src="https://user-images.githubusercontent.com/1206987/170990243-07ea0978-77cf-4e66-b9fd-2f1e0fbcc754.png">
