### PR TITLE
ocrvs-2971 Fixed 'no' appearing instead of '-'

### DIFF
--- a/packages/client/src/views/RegisterForm/review/ReviewSection.tsx
+++ b/packages/client/src/views/RegisterForm/review/ReviewSection.tsx
@@ -373,9 +373,9 @@ const getFormFieldValue = (
   let tempField: IFormField
   for (const key in sectionDraftData) {
     tempField = sectionDraftData[key] as IFormField
-    return (tempField &&
-      tempField.nestedFields &&
-      tempField.nestedFields[field.name]) as IFormFieldValue
+    if (tempField?.nestedFields?.[field.name]) {
+      return tempField.nestedFields[field.name] as IFormFieldValue
+    }
   }
   return ''
 }
@@ -1035,7 +1035,7 @@ class ReviewSectionComp extends React.Component<FullProps, State> {
               field,
               errorsOnFields,
               undefined,
-              !!index
+              !index
             )
           )
           .filter((value) => value)


### PR DESCRIPTION
![2971](https://user-images.githubusercontent.com/29002716/171839162-f960f2a0-2ca0-477e-ac84-2e5003bcedf9.gif)
