### PR TITLE
ocrvs-3363: default message added for registerConfirmationTitle

### DIFF
--- a/packages/client/src/i18n/messages/views/review.ts
+++ b/packages/client/src/i18n/messages/views/review.ts
@@ -136,7 +136,7 @@ const messagesToDefine: IReviewMessages = {
     id: 'review.actions.title.registerActionTitle'
   },
   registerConfirmationTitle: {
-    defaultMessage: '',
+    defaultMessage: 'Register the {event}?',
     description: 'Title for register confirmation modal',
     id: 'review.modal.title.registerConfirmation'
   },


### PR DESCRIPTION
![Screenshot from 2022-06-07 15-28-35](https://user-images.githubusercontent.com/43314141/172346761-c1c65d1c-f504-4ea6-8c05-c946fafc6096.png)
