### PR TITLE
ocrvs-3261 Improved maxLength input state in CustomFieldTools

### DIFF
--- a/packages/client/src/components/formConfig/formTools/CustomFieldTools.tsx
+++ b/packages/client/src/components/formConfig/formTools/CustomFieldTools.tsx
@@ -52,6 +52,8 @@ import { getConfigFieldIdentifiers } from '@client/forms/configuration/formConfi
 import { useFieldDefinition } from '@client/views/SysAdmin/Config/Forms/hooks'
 import { Title, Label, RequiredToggleAction, StyledTooltip } from './components'
 
+const DEFAULT_MAX_LENGTH = 250
+
 const CInputField = styled(InputField)`
   label {
     ${({ theme }) => theme.fonts.reg14};
@@ -162,7 +164,7 @@ interface ICustomFieldState {
   selectedLanguage: string
   handleBars: string
   hideField: string
-  maxLength: number | undefined
+  maxLength: number
   fieldForms: IFieldForms
 }
 
@@ -203,7 +205,7 @@ class CustomFieldToolsComp extends React.Component<
         camelCase(fieldForms[defaultLanguage].label),
       selectedLanguage: defaultLanguage,
       hideField: selectedField.enabled,
-      maxLength: selectedField.maxLength,
+      maxLength: selectedField.maxLength ?? DEFAULT_MAX_LENGTH,
       fieldForms
     }
   }
@@ -341,9 +343,10 @@ class CustomFieldToolsComp extends React.Component<
       fieldName: handleBars,
       enabled: this.state.hideField,
       fieldId: newFieldID,
+      /* We can't let maxlength be 0 as it doesn't make any sense */
+      maxLength: this.state.maxLength || DEFAULT_MAX_LENGTH,
       label
     }
-    modifiedField.maxLength = this.state.maxLength
     return modifiedField
   }
 
@@ -536,8 +539,8 @@ class CustomFieldToolsComp extends React.Component<
                 </CInputField>
               </FieldContainer>
 
+              {/*errorMessage is not implemented yet*/}
               {/*
-              errorMessage is not implemented yet
               <FieldContainer hide={language !== this.state.selectedLanguage}>
                 <CInputField
                   required={false}
@@ -559,31 +562,27 @@ class CustomFieldToolsComp extends React.Component<
                 </CInputField>
               </FieldContainer>
             */}
-
-              <FieldContainer hide={language !== this.state.selectedLanguage}>
-                <CInputField
-                  required={true}
-                  id={`custom-form-max-length-${language}`}
-                  label={intl.formatMessage(
-                    customFieldFormMessages.maxLengthLabel
-                  )}
-                  touched={false}
-                >
-                  <CTextInput
-                    type="number"
-                    maxLength={this.state.maxLength || 250}
-                    value={this.state.maxLength || 250}
-                    onChange={(event: any) =>
-                      this.setState({
-                        maxLength: event.target.value
-                      })
-                    }
-                  />
-                </CInputField>
-              </FieldContainer>
             </React.Fragment>
           )
         })}
+        <FieldContainer>
+          <CInputField
+            required={false}
+            id="custom-form-max-length"
+            label={intl.formatMessage(customFieldFormMessages.maxLengthLabel)}
+            touched={false}
+          >
+            <CTextInput
+              type="number"
+              defaultValue={this.state.maxLength}
+              onChange={(event) =>
+                this.setState({
+                  maxLength: +event.target.value
+                })
+              }
+            />
+          </CInputField>
+        </FieldContainer>
         <ListContainer>
           <ListRow>
             <ListColumn>


### PR DESCRIPTION
Also used only a single input field per custom field instead of
using one for each language.
![3261](https://user-images.githubusercontent.com/29002716/172597463-bdc9e905-d19e-4ce5-9aba-9f127527064f.gif)