### PR TITLE
[hotfix]Queried for declaration info as a fallback

### DIFF
--- a/packages/client/src/views/OfficeHome/inProgress/InProgress.tsx
+++ b/packages/client/src/views/OfficeHome/inProgress/InProgress.tsx
@@ -254,7 +254,12 @@ export class InProgressComponent extends React.Component<
           id={`name_${index}`}
           isBoldLink={true}
           onClick={() =>
-            this.props.goToDeclarationRecordAudit('inProgressTab', regId)
+            this.props.goToDeclarationRecordAudit(
+              this.props.selectorId === SELECTOR_ID.hospitalDrafts
+                ? 'notificationTab'
+                : 'inProgressTab',
+              regId
+            )
           }
         >
           {name}

--- a/packages/client/src/views/OfficeHome/inProgress/inProgress.test.tsx
+++ b/packages/client/src/views/OfficeHome/inProgress/inProgress.test.tsx
@@ -684,7 +684,7 @@ describe('In Progress tab', () => {
       testComponent.update()
 
       expect(window.location.href).toContain(
-        '/record-audit/inProgressTab/956281c9-1f47-4c26-948a-970dd23c4094'
+        '/record-audit/notificationTab/956281c9-1f47-4c26-948a-970dd23c4094'
       )
     })
 

--- a/packages/client/src/views/RecordAudit/RecordAudit.test.tsx
+++ b/packages/client/src/views/RecordAudit/RecordAudit.test.tsx
@@ -29,7 +29,9 @@ import {
   storeDeclaration,
   IDeclaration,
   SUBMISSION_STATUS,
-  DOWNLOAD_STATUS
+  DOWNLOAD_STATUS,
+  IWorkqueue,
+  getCurrentUserWorkqueuSuccess
 } from '@client/declarations'
 import { Event } from '@client/forms'
 import { formatUrl } from '@client/navigation'
@@ -68,6 +70,22 @@ declaration.data.history = [
     output: []
   }
 ]
+
+const workqueue: IWorkqueue = {
+  data: {
+    inProgressTab: {},
+    notificationTab: {},
+    reviewTab: {
+      results: [{ id: declaration.id, registration: {} }],
+      totalItems: 1
+    },
+    rejectTab: {},
+    approvalTab: {},
+    printTab: {},
+    externalValidationTab: {}
+  },
+  initialSyncDone: true
+}
 
 describe('Record audit summary for a draft birth declaration', () => {
   let component: ReactWrapper<{}, {}>
@@ -254,6 +272,7 @@ describe('Record audit for a draft declaration', () => {
     declaration.downloadStatus = DOWNLOAD_STATUS.DOWNLOADED
 
     store.dispatch(storeDeclaration(declaration))
+    store.dispatch(getCurrentUserWorkqueuSuccess(JSON.stringify(workqueue)))
 
     component = await createTestComponent(
       <RecordAudit
@@ -440,6 +459,7 @@ describe('Record audit for a reinstate declaration', () => {
     declaration.submissionStatus = SUBMISSION_STATUS.ARCHIVED
     declaration.downloadStatus = DOWNLOAD_STATUS.DOWNLOADED
     store.dispatch(storeDeclaration(declaration))
+    store.dispatch(getCurrentUserWorkqueuSuccess(JSON.stringify(workqueue)))
 
     component = await createTestComponent(
       <RecordAudit

--- a/packages/client/src/views/RecordAudit/RecordAudit.tsx
+++ b/packages/client/src/views/RecordAudit/RecordAudit.tsx
@@ -572,7 +572,11 @@ function getBodyContent({
   goBack,
   ...actionProps
 }: IFullProps) {
-  if (tab === 'search' || !workqueueDeclaration) {
+  if (
+    tab === 'search' ||
+    (draft?.submissionStatus !== SUBMISSION_STATUS.DRAFT &&
+      !workqueueDeclaration)
+  ) {
     return (
       <>
         <Query

--- a/packages/client/src/views/RecordAudit/RecordAudit.tsx
+++ b/packages/client/src/views/RecordAudit/RecordAudit.tsx
@@ -572,7 +572,7 @@ function getBodyContent({
   goBack,
   ...actionProps
 }: IFullProps) {
-  if (tab === 'search') {
+  if (tab === 'search' || !workqueueDeclaration) {
     return (
       <>
         <Query


### PR DESCRIPTION
Opening the record audit of a declaration from any page > 1 does a
refetch of the workqueue for the first page thus replacing the
workqueue data for the selected record.