### PR TITLE
ocrvs-2544-fix: column alignmnt set to left on workflow status

### DIFF
--- a/packages/client/src/views/SysAdmin/Performance/WorkflowStatus.tsx
+++ b/packages/client/src/views/SysAdmin/Performance/WorkflowStatus.tsx
@@ -357,7 +357,7 @@ function WorkflowStatusComponent(props: WorkflowStatusProps) {
         label: intl.formatMessage(constantsMessages.timeReadyToPrint),
         key: 'timeLoggedRegistered',
         width: 12,
-        alignment: ColumnContentAlignment.RIGHT,
+        alignment: ColumnContentAlignment.LEFT,
         isSortable: true,
         sortFunction: () => toggleSort('timeLoggedRegistered'),
         icon:


### PR DESCRIPTION
![Screenshot from 2022-06-14 11-48-27](https://user-images.githubusercontent.com/43314141/173504089-f922387f-e94c-4b1f-881c-4dd3c7a23d73.png)
