### PR TITLE
Fix multi-location-id queries not finding anything

### DIFF
--- a/packages/gateway/src/features/search/root-resolvers.ts
+++ b/packages/gateway/src/features/search/root-resolvers.ts
@@ -82,7 +82,7 @@ export const resolvers: GQLResolver = {
         if (locationIds.length <= 0 || locationIds.includes('')) {
           return await Promise.reject(new Error('Invalid location id'))
         }
-        searchCriteria.declarationLocationId = locationIds.join(',')
+        searchCriteria.declarationLocationId = locationIds
       } else if (authHeader && !hasScope(authHeader, 'register')) {
         // Only register scope user can search without locationIds
         return await Promise.reject(new Error('User does not have permission'))

--- a/packages/gateway/src/features/search/schema.graphql
+++ b/packages/gateway/src/features/search/schema.graphql
@@ -87,7 +87,7 @@ type EventProgressSet {
 type Query {
   searchEvents(
     userId: String
-    locationIds: [String]
+    locationIds: [String!]
     status: [String]
     type: [String]
     trackingId: String

--- a/packages/gateway/src/features/search/type-resolvers.ts
+++ b/packages/gateway/src/features/search/type-resolvers.ts
@@ -26,7 +26,7 @@ interface ISearchDataTemplate {
   [key: string]: any
 }
 export interface ISearchCriteria {
-  declarationLocationId?: string
+  declarationLocationId?: string[]
   declarationLocationHirarchyId?: string
   status?: string[]
   type?: string[]

--- a/packages/gateway/src/graphql/schema.d.ts
+++ b/packages/gateway/src/graphql/schema.d.ts
@@ -1933,7 +1933,7 @@ export interface QueryToFetchTimeLoggedMetricsByPractitionerResolver<
 
 export interface QueryToSearchEventsArgs {
   userId?: string
-  locationIds?: Array<string | null>
+  locationIds?: Array<string>
   status?: Array<string | null>
   type?: Array<string | null>
   trackingId?: string

--- a/packages/gateway/src/graphql/schema.graphql
+++ b/packages/gateway/src/graphql/schema.graphql
@@ -111,7 +111,7 @@ type Query {
   ): TimeLoggedMetricsResultSet
   searchEvents(
     userId: String
-    locationIds: [String]
+    locationIds: [String!]
     status: [String]
     type: [String]
     trackingId: String

--- a/packages/search/src/features/search/types.ts
+++ b/packages/search/src/features/search/types.ts
@@ -26,7 +26,7 @@ export interface ISearchQuery {
   event?: string
   type?: string[]
   status?: string[]
-  declarationLocationId?: string
+  declarationLocationId?: string | string[]
   declarationLocationHirarchyId?: string
   createdBy?: string
   from?: number

--- a/packages/search/src/features/search/utils.ts
+++ b/packages/search/src/features/search/utils.ts
@@ -73,7 +73,7 @@ export function queryBuilder(
   eventLocationId: string,
   gender: string,
   nameCombinations: INameCombination[],
-  declarationLocationId: string,
+  declarationLocationId: string | string[],
   declarationLocationHirarchyId: string,
   createdBy: string,
   filters: IFilter
@@ -147,13 +147,23 @@ export function queryBuilder(
     })
   }
 
-  if (declarationLocationId !== EMPTY_STRING) {
+  if (Array.isArray(declarationLocationId)) {
+    declarationLocationId.forEach((id) => {
+      should.push({
+        term: {
+          'declarationLocationId.keyword': {
+            value: id,
+            boost: 2
+          }
+        }
+      })
+    })
+  } else if (declarationLocationId !== EMPTY_STRING) {
     must.push({
       term: {
         'declarationLocationId.keyword': {
           value: declarationLocationId,
-          // tslint:disable-next-line
-          boost: 2.0
+          boost: 2
         }
       }
     })


### PR DESCRIPTION
Our query builder logic wasn't handling multiple location ids properly, which caused issues in districts with multiple CRVS offices. This change makes the query with multiple location ids into an OR statement