### PR TITLE
Auto-generate shades in colour palette & document Colors and Typography in Storybook

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -30,5 +30,5 @@
   },
   "[typescript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
-  },
+  }
 }

--- a/infrastructure/license-config.json
+++ b/infrastructure/license-config.json
@@ -28,6 +28,7 @@
     "infrastructure/configure-file-monitoring.sh",
     "packages/client/public/index.html",
     "packages/login/public/index.html",
+    "packages/components/**/*.mdx",
     "grafana"
   ],
   "license": "infrastructure/license-header.txt",
@@ -37,7 +38,7 @@
         "prepend": "# "
       }
     },
-    "html|xml|svg": {
+    "html|xml|svg|mdx": {
       "prepend": "<!--",
       "append": "-->"
     },

--- a/packages/client/src/components/formConfig/formTools/CustomFieldTools.tsx
+++ b/packages/client/src/components/formConfig/formTools/CustomFieldTools.tsx
@@ -107,7 +107,7 @@ const ListRow = styled.div`
 
 const LanguageSelect = styled(Select)`
   width: 175px;
-  border: solid 2px ${({ theme }) => theme.colors.indigoDark};
+  border: solid 2px ${({ theme }) => theme.colors.primaryDark};
   border-radius: 2px;
   .react-select__control {
     max-height: 32px;
@@ -118,7 +118,7 @@ const LanguageSelect = styled(Select)`
   }
   div {
     ${({ theme }) => theme.fonts.reg14};
-    color: ${({ theme }) => theme.colors.indigoDark};
+    color: ${({ theme }) => theme.colors.primaryDark};
   }
 `
 

--- a/packages/client/src/components/interface/Header/Header.tsx
+++ b/packages/client/src/components/interface/Header/Header.tsx
@@ -144,13 +144,13 @@ const StyledPrimaryButton = styled(PrimaryButton)`
     display: none;
   }
   &:hover {
-    background: ${({ theme }) => theme.colors.indigoDark};
+    background: ${({ theme }) => theme.colors.primaryDark};
   }
   &:focus {
     background: ${({ theme }) => theme.colors.yellow};
   }
   &:active {
-    background: ${({ theme }) => theme.colors.indigoDark};
+    background: ${({ theme }) => theme.colors.primaryDark};
   }
 `
 

--- a/packages/components/.storybook/main.ts
+++ b/packages/components/.storybook/main.ts
@@ -23,6 +23,9 @@ const config = {
 
   managerHead: (head: string) => {
     return `${head}
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;600&display=swap" rel="stylesheet">
     <link rel="icon" href="favicon.png" />
     <style type="text/css">
       #storybook-explorer-tree .sidebar-item[data-selected=false] svg {

--- a/packages/components/.storybook/main.ts
+++ b/packages/components/.storybook/main.ts
@@ -23,9 +23,6 @@ const config = {
 
   managerHead: (head: string) => {
     return `${head}
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;600&display=swap" rel="stylesheet">
     <link rel="icon" href="favicon.png" />
     <style type="text/css">
       #storybook-explorer-tree .sidebar-item[data-selected=false] svg {

--- a/packages/components/.storybook/manager.ts
+++ b/packages/components/.storybook/manager.ts
@@ -11,5 +11,12 @@
  */
 import { addons } from '@storybook/addons'
 import theme from './theme'
+import WebFont from 'webfontloader'
+
+WebFont.load({
+  google: {
+    families: ['Noto+Sans:600', 'Noto+Sans:400']
+  }
+})
 
 addons.setConfig({ theme })

--- a/packages/components/.storybook/preview.tsx
+++ b/packages/components/.storybook/preview.tsx
@@ -11,16 +11,9 @@
  */
 import React from 'react'
 import { ThemeProvider, createGlobalStyle } from 'styled-components'
-import WebFont from 'webfontloader'
 import { getTheme } from '@opencrvs/components/lib/theme'
 
 const theme = getTheme()
-
-WebFont.load({
-  google: {
-    families: ['Noto+Sans:600', 'Noto+Sans:400']
-  }
-})
 
 const GlobalStyle = createGlobalStyle`
 html,
@@ -41,9 +34,13 @@ body,
   @font-face {
     /* stylelint-disable-next-line opencrvs/no-font-styles */
     font-family: ${theme.fonts.fontFamily};
+    font-style: normal;
+    font-weight: 400;
   }
   *:not(i) {
     font-family: ${theme.fonts.fontFamily};
+    font-style: normal;
+    font-weight: 400;
   }
 }
 

--- a/packages/components/.storybook/preview.tsx
+++ b/packages/components/.storybook/preview.tsx
@@ -12,6 +12,7 @@
 import React from 'react'
 import { ThemeProvider, createGlobalStyle } from 'styled-components'
 import { getTheme } from '@opencrvs/components/lib/theme'
+import WebFont from 'webfontloader'
 
 const theme = getTheme()
 
@@ -67,6 +68,12 @@ export const decorators = [
     </ThemeProvider>
   )
 ]
+
+WebFont.load({
+  google: {
+    families: ['Noto+Sans:600', 'Noto+Sans:400']
+  }
+})
 
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },

--- a/packages/components/.storybook/preview.tsx
+++ b/packages/components/.storybook/preview.tsx
@@ -11,8 +11,10 @@
  */
 import React from 'react'
 import { ThemeProvider, createGlobalStyle } from 'styled-components'
-import { getTheme } from '../src/components/theme'
 import WebFont from 'webfontloader'
+import { getTheme } from '@opencrvs/components/lib/theme'
+
+const theme = getTheme()
 
 WebFont.load({
   google: {
@@ -38,12 +40,13 @@ body,
   }
   @font-face {
     /* stylelint-disable-next-line opencrvs/no-font-styles */
-    font-family: "Noto Sans";
+    font-family: ${theme.fonts.fontFamily};
   }
   *:not(i) {
-    font-family: "Noto Sans";
+    font-family: ${theme.fonts.fontFamily};
   }
 }
+
 body,
 h1, h2, h3, h4, h5, h6,
 blockquote, p, pre, code,
@@ -61,7 +64,7 @@ fieldset, legend
 `
 export const decorators = [
   (Story) => (
-    <ThemeProvider theme={getTheme()}>
+    <ThemeProvider theme={theme}>
       <GlobalStyle />
       <Story />
     </ThemeProvider>

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -8,6 +8,7 @@
     "css-animation": "^2.0.4",
     "jest": "26.6.0",
     "patch-package": "^6.1.2",
+    "polished": "^4.2.2",
     "postinstall-postinstall": "^2.0.0",
     "rc-menu": "^7.4.13",
     "rc-progress": "^2.5.2",
@@ -45,6 +46,7 @@
   },
   "devDependencies": {
     "@storybook/addon-actions": "6.5.10",
+    "@storybook/addon-docs": "^6.5.10",
     "@storybook/addon-essentials": "6.5.10",
     "@storybook/addon-links": "6.5.10",
     "@storybook/node-logger": "6.5.10",

--- a/packages/components/src/components/buttons/CircleButton.tsx
+++ b/packages/components/src/components/buttons/CircleButton.tsx
@@ -34,13 +34,13 @@ const Button = styled.button<ICircleButtonProps & { size: IButtonSize }>`
   &:hover:not([disabled]) {
     ${({ theme, dark }) =>
       dark
-        ? theme.colors.indigoDark
+        ? theme.colors.primaryDark
         : 'background-color: ' + theme.colors.grey200};
   }
   &:not([data-focus-visible-added]):not([disabled]):hover {
     ${({ theme, dark }) =>
       dark
-        ? theme.colors.indigoDark
+        ? theme.colors.primaryDark
         : 'background-color: ' + theme.colors.grey200};
   }
   cursor: pointer;

--- a/packages/components/src/components/buttons/DangerButton.tsx
+++ b/packages/components/src/components/buttons/DangerButton.tsx
@@ -15,7 +15,7 @@ import { PrimaryButton } from './PrimaryButton'
 export const DangerButton = styled(PrimaryButton)`
   background-color: ${({ theme }) => theme.colors.negative};
   &:hover:enabled {
-    background: ${({ theme }) => theme.colors.redDark};
+    background: ${({ theme }) => theme.colors.negativeDark};
   }
   &:focus {
     outline: none;

--- a/packages/components/src/components/buttons/FloatingActionButton.tsx
+++ b/packages/components/src/components/buttons/FloatingActionButton.tsx
@@ -24,7 +24,7 @@ const ButtonStyled = styled.button`
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
   &:hover:enabled {
-    ${({ theme }) => theme.colors.indigoDark};
+    ${({ theme }) => theme.colors.primaryDark};
     color: ${({ theme }) => theme.colors.white};
   }
 

--- a/packages/components/src/components/buttons/IconButton.tsx
+++ b/packages/components/src/components/buttons/IconButton.tsx
@@ -24,7 +24,7 @@ export const IconButton = styled(Button)`
   ${({ theme }) => theme.fonts.bold14};
 
   &:hover:enabled {
-    ${({ theme }) => theme.colors.indigoDark};
+    ${({ theme }) => theme.colors.primaryDark};
     color: ${({ theme }) => theme.colors.white};
   }
   &:focus {

--- a/packages/components/src/components/buttons/LinkButton.tsx
+++ b/packages/components/src/components/buttons/LinkButton.tsx
@@ -32,13 +32,13 @@ export const LinkButton = styled(Button)<{
   }
 
   &:active {
-    color: ${({ theme }) => theme.colors.indigoDark};
+    color: ${({ theme }) => theme.colors.primaryDark};
     text-decoration-line: underline;
     text-underline-offset: 4px;
   }
 
   &:hover {
-    color: ${({ theme }) => theme.colors.indigoDark};
+    color: ${({ theme }) => theme.colors.primaryDark};
     text-decoration-line: underline;
     text-underline-offset: 4px;
   }

--- a/packages/components/src/components/buttons/PrimaryButton.tsx
+++ b/packages/components/src/components/buttons/PrimaryButton.tsx
@@ -22,7 +22,7 @@ export const PrimaryButton = styled(Button)`
   ${({ theme }) => theme.fonts.bold16};
 
   &:hover:enabled {
-    background: ${({ theme }) => theme.colors.indigoDark};
+    background: ${({ theme }) => theme.colors.primaryDark};
   }
   &:focus {
     background: ${({ theme }) => theme.colors.yellow};
@@ -35,7 +35,7 @@ export const PrimaryButton = styled(Button)`
   }
 
   &:active:enabled {
-    background: ${({ theme }) => theme.colors.indigoDark};
+    background: ${({ theme }) => theme.colors.primaryDark};
     color: ${({ theme }) => theme.colors.white};
   }
 

--- a/packages/components/src/components/buttons/SecondaryButton.tsx
+++ b/packages/components/src/components/buttons/SecondaryButton.tsx
@@ -30,8 +30,8 @@ const StyledButton = styled(Button)`
   ${({ theme }) => theme.fonts.bold16};
 
   &:hover:enabled {
-    border: ${({ theme }) => `2px solid ${theme.colors.indigoDark}`};
-    color: ${({ theme }) => theme.colors.indigoDark};
+    border: ${({ theme }) => `2px solid ${theme.colors.primaryDark}`};
+    color: ${({ theme }) => theme.colors.primaryDark};
     background: ${({ theme }) => theme.colors.grey100};
   }
 
@@ -50,8 +50,8 @@ const StyledButton = styled(Button)`
   }
 
   &:active:enabled {
-    border: ${({ theme }) => `2px solid ${theme.colors.indigoDark}`};
-    color: ${({ theme }) => theme.colors.indigoDark};
+    border: ${({ theme }) => `2px solid ${theme.colors.primaryDark}`};
+    color: ${({ theme }) => theme.colors.primaryDark};
     background: ${({ theme }) => theme.colors.grey100};
   }
 

--- a/packages/components/src/components/buttons/SuccessButton.tsx
+++ b/packages/components/src/components/buttons/SuccessButton.tsx
@@ -15,7 +15,7 @@ import { PrimaryButton } from './PrimaryButton'
 export const SuccessButton = styled(PrimaryButton)`
   background-color: ${({ theme }) => theme.colors.positive};
   &:hover:enabled {
-    background: ${({ theme }) => theme.colors.greenDark};
+    background: ${({ theme }) => theme.colors.positiveDark};
   }
   &:focus {
     outline: none;

--- a/packages/components/src/components/buttons/Toggle.tsx
+++ b/packages/components/src/components/buttons/Toggle.tsx
@@ -32,7 +32,7 @@ const CheckBoxLabel = styled.label<{ checked: boolean }>`
     checked ? theme.colors.positive : theme.colors.grey300};
   :hover {
     background: ${({ checked, theme }) =>
-      checked ? theme.colors.greenDark : theme.colors.grey400};
+      checked ? theme.colors.positiveDark : theme.colors.grey400};
   }
   cursor: pointer;
   &::after {

--- a/packages/components/src/components/colors.ts
+++ b/packages/components/src/components/colors.ts
@@ -70,7 +70,38 @@ export const colors = {
   ...config,
 
   primaryDark: darken(0.075)(config.primary),
+  primaryLight: lighten(0.075)(config.primary),
+  primaryLighter: lighten(0.1)(config.primary),
+
+  purpleDark: darken(0.075)(config.purple),
+  purpleLight: lighten(0.075)(config.purple),
+  purpleLighter: lighten(0.1)(config.purple),
+
+  orangeDark: darken(0.075)(config.orange),
+  orangeLight: lighten(0.05)(config.orange),
+  orangeLighter: lighten(0.1)(config.orange),
+
+  redDark: darken(0.075)(config.red),
+  redLight: lighten(0.075)(config.red),
+  redLighter: lighten(0.1)(config.red),
+
+  greenDark: darken(0.075)(config.green),
+  greenLight: lighten(0.075)(config.green),
+  greenLighter: lighten(0.1)(config.green),
+
+  blueDark: darken(0.075)(config.blue),
+  blueLight: lighten(0.075)(config.blue),
+  blueLighter: lighten(0.1)(config.blue),
+
+  tealDark: darken(0.075)(config.teal),
+  tealLight: lighten(0.075)(config.teal),
+  tealLighter: lighten(0.1)(config.teal),
+
+  yellowDark: darken(0.075)(config.yellow),
+  yellowLight: lighten(0.075)(config.yellow),
+  yellowLighter: lighten(0.1)(config.yellow),
+
   positiveDark: darken(0.075)(config.positive),
-  negativeDark: darken(0.075)(config.negative),
-  tealLight: lighten(0.075)(config.teal)
+  neutralDark: darken(0.075)(config.neutral),
+  negativeDark: darken(0.075)(config.negative)
 }

--- a/packages/components/src/components/colors.ts
+++ b/packages/components/src/components/colors.ts
@@ -11,6 +11,7 @@
  */
 
 import darken from 'polished/lib/color/darken'
+import lighten from 'polished/lib/color/lighten'
 
 const config = {
   // Pallete
@@ -25,9 +26,6 @@ const config = {
   blue: '#4A8AD7', // certified
   teal: '#4CC1BA', // charts
   yellow: '#EDC55E', // focus state
-
-  // Lights
-  tealLight: '#D3EEE4',
 
   // Status
   positive: '#49B78D', // green
@@ -47,7 +45,7 @@ const config = {
   opacity24: 'rgba(41, 47, 51, 0.24)',
   opacity54: 'rgba(41, 47, 51, 0.54)',
 
-  // Alternative defintions
+  // Alternative definitions
   copy: '#222222', // grey600
   supportingCopy: '#5B5B5B', // grey500
   placeholderCopy: '#959595', // grey400
@@ -73,5 +71,6 @@ export const colors = {
 
   primaryDark: darken(0.075)(config.primary),
   positiveDark: darken(0.075)(config.positive),
-  negativeDark: darken(0.075)(config.negative)
+  negativeDark: darken(0.075)(config.negative),
+  tealLight: lighten(0.075)(config.teal)
 }

--- a/packages/components/src/components/colors.ts
+++ b/packages/components/src/components/colors.ts
@@ -69,39 +69,39 @@ export const shadows = {
 export const colors = {
   ...config,
 
-  primaryDark: darken(0.075)(config.primary),
-  primaryLight: lighten(0.075)(config.primary),
-  primaryLighter: lighten(0.1)(config.primary),
+  primaryDark: darken(0.2)(config.primary),
+  primaryLight: lighten(0.2)(config.primary),
+  primaryLighter: lighten(0.4)(config.primary),
 
-  purpleDark: darken(0.075)(config.purple),
-  purpleLight: lighten(0.075)(config.purple),
-  purpleLighter: lighten(0.1)(config.purple),
+  purpleDark: darken(0.2)(config.purple),
+  purpleLight: lighten(0.2)(config.purple),
+  purpleLighter: lighten(0.4)(config.purple),
 
-  orangeDark: darken(0.075)(config.orange),
-  orangeLight: lighten(0.05)(config.orange),
-  orangeLighter: lighten(0.1)(config.orange),
+  orangeDark: darken(0.2)(config.orange),
+  orangeLight: lighten(0.2)(config.orange),
+  orangeLighter: lighten(0.3)(config.orange),
 
-  redDark: darken(0.075)(config.red),
-  redLight: lighten(0.075)(config.red),
-  redLighter: lighten(0.1)(config.red),
+  redDark: darken(0.2)(config.red),
+  redLight: lighten(0.2)(config.red),
+  redLighter: lighten(0.4)(config.red),
 
-  greenDark: darken(0.075)(config.green),
-  greenLight: lighten(0.075)(config.green),
-  greenLighter: lighten(0.1)(config.green),
+  greenDark: darken(0.2)(config.green),
+  greenLight: lighten(0.2)(config.green),
+  greenLighter: lighten(0.4)(config.green),
 
-  blueDark: darken(0.075)(config.blue),
-  blueLight: lighten(0.075)(config.blue),
-  blueLighter: lighten(0.1)(config.blue),
+  blueDark: darken(0.2)(config.blue),
+  blueLight: lighten(0.2)(config.blue),
+  blueLighter: lighten(0.35)(config.blue),
 
-  tealDark: darken(0.075)(config.teal),
-  tealLight: lighten(0.075)(config.teal),
-  tealLighter: lighten(0.1)(config.teal),
+  tealDark: darken(0.2)(config.teal),
+  tealLight: lighten(0.2)(config.teal),
+  tealLighter: lighten(0.4)(config.teal),
 
-  yellowDark: darken(0.075)(config.yellow),
-  yellowLight: lighten(0.075)(config.yellow),
-  yellowLighter: lighten(0.1)(config.yellow),
+  yellowDark: darken(0.2)(config.yellow),
+  yellowLight: lighten(0.2)(config.yellow),
+  yellowLighter: lighten(0.3)(config.yellow),
 
-  positiveDark: darken(0.075)(config.positive),
-  neutralDark: darken(0.075)(config.neutral),
-  negativeDark: darken(0.075)(config.negative)
+  positiveDark: darken(0.2)(config.positive),
+  neutralDark: darken(0.2)(config.neutral),
+  negativeDark: darken(0.2)(config.negative)
 }

--- a/packages/components/src/components/colors.ts
+++ b/packages/components/src/components/colors.ts
@@ -10,7 +10,9 @@
  * graphic logo are (registered/a) trademark(s) of Plan International.
  */
 
-export const colors = {
+import darken from 'polished/lib/color/darken'
+
+const config = {
   // Pallete
   primary: '#4972BB', // indigo
   secondary: '#4A8AD7', // blue
@@ -23,11 +25,6 @@ export const colors = {
   blue: '#4A8AD7', // certified
   teal: '#4CC1BA', // charts
   yellow: '#EDC55E', // focus state
-
-  // Darks
-  indigoDark: '#42639C',
-  redDark: '#994040',
-  greenDark: '#409977',
 
   // Lights
   tealLight: '#D3EEE4',
@@ -66,4 +63,15 @@ export const gradients = {
 export const shadows = {
   light: 'box-shadow: 0px 2px 6px rgba(53, 67, 93, 0.32)',
   heavy: 'box-shadow: 0px 2px 8px rgba(53, 67, 93, 0.54)'
+}
+
+/**
+ * Color palette with auto-generated light / dark colors from color configuration
+ */
+export const colors = {
+  ...config,
+
+  primaryDark: darken(0.075)(config.primary),
+  positiveDark: darken(0.075)(config.positive),
+  negativeDark: darken(0.075)(config.negative)
 }

--- a/packages/components/src/components/fonts.ts
+++ b/packages/components/src/components/fonts.ts
@@ -29,7 +29,7 @@ export interface IFonts {
 }
 
 export const fonts = (): IFonts => {
-  const fontFamily = 'Noto Sans'
+  const fontFamily = "'Noto Sans', sans-serif"
   return {
     fontFamily,
 

--- a/packages/components/src/components/forms/Select.tsx
+++ b/packages/components/src/components/forms/Select.tsx
@@ -105,7 +105,7 @@ const StyledSelect = styled(ReactSelect)<IStyledSelectProps>`
     background-color: ${({ theme }) => theme.colors.primary};
     color: ${({ theme }) => theme.colors.white};
     &:active {
-      background: ${({ theme }) => theme.colors.indigoDark};
+      background: ${({ theme }) => theme.colors.primaryDark};
       color: ${({ theme }) => theme.colors.white};
     }
   }

--- a/packages/components/src/components/interface/ExpandableNotification/ExpandableNotification.tsx
+++ b/packages/components/src/components/interface/ExpandableNotification/ExpandableNotification.tsx
@@ -40,7 +40,7 @@ const NotificationBar = styled.div`
   ${({ theme }) => theme.shadows.heavy};
   z-index: 3;
   &:hover {
-    ${({ theme }) => theme.colors.indigoDark};
+    ${({ theme }) => theme.colors.primaryDark};
   }
 `
 const ExpandableOverlay = styled.div<{ show: boolean }>`

--- a/packages/components/src/components/interface/InvertSpinner.tsx
+++ b/packages/components/src/components/interface/InvertSpinner.tsx
@@ -30,22 +30,22 @@ const StyledSpinner = styled.div<IInvertSpinner>`
   /* stylelint-disable value-no-vendor-prefix */
   background: -moz-linear-gradient(
     left,
-    ${({ theme }) => theme.colors.indigoDark} 10%,
+    ${({ theme }) => theme.colors.primaryDark} 10%,
     ${({ theme }) => theme.colors.white} 42%
   );
   background: -webkit-linear-gradient(
     left,
-    ${({ theme }) => theme.colors.indigoDark} 10%,
+    ${({ theme }) => theme.colors.primaryDark} 10%,
     ${({ theme }) => theme.colors.white} 42%
   );
   background: -o-linear-gradient(
     left,
-    ${({ theme }) => theme.colors.indigoDark} 10%,
+    ${({ theme }) => theme.colors.primaryDark} 10%,
     ${({ theme }) => theme.colors.white} 42%
   );
   background: linear-gradient(
     to right,
-    ${({ theme }) => theme.colors.indigoDark} 10%,
+    ${({ theme }) => theme.colors.primaryDark} 10%,
     ${({ theme }) => theme.colors.white} 42%
   );
   position: relative;

--- a/packages/components/src/components/select/Select.tsx
+++ b/packages/components/src/components/select/Select.tsx
@@ -85,7 +85,7 @@ const StyledSelect = styled(ReactSelect)<{
     background-color: ${({ theme }) => theme.colors.primary};
     color: ${({ theme }) => theme.colors.white};
     &:active {
-      background: ${({ theme }) => theme.colors.indigoDark};
+      background: ${({ theme }) => theme.colors.primaryDark};
       color: ${({ theme }) => theme.colors.white};
     }
   }

--- a/packages/components/src/stories/colors.stories.mdx
+++ b/packages/components/src/stories/colors.stories.mdx
@@ -13,18 +13,6 @@ import { colors, shadows, gradients } from '@opencrvs/components/lib/colors'
 import { Box } from '@opencrvs/components/lib/interface/Box'
 import styled from 'styled-components'
 
-export const LightShadowBox = styled.div`
-  border: 1px solid ${colors.grey300};
-  padding: 16px;
-  ${shadows.light}
-`
-
-export const HeavyShadowBox = styled.div`
-  border: 1px solid ${colors.grey300};
-  padding: 16px;
-  ${shadows.heavy}
-`
-
 <Meta title="Styles/Colors" />
 
 # Colors
@@ -35,48 +23,82 @@ export const HeavyShadowBox = styled.div`
   <ColorItem
     title="colors.primary"
     subtitle="Primary"
-    colors={{ primary: colors.primary, primaryDark: colors.primaryDark }}
-  />
-  <ColorItem
-    title="colors.secondary"
-    subtitle="Secondary"
-    colors={{ secondary: colors.secondary }}
-  />
-  <ColorItem
-    title="colors.tertiary"
-    subtitle="Grey"
-    colors={{ tertiary: colors.tertiary }}
+    colors={{
+      primaryLighter: colors.primaryLighter,
+      primaryLight: colors.primaryLight,
+      primary: colors.primary,
+      primaryDark: colors.primaryDark
+    }}
   />
   <ColorItem
     title="colors.purple"
     subtitle="Purple"
-    colors={{ purple: colors.purple }}
+    colors={{
+      purpleLighter: colors.purpleLighter,
+      purpleLight: colors.purpleLight,
+      purple: colors.purple,
+      purpleDark: colors.purpleDark
+    }}
   />
   <ColorItem
     title="colors.orange"
     subtitle="Orange"
-    colors={{ orange: colors.orange }}
+    colors={{
+      orangeLighter: colors.orangeLighter,
+      orangeLight: colors.orangeLight,
+      orange: colors.orange,
+      orangeDark: colors.orangeDark
+    }}
   />
-  <ColorItem title="colors.red" subtitle="Red" colors={{ red: colors.red }} />
+  <ColorItem
+    title="colors.red"
+    subtitle="Red"
+    colors={{
+      redLighter: colors.redLighter,
+      redLight: colors.redLight,
+      red: colors.red,
+      redDark: colors.redDark
+    }}
+  />
   <ColorItem
     title="colors.green"
     subtitle="Green"
-    colors={{ green: colors.green }}
+    colors={{
+      greenLighter: colors.greenLighter,
+      greenLight: colors.greenLight,
+      green: colors.green,
+      greenDark: colors.greenDark
+    }}
   />
   <ColorItem
     title="colors.blue"
     subtitle="Blue"
-    colors={{ blue: colors.blue }}
+    colors={{
+      blueLighter: colors.blueLighter,
+      blueLight: colors.blueLight,
+      blue: colors.blue,
+      blueDark: colors.blueDark
+    }}
   />
   <ColorItem
     title="colors.teal"
     subtitle="Teal"
-    colors={{ teal: colors.teal, tealLight: colors.tealLight }}
+    colors={{
+      tealLighter: colors.tealLighter,
+      tealLight: colors.tealLight,
+      teal: colors.teal,
+      tealDark: colors.tealDark
+    }}
   />
   <ColorItem
     title="colors.yellow"
     subtitle="Yellow"
-    colors={{ yellow: colors.yellow }}
+    colors={{
+      yellowLighter: colors.yellowLighter,
+      yellowLight: colors.yellowLight,
+      yellow: colors.yellow,
+      yellowDark: colors.yellowDark
+    }}
   />
   <ColorItem
     title="colors.grey"
@@ -92,6 +114,19 @@ export const HeavyShadowBox = styled.div`
     }}
   />
   <ColorItem
+    title="colors.opacity"
+    subtitle="Translucent"
+    colors={{
+      opacity24: colors.opacity24,
+      opacity54: colors.opacity54
+    }}
+  />
+</ColorPalette>
+
+## Application
+
+<ColorPalette>
+  <ColorItem
     title="colors.positive"
     subtitle="Status Green"
     colors={{
@@ -103,7 +138,8 @@ export const HeavyShadowBox = styled.div`
     title="colors.neutral"
     subtitle="Status Orange"
     colors={{
-      neutral: colors.neutral
+      neutral: colors.neutral,
+      neutralDark: colors.neutralDark
     }}
   />
   <ColorItem
@@ -115,21 +151,10 @@ export const HeavyShadowBox = styled.div`
     }}
   />
   <ColorItem
-    title="colors.opacity"
-    subtitle="Translucent"
+    title="colors.background"
+    subtitle="Background"
     colors={{
-      opacity24: colors.opacity24,
-      opacity54: colors.opacity54
+      background: colors.background
     }}
   />
 </ColorPalette>
-
-## Shadows
-
-**Light**
-
-<LightShadowBox />
-
-**Heavy**
-
-<HeavyShadowBox />

--- a/packages/components/src/stories/colors.stories.mdx
+++ b/packages/components/src/stories/colors.stories.mdx
@@ -124,10 +124,6 @@ export const HeavyShadowBox = styled.div`
   />
 </ColorPalette>
 
-## Gradient
-
-? do we wanna include gradient here
-
 ## Shadows
 
 **Light**

--- a/packages/components/src/stories/colors.stories.mdx
+++ b/packages/components/src/stories/colors.stories.mdx
@@ -9,67 +9,181 @@ Copyright (C) The OpenCRVS Authors. OpenCRVS and the OpenCRVS
 graphic logo are (registered/a) trademark(s) of Plan International.-->
 
 import { Meta, ColorPalette, ColorItem } from '@storybook/addon-docs'
-import { colors } from '@opencrvs/components/lib/colors'
+import { colors, shadows, gradients } from '@opencrvs/components/lib/colors'
+import { Box } from '@opencrvs/components/lib/interface/Box'
+import styled from 'styled-components'
+
+export const LightShadowBox = styled.div`
+  border: 1px solid ${colors.grey300};
+  padding: 16px;
+  ${shadows.light}
+`
+
+export const HeavyShadowBox = styled.div`
+  border: 1px solid ${colors.grey300};
+  padding: 16px;
+  ${shadows.heavy}
+`
 
 <Meta title="Styles/Colors" />
 
-<h1>Colors</h1>
+# Colors
 
-<h2>Palette</h2>
+## Palette
+
 <ColorPalette>
   <ColorItem
-    title="colors.greyscale"
-    subtitle="Greyscale"
-    colors={{
-      White: colors.white,
-      Grey100: colors.grey100,
-      Grey200: colors.grey200,
-      Grey300: colors.grey300,
-      Grey400: colors.grey400,
-      Grey500: colors.grey500,
-      Grey600: colors.grey600
-    }}
-  />
-  <ColorItem
     title="colors.primary"
-    subtitle="Indigo"
-    colors={{ Primary: colors.primary, 'Primary Dark': colors.primaryDark }}
+    subtitle="Primary"
+    colors={{ primary: colors.primary, primaryDark: colors.primaryDark }}
   />
   <ColorItem
     title="colors.secondary"
-    subtitle="Blue"
-    colors={{ Secondary: colors.secondary }}
+    subtitle="Secondary"
+    colors={{ secondary: colors.secondary }}
   />
   <ColorItem
     title="colors.tertiary"
     subtitle="Grey"
-    colors={{ Tertiary: colors.tertiary }}
+    colors={{ tertiary: colors.tertiary }}
   />
-</ColorPalette>
-
-<h2>Status</h2>
-<ColorPalette>
+  <ColorItem
+    title="colors.purple"
+    subtitle="Purple"
+    colors={{ purple: colors.purple }}
+  />
+  <ColorItem
+    title="colors.orange"
+    subtitle="Orange"
+    colors={{ orange: colors.orange }}
+  />
+  <ColorItem title="colors.red" subtitle="Red" colors={{ red: colors.red }} />
+  <ColorItem
+    title="colors.green"
+    subtitle="Green"
+    colors={{ green: colors.green }}
+  />
+  <ColorItem
+    title="colors.blue"
+    subtitle="Blue"
+    colors={{ blue: colors.blue }}
+  />
+  <ColorItem
+    title="colors.teal"
+    subtitle="Teal"
+    colors={{ teal: colors.teal, tealLight: colors.tealLight }}
+  />
+  <ColorItem
+    title="colors.yellow"
+    subtitle="Yellow"
+    colors={{ yellow: colors.yellow }}
+  />
+  <ColorItem
+    title="colors.grey"
+    subtitle="Monochrome"
+    colors={{
+      white: colors.white,
+      grey100: colors.grey100,
+      grey200: colors.grey200,
+      grey300: colors.grey300,
+      grey400: colors.grey400,
+      grey500: colors.grey500,
+      grey600: colors.grey600
+    }}
+  />
   <ColorItem
     title="colors.positive"
     subtitle="Status Green"
     colors={{
-      Positive: colors.positive,
-      'Positive Dark': colors.positiveDark
+      positive: colors.positive,
+      positiveDark: colors.positiveDark
     }}
   />
   <ColorItem
     title="colors.neutral"
     subtitle="Status Orange"
     colors={{
-      Neutral: colors.neutral
+      neutral: colors.neutral
     }}
   />
   <ColorItem
     title="colors.negative"
     subtitle="Status Red"
     colors={{
-      Negative: colors.negative,
-      'Negative Dark': colors.negativeDark
+      negative: colors.negative,
+      negativeDark: colors.negativeDark
+    }}
+  />
+  <ColorItem
+    title="colors.opacity"
+    subtitle="Translucent"
+    colors={{
+      opacity24: colors.opacity24,
+      opacity54: colors.opacity54
+    }}
+  />
+  <ColorItem
+    title="colors.opacity"
+    subtitle="Translucent"
+    colors={{
+      opacity24: colors.opacity24,
+      opacity54: colors.opacity54
+    }}
+  />
+  <ColorItem
+    title="colors.copy"
+    subtitle="Copy"
+    colors={{
+      copy: colors.copy
+    }}
+  />
+  <ColorItem
+    title="colors.supportingCopy"
+    subtitle="Supporting copy"
+    colors={{
+      supportingCopy: colors.supportingCopy
+    }}
+  />
+  <ColorItem
+    title="colors.placeholderCopy"
+    subtitle="Placeholder copy"
+    colors={{
+      placeholderCopy: colors.placeholderCopy
+    }}
+  />
+  <ColorItem
+    title="colors.disabled"
+    subtitle="Disabled"
+    colors={{
+      disabled: colors.disabled
+    }}
+  />
+  <ColorItem
+    title="colors.background"
+    subtitle="Background"
+    colors={{
+      background: colors.background
+    }}
+  />
+  <ColorItem
+    title="colors.backgroundPrimary"
+    subtitle="Background with primary color"
+    colors={{
+      backgroundPrimary: colors.backgroundPrimary
     }}
   />
 </ColorPalette>
+
+## Gradient
+
+? do we wanna include gradient here
+
+## Shadows
+
+**Light**
+
+<LightShadowBox />
+
+**Heavy**
+
+<HeavyShadowBox />

--- a/packages/components/src/stories/colors.stories.mdx
+++ b/packages/components/src/stories/colors.stories.mdx
@@ -122,56 +122,6 @@ export const HeavyShadowBox = styled.div`
       opacity54: colors.opacity54
     }}
   />
-  <ColorItem
-    title="colors.opacity"
-    subtitle="Translucent"
-    colors={{
-      opacity24: colors.opacity24,
-      opacity54: colors.opacity54
-    }}
-  />
-  <ColorItem
-    title="colors.copy"
-    subtitle="Copy"
-    colors={{
-      copy: colors.copy
-    }}
-  />
-  <ColorItem
-    title="colors.supportingCopy"
-    subtitle="Supporting copy"
-    colors={{
-      supportingCopy: colors.supportingCopy
-    }}
-  />
-  <ColorItem
-    title="colors.placeholderCopy"
-    subtitle="Placeholder copy"
-    colors={{
-      placeholderCopy: colors.placeholderCopy
-    }}
-  />
-  <ColorItem
-    title="colors.disabled"
-    subtitle="Disabled"
-    colors={{
-      disabled: colors.disabled
-    }}
-  />
-  <ColorItem
-    title="colors.background"
-    subtitle="Background"
-    colors={{
-      background: colors.background
-    }}
-  />
-  <ColorItem
-    title="colors.backgroundPrimary"
-    subtitle="Background with primary color"
-    colors={{
-      backgroundPrimary: colors.backgroundPrimary
-    }}
-  />
 </ColorPalette>
 
 ## Gradient

--- a/packages/components/src/stories/colors.stories.mdx
+++ b/packages/components/src/stories/colors.stories.mdx
@@ -17,6 +17,8 @@ import styled from 'styled-components'
 
 # Colors
 
+<br />
+
 ## Palette
 
 <ColorPalette>

--- a/packages/components/src/stories/colors.stories.mdx
+++ b/packages/components/src/stories/colors.stories.mdx
@@ -1,0 +1,75 @@
+<!--This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+OpenCRVS is also distributed under the terms of the Civil Registration
+& Healthcare Disclaimer located at http://opencrvs.org/license.
+
+Copyright (C) The OpenCRVS Authors. OpenCRVS and the OpenCRVS
+graphic logo are (registered/a) trademark(s) of Plan International.-->
+
+import { Meta, ColorPalette, ColorItem } from '@storybook/addon-docs'
+import { colors } from '@opencrvs/components/lib/colors'
+
+<Meta title="Styles/Colors" />
+
+<h1>Colors</h1>
+
+<h2>Palette</h2>
+<ColorPalette>
+  <ColorItem
+    title="colors.greyscale"
+    subtitle="Greyscale"
+    colors={{
+      White: colors.white,
+      Grey100: colors.grey100,
+      Grey200: colors.grey200,
+      Grey300: colors.grey300,
+      Grey400: colors.grey400,
+      Grey500: colors.grey500,
+      Grey600: colors.grey600
+    }}
+  />
+  <ColorItem
+    title="colors.primary"
+    subtitle="Indigo"
+    colors={{ Primary: colors.primary, 'Primary Dark': colors.primaryDark }}
+  />
+  <ColorItem
+    title="colors.secondary"
+    subtitle="Blue"
+    colors={{ Secondary: colors.secondary }}
+  />
+  <ColorItem
+    title="colors.tertiary"
+    subtitle="Grey"
+    colors={{ Tertiary: colors.tertiary }}
+  />
+</ColorPalette>
+
+<h2>Status</h2>
+<ColorPalette>
+  <ColorItem
+    title="colors.positive"
+    subtitle="Status Green"
+    colors={{
+      Positive: colors.positive,
+      'Positive Dark': colors.positiveDark
+    }}
+  />
+  <ColorItem
+    title="colors.neutral"
+    subtitle="Status Orange"
+    colors={{
+      Neutral: colors.neutral
+    }}
+  />
+  <ColorItem
+    title="colors.negative"
+    subtitle="Status Red"
+    colors={{
+      Negative: colors.negative,
+      'Negative Dark': colors.negativeDark
+    }}
+  />
+</ColorPalette>

--- a/packages/components/src/stories/typography.stories.mdx
+++ b/packages/components/src/stories/typography.stories.mdx
@@ -8,61 +8,34 @@ OpenCRVS is also distributed under the terms of the Civil Registration
 Copyright (C) The OpenCRVS Authors. OpenCRVS and the OpenCRVS
 graphic logo are (registered/a) trademark(s) of Plan International.-->
 
-import { Meta, ColorPalette, ColorItem } from '@storybook/addon-docs'
+import { Meta, Typeset, ColorPalette, ColorItem } from '@storybook/addon-docs'
 import styled from 'styled-components'
 import { getTheme } from '@opencrvs/components/lib/theme'
 
 export const theme = getTheme()
 
-export const H1 = styled.span`
-  ${theme.fonts.h1}
-`
-
-export const H2 = styled.span`
-  ${theme.fonts.h2}
-`
-
-export const H3 = styled.span`
-  ${theme.fonts.h3}
-`
-
-export const H4 = styled.span`
-  ${theme.fonts.h4}
-`
-
-export const Bold18 = styled.span`
-  ${theme.fonts.bold18}
-`
-
-export const Bold16 = styled.span`
-  ${theme.fonts.bold16}
-`
-
-export const Bold14 = styled.span`
-  ${theme.fonts.bold14}
-`
-
-export const Bold12 = styled.span`
-  ${theme.fonts.bold12}
-`
-
-export const Reg18 = styled.span`
-  ${theme.fonts.reg18}
-`
-
-export const Reg16 = styled.span`
-  ${theme.fonts.reg16}
-`
-
-export const Reg14 = styled.span`
-  ${theme.fonts.reg14}
-`
-
-export const Reg12 = styled.span`
-  ${theme.fonts.reg12}
-`
-
 <Meta title="Styles/Typography" />
+
+export const typography = {
+  type: {
+    primary: theme.fonts.fontFamily
+  },
+  weight: {
+    regular: '400',
+    bold: '600'
+  },
+  size: {
+    s1: 12,
+    s2: 14,
+    m1: 16,
+    m2: 18,
+    m3: 21,
+    l1: 24,
+    l2: 36
+  }
+}
+
+export const SampleText = 'The gold standard for digital civil registration'
 
 # Typography
 
@@ -74,33 +47,75 @@ Currently OpenCRVS supports Noto Sans in 400 (regular) and 600 (semi-bold). We w
 
 <br />
 
+### Font sizes
+
+<Typeset
+  fontSizes={[
+    Number(typography.size.l2),
+    Number(typography.size.l1),
+    Number(typography.size.m3),
+    Number(typography.size.m2),
+    Number(typography.size.m1),
+    Number(typography.size.s2),
+    Number(typography.size.s1)
+  ]}
+  fontWeight={typography.weight.bold}
+  sampleText={SampleText}
+  fontFamily={typography.type.primary}
+/>{' '}
+
 ### Headings
 
-| Font&nbsp;style | Example                                                                                                     |
-| --------------- | ----------------------------------------------------------------------------------------------------------- |
-| h1              | <H1>Our vision is that every person on the planet is...</H1>                                                |
-| h2              | <H2>Our vision is that every person on the planet is recognised, protected...</H2>                          |
-| h3              | <H3>Our vision is that every person on the planet is recognised, protected and provided...</H3>             |
-| h4              | <H4>Our vision is that every person on the planet is recognised, protected and provided for from birth</H4> |
+<Typeset
+  fontSizes={['36px']}
+  sampleText="Heading 1"
+  fontWeight={typography.weight.bold}
+  fontFamily={typography.type.primary}
+/>
+<Typeset
+  fontSizes={['24px']}
+  sampleText="Heading 2"
+  fontWeight={typography.weight.bold}
+  fontFamily={typography.type.primary}
+/>
+<Typeset
+  fontSizes={['21px']}
+  sampleText="Heading 3"
+  fontWeight={typography.weight.bold}
+  fontFamily={typography.type.primary}
+/>
 
-<br />
+<Typeset
+  fontSizes={['18px']}
+  sampleText="Heading 4"
+  fontWeight={typography.weight.bold}
+  fontFamily={typography.type.primary}
+/>
 
-### Bold body styles
+### Body
 
-| Font&nbsp;style | Example                                                                                                             |
-| --------------- | ------------------------------------------------------------------------------------------------------------------- |
-| bold18          | <Bold18>Our vision is that every person on the planet is recognised, protected and provided for from birth</Bold18> |
-| bold16          | <Bold16>Our vision is that every person on the planet is recognised, protected and provided for from birth</Bold16> |
-| bold14          | <Bold14>Our vision is that every person on the planet is recognised, protected and provided for from birth</Bold14> |
-| bold12          | <Bold12>Our vision is that every person on the planet is recognised, protected and provided for from birth</Bold12> |
+<Typeset
+  fontSizes={['18px']}
+  sampleText="Body text 1"
+  fontWeight={typography.weight.regular}
+  fontFamily={typography.type.primary}
+/>
+<Typeset
+  fontSizes={['16px']}
+  sampleText="Body text 2"
+  fontWeight={typography.weight.regular}
+  fontFamily={typography.type.primary}
+/>
+<Typeset
+  fontSizes={['14px']}
+  sampleText="Body text 3"
+  fontWeight={typography.weight.regular}
+  fontFamily={typography.type.primary}
+/>
 
-<br />
-
-### Regular body styles
-
-| Font&nbsp;style | Example                                                                                                           |
-| --------------- | ----------------------------------------------------------------------------------------------------------------- |
-| reg18           | <Reg18>Our vision is that every person on the planet is recognised, protected and provided for from birth</Reg18> |
-| reg16           | <Reg16>Our vision is that every person on the planet is recognised, protected and provided for from birth</Reg16> |
-| reg14           | <Reg14>Our vision is that every person on the planet is recognised, protected and provided for from birth</Reg14> |
-| reg12           | <Reg12>Our vision is that every person on the planet is recognised, protected and provided for from birth</Reg12> |
+<Typeset
+  fontSizes={['12px']}
+  sampleText="Body text 4"
+  fontWeight={typography.weight.regular}
+  fontFamily={typography.type.primary}
+/>

--- a/packages/components/src/stories/typography.stories.mdx
+++ b/packages/components/src/stories/typography.stories.mdx
@@ -66,13 +66,15 @@ export const Reg12 = styled.span`
 
 # Typography
 
-**Font:** Noto Sans
+OpenCRVS’s user interface uses a single font family called [Noto Sans](https://fonts.google.com/noto/fonts).
 
-**Weights:** 400 (regular), 600 (semibold)
+The Noto font collection is designed for typographically correct and aesthetically pleasing global communication in more than 1,000 languages and over 150 scripts.
+
+Currently OpenCRVS supports Noto Sans in 400 (regular) and 600 (semi-bold). We will add additional Noto Sans scripts based on country implementation requirements.
 
 <br />
 
-## Headings
+### Headings
 
 | Font&nbsp;style | Example                                                                                                     |
 | --------------- | ----------------------------------------------------------------------------------------------------------- |
@@ -83,7 +85,7 @@ export const Reg12 = styled.span`
 
 <br />
 
-## Bold body styles
+### Bold body styles
 
 | Font&nbsp;style | Example                                                                                                             |
 | --------------- | ------------------------------------------------------------------------------------------------------------------- |
@@ -94,7 +96,7 @@ export const Reg12 = styled.span`
 
 <br />
 
-## Regular body styles
+### Regular body styles
 
 | Font&nbsp;style | Example                                                                                                           |
 | --------------- | ----------------------------------------------------------------------------------------------------------------- |

--- a/packages/components/src/stories/typography.stories.mdx
+++ b/packages/components/src/stories/typography.stories.mdx
@@ -1,0 +1,104 @@
+<!--This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+OpenCRVS is also distributed under the terms of the Civil Registration
+& Healthcare Disclaimer located at http://opencrvs.org/license.
+
+Copyright (C) The OpenCRVS Authors. OpenCRVS and the OpenCRVS
+graphic logo are (registered/a) trademark(s) of Plan International.-->
+
+import { Meta, ColorPalette, ColorItem } from '@storybook/addon-docs'
+import styled from 'styled-components'
+import { getTheme } from '@opencrvs/components/lib/theme'
+
+export const theme = getTheme()
+
+export const H1 = styled.span`
+  ${theme.fonts.h1}
+`
+
+export const H2 = styled.span`
+  ${theme.fonts.h2}
+`
+
+export const H3 = styled.span`
+  ${theme.fonts.h3}
+`
+
+export const H4 = styled.span`
+  ${theme.fonts.h4}
+`
+
+export const Bold18 = styled.span`
+  ${theme.fonts.bold18}
+`
+
+export const Bold16 = styled.span`
+  ${theme.fonts.bold16}
+`
+
+export const Bold14 = styled.span`
+  ${theme.fonts.bold14}
+`
+
+export const Bold12 = styled.span`
+  ${theme.fonts.bold12}
+`
+
+export const Reg18 = styled.span`
+  ${theme.fonts.reg18}
+`
+
+export const Reg16 = styled.span`
+  ${theme.fonts.reg16}
+`
+
+export const Reg14 = styled.span`
+  ${theme.fonts.reg14}
+`
+
+export const Reg12 = styled.span`
+  ${theme.fonts.reg12}
+`
+
+<Meta title="Styles/Typography" />
+
+# Typography
+
+**Font:** Noto Sans
+
+**Weights:** 400 (regular), 600 (semibold)
+
+<br />
+
+## Headings
+
+| Font&nbsp;style | Example                                                                                                     |
+| --------------- | ----------------------------------------------------------------------------------------------------------- |
+| h1              | <H1>Our vision is that every person on the planet is...</H1>                                                |
+| h2              | <H2>Our vision is that every person on the planet is recognised, protected...</H2>                          |
+| h3              | <H3>Our vision is that every person on the planet is recognised, protected and provided...</H3>             |
+| h4              | <H4>Our vision is that every person on the planet is recognised, protected and provided for from birth</H4> |
+
+<br />
+
+## Bold body styles
+
+| Font&nbsp;style | Example                                                                                                             |
+| --------------- | ------------------------------------------------------------------------------------------------------------------- |
+| bold18          | <Bold18>Our vision is that every person on the planet is recognised, protected and provided for from birth</Bold18> |
+| bold16          | <Bold16>Our vision is that every person on the planet is recognised, protected and provided for from birth</Bold16> |
+| bold14          | <Bold14>Our vision is that every person on the planet is recognised, protected and provided for from birth</Bold14> |
+| bold12          | <Bold12>Our vision is that every person on the planet is recognised, protected and provided for from birth</Bold12> |
+
+<br />
+
+## Regular body styles
+
+| Font&nbsp;style | Example                                                                                                           |
+| --------------- | ----------------------------------------------------------------------------------------------------------------- |
+| reg18           | <Reg18>Our vision is that every person on the planet is recognised, protected and provided for from birth</Reg18> |
+| reg16           | <Reg16>Our vision is that every person on the planet is recognised, protected and provided for from birth</Reg16> |
+| reg14           | <Reg14>Our vision is that every person on the planet is recognised, protected and provided for from birth</Reg14> |
+| reg12           | <Reg12>Our vision is that every person on the planet is recognised, protected and provided for from birth</Reg12> |

--- a/yarn.lock
+++ b/yarn.lock
@@ -5133,7 +5133,7 @@
     lodash "^4.17.21"
     ts-dedent "^2.0.0"
 
-"@storybook/addon-docs@6.5.10":
+"@storybook/addon-docs@6.5.10", "@storybook/addon-docs@^6.5.10":
   version "6.5.10"
   resolved "https://registry.yarnpkg.com/@storybook/addon-docs/-/addon-docs-6.5.10.tgz#dde18b5659e8033651e139a231a7f69306433b92"
   integrity sha512-1kgjo3f0vL6GN8fTwLL05M/q/kDdzvuqwhxPY/v5hubFb3aQZGr2yk9pRBaLAbs4bez0yG0ASXcwhYnrEZUppg==


### PR DESCRIPTION
Closes #3775
Closes #3752 

* `indigoDark` -> `primaryDark`
* `redDark` -> `negativeDark` 
* `greenDark` -> `positiveDark`
* ^ autogenerate dark shades for primary, negative, positive and teal. This is to help support theming in the future.
* Create documentation for colors and typography
* Installs `polished` for `lighten` / `darken` functions. **Question:** do we want to install a new dependency for this or to create our own functions? `polished` should support tree-shaking but [Bundlephobia](https://bundlephobia.com/package/polished@4.2.2) says that every export is the same size 🤔  