### PR TITLE
ocrvs-3788 Fixed default form not published issue

### DIFF
--- a/packages/client/src/views/SysAdmin/Config/Forms/Home/PreviewTab.test.tsx
+++ b/packages/client/src/views/SysAdmin/Config/Forms/Home/PreviewTab.test.tsx
@@ -46,7 +46,7 @@ function WrappedPreviewTab() {
 const inPreviewDraft: IFormDraft = {
   event: Event.Birth,
   status: DraftStatus.InPreview,
-  version: 1,
+  version: 0,
   history: [],
   updatedAt: Date.now(),
   createdAt: Date.now()

--- a/packages/client/src/views/SysAdmin/Config/Forms/Home/PreviewTab.tsx
+++ b/packages/client/src/views/SysAdmin/Config/Forms/Home/PreviewTab.tsx
@@ -32,10 +32,12 @@ import { ActionContext, Actions } from './ActionsModal'
 
 function ActionButton({
   action,
-  event
+  event,
+  disabled
 }: {
   action: Actions.EDIT | Actions.PUBLISH
   event: Event
+  disabled?: boolean
 }) {
   const intl = useIntl()
   const { setAction } = React.useContext(ActionContext)
@@ -43,6 +45,7 @@ function ActionButton({
   return (
     <LinkButton
       id={`${action.toLowerCase()}-btn`}
+      disabled={disabled}
       onClick={() => {
         setAction({
           action: action,
@@ -69,7 +72,7 @@ function EventDrafts({ event }: { event: Event }) {
       label={<DraftVersion event={event} version={version} />}
       value={
         <Value>
-          {status === DraftStatus.Draft
+          {version === 0
             ? intl.formatMessage(messages.defaultComment)
             : intl.formatMessage(messages.previewDate, {
                 updatedAt
@@ -89,7 +92,11 @@ function EventDrafts({ event }: { event: Event }) {
             {status === DraftStatus.InPreview && (
               <ActionButton action={Actions.EDIT} event={event} />
             )}
-            <ActionButton action={Actions.PUBLISH} event={event} />
+            <ActionButton
+              action={Actions.PUBLISH}
+              event={event}
+              disabled={formDraft.version !== 0}
+            />
           </>
         )
       }

--- a/packages/config/src/handlers/formDraft/updateFormDraft/handler.test.ts
+++ b/packages/config/src/handlers/formDraft/updateFormDraft/handler.test.ts
@@ -137,6 +137,21 @@ describe('modifyDraftStatusHandler test', () => {
   })
 
   it('should update form draft status using mongoose', async () => {
+    fetch.mockResponse(
+      JSON.stringify([
+        {
+          status: 'ok'
+        },
+
+        {
+          status: 'ok'
+        }
+      ])
+    )
+    // @ts-ignore
+    jest.spyOn(fhirService, 'fetchFHIR').mockReturnValue(taskBundleMock)
+    // @ts-ignore
+    jest.spyOn(fhirService, 'deleteFHIR').mockReturnValue({ status: 'ok' })
     mockingoose(FormDraft).toReturn(birthMockFormDraft, 'findOne')
     mockingoose(FormDraft).toReturn(birthUpdatedMockFormDraft, 'updateOne')
 

--- a/packages/config/src/handlers/formDraft/updateFormDraft/handler.ts
+++ b/packages/config/src/handlers/formDraft/updateFormDraft/handler.ts
@@ -22,12 +22,12 @@ import { Event } from '@config/models/certificate'
 import { clearHearthElasticInfluxData } from '@config/services/formDraftService'
 
 const STATUS_TRANSITION: Record<DraftStatus, DraftStatus[]> = {
-  [DraftStatus.DRAFT]: [DraftStatus.DRAFT, DraftStatus.IN_PREVIEW],
+  [DraftStatus.DRAFT]: [DraftStatus.IN_PREVIEW, DraftStatus.PUBLISHED],
   [DraftStatus.IN_PREVIEW]: [DraftStatus.PUBLISHED, DraftStatus.DRAFT],
   [DraftStatus.PUBLISHED]: []
 }
 
-export function isValidStatusTransition(
+function isValidStatusTransition(
   currentStatus: DraftStatus,
   newStatus: DraftStatus
 ) {
@@ -89,9 +89,7 @@ export async function modifyDraftStatusHandler(
   }
 
   try {
-    if (currentStatus === DraftStatus.IN_PREVIEW) {
-      await clearHearthElasticInfluxData(request)
-    }
+    await clearHearthElasticInfluxData(request)
     draft.status = newStatus
     draft.updatedAt = Date.now()
     await FormDraft.updateOne({ _id: draft._id }, draft)


### PR DESCRIPTION
I have changed the logic for the default form config. If the draft version is **0** then the national sys admin can publish the default form config, but if the national sys admin already make a form draft and the draft version increased from 0 then they have to move the form draft to in preview first for published. Otherwise, the publish button will be disabled.

![Screenshot from 2022-08-17 18-54-20](https://user-images.githubusercontent.com/36187489/185141574-2062689e-c123-4e93-b899-f7af27c749d3.png)
