### PR TITLE
Move deprecated components to their own section

### DIFF
--- a/packages/components/src/components/buttons/Action.stories.tsx
+++ b/packages/components/src/components/buttons/Action.stories.tsx
@@ -17,7 +17,7 @@ import { Action, IActionProps } from './Action'
 const Template: Story<IActionProps> = (args) => <Action {...args} />
 
 export default {
-  title: 'Controls/Button/Action (deprecated)',
+  title: 'Deprecated/Button/Action',
   component: Action
 } as Meta
 

--- a/packages/components/src/components/buttons/ArrowExpansionButton.stories.tsx
+++ b/packages/components/src/components/buttons/ArrowExpansionButton.stories.tsx
@@ -19,7 +19,7 @@ const Template: Story<IExpansionButtonProps> = (args) => (
 )
 
 export default {
-  title: 'Controls/Button/ArrowExpansionButton (deprecated)',
+  title: 'Deprecated/Button/ArrowExpansionButton',
   component: ArrowExpansionButton
 } as Meta
 

--- a/packages/components/src/components/buttons/ExpansionButton.stories.tsx
+++ b/packages/components/src/components/buttons/ExpansionButton.stories.tsx
@@ -18,7 +18,7 @@ const Template: Story<IExpansionButtonProps> = (args) => (
 )
 
 export default {
-  title: 'Controls/Button/ExpansionButton (deprecated)',
+  title: 'Deprecated/Button/ExpansionButton',
   component: ExpansionButton
 } as Meta
 

--- a/packages/components/src/components/buttons/IconButton.stories.tsx
+++ b/packages/components/src/components/buttons/IconButton.stories.tsx
@@ -16,7 +16,7 @@ import { IconButton, IButtonProps } from '.'
 const Template: Story<IButtonProps> = (args) => <IconButton {...args} />
 
 export default {
-  title: 'Controls/Button/IconButton (deprecated)',
+  title: 'Deprecated/Button/IconButton',
   component: IconButton,
   argTypes: {
     icon: {

--- a/packages/components/src/components/charts/Bar.stories.tsx
+++ b/packages/components/src/components/charts/Bar.stories.tsx
@@ -14,7 +14,7 @@ import { Meta, Story } from '@storybook/react'
 import { Bar, IBarChartProps } from './Bar'
 
 export default {
-  title: 'Data/Charts/Bar (deprecated)',
+  title: 'Deprecated/Charts/Bar',
   component: Bar
 } as Meta
 

--- a/packages/components/src/components/charts/Legend.stories.tsx
+++ b/packages/components/src/components/charts/Legend.stories.tsx
@@ -15,7 +15,7 @@ import { MinusTransparent, PlusTransparent } from '../icons'
 import { Legend, ILegendProps } from './Legend'
 
 export default {
-  title: 'Data/Charts/Legend (deprecated)',
+  title: 'Deprecated/Charts/Legend',
   component: Legend
 } as Meta
 

--- a/packages/components/src/components/interface/ActionPage.stories.tsx
+++ b/packages/components/src/components/interface/ActionPage.stories.tsx
@@ -36,6 +36,6 @@ ActionPageView.args = {
 }
 
 export default {
-  title: 'Layout/Action page (deprecated)',
+  title: 'Deprecated/Action page',
   component: ActionPage
 } as Meta

--- a/packages/components/src/components/interface/Banner.stories.tsx
+++ b/packages/components/src/components/interface/Banner.stories.tsx
@@ -28,6 +28,6 @@ BannerView.args = {
 }
 
 export default {
-  title: 'Layout/Banner (deprecated)',
+  title: 'Deprecated/Banner',
   component: Banner
 } as Meta

--- a/packages/components/src/components/interface/Chip.stories.tsx
+++ b/packages/components/src/components/interface/Chip.stories.tsx
@@ -26,6 +26,6 @@ ChipView.args = {
 }
 
 export default {
-  title: 'Layout/Chip (deprecated)',
+  title: 'Layout/Chip',
   component: Chip
 } as Meta

--- a/packages/components/src/components/interface/DataTable/DataTable.stories.tsx
+++ b/packages/components/src/components/interface/DataTable/DataTable.stories.tsx
@@ -22,7 +22,7 @@ import React from 'react'
 import { IDynamicValues } from 'src/components/common-types'
 
 export default {
-  title: 'Data/DataTable (deprecated)',
+  title: 'Deprecated/DataTable',
   component: DataTable
 } as Meta
 

--- a/packages/components/src/components/interface/DataTable/Pagination.stories.tsx
+++ b/packages/components/src/components/interface/DataTable/Pagination.stories.tsx
@@ -14,7 +14,7 @@ import { Pagination, IPaginationCustomProps } from './Pagination'
 import React from 'react'
 
 export default {
-  title: 'Controls/Pagination (deprecated)',
+  title: 'Deprecated/Pagination',
   component: Pagination
 } as Meta
 

--- a/packages/components/src/components/interface/DataTable/SortAndFilter.stories.tsx
+++ b/packages/components/src/components/interface/DataTable/SortAndFilter.stories.tsx
@@ -15,7 +15,7 @@ import React from 'react'
 import { ISelectGroupValue } from '../SelectGroup'
 
 export default {
-  title: 'Data/DataTable (deprecated)/SortAndFilter',
+  title: 'Deprecated/DataTable/SortAndFilter',
   component: SortAndFilter
 } as Meta
 

--- a/packages/components/src/components/interface/ExpandableNotification/ExpandableNotification.stories.tsx
+++ b/packages/components/src/components/interface/ExpandableNotification/ExpandableNotification.stories.tsx
@@ -14,7 +14,7 @@ import { ExpandableNotification } from './ExpandableNotification'
 import React from 'react'
 
 export default {
-  title: 'Data/ExpandableNotification (deprecated)',
+  title: 'Deprecated/ExpandableNotification',
   component: ExpandableNotification
 } as Meta
 

--- a/packages/components/src/components/interface/HamburgerMenu.stories.tsx
+++ b/packages/components/src/components/interface/HamburgerMenu.stories.tsx
@@ -38,6 +38,6 @@ HamburgerMenuView.args = {
 }
 
 export default {
-  title: 'Layout/Hamburger (deprecated)',
+  title: 'Deprecated/Hamburger',
   component: HamburgerMenu
 }

--- a/packages/components/src/components/interface/InvertSpinner.stories.tsx
+++ b/packages/components/src/components/interface/InvertSpinner.stories.tsx
@@ -21,6 +21,6 @@ InvertSpinnerView.args = {
 }
 
 export default {
-  title: 'Input/InvertSpinner (deprecated)',
+  title: 'Deprecated/InvertSpinner',
   component: InvertSpinner
 } as Meta

--- a/packages/components/src/components/interface/ListItem.stories.tsx
+++ b/packages/components/src/components/interface/ListItem.stories.tsx
@@ -68,6 +68,6 @@ ListItemView.args = {
 }
 
 export default {
-  title: 'Data/ListItem (deprecated)',
+  title: 'Deprecated/ListItem',
   component: ListItem
 } as Meta

--- a/packages/components/src/components/interface/ListItemExpansion.stories.tsx
+++ b/packages/components/src/components/interface/ListItemExpansion.stories.tsx
@@ -30,6 +30,6 @@ ListItemExpansionView.args = {
 }
 
 export default {
-  title: 'Data/ListItemExpansion (deprecated)',
+  title: 'Deprecated/ListItemExpansion',
   component: ListItemExpansion
 } as Meta

--- a/packages/components/src/components/interface/Modal.stories.tsx
+++ b/packages/components/src/components/interface/Modal.stories.tsx
@@ -51,6 +51,6 @@ ModalView.args = {
 }
 
 export default {
-  title: 'Layout/Modal (deprecated)',
+  title: 'Deprecated/Modal',
   component: Modal
 } as Meta

--- a/packages/components/src/components/interface/ResultList.stories.tsx
+++ b/packages/components/src/components/interface/ResultList.stories.tsx
@@ -145,6 +145,6 @@ ResultListView.args = {
   ]
 }
 export default {
-  title: 'Data/ResultList (deprecated)',
+  title: 'Deprecated/ResultList',
   component: ResultList
 } as Meta

--- a/packages/components/src/components/interface/SectionDrawer.stories.tsx
+++ b/packages/components/src/components/interface/SectionDrawer.stories.tsx
@@ -37,6 +37,6 @@ SectionDrawerView.args = {
   expansionButtonHandler: () => alert('Expansion clicked')
 }
 export default {
-  title: 'Data/SectionDrawer (deprecated)',
+  title: 'Deprecated/SectionDrawer',
   component: SectionDrawer
 } as Meta

--- a/packages/components/src/components/interface/SelectGroup.stories.tsx
+++ b/packages/components/src/components/interface/SelectGroup.stories.tsx
@@ -48,6 +48,6 @@ SelectGroupView.args = {
   ]
 }
 export default {
-  title: 'Input/SelectGroup (deprecated)',
+  title: 'Deprecated/SelectGroup',
   component: SelectGroup
 } as Meta

--- a/packages/components/src/components/interface/SubPage.stories.tsx
+++ b/packages/components/src/components/interface/SubPage.stories.tsx
@@ -34,6 +34,6 @@ SubPageView.args = {
 }
 
 export default {
-  title: 'Layout/Sub page (deprecated)',
+  title: 'Deprecated/Sub page',
   component: SubPage
 } as Meta

--- a/packages/components/src/components/interface/TopBar.stories.tsx
+++ b/packages/components/src/components/interface/TopBar.stories.tsx
@@ -28,6 +28,6 @@ TopBarView.args = {
 }
 
 export default {
-  title: 'Layout/TopBar (deprecated)',
+  title: 'Deprecated/TopBar',
   component: TopBar
 }

--- a/packages/components/src/components/interface/ViewData/DataRow.stories.tsx
+++ b/packages/components/src/components/interface/ViewData/DataRow.stories.tsx
@@ -14,7 +14,7 @@ import { DataRow, IDataProps } from './DataRow'
 import React from 'react'
 
 export default {
-  title: 'Data/ViewData (deprecated)/DataRow',
+  title: 'Deprecated/ViewData/DataRow',
   component: DataRow
 } as Meta
 

--- a/packages/components/src/components/interface/ViewData/DataSection.stories.tsx
+++ b/packages/components/src/components/interface/ViewData/DataSection.stories.tsx
@@ -22,7 +22,7 @@ interface IProps {
 }
 
 export default {
-  title: 'Data/ViewData (deprecated)/DataSection',
+  title: 'Deprecated/ViewData/DataSection',
   component: DataSection
 } as Meta
 

--- a/packages/components/src/components/interface/ViewData/LabelValuePair.stories.tsx
+++ b/packages/components/src/components/interface/ViewData/LabelValuePair.stories.tsx
@@ -19,7 +19,7 @@ interface ILabelValuePairProps {
 }
 
 export default {
-  title: 'Data/ViewData (deprecated)/LabelValuePair',
+  title: 'Deprecated/ViewData/LabelValuePair',
   component: LabelValuePair
 } as Meta
 


### PR DESCRIPTION
Moves for example `ActionButton (deprecated)` into a section called `Deprecated`, to make the Storybook look nicer.

<img width="366" alt="image" src="https://user-images.githubusercontent.com/1322608/186132920-f368cf1f-00e4-41e4-8470-b41c67794b79.png">
