### PR TITLE
Fix app main loader spinning infinitely

### DIFF
--- a/packages/client/src/components/ProtectedPage.tsx
+++ b/packages/client/src/components/ProtectedPage.tsx
@@ -88,7 +88,9 @@ class ProtectedPageComponent extends React.Component<Props, IProtectPageState> {
 
   async componentDidMount() {
     setTimeout(this.setLoadingTimeOut, LOADER_MIN_DISPLAY_TIME)
-    const newState = { ...this.state }
+
+    const { loadingTimeout, ...stateWithoutLoadingTimeout } = this.state
+    const newState = { ...stateWithoutLoadingTimeout }
 
     if (await storage.getItem(SCREEN_LOCK)) {
       newState.secured = false


### PR DESCRIPTION
On some devices, it might take so long to read data from the storage that the timeout for a minimum time of showing the main loader finishes before reading from storage does. This caused the app to stay in a state where the loader is shown infinitely. 
