### PR TITLE
fix app main loader spinning infinitely when reading storage and othe…

### DIFF
--- a/packages/client/src/components/ProtectedPage.tsx
+++ b/packages/client/src/components/ProtectedPage.tsx
@@ -88,7 +88,9 @@ class ProtectedPageComponent extends React.Component<Props, IProtectPageState> {
 
   async componentDidMount() {
     setTimeout(this.setLoadingTimeOut, LOADER_MIN_DISPLAY_TIME)
-    const newState = { ...this.state }
+
+    const { loadingTimeout, ...stateWithoutLoadingTimeout } = this.state
+    const newState = { ...stateWithoutLoadingTimeout }
 
     if (await storage.getItem(SCREEN_LOCK)) {
       newState.secured = false


### PR DESCRIPTION
…r preparation takes more time than the minimum time for the loader to be visible