### PR TITLE
Use English and French as default languages in the application

### DIFF
--- a/packages/gateway/src/constants.ts
+++ b/packages/gateway/src/constants.ts
@@ -39,7 +39,7 @@ export const QA_ENV = process.env.QA_ENV || false
 // This needs to be a string to make it easy to pass as an ENV var.
 export const CHECK_INVALID_TOKEN = process.env.CHECK_INVALID_TOKEN || 'false'
 export function getLanguages() {
-  const LANGUAGES = process.env.LANGUAGES || 'bn,en'
+  const LANGUAGES = process.env.LANGUAGES || 'en,fr'
   return LANGUAGES.split(',')
 }
 

--- a/packages/notification/src/i18n/utils.ts
+++ b/packages/notification/src/i18n/utils.ts
@@ -10,7 +10,7 @@
  * graphic logo are (registered/a) trademark(s) of Plan International.
  */
 export function getAvailableLanguages() {
-  const LANGUAGES = (process.env.LANGUAGES && process.env.LANGUAGES) || 'bn,en'
+  const LANGUAGES = (process.env.LANGUAGES && process.env.LANGUAGES) || 'en,fr'
   return LANGUAGES.split(',')
 }
 

--- a/packages/notification/src/i18n/utils.ts
+++ b/packages/notification/src/i18n/utils.ts
@@ -10,7 +10,7 @@
  * graphic logo are (registered/a) trademark(s) of Plan International.
  */
 export function getAvailableLanguages() {
-  const LANGUAGES = (process.env.LANGUAGES && process.env.LANGUAGES) || 'en,fr'
+  const LANGUAGES = process.env.LANGUAGES || 'en,fr'
   return LANGUAGES.split(',')
 }
 

--- a/packages/workflow/src/constants.ts
+++ b/packages/workflow/src/constants.ts
@@ -30,7 +30,7 @@ export const USER_MANAGEMENT_URL =
 export const SENTRY_DSN = process.env.SENTRY_DSN
 
 function getAvailableLanguages() {
-  const LANGUAGES = (process.env.LANGUAGES && process.env.LANGUAGES) || 'en,fr'
+  const LANGUAGES = process.env.LANGUAGES || 'en,fr'
   return LANGUAGES.split(',')
 }
 

--- a/packages/workflow/src/constants.ts
+++ b/packages/workflow/src/constants.ts
@@ -30,7 +30,7 @@ export const USER_MANAGEMENT_URL =
 export const SENTRY_DSN = process.env.SENTRY_DSN
 
 function getAvailableLanguages() {
-  const LANGUAGES = (process.env.LANGUAGES && process.env.LANGUAGES) || 'bn,en'
+  const LANGUAGES = (process.env.LANGUAGES && process.env.LANGUAGES) || 'en,fr'
   return LANGUAGES.split(',')
 }
 


### PR DESCRIPTION
I was running the application with just `yarn start` from opencrvs-core. When I was creating a registration, I ran into this error:
![image](https://user-images.githubusercontent.com/1322608/189120046-bdb4e32d-9d53-4258-ad3c-880bd7ba7e1c.png)

When we looked it further with Riku, noticed that
https://github.com/opencrvs/opencrvs-core/blob/develop/packages/workflow/src/features/registration/fhir/fhir-utils.ts#L57
this row throws an error, as "bn" language wasn't found from informants name. I hadn't set the `LANGUAGES` environment (like `dev.sh` does)

Should we use English and French as default languages?

Tests need to be fixed, but we can look into those if we wanna actually merge this 🤔 