### PR TITLE
OCRVS-4056 Fix application config regex overflow

### DIFF
--- a/packages/client/src/views/SysAdmin/Config/Application/Components.tsx
+++ b/packages/client/src/views/SysAdmin/Config/Application/Components.tsx
@@ -9,6 +9,7 @@
  * Copyright (C) The OpenCRVS Authors. OpenCRVS and the OpenCRVS
  * graphic logo are (registered/a) trademark(s) of Plan International.
  */
+import { Text } from '@opencrvs/components/lib/Text'
 import styled from '@client/styledComponents'
 import { PrimaryButton, TertiaryButton } from '@opencrvs/components/lib/buttons'
 import { TextInput } from '@opencrvs/components/lib/TextInput'
@@ -78,9 +79,8 @@ export const Message = styled.div`
   margin-bottom: 16px;
 `
 
-export const Label = styled.span`
-  ${({ theme }) => theme.fonts.bold16};
-`
-export const Value = styled.span`
-  ${({ theme }) => theme.fonts.reg16}
-`
+export const Label = styled(Text).attrs({
+  variant: 'bold16',
+  element: 'span'
+})``
+export const Value = styled(Text).attrs({ variant: 'reg16', element: 'span' })``

--- a/packages/client/src/views/SysAdmin/Config/Application/Tabs/GeneralProperties/NIDNumPattern.tsx
+++ b/packages/client/src/views/SysAdmin/Config/Application/Tabs/GeneralProperties/NIDNumPattern.tsx
@@ -93,7 +93,7 @@ export function NIDNumPattern() {
           </Label>
         }
         value={
-          <Value id={`${id}_value`}>
+          <Value id={`${id}_value`} overflowWrap="anywhere">
             {String(offlineCountryConfiguration.config.NID_NUMBER_PATTERN)}
           </Value>
         }

--- a/packages/client/src/views/SysAdmin/Config/Application/Tabs/GeneralProperties/PhoneNumPattern.tsx
+++ b/packages/client/src/views/SysAdmin/Config/Application/Tabs/GeneralProperties/PhoneNumPattern.tsx
@@ -100,7 +100,7 @@ export function PhoneNumPattern() {
           </Label>
         }
         value={
-          <Value id={`${id}_value`}>
+          <Value id={`${id}_value`} overflowWrap="anywhere">
             {String(offlineCountryConfiguration.config.PHONE_NUMBER_PATTERN)}
           </Value>
         }

--- a/packages/components/src/Text/Text.stories.tsx
+++ b/packages/components/src/Text/Text.stories.tsx
@@ -15,6 +15,8 @@ import { ComponentMeta, ComponentStory } from '@storybook/react'
 import { Text } from './Text'
 import { Stack } from '../Stack'
 import { UserIcon } from '../icons/User.stories'
+import { Box } from '../Box'
+import styled from 'styled-components'
 
 export default {
   title: 'Typography/Text',
@@ -67,4 +69,34 @@ export const Caption = () => (
   <Text variant="reg12" element="p">
     OpenCRVS is highly configurable
   </Text>
+)
+
+const NarrowBox = styled(Box)`
+  width: 150px;
+`
+
+export const OverflowWrap = () => (
+  <>
+    <Text variant="bold16" element="h4">
+      No overflow
+    </Text>
+
+    <NarrowBox>
+      <Text variant="reg16" element="p">
+        This is text with a long string 012345678901234567890123456789
+      </Text>
+    </NarrowBox>
+
+    <br />
+
+    <Text variant="bold16" element="h4">
+      Overflow anywhere
+    </Text>
+
+    <NarrowBox>
+      <Text variant="reg16" element="p" overflowWrap="anywhere">
+        This is text with a long string 012345678901234567890123456789
+      </Text>
+    </NarrowBox>
+  </>
 )

--- a/packages/components/src/Text/Text.tsx
+++ b/packages/components/src/Text/Text.tsx
@@ -36,7 +36,7 @@ const StyledText = styled.span<{
 }>`
   ${({ $variant }) => fonts[$variant]}
   ${({ $color }) => `color: ${colors[$color]};`}
-  ${({ $overflowWrap }) => $overflowWrap && `overflow-wrap: ${$overflowWrap}`}
+  ${({ $overflowWrap }) => $overflowWrap && `overflow-wrap: ${$overflowWrap};`}
 `
 
 /** Text helps present your content with correct hierarchy and font sizes */

--- a/packages/components/src/Text/Text.tsx
+++ b/packages/components/src/Text/Text.tsx
@@ -14,6 +14,7 @@ import React from 'react'
 import { fonts, IFont } from '../fonts'
 import { colors, IColor } from '../colors'
 import styled from 'styled-components'
+import type { Property } from 'csstype'
 
 type Element = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p' | 'span'
 
@@ -24,19 +25,33 @@ export interface ITextProps extends React.HTMLAttributes<HTMLSpanElement> {
   element: Element
   /** Color */
   color?: IColor
+  /** Setting whether the browser should insert line breaks within an otherwise unbreakable string to prevent text from overflowing its line box */
+  overflowWrap?: Property.OverflowWrap
 }
 
-const StyledText = styled.span<{ $variant: IFont; $color: IColor }>`
+const StyledText = styled.span<{
+  $variant: IFont
+  $color: IColor
+  $overflowWrap?: Property.OverflowWrap
+}>`
   ${({ $variant }) => fonts[$variant]}
   ${({ $color }) => `color: ${colors[$color]};`}
+  ${({ $overflowWrap }) => $overflowWrap && `overflow-wrap: ${$overflowWrap}`}
 `
 
 /** Text helps present your content with correct hierarchy and font sizes */
 export const Text = ({
   variant,
   element,
+  overflowWrap,
   color = 'copy',
   ...props
 }: ITextProps) => (
-  <StyledText $variant={variant} $color={color} as={element} {...props} />
+  <StyledText
+    $variant={variant}
+    $color={color}
+    as={element}
+    $overflowWrap={overflowWrap}
+    {...props}
+  />
 )


### PR DESCRIPTION
Closes #4056 

* Implements `overflowWrap` to `Text`
* Changes regex Texts to overflow anywhere
---
<img width="787" alt="image" src="https://user-images.githubusercontent.com/1322608/195570661-5e7166dc-a60b-458a-9fc0-823826c43a22.png">
