### PR TITLE
Disable generate-test-forms from precommit

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -95,7 +95,6 @@
   "lint-staged": {
     "src/**/*.{ts,tsx}": [
       "prettier --write",
-      "yarn generate:test:forms",
       "yarn lint:ts",
       "stylelint",
       "yarn extract:translations",


### PR DESCRIPTION
@euanmillar Disabling this temporarily until we amend this script to support esnext features.