### PR TITLE
Updated error toast messages and  sync messages

### DIFF
--- a/packages/client/src/components/Notification.tsx
+++ b/packages/client/src/components/Notification.tsx
@@ -113,6 +113,7 @@ class Component extends React.Component<
         {children}
         {backgroundSyncMessageVisible && (
           <Toast
+            type="success"
             id="backgroundSyncShowNotification"
             onClose={this.hideBackgroundSyncedNotification}
           >

--- a/packages/client/src/i18n/messages/errors.ts
+++ b/packages/client/src/i18n/messages/errors.ts
@@ -79,7 +79,8 @@ const messagesToDefine: IErrorMessages = {
     id: 'fieldAgentHome.queryError'
   },
   pleaseTryAgainError: {
-    defaultMessage: 'An error occurred. Please try again.',
+    defaultMessage:
+      'You are offline, please reconnect to complete your onboarding.',
     description:
       'The error message that displays if we want the user to try the action again',
     id: 'error.occurred'

--- a/packages/client/src/i18n/messages/views/notifications.ts
+++ b/packages/client/src/i18n/messages/views/notifications.ts
@@ -40,8 +40,7 @@ interface INotificationsMessages
 
 const messagesToDefine: INotificationsMessages = {
   declarationsSynced: {
-    defaultMessage:
-      'As you have connectivity, we can synchronize your declarations.',
+    defaultMessage: 'You have reconnected',
     description:
       'The message that appears in notification when background sync takes place',
     id: 'misc.notif.declarationsSynced'

--- a/packages/client/src/views/UserSetup/SetupReviewPage.tsx
+++ b/packages/client/src/views/UserSetup/SetupReviewPage.tsx
@@ -43,6 +43,7 @@ import {
   SubmitActivateUserMutation,
   SubmitActivateUserMutationVariables
 } from '@client/utils/gateway'
+import { Toast } from '@client/../../components/lib'
 
 const GlobalError = styled.div`
   color: ${({ theme }) => theme.colors.negative};
@@ -198,9 +199,9 @@ export function UserSetupReview({ setupData, goToStep }: IProps) {
               >
                 <GlobalError id="GlobalError">
                   {submitError && (
-                    <WarningMessage>
+                    <Toast type="error" onClose={() => setSubmitError(false)}>
                       {intl.formatMessage(errorMessages.pleaseTryAgainError)}
-                    </WarningMessage>
+                    </Toast>
                   )}
                 </GlobalError>
                 <div id="UserSetupData">


### PR DESCRIPTION
- displayed appropriate messages when offline and online.
- updated respective translations on farajaland
https://github.com/opencrvs/opencrvs-farajaland/pull/377