### PR TITLE
Ocrvs 3599 reveal keys for client in a modal view

### DIFF
--- a/packages/client/src/i18n/messages/buttons.ts
+++ b/packages/client/src/i18n/messages/buttons.ts
@@ -45,6 +45,7 @@ interface IButtonsMessages
   retry: MessageDescriptor
   review: MessageDescriptor
   save: MessageDescriptor
+  refresh: MessageDescriptor
   saveExitButton: MessageDescriptor
   deleteDeclaration: MessageDescriptor
   closeDeclaration: MessageDescriptor
@@ -236,6 +237,13 @@ const messagesToDefine: IButtonsMessages = {
     description: 'Review button text',
     id: 'buttons.review'
   },
+
+  refresh: {
+    defaultMessage: 'Refresh',
+    description: 'Refresh button',
+    id: 'buttons.refresh'
+  },
+
   save: {
     defaultMessage: 'Save',
     description: 'Save Button Text',

--- a/packages/client/src/i18n/messages/views/integrations.ts
+++ b/packages/client/src/i18n/messages/views/integrations.ts
@@ -79,6 +79,30 @@ const messagesToDefine = {
     defaultMessage: 'Activate Client?',
     description: 'Label for activate client option'
   },
+
+  clientId: {
+    id: 'integrations.clientId',
+    defaultMessage: 'Client ID',
+    description: 'Label for client Id'
+  },
+
+  clientSecret: {
+    id: 'integrations.clientSecret',
+    defaultMessage: 'Client Secret',
+    description: 'Label for client secret'
+  },
+  shaSecret: {
+    id: 'integrations.shaSecret',
+    defaultMessage: 'SHA Secret',
+    description: 'Label for SHA secret'
+  },
+  uniqueKeysDescription: {
+    id: 'integrations.uniqueKeyDescription',
+    defaultMessage:
+      'These unique keys will be required by the client integrating...',
+    description: 'Label for the unique key description'
+  },
+
   activateClientStatus: {
     id: 'integrations.activate.status',
     defaultMessage: 'Client activated',

--- a/packages/client/src/views/SysAdmin/Config/Integrations/Integrations.tsx
+++ b/packages/client/src/views/SysAdmin/Config/Integrations/Integrations.tsx
@@ -9,7 +9,7 @@
  * Copyright (C) The OpenCRVS Authors. OpenCRVS and the OpenCRVS
  * graphic logo are (registered/a) trademark(s) of Plan International.
  */
-import React, { useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import { Content } from '@opencrvs/components/lib/Content'
 import { useIntl } from 'react-intl'
 import { messages } from '@client/i18n/messages/views/formConfig'
@@ -23,7 +23,7 @@ import { Frame } from '@opencrvs/components/lib/Frame'
 import { Navigation } from '@client/components/interface/Navigation'
 import { Header } from '@client/components/Header/Header'
 import { Plus, VerticalThreeDots } from '@client/../../components/lib/icons'
-import { Pill, Toast, ToggleMenu } from '@client/../../components/lib'
+import { Link, Pill, Toast, ToggleMenu } from '@client/../../components/lib'
 import { buttonMessages, constantsMessages } from '@client/i18n/messages'
 import { Button } from '@client/../../components/lib/Button'
 import { integrationMessages } from '@client/i18n/messages/views/integrations'
@@ -33,6 +33,8 @@ import { gql } from '@apollo/client'
 import { updateOfflineIntegrations } from '@client/offline/actions'
 import { Mutation } from '@apollo/client/react/components'
 import { Integration } from '@client/utils/referenceApi'
+import styled from 'styled-components'
+import { Text } from '@opencrvs/components/lib/Text'
 
 export const statuses = {
   PENDING: 'pending',
@@ -52,6 +54,19 @@ export interface IntegrationType {
   sha_secret: string
   status: string
 }
+
+interface ToggleModal {
+  modalVisible: boolean
+  selectedClient: Integration | null
+}
+
+const TopText = styled(Text)`
+  margin-top: 20px;
+`
+const ButtonLink = styled(Link)`
+  text-align: left;
+`
+
 export const deactivateClient = gql`
   mutation deactivateSystemClient($clientDetails: ClientPayload) {
     deactivateSystemClient(clientDetails: $clientDetails) {
@@ -80,6 +95,11 @@ function Integrations() {
   const [showModal, setShowModal] = useState(false)
   const [clientId, setClientId] = useState('')
   const [clientStatus, setClientStatus] = useState('')
+  const [toggleKeyModal, setToggleKeyModal] = useState<ToggleModal>({
+    modalVisible: false,
+    selectedClient: null
+  })
+
   const [notificationStatus, setNotificationStatus] = useState(
     NOTIFICATION_STATUS.IDLE
   )
@@ -90,6 +110,24 @@ function Integrations() {
       return intl.formatMessage(integrationMessages.deactivate)
     }
   }
+
+  const toggleRevealKeyModal = useCallback(
+    function toggleRevealKeyModal(integration?: Integration) {
+      if (integration !== undefined) {
+        setToggleKeyModal({
+          ...toggleKeyModal,
+          modalVisible: true,
+          selectedClient: integration
+        })
+      } else {
+        setToggleKeyModal({
+          ...toggleKeyModal,
+          modalVisible: false
+        })
+      }
+    },
+    [toggleKeyModal]
+  )
 
   function showSuccessToast() {
     setShowModal(false)
@@ -155,7 +193,9 @@ function Integrations() {
                     id="toggleMenu"
                     menuItems={[
                       {
-                        handler: () => {},
+                        handler: () => {
+                          toggleRevealKeyModal(integration)
+                        },
                         label: intl.formatMessage(
                           integrationMessages.revealKeys
                         )
@@ -276,6 +316,46 @@ function Integrations() {
             </ResponsiveModal>
           )}
         </ListViewSimplified>
+
+        <ResponsiveModal
+          actions={[
+            <Link onClick={() => toggleRevealKeyModal()}>
+              {intl.formatMessage(buttonMessages.cancel)}
+            </Link>
+          ]}
+          autoHeight={true}
+          titleHeightAuto={true}
+          show={toggleKeyModal.modalVisible}
+          handleClose={() => toggleRevealKeyModal()}
+          title={toggleKeyModal.selectedClient?.name}
+        >
+          {intl.formatMessage(integrationMessages.uniqueKeysDescription)}
+
+          <>
+            <TopText variant="bold16" element="span">
+              {intl.formatMessage(integrationMessages.clientId)}{' '}
+            </TopText>
+            <Text variant="reg16" element="p">
+              {' '}
+              {toggleKeyModal.selectedClient?.client_id}
+            </Text>
+
+            <TopText variant="bold16" element="span">
+              {' '}
+              {intl.formatMessage(integrationMessages.clientSecret)}
+            </TopText>
+            <ButtonLink>
+              {intl.formatMessage(buttonMessages.refresh)}
+            </ButtonLink>
+
+            <TopText variant="bold16" element="span">
+              {intl.formatMessage(integrationMessages.shaSecret)}
+            </TopText>
+            <Text variant="reg16" element="p">
+              {toggleKeyModal.selectedClient?.sha_secret}
+            </Text>
+          </>
+        </ResponsiveModal>
       </Content>
     </Frame>
   )

--- a/packages/gateway/src/features/integrations/schema.graphql
+++ b/packages/gateway/src/features/integrations/schema.graphql
@@ -28,6 +28,21 @@ type IntegrationResponse {
   client_id: String
 }
 
+input IdsInput {
+  systemId: String
+  clientId: String
+}
+
+type SystemIntegrationsResponse {
+  name: String
+  clientId: String
+  shaSecret: String
+}
+
+type Query {
+  fetchIntegration(ids: IdsInput): SystemIntegrationsResponse
+}
+
 type Mutation {
   reactivateSystemClient(clientDetails: ClientPayload): IntegrationResponse
 }

--- a/packages/gateway/src/graphql/config.ts
+++ b/packages/gateway/src/graphql/config.ts
@@ -13,7 +13,10 @@
 import { resolvers as certificateResolvers } from '@gateway/features/certificate/root-resolvers'
 import { resolvers as locationRootResolvers } from '@gateway/features/location/root-resolvers'
 import { resolvers as metricsRootResolvers } from '@gateway/features/metrics/root-resolvers'
-import { resolvers as integrationResolver } from '@gateway/features/integrations/root-resolvers'
+import {
+  resolvers as integrationResolver,
+  resolvers as integrationResolvers
+} from '@gateway/features/integrations/root-resolvers'
 import { typeResolvers as metricsTypeResolvers } from '@gateway/features/metrics/type-resolvers'
 import { resolvers as notificationRootResolvers } from '@gateway/features/notification/root-resolvers'
 import { resolvers as registrationRootResolvers } from '@gateway/features/registration/root-resolvers'
@@ -71,7 +74,8 @@ const resolvers: StringIndexed<IResolvers> = merge(
   certificateResolvers as IResolvers,
   correctionRootResolvers as IResolvers,
   formDraftResolvers as IResolvers,
-  applicationRootResolvers as IResolvers
+  applicationRootResolvers as IResolvers,
+  integrationResolvers as IResolvers
 )
 
 export const getExecutableSchema = (): GraphQLSchema => {

--- a/packages/gateway/src/graphql/index.graphql
+++ b/packages/gateway/src/graphql/index.graphql
@@ -25,6 +25,7 @@
 # import Query.* from '../features/formDraft/schema.graphql'
 # import * from '../features/questions/schema.graphql'
 # import * from 'common.graphql'
+# import Query.* from '../features/integrations/schema.graphql'
 
 # TODO
 # https://github.com/prismagraphql/graphql-import/issues/180

--- a/packages/gateway/src/graphql/schema.d.ts
+++ b/packages/gateway/src/graphql/schema.d.ts
@@ -48,6 +48,7 @@ export interface GQLQuery {
   getCertificateSVG?: GQLCertificateSVG
   getActiveCertificatesSVG?: Array<GQLCertificateSVG | null>
   getFormDraft?: Array<GQLFormDraft>
+  fetchIntegration?: GQLSystemIntegrationsResponse
 }
 
 export interface GQLMutation {
@@ -368,6 +369,17 @@ export interface GQLFormDraft {
   history: Array<GQLDraftHistory>
   updatedAt: GQLDate
   createdAt: GQLDate
+}
+
+export interface GQLSystemIntegrationsResponse {
+  name?: string
+  clientId?: string
+  shaSecret?: string
+}
+
+export interface GQLIdsInput {
+  systemId?: string
+  clientId?: string
 }
 
 export interface GQLNotificationInput {
@@ -1457,6 +1469,7 @@ export interface GQLResolver {
   Role?: GQLRoleTypeResolver
   CertificateSVG?: GQLCertificateSVGTypeResolver
   FormDraft?: GQLFormDraftTypeResolver
+  SystemIntegrationsResponse?: GQLSystemIntegrationsResponseTypeResolver
   CreatedIds?: GQLCreatedIdsTypeResolver
   Reinstated?: GQLReinstatedTypeResolver
   Avatar?: GQLAvatarTypeResolver
@@ -1554,6 +1567,7 @@ export interface GQLQueryTypeResolver<TParent = any> {
   getCertificateSVG?: QueryToGetCertificateSVGResolver<TParent>
   getActiveCertificatesSVG?: QueryToGetActiveCertificatesSVGResolver<TParent>
   getFormDraft?: QueryToGetFormDraftResolver<TParent>
+  fetchIntegration?: QueryToFetchIntegrationResolver<TParent>
 }
 
 export interface QueryToListNotificationsArgs {
@@ -2148,6 +2162,18 @@ export interface QueryToGetActiveCertificatesSVGResolver<
 
 export interface QueryToGetFormDraftResolver<TParent = any, TResult = any> {
   (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult
+}
+
+export interface QueryToFetchIntegrationArgs {
+  ids?: GQLIdsInput
+}
+export interface QueryToFetchIntegrationResolver<TParent = any, TResult = any> {
+  (
+    parent: TParent,
+    args: QueryToFetchIntegrationArgs,
+    context: any,
+    info: GraphQLResolveInfo
+  ): TResult
 }
 
 export interface GQLMutationTypeResolver<TParent = any> {
@@ -3963,6 +3989,33 @@ export interface FormDraftToUpdatedAtResolver<TParent = any, TResult = any> {
 }
 
 export interface FormDraftToCreatedAtResolver<TParent = any, TResult = any> {
+  (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult
+}
+
+export interface GQLSystemIntegrationsResponseTypeResolver<TParent = any> {
+  name?: SystemIntegrationsResponseToNameResolver<TParent>
+  clientId?: SystemIntegrationsResponseToClientIdResolver<TParent>
+  shaSecret?: SystemIntegrationsResponseToShaSecretResolver<TParent>
+}
+
+export interface SystemIntegrationsResponseToNameResolver<
+  TParent = any,
+  TResult = any
+> {
+  (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult
+}
+
+export interface SystemIntegrationsResponseToClientIdResolver<
+  TParent = any,
+  TResult = any
+> {
+  (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult
+}
+
+export interface SystemIntegrationsResponseToShaSecretResolver<
+  TParent = any,
+  TResult = any
+> {
   (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult
 }
 

--- a/packages/gateway/src/graphql/schema.graphql
+++ b/packages/gateway/src/graphql/schema.graphql
@@ -170,6 +170,7 @@ type Query {
   getCertificateSVG(status: String, event: String): CertificateSVG
   getActiveCertificatesSVG: [CertificateSVG]
   getFormDraft: [FormDraft!]
+  fetchIntegration(ids: IdsInput): SystemIntegrationsResponse
 }
 
 type Mutation {
@@ -519,6 +520,17 @@ type FormDraft {
   history: [DraftHistory!]!
   updatedAt: Date!
   createdAt: Date!
+}
+
+type SystemIntegrationsResponse {
+  name: String
+  clientId: String
+  shaSecret: String
+}
+
+input IdsInput {
+  systemId: String
+  clientId: String
 }
 
 input NotificationInput {


### PR DESCRIPTION
Updated [getSystemHandler] to allow searching with either systemId or clientId .
created a GraphQL gateway endpoint for fetchIntegration that returns name, clientId, shaSecret.
defined schema for expected values.
Added a 3-dot menu to , component to reveal keys.
Updated translations on Farajaland project
https://github.com/opencrvs/opencrvs-farajaland/pull/398