### PR TITLE
Fix the signature requirements only for draft and IN_PROGRESS changes

### DIFF
--- a/packages/client/src/forms/index.ts
+++ b/packages/client/src/forms/index.ts
@@ -215,6 +215,15 @@ export interface IFieldInput {
   type?: string
 }
 
+export interface IRegStatus {
+  type: string
+  statusDate: any
+  officeName: string
+  officeAlias: string
+  officeAddressLevel3: string
+  officeAddressLevel4: string
+}
+
 export type IFormFieldValue =
   | string
   | string[]

--- a/packages/client/src/forms/register/fieldMappings/birth/query/registration-mappings.ts
+++ b/packages/client/src/forms/register/fieldMappings/birth/query/registration-mappings.ts
@@ -54,7 +54,9 @@ export function transformStatusData(
           new Date(a.timestamp).valueOf() - new Date(b.timestamp).valueOf()
       )
       .find((status) => {
-        return ['REGISTERED', 'VALIDATED'].includes(status.type!)
+        return ['REGISTERED', 'VALIDATED', 'IN_PROGRESS', 'DECLARED'].includes(
+          status.type!
+        )
       })
 
   transformedData[sectionId] = {

--- a/packages/client/src/views/RegisterForm/review/ReviewSection.tsx
+++ b/packages/client/src/views/RegisterForm/review/ReviewSection.tsx
@@ -69,7 +69,8 @@ import {
   IDocumentUploaderWithOptionsFormField,
   LOCATION_SEARCH_INPUT,
   IAttachmentValue,
-  SubmissionAction
+  SubmissionAction,
+  IRegStatus
 } from '@client/forms'
 import { Event } from '@client/utils/gateway'
 import {
@@ -930,8 +931,18 @@ class ReviewSectionComp extends React.Component<FullProps, State> {
   ) => {
     const { draft, pageRoute, writeDeclaration, goToPageGroup } = this.props
     const declaration = draft
-    if (declaration.data.registration) {
-      declaration.data.registration.informantsSignature = ''
+    if (
+      declaration.data.registration &&
+      declaration.data.registration.informantsSignature
+    ) {
+      if (!declaration.data.registration.regStatus) {
+        declaration.data.registration.informantsSignature = ''
+      } else {
+        const regStatus = declaration.data.registration.regStatus as IRegStatus
+        if (regStatus.type === 'IN_PROGRESS') {
+          declaration.data.registration.informantsSignature = ''
+        }
+      }
     }
     declaration.review = true
     writeDeclaration(declaration)


### PR DESCRIPTION
1. GIVEN I am a DCR (Registrar) or Registrar (Reg Agent), and I am reviewing a submitted application in which the signature block has been used, WHEN I make an edit to the application, THEN the previously used signature block should still be present on the review page. I am then able to leave the existing signature or delete and upload a new one, as required.
2. GIVEN I am a DCR (Registrar) or Registrar (Reg Agent), and I am reviewing a submitted application in which the signature block has NOT been used (because the B1 form has been attached), WHEN I make an edit to the application, THEN the signature block should not appear or be required.