### PR TITLE
MINIO_SERVER_URL must be internal for minio-console to work

### DIFF
--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -274,7 +274,7 @@ services:
       - MINIO_ROOT_USER=${MINIO_ROOT_USER}
       - MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD}
       - MINIO_DOMAIN=minio.{{hostname}}
-      - MINIO_SERVER_URL=https://minio.{{hostname}}
+      - MINIO_SERVER_URL=http://minio:9000
       - MINIO_BROWSER_REDIRECT_URL=https://minio-console.{{hostname}}
     ports:
       - '9000:9000'


### PR DESCRIPTION
MINIO_SERVER_URL had to be accessible internally using the name of the service in docker-compose otherwise minio-console cant resolve the server through Traefik.

