### PR TITLE
As a user (except fa) i want to navigate the organisation tree of administrative levels and offices location

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -65,6 +65,7 @@ import { ViewRecord } from '@client/views/ViewRecord/ViewRecord'
 import { UserAudit } from './views/UserAudit/UserAudit'
 import { AdvancedSearchResult } from '@client/views/AdvancedSearch/AdvancedSearchResult'
 import { RegistrationList } from '@client/views/Performance/RegistrationsList'
+import { ListOfOrganizations } from '@client/views/Organization/ListOfOrganizations'
 
 interface IAppProps {
   client?: ApolloClient<{}>
@@ -423,6 +424,19 @@ export class App extends React.Component<IAppProps> {
                                               routes.PERFORMANCE_REGISTRATIONS_LIST
                                             }
                                             component={RegistrationList}
+                                          />
+                                          <ProtectedRoute
+                                            exact
+                                            roles={[
+                                              Roles.REGISTRATION_AGENT,
+                                              Roles.LOCAL_REGISTRAR,
+                                              Roles.LOCAL_SYSTEM_ADMIN,
+                                              Roles.NATIONAL_SYSTEM_ADMIN,
+                                              Roles.PERFORMANCE_MANAGEMENT,
+                                              Roles.NATIONAL_REGISTRAR
+                                            ]}
+                                            path={routes.LIST_OF_ORGANIZATIONS}
+                                            component={ListOfOrganizations}
                                           />
                                         </Switch>
                                       </TransitionWrapper>

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -435,7 +435,7 @@ export class App extends React.Component<IAppProps> {
                                               Roles.PERFORMANCE_MANAGEMENT,
                                               Roles.NATIONAL_REGISTRAR
                                             ]}
-                                            path={routes.LIST_OF_ORGANIZATIONS}
+                                            path={routes.ORGANIZATIONS_INDEX}
                                             component={ListOfOrganizations}
                                           />
                                         </Switch>

--- a/packages/client/src/components/interface/Navigation.tsx
+++ b/packages/client/src/components/interface/Navigation.tsx
@@ -34,7 +34,9 @@ import {
   goToFormConfigHome,
   goToApplicationConfig,
   goToAdvancedSearchResult,
-  goToVSExport
+  goToVSExport,
+  goToOrganizationList,
+  goToOrganizationView
 } from '@client/navigation'
 import { redirectToAuthentication } from '@client/profile/profileActions'
 import { getUserDetails } from '@client/profile/profileSelectors'
@@ -85,6 +87,7 @@ export const WORKQUEUE_TABS = {
   vsexports: 'vsexports',
   team: 'team',
   config: 'config',
+  organization: 'organization',
   application: 'application',
   certificate: 'certificate',
   systems: 'integration',
@@ -117,6 +120,7 @@ const USER_SCOPE: IUSER_SCOPE = {
     WORKQUEUE_TABS.sentForApproval,
     WORKQUEUE_TABS.readyToPrint,
     WORKQUEUE_TABS.performance,
+    WORKQUEUE_TABS.organization,
     WORKQUEUE_TABS.team,
     WORKQUEUE_TABS.outbox,
     GROUP_ID.declarationGroup,
@@ -128,6 +132,7 @@ const USER_SCOPE: IUSER_SCOPE = {
     WORKQUEUE_TABS.requiresUpdate,
     WORKQUEUE_TABS.readyToPrint,
     WORKQUEUE_TABS.performance,
+    WORKQUEUE_TABS.organization,
     WORKQUEUE_TABS.team,
     WORKQUEUE_TABS.outbox,
     GROUP_ID.declarationGroup,
@@ -139,6 +144,7 @@ const USER_SCOPE: IUSER_SCOPE = {
     WORKQUEUE_TABS.requiresUpdate,
     WORKQUEUE_TABS.readyToPrint,
     WORKQUEUE_TABS.performance,
+    WORKQUEUE_TABS.organization,
     WORKQUEUE_TABS.team,
     WORKQUEUE_TABS.outbox,
     GROUP_ID.declarationGroup,
@@ -150,6 +156,7 @@ const USER_SCOPE: IUSER_SCOPE = {
     WORKQUEUE_TABS.requiresUpdate,
     WORKQUEUE_TABS.readyToPrint,
     WORKQUEUE_TABS.performance,
+    WORKQUEUE_TABS.organization,
     WORKQUEUE_TABS.vsexports,
     WORKQUEUE_TABS.team,
     WORKQUEUE_TABS.outbox,
@@ -158,6 +165,7 @@ const USER_SCOPE: IUSER_SCOPE = {
   ],
   LOCAL_SYSTEM_ADMIN: [
     WORKQUEUE_TABS.performance,
+    WORKQUEUE_TABS.organization,
     WORKQUEUE_TABS.team,
     GROUP_ID.menuGroup
   ],
@@ -165,6 +173,7 @@ const USER_SCOPE: IUSER_SCOPE = {
     WORKQUEUE_TABS.performance,
     WORKQUEUE_TABS.team,
     WORKQUEUE_TABS.config,
+    WORKQUEUE_TABS.organization,
     WORKQUEUE_TABS.vsexports,
     GROUP_ID.menuGroup
   ],
@@ -208,6 +217,7 @@ interface IDispatchProps {
   redirectToAuthentication: typeof redirectToAuthentication
   goToPerformanceViewAction: typeof goToPerformanceView
   goToTeamViewAction: typeof goToTeamView
+  goToOrganizationViewAction: typeof goToOrganizationView
   goToSystemViewAction: typeof goToSystemList
   goToSettings: typeof goToSettings
   updateRegistrarWorkqueue: typeof updateRegistrarWorkqueue
@@ -599,6 +609,25 @@ export const NavigationView = (props: IFullProps) => {
                   )}
                 {userDetails?.role &&
                   USER_SCOPE[userDetails.role].includes(
+                    WORKQUEUE_TABS.organization
+                  ) && (
+                    <NavigationItem
+                      icon={() => <Users />}
+                      id={`navigation_${WORKQUEUE_TABS.organization}`}
+                      label={intl.formatMessage(
+                        navigationMessages[WORKQUEUE_TABS.organization]
+                      )}
+                      onClick={() =>
+                        props.goToOrganizationViewAction(userDetails)
+                      }
+                      isSelected={
+                        enableMenuSelection &&
+                        activeMenuItem === WORKQUEUE_TABS.organization
+                      }
+                    />
+                  )}
+                {userDetails?.role &&
+                  USER_SCOPE[userDetails.role].includes(
                     WORKQUEUE_TABS.team
                   ) && (
                     <NavigationItem
@@ -797,6 +826,7 @@ export const Navigation = connect<
   goToAdvancedSearchResultAction: goToAdvancedSearchResult,
   goToVSExportsAction: goToVSExport,
   goToPerformanceViewAction: goToPerformanceView,
+  goToOrganizationViewAction: goToOrganizationView,
   goToTeamViewAction: goToTeamView,
   goToSystemViewAction: goToSystemList,
   redirectToAuthentication,

--- a/packages/client/src/i18n/messages/views/navigation.ts
+++ b/packages/client/src/i18n/messages/views/navigation.ts
@@ -22,6 +22,7 @@ interface INavigationMessages
   print: MessageDescriptor
   application: MessageDescriptor
   performance: MessageDescriptor
+  organization: MessageDescriptor
   team: MessageDescriptor
   vsexports: MessageDescriptor
   config: MessageDescriptor
@@ -96,6 +97,11 @@ const messagesToDefine: INavigationMessages = {
     defaultMessage: 'Vital statistics',
     description: 'Reports label in navigation',
     id: 'navigation.reports'
+  },
+  organization: {
+    defaultMessage: 'Organization',
+    description: 'List of organizations',
+    id: 'navigation.organization'
   },
   completenessRates: {
     defaultMessage: 'Completeness rates',

--- a/packages/client/src/navigation/index.ts
+++ b/packages/client/src/navigation/index.ts
@@ -55,7 +55,8 @@ import {
   VS_EXPORTS,
   VIEW_RECORD,
   ADVANCED_SEARCH_RESULT,
-  PERFORMANCE_REGISTRATIONS_LIST
+  PERFORMANCE_REGISTRATIONS_LIST,
+  LIST_OF_ORGANIZATIONS
 } from '@client/navigation/routes'
 import {
   NATL_ADMIN_ROLES,
@@ -242,6 +243,15 @@ export function goToTeamUserList(id: string) {
     pathname: TEAM_USER_LIST,
     search: stringify({
       locationId: id
+    })
+  })
+}
+
+export function goToOrganizationList(partOf: string) {
+  return push({
+    pathname: LIST_OF_ORGANIZATIONS,
+    search: stringify({
+      partOf: partOf ?? 'Location/0'
     })
   })
 }
@@ -648,6 +658,12 @@ export function goToTeamView(userDetails: IUserDetails) {
     return goToTeamUserList(
       (userDetails.primaryOffice && userDetails.primaryOffice.id) || ''
     )
+  }
+}
+
+export function goToOrganizationView(userDetails: IUserDetails) {
+  if (userDetails && userDetails.role) {
+    return goToOrganizationList('Location/0')
   }
 }
 

--- a/packages/client/src/navigation/index.ts
+++ b/packages/client/src/navigation/index.ts
@@ -56,7 +56,8 @@ import {
   VIEW_RECORD,
   ADVANCED_SEARCH_RESULT,
   PERFORMANCE_REGISTRATIONS_LIST,
-  LIST_OF_ORGANIZATIONS
+  LIST_OF_ORGANIZATIONS,
+  ORGANIZATIONS_INDEX
 } from '@client/navigation/routes'
 import {
   NATL_ADMIN_ROLES,
@@ -247,13 +248,8 @@ export function goToTeamUserList(id: string) {
   })
 }
 
-export function goToOrganizationList(partOf: string) {
-  return push({
-    pathname: LIST_OF_ORGANIZATIONS,
-    search: stringify({
-      partOf: partOf ?? 'Location/0'
-    })
-  })
+export function goToOrganizationList(index?: string) {
+  return push(formatUrl(ORGANIZATIONS_INDEX, { index: index ?? '' }))
 }
 
 export function goToSystemList() {
@@ -663,7 +659,7 @@ export function goToTeamView(userDetails: IUserDetails) {
 
 export function goToOrganizationView(userDetails: IUserDetails) {
   if (userDetails && userDetails.role) {
-    return goToOrganizationList('Location/0')
+    return goToOrganizationList()
   }
 }
 

--- a/packages/client/src/navigation/routes.ts
+++ b/packages/client/src/navigation/routes.ts
@@ -96,3 +96,4 @@ export const USER_PROFILE = '/userProfile/:userId'
 export const FORM_CONFIG_WIZARD = '/config/form/wizard/:event/:section'
 
 export const VIEW_RECORD = '/:declarationId/viewRecord'
+export const LIST_OF_ORGANIZATIONS = '/organization'

--- a/packages/client/src/navigation/routes.ts
+++ b/packages/client/src/navigation/routes.ts
@@ -96,4 +96,5 @@ export const USER_PROFILE = '/userProfile/:userId'
 export const FORM_CONFIG_WIZARD = '/config/form/wizard/:event/:section'
 
 export const VIEW_RECORD = '/:declarationId/viewRecord'
-export const LIST_OF_ORGANIZATIONS = '/organization'
+// export const LIST_OF_ORGANIZATIONS = '/organization/'
+export const ORGANIZATIONS_INDEX = '/organization/:index?'

--- a/packages/client/src/views/Organization/ListOfOrganization.test.tsx
+++ b/packages/client/src/views/Organization/ListOfOrganization.test.tsx
@@ -1,0 +1,11 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors. OpenCRVS and the OpenCRVS
+ * graphic logo are (registered/a) trademark(s) of Plan International.
+ */

--- a/packages/client/src/views/Organization/ListOfOrganizations.tsx
+++ b/packages/client/src/views/Organization/ListOfOrganizations.tsx
@@ -1,0 +1,108 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors. OpenCRVS and the OpenCRVS
+ * graphic logo are (registered/a) trademark(s) of Plan International.
+ */
+import React from 'react'
+import { Frame } from '@opencrvs/components/lib/Frame'
+import { Header } from '@client/components/Header/Header'
+import { navigationMessages } from '@client/i18n/messages/views/navigation'
+import { constantsMessages } from '@client/i18n/messages'
+import { Navigation } from '@client/components/interface/Navigation'
+import { useIntl } from 'react-intl'
+import {
+  Content,
+  Link,
+  ListViewItemSimplified,
+  ListViewSimplified,
+  Text
+} from '@opencrvs/components'
+import { useDispatch, useSelector } from 'react-redux'
+import { IStoreState } from '@client/store'
+import { ILocation } from '@client/offline/reducer'
+import { useLocation, useHistory } from 'react-router'
+import { goToOrganizationList } from '@client/navigation'
+
+export function ListOfOrganizations() {
+  const intl = useIntl()
+  const params = useLocation()
+  const levelOne = useSelector<IStoreState, any>((state) =>
+    Object.values(
+      state.offline.offlineData.locations as { [key: string]: ILocation }
+    ).filter((s) => s.partOf === 'Location/0')
+  )
+  const [level, setLevel] = React.useState<ILocation[]>(levelOne)
+  const history = useHistory()
+  const dispatch = useDispatch()
+  return (
+    <Frame
+      header={
+        <Header title={intl.formatMessage(navigationMessages.organization)} />
+      }
+      skipToContentText={intl.formatMessage(
+        constantsMessages.skipToMainContent
+      )}
+      navigation={<Navigation />}
+    >
+      <Content
+        title={intl.formatMessage(navigationMessages.organization)}
+        showTitleOnMobile={true}
+      >
+        <ListViewSimplified bottomBorder={true}>
+          <ListViewItemSimplified
+            label={
+              <BreadCrumb
+                Links={[
+                  {
+                    pathname: history.location.pathname,
+                    search: history.location.search
+                  }
+                ]}
+              />
+            }
+          />
+          {level?.map((level: ILocation, index: number) => (
+            <ListViewItemSimplified
+              key={index}
+              label={
+                <Link
+                  element="a"
+                  onClick={(e) => {
+                    console.log(params.search)
+                    return dispatch(
+                      goToOrganizationList(`Location/${level.id}`)
+                    )
+                  }}
+                >
+                  {level?.name}
+                </Link>
+              }
+            />
+          ))}
+        </ListViewSimplified>
+      </Content>
+    </Frame>
+  )
+}
+
+function BreadCrumb(props: { Links: Record<any, string>[] }) {
+  return (
+    <Text variant="h4" element="span">
+      {props.Links.map((x, idx) => {
+        return props.Links.indexOf(x) === props.Links.length - 1 ? (
+          <span key={idx}> {x?.pathname.replace('/', '') ?? ''} </span>
+        ) : (
+          <Link key={idx} element="a">
+            {x?.pathname}
+          </Link>
+        )
+      })}
+    </Text>
+  )
+}

--- a/packages/client/src/views/Organization/ListOfOrganizations.tsx
+++ b/packages/client/src/views/Organization/ListOfOrganizations.tsx
@@ -16,30 +16,77 @@ import { navigationMessages } from '@client/i18n/messages/views/navigation'
 import { constantsMessages } from '@client/i18n/messages'
 import { Navigation } from '@client/components/interface/Navigation'
 import { useIntl } from 'react-intl'
+import { Pagination } from '@opencrvs/components/lib/Pagination'
 import {
   Content,
   Link,
   ListViewItemSimplified,
   ListViewSimplified,
+  Stack,
   Text
 } from '@opencrvs/components'
 import { useDispatch, useSelector } from 'react-redux'
 import { IStoreState } from '@client/store'
 import { ILocation } from '@client/offline/reducer'
-import { useLocation, useHistory } from 'react-router'
+import { useHistory, useParams } from 'react-router'
 import { goToOrganizationList } from '@client/navigation'
+import { Activity } from '@opencrvs/components/lib/icons'
+import { Button } from '@opencrvs/components/lib/Button'
 
+const DEFAULT_PAGINATION_LIST_SIZE = 10
 export function ListOfOrganizations() {
   const intl = useIntl()
-  const params = useLocation()
-  const levelOne = useSelector<IStoreState, any>((state) =>
-    Object.values(
-      state.offline.offlineData.locations as { [key: string]: ILocation }
-    ).filter((s) => s.partOf === 'Location/0')
-  )
-  const [level, setLevel] = React.useState<ILocation[]>(levelOne)
-  const history = useHistory()
+  const { index } = useParams()
   const dispatch = useDispatch()
+  //
+  const getNewLevel =
+    (index: string) =>
+    (store: IStoreState): ILocation[] => {
+      let currentLevel = Object.values(
+        store.offline.offlineData.locations as { [key: string]: ILocation }
+      ).filter((s) => s.partOf === `Location/${index ?? '0'}`)
+      if (currentLevel.length === 0) {
+        currentLevel = Object.values(
+          store.offline.offlineData.offices as { [key: string]: ILocation }
+        ).filter((s) => s.partOf === `Location/${index ?? '0'}`)
+      }
+      return currentLevel
+    }
+
+  const levelOne = useSelector<IStoreState, any>(getNewLevel(index))
+  const totalNumber = levelOne.length
+  const [currentPageNumber, setCurrentPageNumber] = React.useState<number>(1)
+
+  const [links, setLink] = React.useState([
+    {
+      label: 'Cameroon',
+      to: '/organization/',
+      isActive: false
+    }
+  ])
+
+  //
+
+  const changeLevelAction = (
+    e: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement, MouseEvent>,
+    id: string
+  ) => {
+    e.preventDefault()
+    dispatch(goToOrganizationList(id))
+  }
+
+  React.useEffect(() => {
+    setLink((links) => [
+      ...links,
+      {
+        label: 'New Label',
+        to: `organization/${index}`,
+        isActive: true
+      }
+    ])
+    console.log(index)
+  }, [index])
+  //
   return (
     <Frame
       header={
@@ -55,37 +102,44 @@ export function ListOfOrganizations() {
         showTitleOnMobile={true}
       >
         <ListViewSimplified bottomBorder={true}>
-          <ListViewItemSimplified
-            label={
-              <BreadCrumb
-                Links={[
-                  {
-                    pathname: history.location.pathname,
-                    search: history.location.search
-                  }
-                ]}
+          <ListViewItemSimplified label={<BreadCrumb Links={links} />} />
+          {levelOne
+            ?.slice(
+              (currentPageNumber - 1) * DEFAULT_PAGINATION_LIST_SIZE,
+              currentPageNumber * DEFAULT_PAGINATION_LIST_SIZE
+            )
+            .map((level: ILocation, index: number) => (
+              <ListViewItemSimplified
+                key={index}
+                label={
+                  <Link
+                    element="a"
+                    onClick={(e) => changeLevelAction(e, level.id)}
+                  >
+                    {level?.name}
+                  </Link>
+                }
+                actions={
+                  <Button
+                    type="icon"
+                    size="large"
+                    aria-label="View performance data"
+                  >
+                    <Activity />
+                  </Button>
+                }
               />
+            ))}
+        </ListViewSimplified>
+        {totalNumber > DEFAULT_PAGINATION_LIST_SIZE && (
+          <Pagination
+            currentPage={currentPageNumber}
+            totalPages={Math.ceil(totalNumber / DEFAULT_PAGINATION_LIST_SIZE)}
+            onPageChange={(currentPage: number) =>
+              setCurrentPageNumber(currentPage)
             }
           />
-          {level?.map((level: ILocation, index: number) => (
-            <ListViewItemSimplified
-              key={index}
-              label={
-                <Link
-                  element="a"
-                  onClick={(e) => {
-                    console.log(params.search)
-                    return dispatch(
-                      goToOrganizationList(`Location/${level.id}`)
-                    )
-                  }}
-                >
-                  {level?.name}
-                </Link>
-              }
-            />
-          ))}
-        </ListViewSimplified>
+        )}
       </Content>
     </Frame>
   )
@@ -93,16 +147,41 @@ export function ListOfOrganizations() {
 
 function BreadCrumb(props: { Links: Record<any, string>[] }) {
   return (
-    <Text variant="h4" element="span">
+    <Stack gap={8} direction="row">
       {props.Links.map((x, idx) => {
-        return props.Links.indexOf(x) === props.Links.length - 1 ? (
-          <span key={idx}> {x?.pathname.replace('/', '') ?? ''} </span>
-        ) : (
-          <Link key={idx} element="a">
-            {x?.pathname}
+        return (
+          <Link key={idx} color={x.isActive ? 'primary' : 'copy'} element="a">
+            {x?.label}
           </Link>
         )
       })}
-    </Text>
+    </Stack>
   )
 }
+
+interface BreadCrumbInterface {
+  label: string
+  to: string
+  Icon?: JSX.Element
+}
+const TestBreadCrumb = (props: BreadCrumbInterface[]) => {
+  const [state, setState] = React.useState(props)
+
+  const watchNavigation = (payload: BreadCrumbInterface) => {
+    setState((prevState: BreadCrumbInterface[]) =>
+      prevState.slice(0, state.indexOf(payload))
+    )
+  }
+
+  return props.map(({ label, to, Icon }, idx: number) => (
+    <Link key={idx} element="a" onClick={() => watchNavigation({ label, to })}>
+      {label}
+    </Link>
+  ))
+}
+
+const Separator = ({ children, ...props }: any) => (
+  <span style={{ color: 'teal' }} {...props}>
+    {children}
+  </span>
+)


### PR DESCRIPTION
- [x ] Create a new empty view for the application and a link to navigate to this view to the left sidebar. This link should be shown for all users except for field agents. (1)
- [ x]  Find the list of locations & offices from Redux state (hint: look for offlineData). Render top-level (level 1) locations in the view in a list. [Use ListView component from our component library](https://ui-kit.farajaland-staging.opencrvs.org/?path=/docs/data-list-view--default). (1)
- [x ]  When the user clicks on any of the locations, they should now see locations that are under (part of) the location they just clicked on (2)
- [ x] Notice that different countries can have a different number of administrative levels. How can we make this dynamic?
- [ ]  Render a breadcrumb to all pages showing the user where they have currently navigated to. Use Breadcrumb component from the component library (1)
- [ ]  Add the "performance icon" to every list item. Click this should take the user to the Performance view, so that the same location's data is shown by default