### PR TITLE
Make loggers silent (error) by default in development mode to make debugging with console.log easier

### DIFF
--- a/packages/auth/src/logger.ts
+++ b/packages/auth/src/logger.ts
@@ -15,4 +15,6 @@ export const logger = pino()
 const level = process.env.NODE_ENV === 'test' ? 'silent' : process.env.LOG_LEVEL
 if (level) {
   logger.level = level
+} else {
+  logger.level = 'error'
 }

--- a/packages/config/src/config/logger.ts
+++ b/packages/config/src/config/logger.ts
@@ -15,4 +15,6 @@ export const logger = pino()
 const level = process.env.NODE_ENV === 'test' ? 'silent' : process.env.LOG_LEVEL
 if (level) {
   logger.level = level
+} else {
+  logger.level = 'error'
 }

--- a/packages/config/src/logger.ts
+++ b/packages/config/src/logger.ts
@@ -15,4 +15,6 @@ export const logger = pino()
 const level = process.env.NODE_ENV === 'test' ? 'silent' : process.env.LOG_LEVEL
 if (level) {
   logger.level = level
+} else {
+  logger.level = 'error'
 }

--- a/packages/documents/src/config/plugins.ts
+++ b/packages/documents/src/config/plugins.ts
@@ -18,7 +18,7 @@ import { logger } from '@documents/logger'
 export default function getPlugins() {
   const plugins: any[] = [
     JWT,
-    ...(process.env.NODE_ENV === 'test' || process.env.LOG_LEVEL === 'silent'
+    ...(process.env.NODE_ENV !== 'production'
       ? []
       : [
           {

--- a/packages/documents/src/logger.ts
+++ b/packages/documents/src/logger.ts
@@ -15,4 +15,6 @@ export const logger = pino()
 const level = process.env.NODE_ENV === 'test' ? 'silent' : process.env.LOG_LEVEL
 if (level) {
   logger.level = level
+} else {
+  logger.level = 'error'
 }

--- a/packages/gateway/src/logger.ts
+++ b/packages/gateway/src/logger.ts
@@ -15,4 +15,6 @@ export const logger = pino()
 const level = process.env.NODE_ENV === 'test' ? 'silent' : process.env.LOG_LEVEL
 if (level) {
   logger.level = level
+} else {
+  logger.level = 'error'
 }

--- a/packages/metrics/src/config/plugins.ts
+++ b/packages/metrics/src/config/plugins.ts
@@ -18,7 +18,7 @@ import { logger } from '@metrics/logger'
 export default function getPlugins() {
   const plugins: any[] = [
     JWT,
-    ...(process.env.NODE_ENV === 'test' || process.env.LOG_LEVEL === 'silent'
+    ...(process.env.NODE_ENV !== 'production'
       ? []
       : [
           {

--- a/packages/metrics/src/logger.ts
+++ b/packages/metrics/src/logger.ts
@@ -15,4 +15,6 @@ export const logger = pino()
 const level = process.env.NODE_ENV === 'test' ? 'silent' : process.env.LOG_LEVEL
 if (level) {
   logger.level = level
+} else {
+  logger.level = 'error'
 }

--- a/packages/notification/src/logger.ts
+++ b/packages/notification/src/logger.ts
@@ -15,4 +15,6 @@ export const logger = pino()
 const level = process.env.NODE_ENV === 'test' ? 'silent' : process.env.LOG_LEVEL
 if (level) {
   logger.level = level
+} else {
+  logger.level = 'error'
 }

--- a/packages/search/src/logger.ts
+++ b/packages/search/src/logger.ts
@@ -15,4 +15,6 @@ export const logger = pino()
 const level = process.env.NODE_ENV === 'test' ? 'silent' : process.env.LOG_LEVEL
 if (level) {
   logger.level = level
+} else {
+  logger.level = 'error'
 }

--- a/packages/user-mgnt/src/logger.ts
+++ b/packages/user-mgnt/src/logger.ts
@@ -15,4 +15,6 @@ export const logger = pino()
 const level = process.env.NODE_ENV === 'test' ? 'silent' : process.env.LOG_LEVEL
 if (level) {
   logger.level = level
+} else {
+  logger.level = 'error'
 }

--- a/packages/webhooks/src/logger.ts
+++ b/packages/webhooks/src/logger.ts
@@ -15,4 +15,6 @@ export const logger = pino()
 const level = process.env.NODE_ENV === 'test' ? 'silent' : process.env.LOG_LEVEL
 if (level) {
   logger.level = level
+} else {
+  logger.level = 'error'
 }

--- a/packages/workflow/src/logger.ts
+++ b/packages/workflow/src/logger.ts
@@ -15,4 +15,6 @@ export const logger = pino()
 const level = process.env.NODE_ENV === 'test' ? 'silent' : process.env.LOG_LEVEL
 if (level) {
   logger.level = level
+} else {
+  logger.level = 'error'
 }


### PR DESCRIPTION
This is to make debugging backends easier. In development, we do not need to log all information of all incoming HTTP requests. This only clogs up the terminal window with no real added benefit.