### PR TITLE
fix(client): on click menus now open the menu again

### DIFF
--- a/packages/components/src/LocationSearch/LocationSearch.tsx
+++ b/packages/components/src/LocationSearch/LocationSearch.tsx
@@ -276,7 +276,9 @@ export class LocationSearch extends React.Component<IProps, IState> {
               autoComplete="off"
               onFocus={this.onFocus}
               onBlur={this.onBlurHandler}
-              onClick={() => document.addEventListener('click', this.handler)}
+              onClick={() =>
+                document.addEventListener('click', this.handler, true)
+              }
               value={this.state.selectedText || ''}
               onChange={this.onChangeHandler}
               error={this.props.error}

--- a/packages/components/src/SearchTool/SearchTool.tsx
+++ b/packages/components/src/SearchTool/SearchTool.tsx
@@ -289,10 +289,10 @@ export class SearchTool extends React.Component<IProps, IState> {
   toggleDropdownDisplay = () => {
     const handler = () => {
       this.setState({ dropDownIsVisible: false })
-      document.removeEventListener('click', handler)
+      document.removeEventListener('click', handler, true)
     }
     if (!this.state.dropDownIsVisible) {
-      document.addEventListener('click', handler)
+      document.addEventListener('click', handler, true)
     }
 
     this.setState((prevState) => ({

--- a/packages/components/src/ToggleMenu/ToggleMenu.tsx
+++ b/packages/components/src/ToggleMenu/ToggleMenu.tsx
@@ -99,24 +99,24 @@ export class ToggleMenu extends React.Component<IProps, IState> {
   }
 
   componentWillUnmount() {
-    document.removeEventListener('click', this.closeMenu)
-    document.removeEventListener('click', this.showMenu)
-    document.removeEventListener('keyup', this.closeMenuOnEscape)
+    document.removeEventListener('click', this.closeMenu, true)
+    document.removeEventListener('click', this.showMenu, true)
+    document.removeEventListener('keyup', this.closeMenuOnEscape, true)
   }
   showMenu() {
     this.setState(() => ({
       showSubmenu: true
     }))
-    document.addEventListener('click', this.closeMenu)
-    document.addEventListener('keyup', this.closeMenuOnEscape)
+    document.addEventListener('click', this.closeMenu, true)
+    document.addEventListener('keyup', this.closeMenuOnEscape, true)
   }
 
   closeMenu() {
     this.setState(() => ({
       showSubmenu: false
     }))
-    document.removeEventListener('click', this.closeMenu)
-    document.removeEventListener('keyup', this.closeMenuOnEscape)
+    document.removeEventListener('click', this.closeMenu, true)
+    document.removeEventListener('keyup', this.closeMenuOnEscape, true)
   }
 
   closeMenuOnEscape(e: KeyboardEvent) {


### PR DESCRIPTION
Closes #4644

Adding the `useCapture` -flag fixes the issue:

**useCapture:**
A boolean value indicating whether events of this type will be dispatched to the registered listener before being dispatched to any EventTarget beneath it in the DOM tree. Events that are bubbling upward through the tree will not trigger a listener designated to use capture. Event bubbling and capturing are two ways of propagating events that occur in an element that is nested within another element, when both elements have registered a handle for that event. The event propagation mode determines the order in which elements receive the event. See [DOM Level 3 Events](https://www.w3.org/TR/DOM-Level-3-Events/#event-flow) and [JavaScript Event order](https://www.quirksmode.org/js/events_order.html#link4) for a detailed explanation. If not specified, useCapture defaults to false. 