### PR TITLE
Fix navigate the organisation

### DIFF
--- a/packages/client/.gitignore
+++ b/packages/client/.gitignore
@@ -28,3 +28,5 @@ src/i18n/locales/en.csv
 
 .vscode
 graphql.schema.json
+.lh
+.idea

--- a/packages/client/src/views/UserAudit/UserAudit.tsx
+++ b/packages/client/src/views/UserAudit/UserAudit.tsx
@@ -141,8 +141,6 @@ export const UserAudit = () => {
   const userRole =
     user && intl.formatMessage({ id: getUserRoleIntlKey(user.role._id) })
 
-  console.log(user)
-
   const toggleUserActivationModal = () => {
     setModalVisible(!modalVisible)
   }

--- a/packages/client/src/views/UserAudit/UserAudit.tsx
+++ b/packages/client/src/views/UserAudit/UserAudit.tsx
@@ -45,7 +45,8 @@ import {
   GetUserQuery,
   GetUserQueryVariables,
   HumanName,
-  User
+  User,
+  SystemRoleType
 } from '@client/utils/gateway'
 import { GenericErrorToast } from '@client/components/GenericErrorToast'
 import { ResponsiveModal } from '@opencrvs/components/lib/ResponsiveModal'
@@ -139,6 +140,8 @@ export const UserAudit = () => {
   const user = data?.getUser && transformUserQueryResult(data.getUser, intl)
   const userRole =
     user && intl.formatMessage({ id: getUserRoleIntlKey(user.role._id) })
+
+  console.log(user)
 
   const toggleUserActivationModal = () => {
     setModalVisible(!modalVisible)
@@ -295,15 +298,22 @@ export const UserAudit = () => {
         <Content
           title={user.name}
           icon={() => <UserAvatar name={user.name} avatar={user.avatar} />}
-          topActionButtons={[
-            <Status status={user.status || 'pending'} />,
-            <ToggleMenu
-              id={`sub-page-header-munu-button`}
-              toggleButton={<VerticalThreeDots />}
-              menuItems={getMenuItems(user.id as string, user.status as string)}
-              hide={(scope && !scope.includes('sysadmin')) || false}
-            />
-          ]}
+          topActionButtons={
+            user.systemRole === SystemRoleType.LocalSystemAdmin
+              ? [<Status status={user.status || 'pending'} />]
+              : [
+                  <Status status={user.status || 'pending'} />,
+                  <ToggleMenu
+                    id={`sub-page-header-munu-button`}
+                    toggleButton={<VerticalThreeDots />}
+                    menuItems={getMenuItems(
+                      user.id as string,
+                      user.status as string
+                    )}
+                    hide={(scope && !scope.includes('sysadmin')) || false}
+                  />
+                ]
+          }
           size={ContentSize.LARGE}
         >
           <>


### PR DESCRIPTION
In this PR, we remove the vertical dot menu for users with the local_system_admin role.

Before 
![remove 3dot menu](https://user-images.githubusercontent.com/94350336/218392420-7f41957b-25a5-4e61-b2f6-eef8e0f60223.png)

After
![Capture d’écran 2023-02-20 à 07 48 35](https://user-images.githubusercontent.com/10140488/220034708-de9ba2a8-da09-4315-a943-d56b85eca785.png)
