### PR TITLE
ocrvs-4693: Fix validation for dates when year string length is less than 4 (fix 4693, 4700) . Also add system role in userdetails in record audit history(fix 4714)

### DIFF
--- a/packages/client/src/utils/date-formatting.ts
+++ b/packages/client/src/utils/date-formatting.ts
@@ -15,6 +15,7 @@ import enGB from 'date-fns/locale/en-GB'
 import bn from 'date-fns/locale/bn'
 import fr from 'date-fns/locale/fr'
 import subYears from 'date-fns/subYears'
+import isValid from 'date-fns/isValid'
 
 export const locales: Record<string, Locale> = { en: enGB, bn, fr }
 
@@ -23,6 +24,21 @@ export const formatLongDate = (
   locale = 'en',
   formatString = 'dd MMMM yyyy'
 ) => {
+  const [yyyy, mm, dd] = date.split('-')
+  if (
+    !dd ||
+    !mm ||
+    !yyyy ||
+    dd.length === 0 ||
+    mm.length === 0 ||
+    yyyy.length < 4
+  ) {
+    return ''
+  }
+
+  if (!isValid(new Date(date))) {
+    return ''
+  }
   window.__localeId__ = locale
   return format(new Date(date), formatString, {
     locale: locales[window.__localeId__]
@@ -30,6 +46,9 @@ export const formatLongDate = (
 }
 
 export const formattedDuration = (fromDate: Date | number) => {
+  if (!isValid(fromDate)) {
+    return ''
+  }
   return formatDistanceToNowStrict(fromDate, {
     locale: locales[window.__localeId__],
     addSuffix: true,
@@ -42,6 +61,9 @@ export const convertAgeToDate = (age: string): string => {
 }
 
 export default function formatDate(date: Date | number, formatStr = 'PP') {
+  if (!isValid(date)) {
+    return ''
+  }
   return format(date, formatStr, {
     locale: locales[window.__localeId__]
   })

--- a/packages/client/src/views/RecordAudit/History.tsx
+++ b/packages/client/src/views/RecordAudit/History.tsx
@@ -172,7 +172,8 @@ export const GetHistory = ({
         id: userDetails.userMgntUserID,
         name: userDetails.name,
         avatar: userDetails.avatar,
-        systemRole: userDetails.systemRole
+        systemRole: userDetails.systemRole,
+        role: userDetails.role
       },
       office: userDetails.primaryOffice,
       comments: [],


### PR DESCRIPTION
This PR fixes the following issues - 

* #4693 

[4693_fix.webm](https://user-images.githubusercontent.com/35958228/220569596-065cd2ea-acdf-4441-8908-e8e2a7d4311a.webm)

* #4714 

[4714_fix.webm](https://user-images.githubusercontent.com/35958228/220569666-a233f1d4-87a5-4bd6-aa9c-a3a7dfa946c6.webm)

* #4700  

[4700_fix.webm](https://user-images.githubusercontent.com/35958228/220569688-d86f329c-0d4b-46a2-b246-5f9625e49aab.webm)
