### PR TITLE
Implement more advanced yarn dev experience

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -10,9 +10,59 @@
 set -e
 DIR=$(cd "$(dirname "$0")"; pwd)
 
+export LANGUAGES="en,fr"
+export LOG_LEVEL="error"
+
+if [  -n "$(uname -a | grep Ubuntu)" ]; then
+  OS="UBUNTU"
+  else
+  OS="MAC"
+fi
+
+if [ ! $OS == "UBUNTU" ]; then
+  export LOCAL_IP=host-gateway
+fi
+
+####
+#
+# SUPER USER MODE
+# Using --only-dependences or --only-services will start only the dependencies or services.
+# This is done so that more experienced users could start the stack in different terminal windows
+#
+###
+dependencies=false
+services=false
+
+for arg in "$@"
+do
+  case $arg in
+    --only-dependencies)
+      dependencies=true
+      ;;
+    --only-services)
+      services=true
+      ;;
+    *)
+      # Handle unknown option
+      echo "Unknown option: $arg"
+      exit 1
+      ;;
+  esac
+done
+
+if $dependencies; then
+  yarn run compose:deps
+  exit 0
+elif $services; then
+  yarn dev:secrets:gen
+  yarn run start
+  exit 0
+fi
+
 echo
 echo -e "This command starts the OpenCRVS Core development environment, which consists of multiple NodeJS microservices running in parallel.  OpenCRVS requires a companion country configuration server to also be running. \n\nIf you ran our setup command, the fictional Farajaland country configuration server exists in the directory opencrvs-farajaland alongside this directory, otherwise you may have cloned or forked it somewhere else.\n\nSo, before we start...\n\n1. Copy this command: \033[32myarn dev \033[0m\n\n2. Create another terminal window.\n\n3. cd into your country config directory and prepare to run this command in that terminal window  \033[32myarn dev \033[0m\n\n2, \033[32mWHEN OPENCRVS CORE HAS FULLY STARTED UP\033[0m, in order to start the country config server and be able to use OpenCRVS.\n\nYou know OpenCRVS Core is ready for you to start the country configuration server, when you see this message: \"\033[32m@opencrvs/client: Compiled with warnings.\033[0m\" followed by any NPM dependency warnings."
 echo
+
 sleep 3
 
 # Retrieve 2-step verification to continue
@@ -57,11 +107,7 @@ do
 done
 
 
-if [  -n "$(uname -a | grep Ubuntu)" ]; then
-  OS="UBUNTU"
-  else
-  OS="MAC"
-fi
+
 echo
 echo -e "\033[32m:::::::::: STARTING OPENCRVS ::::::::::\033[0m"
 echo
@@ -71,15 +117,5 @@ echo -e "\033[32m:::::::::: PLEASE WAIT for @opencrvs/client ::::::::::\033[0m"
 echo
 sleep 10
 
-export LANGUAGES="en,fr"
-export LOG_LEVEL="error"
-
-if [ $OS == "UBUNTU" ]; then
-  echo "YOU ARE RUNNING OPENCRVS ON UBUNTU"
-  yarn dev:secrets:gen && concurrently "yarn run start" "yarn run compose:deps"
-  else
-  export LOCAL_IP=host-gateway
-  yarn dev:secrets:gen && concurrently "yarn run start" "yarn run compose:deps"
-fi
-
-
+yarn dev:secrets:gen
+concurrently "yarn run start" "yarn run compose:deps"


### PR DESCRIPTION
Two new totally optional command line parameters for yarn dev

`--only-dependencies` - Starts docker-compose
`--only-services`  - Starts all microservices

These allow the user to run OpenCRVS in two separate terminal windows. 
This way the user can shutdown only the services if needed while getting better terminal output when debugging
<img width="794" alt="image" src="https://user-images.githubusercontent.com/1206987/220319617-e907388a-785a-4f22-9085-4be1b019d240.png">
