### PR TITLE
feat(national-id-verification): Pass OIDP claims to frontend

### DIFF
--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -751,8 +751,6 @@ services:
       - CERT_PUBLIC_KEY_PATH=/run/secrets/jwt-public-key.{{ts}}
       - MONGO_URL=mongodb://config:${CONFIG_MONGODB_PASSWORD}@mongo1/application-config?replicaSet=rs0
       - DOMAIN={{hostname}}
-      - NATIONAL_ID_OIDP_BASE_URL=${NATIONAL_ID_OIDP_BASE_URL}
-      - NATIONAL_ID_OIDP_CLIENT_ID=${NATIONAL_ID_OIDP_CLIENT_ID}
     deploy:
       labels:
         - 'traefik.enable=true'

--- a/packages/client/graphql.schema.json
+++ b/packages/client/graphql.schema.json
@@ -18454,6 +18454,18 @@
             "deprecationReason": null
           },
           {
+            "name": "openIdProviderClaims",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "openIdProviderClientId",
             "description": null,
             "args": [],

--- a/packages/client/src/utils/gateway.ts
+++ b/packages/client/src/utils/gateway.ts
@@ -2165,6 +2165,7 @@ export type SystemSettings = {
   __typename?: 'SystemSettings'
   dailyQuota?: Maybe<Scalars['Int']>
   openIdProviderBaseUrl?: Maybe<Scalars['String']>
+  openIdProviderClaims?: Maybe<Scalars['String']>
   openIdProviderClientId?: Maybe<Scalars['String']>
   webhook?: Maybe<Array<WebhookPermission>>
 }

--- a/packages/gateway/src/features/systems/schema.graphql
+++ b/packages/gateway/src/features/systems/schema.graphql
@@ -34,6 +34,7 @@ type SystemSettings {
   webhook: [WebhookPermission!]
   openIdProviderClientId: String
   openIdProviderBaseUrl: String
+  openIdProviderClaims: String
 }
 
 type System {

--- a/packages/gateway/src/graphql/schema.d.ts
+++ b/packages/gateway/src/graphql/schema.d.ts
@@ -1096,6 +1096,7 @@ export interface GQLSystemSettings {
   webhook?: Array<GQLWebhookPermission>
   openIdProviderClientId?: string
   openIdProviderBaseUrl?: string
+  openIdProviderClaims?: string
 }
 
 export interface GQLFormDatasetOption {
@@ -6003,6 +6004,7 @@ export interface GQLSystemSettingsTypeResolver<TParent = any> {
   webhook?: SystemSettingsToWebhookResolver<TParent>
   openIdProviderClientId?: SystemSettingsToOpenIdProviderClientIdResolver<TParent>
   openIdProviderBaseUrl?: SystemSettingsToOpenIdProviderBaseUrlResolver<TParent>
+  openIdProviderClaims?: SystemSettingsToOpenIdProviderClaimsResolver<TParent>
 }
 
 export interface SystemSettingsToDailyQuotaResolver<
@@ -6024,6 +6026,13 @@ export interface SystemSettingsToOpenIdProviderClientIdResolver<
 }
 
 export interface SystemSettingsToOpenIdProviderBaseUrlResolver<
+  TParent = any,
+  TResult = any
+> {
+  (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult
+}
+
+export interface SystemSettingsToOpenIdProviderClaimsResolver<
   TParent = any,
   TResult = any
 > {

--- a/packages/gateway/src/graphql/schema.graphql
+++ b/packages/gateway/src/graphql/schema.graphql
@@ -1193,6 +1193,7 @@ type SystemSettings {
   webhook: [WebhookPermission!]
   openIdProviderClientId: String
   openIdProviderBaseUrl: String
+  openIdProviderClaims: String
 }
 
 type FormDatasetOption {

--- a/packages/user-mgnt/src/constants.ts
+++ b/packages/user-mgnt/src/constants.ts
@@ -33,3 +33,9 @@ export const NATIONAL_ID_OIDP_BASE_URL =
 
 export const NATIONAL_ID_OIDP_CLIENT_ID =
   process.env.NATIONAL_ID_OIDP_CLIENT_ID || null
+
+export const NATIONAL_ID_OIDP_ESSENTIAL_CLAIMS =
+  process.env.NATIONAL_ID_OIDP_ESSENTIAL_CLAIMS || null // e.g. given_name,family_name
+
+export const NATIONAL_ID_OIDP_VOLUNTARY_CLAIMS =
+  process.env.NATIONAL_ID_OIDP_VOLUNTARY_CLAIMS || null


### PR DESCRIPTION
To test this, I have just added these to `dev.sh`:

```
export NATIONAL_ID_OIDP_CLIENT_ID="xyz"
export NATIONAL_ID_OIDP_BASE_URL="http://test/foo"
export NATIONAL_ID_OIDP_ESSENTIAL_CLAIMS="first_name,last_name"
export NATIONAL_ID_OIDP_VOLUNTARY_CLAIMS="testi"
```