### PR TITLE
feat(national-id-verification): check nonce in verification callback

### DIFF
--- a/packages/client/src/views/OIDPVerificationCallback/utils.ts
+++ b/packages/client/src/views/OIDPVerificationCallback/utils.ts
@@ -1,0 +1,20 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors. OpenCRVS and the OpenCRVS
+ * graphic logo are (registered/a) trademark(s) of Plan International.
+ */
+
+import { useMemo } from 'react'
+import { useLocation } from 'react-router'
+
+export function useQueryParams() {
+  const { search } = useLocation()
+
+  return useMemo(() => new URLSearchParams(search), [search])
+}


### PR DESCRIPTION
Amends OIDP Verification Callback

- checks the ?state= query parameter for a JSON string like: { pathname: "/path/somewhere" }
- checks that the &nonce= parameter matches the one in localStorage, removes it if yes, throws if not
 - redirects to the pathname in state