### PR TITLE
Fix e2e tests

### DIFF
--- a/packages/client/src/declarations/index.ts
+++ b/packages/client/src/declarations/index.ts
@@ -1154,7 +1154,7 @@ export const declarationsReducer: LoopReducer<IDeclarationsState, Action> = (
             return declaration
           })
         },
-        Cmd.action(writeDeclaration(orignalAppliation))
+        Cmd.action(modifyDeclaration(orignalAppliation))
       )
     }
 

--- a/packages/config/src/models/config.ts
+++ b/packages/config/src/models/config.ts
@@ -151,7 +151,7 @@ const configSchema = new Schema({
   INFORMANT_SIGNATURE_REQUIRED: {
     type: Boolean,
     required: true,
-    default: true
+    default: false
   },
   LOGIN_BACKGROUND: { type: backgroundImageSchema, required: false },
   ADMIN_LEVELS: {


### PR DESCRIPTION
For the birth spec, an unhandled exception is thrown in case of a field agent that causes the entire test to fail. This should be fixed when https://github.com/opencrvs/opencrvs-core/pull/4778 is merged with develop. 
For advanced search spec, the child's exact date of birth date is disabled (not sure why) and that blocks further input typing, consequently causing the test to fail. 
Some amends are also done in https://github.com/opencrvs/opencrvs-farajaland/pull/506