### PR TITLE
Link underline

### DIFF
--- a/packages/client/src/components/Header/HistoryNavigator.tsx
+++ b/packages/client/src/components/Header/HistoryNavigator.tsx
@@ -58,7 +58,7 @@ export function HistoryNavigator({
       <Button
         id="header-go-back-button"
         type="icon"
-        size="large"
+        size="medium"
         disabled={
           (history.action === 'POP' || history.action === 'REPLACE') &&
           isLandingPage()
@@ -70,7 +70,7 @@ export function HistoryNavigator({
       {!hideForward && (
         <Button
           type="icon"
-          size="large"
+          size="medium"
           disabled={history.action === 'PUSH' || history.action === 'REPLACE'}
           onClick={() => dispatch(goForward())}
         >

--- a/packages/components/src/Link/Link.tsx
+++ b/packages/components/src/Link/Link.tsx
@@ -31,7 +31,7 @@ export interface LinkProps
 const underlineStyles = css`
   text-decoration: underline;
   text-decoration-thickness: 2px;
-  text-underline-offset: 4px;
+  text-underline-offset: 2px;
 `
 
 const StyledLink = styled.button<{


### PR DESCRIPTION
- Reduces text-underline-offset to 2px. So when Link element is a button. The underline shows properly. 
- Before it would cut off leaving less than 1px underline if bold14 and no underline if bold12