### PR TITLE
fix(metabase): update-database script 'envsubst' -check for Ubuntu

### DIFF
--- a/packages/dashboards/update-database.sh
+++ b/packages/dashboards/update-database.sh
@@ -29,8 +29,7 @@ environment_configuration_sql_file=${OPENCRVS_ENVIRONMENT_CONFIGURATION_SQL_FILE
 # as environment variables
 #########
 
-if ! command -v envsubst &> /dev/null
-then
+if ! which envsubst >/dev/null; then
   echo "envsubst could not be found. Please install envsubst before continuing."
   echo "MacOS: brew install gettext && brew link --force gettext"
   exit 1


### PR DESCRIPTION
The existing `command -v` did not work for my machine:
```
  opencrvs-core git:(dashboard-demo-data) lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 20.04.3 LTS
Release:        20.04
Codename:       focal
```

This updates the script to use "which" which seems to work on my machine.