### PR TITLE
Fixed spelling of 'two' for 2nd witness while declaring marriage records

### DIFF
--- a/packages/client/src/forms/configuration/default/marriage.ts
+++ b/packages/client/src/forms/configuration/default/marriage.ts
@@ -1268,7 +1268,7 @@ export const marriageRegisterForms: ISerializedForm = {
             {
               id: 'witnessTwoNameInEnglish',
               label: {
-                defaultMessage: 'Witness Tow English name',
+                defaultMessage: 'Witness Two English name',
                 description: 'Label for Witness two name in english',
                 id: 'form.preview.group.label.witness.two.english.name'
               },


### PR DESCRIPTION
Farajaland: https://github.com/opencrvs/opencrvs-farajaland/pull/538