### PR TITLE
[OCRVS-4681] Dashboards: fix how currently connected database name is looked up

### DIFF
--- a/packages/metrics/src/features/performance/viewRefresher.ts
+++ b/packages/metrics/src/features/performance/viewRefresher.ts
@@ -40,8 +40,8 @@ export async function refresh() {
   const client = new MongoClient(HEARTH_MONGO_URL)
   try {
     updateInProgress = true
-    await client.connect()
-    await refreshPerformanceMaterialisedViews(client)
+    const connectedClient = await client.connect()
+    await refreshPerformanceMaterialisedViews(connectedClient)
     logger.info('Performance materialised views refreshed')
   } catch (error) {
     logger.error(`Error refreshing performances materialised views ${error}`)
@@ -57,8 +57,7 @@ export async function refresh() {
 }
 
 async function refreshPerformanceMaterialisedViews(client: MongoClient) {
-  const db = client.db(client.options.dbName)
-
+  const db = client.db()
   const lastUpdatedAt = subMinutes(new Date(), 5).toISOString()
   await db
     .collection('Task')


### PR DESCRIPTION
I noticed something a little off with this when working in my own environment. `client.options` was undefined for some reason and I just couldn't get the settings to show through there. A little bit of googling led me to just do what's in the PR which seems to work better.