### PR TITLE
HOTFIX: Address fields exception

### DIFF
--- a/packages/client/src/utils/referenceApi.ts
+++ b/packages/client/src/utils/referenceApi.ts
@@ -15,6 +15,7 @@ import { ILocation } from '@client/offline/reducer'
 import { getToken } from '@client/utils/authUtils'
 import { Event, System } from '@client/utils/gateway'
 import { questionsTransformer } from '@client/forms/questionConfig'
+import { merge } from 'lodash'
 
 export interface ILocationDataResponse {
   [locationId: string]: ILocation
@@ -124,7 +125,7 @@ async function loadConfig(): Promise<IApplicationConfigResponse> {
       return { ...rest, id: _id }
     }
   )
-
+  merge(window.config, response.config)
   response.formConfig.questionConfig = questionsTransformer(
     response.formConfig.questionConfig
   )

--- a/packages/client/src/utils/referenceApi.ts
+++ b/packages/client/src/utils/referenceApi.ts
@@ -125,7 +125,16 @@ async function loadConfig(): Promise<IApplicationConfigResponse> {
       return { ...rest, id: _id }
     }
   )
+  /*
+   * This is a temporary fix to merge the config from the config API with the global config object.
+   * Without this questionsTransformer doesn't have the correct window.config.ADMIN_LEVELS value
+   * when the application is loaded with no offline data.
+   * This causes:
+   * - incorrect form fields for address to be shown in the forms
+   * - runtime errors if an implementing country has customized address fields
+   */
   merge(window.config, response.config)
+
   response.formConfig.questionConfig = questionsTransformer(
     response.formConfig.questionConfig
   )


### PR DESCRIPTION
This fixes an initialization issue on a first OpenCRVS load:

Our scenario:
- We’ve customized districtPrimary  field (or rather, we have a field that has it as its precedingFieldId)
- We started noticing the error in the screenshot. This happens randomly which has made debugging even more difficult
- After a long time of reading the code I traced it here. ADMIN_LEVELS seems to be undefined
- Looking at the config endpoint, ADMIN_LEVELS  is returned correctly

More details in the code comment

![image](https://user-images.githubusercontent.com/1206987/232042548-a2924353-2e4b-4ba4-b4f3-c4c1b8d7b779.png)
![image](https://user-images.githubusercontent.com/1206987/232042568-d8e11a5f-eb51-43a1-b475-124e4136e161.png)
![image](https://user-images.githubusercontent.com/1206987/232042587-e647c98d-c8f8-4626-ad73-ca5345ccff0b.png)
