### PR TITLE
feat(search): allow searching with record/composition/declaration id

### DIFF
--- a/packages/gateway/src/features/bookmarkAdvancedSearch/schema.graphql
+++ b/packages/gateway/src/features/bookmarkAdvancedSearch/schema.graphql
@@ -88,6 +88,7 @@ input AdvancedSearchParametersInput {
   nationalId: String
   registrationNumber: String
   trackingId: String
+  recordId: ID
   dateOfRegistration: String
   dateOfRegistrationStart: String
   dateOfRegistrationEnd: String

--- a/packages/gateway/src/graphql/schema.d.ts
+++ b/packages/gateway/src/graphql/schema.d.ts
@@ -419,6 +419,7 @@ export interface GQLAdvancedSearchParametersInput {
   nationalId?: string
   registrationNumber?: string
   trackingId?: string
+  recordId?: string
   dateOfRegistration?: string
   dateOfRegistrationStart?: string
   dateOfRegistrationEnd?: string

--- a/packages/gateway/src/graphql/schema.graphql
+++ b/packages/gateway/src/graphql/schema.graphql
@@ -550,6 +550,7 @@ input AdvancedSearchParametersInput {
   nationalId: String
   registrationNumber: String
   trackingId: String
+  recordId: ID
   dateOfRegistration: String
   dateOfRegistrationStart: String
   dateOfRegistrationEnd: String

--- a/packages/search/src/features/search/types.ts
+++ b/packages/search/src/features/search/types.ts
@@ -24,6 +24,7 @@ export interface IAdvancedSearchParam {
   nationalId?: string
   registrationNumber?: string
   trackingId?: string
+  recordId?: string
   dateOfRegistration?: string
   dateOfRegistrationStart?: string
   dateOfRegistrationEnd?: string

--- a/packages/search/src/features/search/utils.ts
+++ b/packages/search/src/features/search/utils.ts
@@ -519,6 +519,14 @@ export function advancedQueryBuilder(
     })
   }
 
+  if (params.recordId) {
+    must.push({
+      match: {
+        _id: params.recordId
+      }
+    })
+  }
+
   if (params.nationalId) {
     must.push({
       bool: {


### PR DESCRIPTION
Allows searching by "record id". [Documentation](https://documentation.opencrvs.org/technology/interoperability/record-search-clients) needs to be amended.