### PR TITLE
fix: performance mongo url in migrations

### DIFF
--- a/packages/migration/migrate-mongo-config-performance.js
+++ b/packages/migration/migrate-mongo-config-performance.js
@@ -11,7 +11,7 @@
  */
 const config = {
   mongodb: {
-    url: process.env.ANALYTICS_MONGO_URL || 'mongodb://localhost/performance',
+    url: process.env.PERFORMANCE_MONGO_URL || 'mongodb://localhost/performance',
     options: {
       useNewUrlParser: true, // removes a deprecation warning when connecting
       useUnifiedTopology: true // removes a deprecating warning when connecting


### PR DESCRIPTION
This fixes migrations using 'ANALYTICS_MONGO_URL' which doesn't exist, and it caused some migrations to fail