### PR TITLE
fix: history label in record audit

### DIFF
--- a/packages/client/src/views/RecordAudit/History.tsx
+++ b/packages/client/src/views/RecordAudit/History.tsx
@@ -170,7 +170,9 @@ export const GetHistory = ({
     return (
       <>
         <Divider />
-        <Heading>{intl.formatMessage(constantsMessages.history)}</Heading>
+        <Text variant="h3" element="h3" color="copy">
+          {intl.formatMessage(constantsMessages.history)}
+        </Text>
         <LargeGreyedInfo />
       </>
     )

--- a/packages/client/src/views/RecordAudit/History.tsx
+++ b/packages/client/src/views/RecordAudit/History.tsx
@@ -11,6 +11,7 @@
  */
 import React from 'react'
 import { Table } from '@opencrvs/components/lib/Table'
+import { Text } from '@opencrvs/components/lib/Text'
 import { Divider } from '@opencrvs/components/lib/Divider'
 import styled from '@client/styledComponents'
 import { ColumnContentAlignment } from '@opencrvs/components/lib/common-types'
@@ -42,11 +43,6 @@ import { useSelector } from 'react-redux'
 
 const TableDiv = styled.div`
   overflow: auto;
-`
-
-const Heading = styled.h3`
-  ${({ theme }) => theme.fonts.h3}
-  margin-bottom: 0px !important;
 `
 
 const LargeGreyedInfo = styled.div`
@@ -323,7 +319,9 @@ export const GetHistory = ({
   return (
     <>
       <Divider />
-      <Heading>{intl.formatMessage(constantsMessages.history)}</Heading>
+      <Text variant="h3" element="h3" color="copy">
+        {intl.formatMessage(constantsMessages.history)}
+      </Text>
       <TableDiv>
         <Table
           id="task-history"

--- a/packages/client/src/views/UserAudit/UserAuditHistory.tsx
+++ b/packages/client/src/views/UserAudit/UserAuditHistory.tsx
@@ -47,6 +47,7 @@ import {
 import { ResponsiveModal } from '@opencrvs/components/lib/ResponsiveModal'
 import format from '@client/utils/date-formatting'
 import { Link } from '@opencrvs/components'
+import { Text } from '@opencrvs/components/lib/Text'
 
 const DEFAULT_LIST_SIZE = 10
 
@@ -56,22 +57,13 @@ const TableDiv = styled.div`
 
 const HistoryHeader = styled.div`
   display: flex;
+  align-items: center;
   justify-content: space-between;
 `
 
 const RecentActionsHolder = styled.div`
-  margin-top: 40px;
-  padding-top: 30px;
-  @media (max-width: ${({ theme }) => theme.grid.breakpoints.md}px) {
-    margin-top: 24px;
-    padding-top: 24px;
-  }
+  margin-top: 24px;
   border-top: 1px solid ${({ theme }) => theme.colors.grey200};
-`
-
-const AlignedDateRangePicker = styled(DateRangePicker)`
-  position: absolute;
-  top: 6px;
 `
 
 const SectionTitle = styled.div`
@@ -387,10 +379,10 @@ class UserAuditHistoryComponent extends React.Component<Props, State> {
         <>
           <>
             <HistoryHeader>
-              <SectionTitle>
+              <Text variant="h3" element="h3" color="copy">
                 {intl.formatMessage(messages.auditSectionTitle)}
-              </SectionTitle>
-              <AlignedDateRangePicker
+              </Text>
+              <DateRangePicker
                 startDate={timeStart}
                 endDate={timeEnd}
                 onDatesChange={({ startDate, endDate }) => {


### PR DESCRIPTION
- fixes spacing on history label
<img width="1157" alt="image" src="https://user-images.githubusercontent.com/46478402/236802692-7565f9cd-1eed-4237-8b22-711637bf38cb.png">

<img width="1160" alt="image" src="https://user-images.githubusercontent.com/46478402/236805176-d8944e8e-61d4-4b7d-bd29-56270b4891f1.png">

