### PR TITLE
ocrvs-5280 Use both section & group id for form key

### DIFF
--- a/packages/client/src/views/RegisterForm/RegisterForm.tsx
+++ b/packages/client/src/views/RegisterForm/RegisterForm.tsx
@@ -835,8 +835,8 @@ class RegisterFormView extends React.Component<FullProps, State> {
                               </Alert>
                             )}
                           <FormFieldGenerator
-                            id={activeSectionGroup.id}
-                            key={activeSectionGroup.id}
+                            id={`${activeSection.id}-${activeSectionGroup.id}`}
+                            key={`${activeSection.id}-${activeSectionGroup.id}`}
                             onChange={(values) => {
                               debouncedModifyDeclaration(
                                 values,


### PR DESCRIPTION
Witness one & witness two both had the same group id which caused the key to stay the same even after changing the form page
![5280-fix](https://github.com/opencrvs/opencrvs-core/assets/29002716/ce79f9dc-89df-4637-863f-c4b919fea35d)
