### PR TITLE
Add declarant label for a better reading for record audit page

### DIFF
--- a/packages/client/src/views/PrintCertificate/PDFUtils.ts
+++ b/packages/client/src/views/PrintCertificate/PDFUtils.ts
@@ -183,24 +183,24 @@ export function executeHandlebarsTemplate(
         return ''
       }
 
-      const id =
-        idParts.length === 3
-          ? idParts.slice(0, -1).join('.')
-          : idParts.join('.')
+      const id = idParts.join('.')
 
-      const value = intl.formatMessage({
+      // const value = intl.formatMessage({
+      //   id,
+      //   defaultMessage: 'Missing translation for ' + id
+      // })
+
+      // if (
+      //   idParts.includes('uppercase') &&
+      //   !value.split(' ').includes('Missing')
+      // ) {
+      //   return value.toUpperCase()
+      // }
+
+      return intl.formatMessage({
         id,
         defaultMessage: 'Missing translation for ' + id
       })
-
-      if (
-        idParts.includes('uppercase') &&
-        !value.split(' ').includes('Missing')
-      ) {
-        return value.toUpperCase()
-      }
-
-      return value
     } as any /* This is here because Handlebars typing is insufficient and we can make the function type stricter */
   )
 

--- a/packages/client/src/views/PrintCertificate/PDFUtils.ts
+++ b/packages/client/src/views/PrintCertificate/PDFUtils.ts
@@ -183,12 +183,24 @@ export function executeHandlebarsTemplate(
         return ''
       }
 
-      const id = idParts.join('.')
+      const id =
+        idParts.length === 3
+          ? idParts.slice(0, -1).join('.')
+          : idParts.join('.')
 
-      return intl.formatMessage({
+      const value = intl.formatMessage({
         id,
         defaultMessage: 'Missing translation for ' + id
       })
+
+      if (
+        idParts.includes('uppercase') &&
+        !value.split(' ').includes('Missing')
+      ) {
+        return value.toUpperCase()
+      }
+
+      return value
     } as any /* This is here because Handlebars typing is insufficient and we can make the function type stricter */
   )
 
@@ -284,6 +296,20 @@ export function executeHandlebarsTemplate(
       return options.hash
     }
   )
+
+  Handlebars.registerHelper('uppercase', function (str) {
+    if (str && typeof str === 'string') {
+      return str.toUpperCase()
+    }
+    return ''
+  })
+
+  Handlebars.registerHelper('lowercase', function (str) {
+    if (str && typeof str === 'string') {
+      return str.toLowerCase()
+    }
+    return ''
+  })
 
   const template = Handlebars.compile(templateString)
   const formattedTemplateData = formatAllNonStringValues(data)

--- a/packages/client/src/views/PrintCertificate/PDFUtils.ts
+++ b/packages/client/src/views/PrintCertificate/PDFUtils.ts
@@ -185,18 +185,6 @@ export function executeHandlebarsTemplate(
 
       const id = idParts.join('.')
 
-      // const value = intl.formatMessage({
-      //   id,
-      //   defaultMessage: 'Missing translation for ' + id
-      // })
-
-      // if (
-      //   idParts.includes('uppercase') &&
-      //   !value.split(' ').includes('Missing')
-      // ) {
-      //   return value.toUpperCase()
-      // }
-
       return intl.formatMessage({
         id,
         defaultMessage: 'Missing translation for ' + id

--- a/packages/client/src/views/RegisterForm/review/ReviewSection.tsx
+++ b/packages/client/src/views/RegisterForm/review/ReviewSection.tsx
@@ -1013,13 +1013,17 @@ class ReviewSectionComp extends React.Component<FullProps, State> {
     fieldLabel: MessageDescriptor,
     fieldName: string,
     value: IFormFieldValue | JSX.Element | undefined,
-    ignoreAction = false
+    ignoreAction = false,
+    fieldType = ''
   ) {
     const { intl } = this.props
 
     return {
       label: intl.formatMessage(fieldLabel),
       value,
+      subtitle:
+        fieldType &&
+        [FIELD_GROUP_TITLE, PARAGRAPH, SUBSECTION].includes(fieldType),
       action: !ignoreAction && {
         id: `btn_change_${section.id}_${fieldName}`,
         label: intl.formatMessage(buttonMessages.change),
@@ -1276,8 +1280,7 @@ class ReviewSectionComp extends React.Component<FullProps, State> {
         (tagDef[0] && tagDef[0].label) || field.label,
         (tagDef[0] && tagDef[0].fieldToRedirect) || field.name,
         completeValue,
-        field.readonly ||
-          [FIELD_GROUP_TITLE, PARAGRAPH, SUBSECTION].includes(field.type)
+        field.readonly
       )
     }
   }
@@ -1397,7 +1400,8 @@ class ReviewSectionComp extends React.Component<FullProps, State> {
       field.name,
       value,
       field.readonly ||
-        [FIELD_GROUP_TITLE, PARAGRAPH, SUBSECTION].includes(field.type)
+        [FIELD_GROUP_TITLE, PARAGRAPH, SUBSECTION].includes(field.type),
+      field.type
     )
   }
 
@@ -1462,10 +1466,7 @@ class ReviewSectionComp extends React.Component<FullProps, State> {
               nestedField,
               sectionErrors[section.id][field.name]
             ),
-            nestedField.readonly ||
-              [FIELD_GROUP_TITLE, PARAGRAPH, SUBSECTION].includes(
-                nestedField.type
-              )
+            nestedField.readonly
           )
         )
       }
@@ -1976,7 +1977,7 @@ class ReviewSectionComp extends React.Component<FullProps, State> {
                             <ListViewItemSimplified
                               key={index}
                               label={
-                                <Label section={!item.action}>
+                                <Label section={item.subtitle}>
                                   {item.label}
                                 </Label>
                               }


### PR DESCRIPTION
This PR contains the fix for displaying the labels of the sub-sections in the review page and it also contains the addition of a new helper for capitalising translated information