### PR TITLE
Remove unique prop from user's searches schema

### DIFF
--- a/packages/user-mgnt/src/model/user.ts
+++ b/packages/user-mgnt/src/model/user.ts
@@ -273,7 +273,7 @@ const AdvanceSearchParameters = new Schema(
 
 const SearchesSchema = new Schema(
   {
-    searchId: { type: String, required: true, unique: true },
+    searchId: { type: String, required: true },
     name: { type: String, required: true },
     parameters: { type: AdvanceSearchParameters, required: true }
   },


### PR DESCRIPTION
We use [UUID](https://github.com/opencrvs/opencrvs-core/blob/b2127fddd42eff4ac88d93ed530ae2ab610bc0b1/packages/user-mgnt/src/features/userSearchRecord/handler.ts#L109) to create a new search object for a user so having an index for it is not required