### PR TITLE
GN-025 : Account creation

### DIFF
--- a/packages/client/src/forms/user/fieldDefinitions/createUser.ts
+++ b/packages/client/src/forms/user/fieldDefinitions/createUser.ts
@@ -273,7 +273,7 @@ export const userSectionFormType: ISerializedFormSection = {
           customisable: false,
           type: 'LOCATION_SEARCH_INPUT',
           label: userFormMessages.userOrganisation,
-          required: true,
+          required: false,
           initialValue: '',
           searchableResource: ['facilities'],
           searchableType: ['HEALTH_FACILITY'],


### PR DESCRIPTION
GIVEN that I am creating a new user with type Local Leader or Field Agent, THEN it should not be mandatory to add Organisation type and Organisation fields.

EXPECTED BEHAVIOUR: Only Health Worker should have the option to add Organisation Type and Organisation. 