### PR TITLE
fix(pentest): remove nginx version from being exposed

### DIFF
--- a/infrastructure/nginx-default.conf
+++ b/infrastructure/nginx-default.conf
@@ -64,3 +64,7 @@ server {
         root   /usr/share/nginx/html;
     }
 }
+
+http {
+    server_tokens off;
+}

--- a/infrastructure/nginx-default.conf
+++ b/infrastructure/nginx-default.conf
@@ -50,6 +50,7 @@ add_header Content-Security-Policy "default-src 'self' *.{{hostname}} *.logrocke
 server {
     listen       80;
     server_name  localhost;
+    server_tokens off;
 
     location / {
         root   /usr/share/nginx/html;
@@ -63,8 +64,4 @@ server {
     location = /50x.html {
         root   /usr/share/nginx/html;
     }
-}
-
-http {
-    server_tokens off;
 }


### PR DESCRIPTION
I have tested this on staging and it works.

before:
```
➜  ~ curl -I -L https://login.farajaland-staging.opencrvs.org/ | grep server
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0  1887    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
server: nginx/1.25.1
```
after:
```
➜  ~ curl -I -L https://login.farajaland-staging.opencrvs.org/ | grep server
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0  1887    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
server: nginx
```