### PR TITLE
fix(pentest): remove unsafe inline CSP

### DIFF
--- a/infrastructure/nginx-default.conf
+++ b/infrastructure/nginx-default.conf
@@ -45,7 +45,7 @@ add_header X-Permitted-Cross-Domain-Policies master-only;
 # I need to change our application code so we can increase security by disabling 'unsafe-inline' 'unsafe-eval'
 # directives for css and js(if you have inline css or js, you will need to keep it too).
 # more: http://www.html5rocks.com/en/tutorials/security/content-security-policy/#inline-code-considered-harmful
-add_header Content-Security-Policy "default-src 'self' *.{{hostname}} *.logrocket.io/ *.sentry.io/ sentry.io/;font-src fonts.gstatic.com; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: https: http: storage.googleapis.com/workbox-cdn/ sentry.io/api/embed/error-page/; style-src 'self' fonts.googleapis.com 'unsafe-inline'; img-src 'self' data: http: https: ";
+add_header Content-Security-Policy "default-src 'self' *.{{hostname}} *.logrocket.io/ *.sentry.io/ sentry.io/;font-src fonts.gstatic.com; script-src 'self' 'unsafe-eval' blob: https: http: storage.googleapis.com/workbox-cdn/ sentry.io/api/embed/error-page/; style-src 'self' fonts.googleapis.com 'unsafe-inline'; img-src 'self' data: http: https: ";
 
 server {
     listen       80;

--- a/infrastructure/nginx-default.conf
+++ b/infrastructure/nginx-default.conf
@@ -45,7 +45,7 @@ add_header X-Permitted-Cross-Domain-Policies master-only;
 # I need to change our application code so we can increase security by disabling 'unsafe-inline' 'unsafe-eval'
 # directives for css and js(if you have inline css or js, you will need to keep it too).
 # more: http://www.html5rocks.com/en/tutorials/security/content-security-policy/#inline-code-considered-harmful
-add_header Content-Security-Policy "default-src 'self' *.{{hostname}} *.logrocket.io/ *.sentry.io/ sentry.io/;font-src fonts.gstatic.com; script-src 'self' 'unsafe-eval' blob: https: http: storage.googleapis.com/workbox-cdn/ sentry.io/api/embed/error-page/; style-src 'self' fonts.googleapis.com 'unsafe-inline'; img-src 'self' data: http: https: ";
+add_header Content-Security-Policy "default-src 'self' *.{{hostname}} *.logrocket.io/ *.sentry.io/ sentry.io/; font-src fonts.gstatic.com; object-src 'none'; script-src 'self' 'unsafe-eval' blob: https: http: storage.googleapis.com/workbox-cdn/ sentry.io/api/embed/error-page/; style-src 'self' fonts.googleapis.com 'unsafe-inline'; img-src 'self' data: http: https: ";
 
 server {
     listen       80;


### PR DESCRIPTION
I have tested this on staging and it works.

https://csp-evaluator.withgoogle.com/
**Before:**
<img width="846" alt="image" src="https://github.com/opencrvs/opencrvs-core/assets/1322608/4bdf6a85-fc56-402d-9ef3-552232ad6a47">
**After:**
<img width="852" alt="image" src="https://github.com/opencrvs/opencrvs-core/assets/1322608/762a583a-afa6-443a-a578-d7a0c2aa4e64">
