### PR TITLE
GN-034 French translation of the nationalities must be in the feminine form. 

### DIFF
--- a/packages/client/src/forms/configuration/default/death.ts
+++ b/packages/client/src/forms/configuration/default/death.ts
@@ -1065,7 +1065,16 @@ export const deathRegisterForms: ISerializedForm = {
             }
           ]
         }
-      ]
+      ],
+      mapping: {
+        template: [
+          {
+            fieldName: 'deceasedGenderKey',
+            operation: 'plainInputTransformerSection',
+            parameters: ['gender']
+          }
+        ]
+      }
     },
     {
       id: DeathSection.Event,

--- a/packages/client/src/forms/register/fieldMappings/birth/query/registration-mappings.ts
+++ b/packages/client/src/forms/register/fieldMappings/birth/query/registration-mappings.ts
@@ -594,3 +594,19 @@ export const QRCodeTransformerTransformer = async (
       )}`
     )
 }
+
+export const plainInputTransformerSection =
+  (fieldName: string) =>
+  (
+    transformedData: IFormData,
+    queryData: any,
+    sectionId: string,
+    targetSectionId?: string,
+    targetFieldName?: string
+  ) => {
+    if (fieldName) {
+      transformedData[targetSectionId || sectionId][
+        targetFieldName || 'informantType'
+      ] = queryData[sectionId][fieldName]
+    }
+  }

--- a/packages/client/src/forms/register/fieldMappings/birth/query/registration-mappings.ts
+++ b/packages/client/src/forms/register/fieldMappings/birth/query/registration-mappings.ts
@@ -604,9 +604,8 @@ export const plainInputTransformerSection =
     targetSectionId?: string,
     targetFieldName?: string
   ) => {
-    if (fieldName) {
-      transformedData[targetSectionId || sectionId][
-        targetFieldName || 'informantType'
-      ] = queryData[sectionId][fieldName]
+    if (fieldName && targetFieldName) {
+      transformedData[targetSectionId || sectionId][targetFieldName] =
+        queryData[sectionId][fieldName]
     }
   }

--- a/packages/client/src/views/PrintCertificate/PDFUtils.ts
+++ b/packages/client/src/views/PrintCertificate/PDFUtils.ts
@@ -352,6 +352,11 @@ export function executeHandlebarsTemplate(
     return ''
   })
 
+  Handlebars.registerHelper('concat', function () {
+    // eslint-disable-next-line prefer-rest-params
+    return Array.prototype.slice.call(arguments, 0, -1).join('')
+  })
+
   const template = Handlebars.compile(templateString)
   const formattedTemplateData = formatAllNonStringValues(data, intl)
   const output = template(formattedTemplateData)


### PR DESCRIPTION
This PR contains:
- a handlebar for text concatenation
- the addition of a template (SVG) to have the gender value in the death certificate
- Add a plainInputTransformerSection function to get the untranslated values of the various fields for SVGs.