### PR TITLE
GN-035 : the 'Confirm' button should be inactive until any change

### DIFF
--- a/packages/client/src/user/userReducer.ts
+++ b/packages/client/src/user/userReducer.ts
@@ -68,7 +68,7 @@ const initialState: IUserFormState = {
   submissionError: false,
   userAuditForm,
   systemRoleMap: {},
-  updateToBeConfirmed: false
+  userDetailsChanged: false
 }
 
 export interface IRoleMessagesLoadedAction {
@@ -85,19 +85,19 @@ interface IUserFormDataModifyAction {
   type: typeof MODIFY_USER_FORM_DATA
   payload: {
     data: IFormSectionData
-    updateToBeConfirmed?: boolean
+    userDetailsChanged?: boolean
   }
 }
 
 export function modifyUserFormData(
   data: IFormSectionData,
-  updateToBeConfirmed?: boolean
+  userDetailsChanged?: boolean
 ): IUserFormDataModifyAction {
   return {
     type: MODIFY_USER_FORM_DATA,
     payload: {
       data,
-      updateToBeConfirmed
+      userDetailsChanged
     }
   }
 }
@@ -261,7 +261,7 @@ export interface IUserFormState {
   submissionError: boolean
   userAuditForm: IUserAuditForm
   systemRoleMap: ISystemRolesMap
-  updateToBeConfirmed: boolean
+  userDetailsChanged: boolean
 }
 
 export const fetchRoles = async () => {
@@ -338,8 +338,8 @@ export const userFormReducer: LoopReducer<IUserFormState, UserFormAction> = (
       return {
         ...state,
         userFormData: (action as IUserFormDataModifyAction).payload.data,
-        updateToBeConfirmed:
-          (action as IUserFormDataModifyAction).payload?.updateToBeConfirmed ||
+        userDetailsChanged:
+          (action as IUserFormDataModifyAction).payload?.userDetailsChanged ||
           false
       }
 

--- a/packages/client/src/user/userReducer.ts
+++ b/packages/client/src/user/userReducer.ts
@@ -67,7 +67,8 @@ const initialState: IUserFormState = {
   loadingRoles: false,
   submissionError: false,
   userAuditForm,
-  systemRoleMap: {}
+  systemRoleMap: {},
+  updateToBeConfirmed: false
 }
 
 export interface IRoleMessagesLoadedAction {
@@ -84,16 +85,19 @@ interface IUserFormDataModifyAction {
   type: typeof MODIFY_USER_FORM_DATA
   payload: {
     data: IFormSectionData
+    updateToBeConfirmed?: boolean
   }
 }
 
 export function modifyUserFormData(
-  data: IFormSectionData
+  data: IFormSectionData,
+  updateToBeConfirmed?: boolean
 ): IUserFormDataModifyAction {
   return {
     type: MODIFY_USER_FORM_DATA,
     payload: {
-      data
+      data,
+      updateToBeConfirmed
     }
   }
 }
@@ -257,6 +261,7 @@ export interface IUserFormState {
   submissionError: boolean
   userAuditForm: IUserAuditForm
   systemRoleMap: ISystemRolesMap
+  updateToBeConfirmed: boolean
 }
 
 export const fetchRoles = async () => {
@@ -332,7 +337,10 @@ export const userFormReducer: LoopReducer<IUserFormState, UserFormAction> = (
     case MODIFY_USER_FORM_DATA:
       return {
         ...state,
-        userFormData: (action as IUserFormDataModifyAction).payload.data
+        userFormData: (action as IUserFormDataModifyAction).payload.data,
+        updateToBeConfirmed:
+          (action as IUserFormDataModifyAction).payload?.updateToBeConfirmed ||
+          false
       }
 
     case CLEAR_USER_FORM_DATA:

--- a/packages/client/src/views/SysAdmin/Team/user/userCreation/CreateNewUser.test.tsx
+++ b/packages/client/src/views/SysAdmin/Team/user/userCreation/CreateNewUser.test.tsx
@@ -478,7 +478,7 @@ describe('edit user tests', () => {
         '#submit-edit-user-form'
       )
       submitButton.hostNodes().simulate('click')
-      expect(store.getState().userForm.submitting).toBe(true)
+      expect(store.getState().userForm.submitting).toBe(false)
     })
   })
 })

--- a/packages/client/src/views/SysAdmin/Team/user/userCreation/CreateNewUser.tsx
+++ b/packages/client/src/views/SysAdmin/Team/user/userCreation/CreateNewUser.tsx
@@ -261,7 +261,7 @@ const mapStateToProps = (state: IStoreState, props: Props) => {
     sectionId,
     section,
     formData,
-    updateToBeConfirmed: state.userForm.updateToBeConfirmed,
+    userDetailsChanged: state.userForm.userDetailsChanged,
     submitting: state.userForm.submitting,
     userDetailsStored: state.userForm.userDetailsStored,
     loadingRoles: state.userForm.loadingRoles,

--- a/packages/client/src/views/SysAdmin/Team/user/userCreation/CreateNewUser.tsx
+++ b/packages/client/src/views/SysAdmin/Team/user/userCreation/CreateNewUser.tsx
@@ -261,6 +261,7 @@ const mapStateToProps = (state: IStoreState, props: Props) => {
     sectionId,
     section,
     formData,
+    updateToBeConfirmed: state.userForm.updateToBeConfirmed,
     submitting: state.userForm.submitting,
     userDetailsStored: state.userForm.userDetailsStored,
     loadingRoles: state.userForm.loadingRoles,

--- a/packages/client/src/views/SysAdmin/Team/user/userCreation/UserForm.tsx
+++ b/packages/client/src/views/SysAdmin/Team/user/userCreation/UserForm.tsx
@@ -49,6 +49,7 @@ import { IOfflineData } from '@client/offline/reducer'
 import { getOfflineData } from '@client/offline/selectors'
 import { Content } from '@opencrvs/components/lib/Content'
 import { selectSystemRoleMap } from '@client/user/selectors'
+import { isEqual } from 'lodash'
 
 export const FormTitle = styled.div`
   ${({ theme }) => theme.fonts.h1};
@@ -144,7 +145,24 @@ class UserFormComponent extends React.Component<IFullProps, IState> {
         const getSystemRoles = this.props.systemRoleMap
         values.systemRole = getSystemRoles[values.role]
       }
-      this.props.modifyUserFormData({ ...formData, ...values })
+
+      let updateToBeConfirmed = false
+
+      if (formData.username) {
+        const oldFormData = { ...values, ...formData, systemRole: '' }
+        const newFormData = { ...formData, ...values, systemRole: '' }
+        if (
+          !isEqual(oldFormData, newFormData) ||
+          (!formData.signature && values.signature?.name)
+        ) {
+          updateToBeConfirmed = true
+        }
+      }
+
+      this.props.modifyUserFormData(
+        { ...formData, ...values },
+        updateToBeConfirmed
+      )
       this.setState({
         disableContinueOnLocation: false
       })

--- a/packages/client/src/views/SysAdmin/Team/user/userCreation/UserForm.tsx
+++ b/packages/client/src/views/SysAdmin/Team/user/userCreation/UserForm.tsx
@@ -148,7 +148,7 @@ class UserFormComponent extends React.Component<IFullProps, IState> {
 
       let updateToBeConfirmed = false
 
-      if (formData.username) {
+      if (formData?.username) {
         const oldFormData = { ...values, ...formData, systemRole: '' }
         const newFormData = { ...formData, ...values, systemRole: '' }
         if (

--- a/packages/client/src/views/SysAdmin/Team/user/userCreation/UserForm.tsx
+++ b/packages/client/src/views/SysAdmin/Team/user/userCreation/UserForm.tsx
@@ -146,7 +146,7 @@ class UserFormComponent extends React.Component<IFullProps, IState> {
         values.systemRole = getSystemRoles[values.role]
       }
 
-      let updateToBeConfirmed = false
+      let userDetailsChanged = false
 
       if (formData?.username) {
         const oldFormData = { ...values, ...formData, systemRole: '' }
@@ -155,13 +155,13 @@ class UserFormComponent extends React.Component<IFullProps, IState> {
           !isEqual(oldFormData, newFormData) ||
           (!formData.signature && values.signature?.name)
         ) {
-          updateToBeConfirmed = true
+          userDetailsChanged = true
         }
       }
 
       this.props.modifyUserFormData(
         { ...formData, ...values },
-        updateToBeConfirmed
+        userDetailsChanged
       )
       this.setState({
         disableContinueOnLocation: false

--- a/packages/client/src/views/SysAdmin/Team/user/userCreation/UserReviewForm.tsx
+++ b/packages/client/src/views/SysAdmin/Team/user/userCreation/UserReviewForm.tsx
@@ -81,6 +81,7 @@ export interface IUserReviewFormProps {
   section: IFormSection
   formData: IFormSectionData
   client: ApolloClient<unknown>
+  updateToBeConfirmed: boolean
 }
 
 interface IDispatchProps {
@@ -287,7 +288,8 @@ class UserReviewFormComponent extends React.Component<
       formData,
       goToTeamUserList,
       userDetails,
-      offlineCountryConfiguration
+      offlineCountryConfiguration,
+      updateToBeConfirmed
     } = this.props
     let title: string
     let actionComponent: JSX.Element
@@ -302,10 +304,11 @@ class UserReviewFormComponent extends React.Component<
         <SuccessButton
           id="submit-edit-user-form"
           disabled={
-            (this.props.formData.systemRole === 'LOCAL_REGISTRAR' ||
+            ((this.props.formData.systemRole === 'LOCAL_REGISTRAR' ||
               this.props.formData.systemRole === 'NATIONAL_REGISTRAR' ||
               this.props.formData.systemRole === 'REGISTRATION_AGENT') &&
-            !this.props.formData.signature
+              !this.props.formData.signature) ||
+            !updateToBeConfirmed
           }
           onClick={() => this.props.submitForm(userFormSection)}
           icon={() => <Check />}

--- a/packages/client/src/views/SysAdmin/Team/user/userCreation/UserReviewForm.tsx
+++ b/packages/client/src/views/SysAdmin/Team/user/userCreation/UserReviewForm.tsx
@@ -81,7 +81,7 @@ export interface IUserReviewFormProps {
   section: IFormSection
   formData: IFormSectionData
   client: ApolloClient<unknown>
-  updateToBeConfirmed?: boolean
+  userDetailsChanged?: boolean
 }
 
 interface IDispatchProps {
@@ -289,7 +289,7 @@ class UserReviewFormComponent extends React.Component<
       goToTeamUserList,
       userDetails,
       offlineCountryConfiguration,
-      updateToBeConfirmed
+      userDetailsChanged
     } = this.props
     let title: string
     let actionComponent: JSX.Element
@@ -308,7 +308,7 @@ class UserReviewFormComponent extends React.Component<
               this.props.formData.systemRole === 'NATIONAL_REGISTRAR' ||
               this.props.formData.systemRole === 'REGISTRATION_AGENT') &&
               !this.props.formData.signature) ||
-            !updateToBeConfirmed
+            !userDetailsChanged
           }
           onClick={() => this.props.submitForm(userFormSection)}
           icon={() => <Check />}

--- a/packages/client/src/views/SysAdmin/Team/user/userCreation/UserReviewForm.tsx
+++ b/packages/client/src/views/SysAdmin/Team/user/userCreation/UserReviewForm.tsx
@@ -81,7 +81,7 @@ export interface IUserReviewFormProps {
   section: IFormSection
   formData: IFormSectionData
   client: ApolloClient<unknown>
-  updateToBeConfirmed: boolean
+  updateToBeConfirmed?: boolean
 }
 
 interface IDispatchProps {


### PR DESCRIPTION
When modifying a user's details, this Pr enables the confirmation button to be activated and deactivated if no changes have been made.