### PR TITLE
Sentry : Error POST /events/birth/mark-voided in metric

### DIFF
--- a/packages/metrics/src/features/registration/fhirUtils.test.ts
+++ b/packages/metrics/src/features/registration/fhirUtils.test.ts
@@ -17,7 +17,7 @@ import {
   getObservationValueByCode,
   getTimeLoggedFromTask,
   isNotification,
-  getStartedByFieldAgent,
+  getRecordInitiator,
   FHIR_RESOURCE_TYPE,
   CAUSE_OF_DEATH_CODE
 } from '@metrics/features/registration/fhirUtils'
@@ -1224,7 +1224,7 @@ describe('fhirUtils', () => {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const taskHistory = require('./test-data/task-history.json')
 
-    expect(getStartedByFieldAgent(taskHistory)).toEqual(
+    expect(getRecordInitiator(taskHistory)).toEqual(
       'fe16875f-3e5f-47bc-85d6-16482a63e7df'
     )
   })
@@ -1233,7 +1233,7 @@ describe('fhirUtils', () => {
     const taskHistory = require('./test-data/task-history.json')
     taskHistory.entry[1].resource.businessStatus.coding[0].code = ''
 
-    expect(() => getStartedByFieldAgent(taskHistory)).toThrowError(
+    expect(() => getRecordInitiator(taskHistory)).toThrowError(
       'Task not found!'
     )
   })

--- a/packages/metrics/src/features/registration/fhirUtils.ts
+++ b/packages/metrics/src/features/registration/fhirUtils.ts
@@ -276,9 +276,10 @@ export function getDeclarationType(task: Task): DECLARATION_TYPE {
   return coding.code as DECLARATION_TYPE
 }
 
-export function getStartedByFieldAgent(taskHistory: fhir.Bundle): string {
+export function getRecordInitiator(taskHistory: fhir.Bundle): string {
   const allowedPreviousStates = [
     'DECLARED',
+    'VALIDATED',
     'IN_PROGRESS',
     'WAITING_VALIDATION'
   ]

--- a/packages/metrics/src/features/registration/pointGenerator.ts
+++ b/packages/metrics/src/features/registration/pointGenerator.ts
@@ -46,7 +46,7 @@ import {
   getDeclarationStatus,
   getTimeLoggedFromTask,
   getDeclarationType,
-  getStartedByFieldAgent,
+  getRecordInitiator,
   getPaymentReconciliation,
   getObservationValueByCode,
   isNotification,
@@ -616,7 +616,7 @@ export async function generateRejectedPoints(
 
   const tags = {
     eventType: getDeclarationType(task),
-    startedBy: getStartedByFieldAgent(taskHistory),
+    startedBy: getRecordInitiator(taskHistory),
     officeLocation: getRegLastOffice(payload),
     ...(await generatePointLocations(payload, authHeader))
   }


### PR DESCRIPTION
**If we understood this issue correctly, what happens is:**
- Registration agent creates a record (thus first task type for the event is now `VALIDATED`)
- Record may or may not go through other tasks
- Someone else marks the record voided
- Metrics tries to log this event with the record initiator with the assumption that `DECLARED` was the first state for the record = field agent started it

**Our proposed fix:**
Also consider `VALIDATED` as a starting state for a record

<img width="1354" alt="image" src="https://github.com/opencrvs/opencrvs-core/assets/1206987/5120ea37-b27d-4c4a-a16c-330f95934136">

https://new-legacy-digital-ltd.sentry.io/organizations/new-legacy-digital-ltd/issues/4233583642/events/684ba7cbdd814284a66a4570ef3c0068/

![image (4)](https://github.com/opencrvs/opencrvs-core/assets/10140488/c0a38567-b792-427f-bb92-e4c59afe762c)
![image (5)](https://github.com/opencrvs/opencrvs-core/assets/10140488/1bb13a51-2c4e-48cb-97f0-1e4ebc7c5b3b)
