### PR TITLE
Rename seed vars, deprecate old secrets

### DIFF
--- a/packages/data-seeder/src/certificates.ts
+++ b/packages/data-seeder/src/certificates.ts
@@ -10,7 +10,7 @@
  * graphic logo are (registered/a) trademark(s) of Plan International.
  */
 
-import { COUNTRY_CONFIG_URL, GATEWAY_GQL_HOST } from './constants'
+import { COUNTRY_CONFIG_HOST, GATEWAY_HOST } from './constants'
 import fetch from 'node-fetch'
 import { parseGQLResponse, raise } from './utils'
 import { TypeOf, z } from 'zod'
@@ -29,7 +29,7 @@ const CertificateSchema = z.array(
 )
 
 async function getCertificate() {
-  const url = new URL('certificates', COUNTRY_CONFIG_URL).toString()
+  const url = new URL('certificates', COUNTRY_CONFIG_HOST).toString()
   const res = await fetch(url)
   if (!res.ok) {
     raise(`Expected to get the certificates from ${url}`)
@@ -74,7 +74,7 @@ async function certificatesAlreadyExist(
   event: CertificateMeta['event'],
   token: string
 ) {
-  const res = await fetch(GATEWAY_GQL_HOST, {
+  const res = await fetch(`${GATEWAY_HOST}/graphql`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -100,7 +100,7 @@ async function uploadCertificate(token: string, certificate: CertificateInput) {
     )
     return
   }
-  const res = await fetch(GATEWAY_GQL_HOST, {
+  const res = await fetch(`${GATEWAY_HOST}/graphql`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/packages/data-seeder/src/constants.ts
+++ b/packages/data-seeder/src/constants.ts
@@ -9,12 +9,10 @@
  * Copyright (C) The OpenCRVS Authors. OpenCRVS and the OpenCRVS
  * graphic logo are (registered/a) trademark(s) of Plan International.
  */
-export const AUTH_URL = process.env.AUTH_URL || 'http://localhost:4040'
-export const COUNTRY_CONFIG_URL =
-  process.env.COUNTRY_CONFIG_URL || 'http://localhost:3040'
-export const GATEWAY_URL = process.env.GATEWAY_URL || 'http://localhost:7070'
-export const GATEWAY_GQL_HOST =
-  process.env.GATEWAY_GQL_HOST || 'http://localhost:7070/graphql'
+export const AUTH_HOST = process.env.AUTH_HOST || 'http://localhost:4040'
+export const COUNTRY_CONFIG_HOST =
+  process.env.COUNTRY_CONFIG_HOST || 'http://localhost:3040'
+export const GATEWAY_HOST = process.env.GATEWAY_HOST || 'http://localhost:7070'
 export const OPENCRVS_SPECIFICATION_URL = 'http://opencrvs.org/specs/'
 
 export const SUPER_USER_PASSWORD = process.env.SUPER_USER_PASSWORD ?? 'password'

--- a/packages/data-seeder/src/index.ts
+++ b/packages/data-seeder/src/index.ts
@@ -9,7 +9,7 @@
  * Copyright (C) The OpenCRVS Authors. OpenCRVS and the OpenCRVS
  * graphic logo are (registered/a) trademark(s) of Plan International.
  */
-import { AUTH_URL, GATEWAY_GQL_HOST, SUPER_USER_PASSWORD } from './constants'
+import { AUTH_HOST, GATEWAY_HOST, SUPER_USER_PASSWORD } from './constants'
 import fetch from 'node-fetch'
 import { seedCertificate } from './certificates'
 import { seedLocations } from './locations'
@@ -21,7 +21,7 @@ import gql from 'graphql-tag'
 import decode from 'jwt-decode'
 
 async function getToken(): Promise<string> {
-  const authUrl = new URL('authenticate-super-user', AUTH_URL).toString()
+  const authUrl = new URL('authenticate-super-user', AUTH_HOST).toString()
   const res = await fetch(authUrl, {
     method: 'POST',
     body: JSON.stringify({
@@ -72,7 +72,7 @@ function getTokenPayload(token: string): TokenPayload {
 
 async function deactivateSuperuser(token: string) {
   const { sub } = getTokenPayload(token)
-  const res = await fetch(GATEWAY_GQL_HOST, {
+  const res = await fetch(`${GATEWAY_HOST}/graphql`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/packages/data-seeder/src/locations.ts
+++ b/packages/data-seeder/src/locations.ts
@@ -11,8 +11,8 @@
  */
 import fetch from 'node-fetch'
 import {
-  COUNTRY_CONFIG_URL,
-  GATEWAY_URL,
+  COUNTRY_CONFIG_HOST,
+  GATEWAY_HOST,
   OPENCRVS_SPECIFICATION_URL
 } from './constants'
 import { TypeOf, z } from 'zod'
@@ -157,7 +157,7 @@ function validateAdminStructure(locations: TypeOf<typeof LocationSchema>) {
 }
 
 async function getLocations() {
-  const url = new URL('locations', COUNTRY_CONFIG_URL).toString()
+  const url = new URL('locations', COUNTRY_CONFIG_HOST).toString()
   const res = await fetch(url)
   if (!res.ok) {
     raise(`Expected to get the locations from ${url}`)
@@ -188,7 +188,7 @@ async function getLocations() {
 }
 
 export async function seedLocations(token: string) {
-  const savedLocations = await fetch(`${GATEWAY_URL}/location?_count=0`, {
+  const savedLocations = await fetch(`${GATEWAY_HOST}/location?_count=0`, {
     headers: {
       'Content-Type': 'application/fhir+json'
     }
@@ -222,7 +222,7 @@ export async function seedLocations(token: string) {
     }
     return !savedLocationsSet.has(location.id)
   })
-  const res = await fetch(`${GATEWAY_URL}/location?`, {
+  const res = await fetch(`${GATEWAY_HOST}/location?`, {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${token}`,

--- a/packages/data-seeder/src/roles.ts
+++ b/packages/data-seeder/src/roles.ts
@@ -9,7 +9,7 @@
  * Copyright (C) The OpenCRVS Authors. OpenCRVS and the OpenCRVS
  * graphic logo are (registered/a) trademark(s) of Plan International.
  */
-import { COUNTRY_CONFIG_URL, GATEWAY_GQL_HOST } from './constants'
+import { COUNTRY_CONFIG_HOST, GATEWAY_HOST } from './constants'
 import { raise, parseGQLResponse } from './utils'
 import fetch from 'node-fetch'
 import { z } from 'zod'
@@ -95,7 +95,7 @@ const getSystemRolesQuery = print(gql`
 `)
 
 async function fetchSystemRoles(token: string): Promise<SystemRole[]> {
-  const res = await fetch(GATEWAY_GQL_HOST, {
+  const res = await fetch(`${GATEWAY_HOST}/graphql`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -124,7 +124,7 @@ async function updateRoles(
   let roleIdMap: RoleIdMap = {}
   await Promise.all(
     systemRoles.map((systemRole) =>
-      fetch(GATEWAY_GQL_HOST, {
+      fetch(`${GATEWAY_HOST}/graphql`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -151,7 +151,7 @@ async function updateRoles(
 }
 
 async function fetchCountryRoles() {
-  const url = new URL('roles', COUNTRY_CONFIG_URL).toString()
+  const url = new URL('roles', COUNTRY_CONFIG_HOST).toString()
   const res = await fetch(url)
   if (!res.ok) {
     raise(`Expected to get the roles from ${url}`)

--- a/packages/data-seeder/src/users.ts
+++ b/packages/data-seeder/src/users.ts
@@ -10,12 +10,7 @@
  * graphic logo are (registered/a) trademark(s) of Plan International.
  */
 import fetch from 'node-fetch'
-import {
-  ACTIVATE_USERS,
-  COUNTRY_CONFIG_URL,
-  GATEWAY_GQL_HOST,
-  GATEWAY_URL
-} from './constants'
+import { ACTIVATE_USERS, COUNTRY_CONFIG_HOST, GATEWAY_HOST } from './constants'
 import { z } from 'zod'
 import { parseGQLResponse, raise } from './utils'
 import { print } from 'graphql'
@@ -73,7 +68,7 @@ const createUserMutation = print(gql`
 `)
 
 async function getUseres() {
-  const url = new URL('users', COUNTRY_CONFIG_URL).toString()
+  const url = new URL('users', COUNTRY_CONFIG_HOST).toString()
   const res = await fetch(url)
   if (!res.ok) {
     raise(`Expected to get the users from ${url}`)
@@ -102,7 +97,7 @@ async function userAlreadyExists(
   token: string,
   username: string
 ): Promise<boolean> {
-  const searchResponse = await fetch(GATEWAY_GQL_HOST, {
+  const searchResponse = await fetch(`${GATEWAY_HOST}/graphql`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -123,7 +118,7 @@ async function userAlreadyExists(
 
 async function getOfficeIdFromIdentifier(identifier: string) {
   const response = await fetch(
-    `${GATEWAY_URL}/location?identifier=${identifier}`,
+    `${GATEWAY_HOST}/location?identifier=${identifier}`,
     {
       headers: {
         'Content-Type': 'application/fhir+json'
@@ -181,7 +176,7 @@ export async function seedUsers(
         ...(ACTIVATE_USERS === 'true' && { status: 'active' }),
         primaryOffice
       }
-      const res = await fetch(GATEWAY_GQL_HOST, {
+      const res = await fetch(`${GATEWAY_HOST}/graphql`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
I didnt really see the need for the additional variable: GATEWAY_GQL_HOST when we already have GATEWAY_HOST.

Requires: https://github.com/opencrvs/opencrvs-farajaland/pull/680