### PR TITLE
Add the ability to hide a form page for a given user type

### DIFF
--- a/packages/client/src/utils/userUtils.ts
+++ b/packages/client/src/utils/userUtils.ts
@@ -29,9 +29,11 @@ export function getUserLocation(userDetails: UserDetails) {
 }
 
 export async function storeUserDetails(userDetails: UserDetails) {
+  window.config.USER_SYSTEM_ROLE = userDetails.systemRole
   storage.setItem(USER_DETAILS, JSON.stringify(userDetails))
 }
 export async function removeUserDetails() {
+  window.config.USER_SYSTEM_ROLE = ''
   storage.removeItem(USER_DETAILS)
 }
 

--- a/packages/client/typings/window.d.ts
+++ b/packages/client/typings/window.d.ts
@@ -12,6 +12,7 @@
 
 interface Window {
   config: {
+    USER_SYSTEM_ROLE: string
     APPLICATION_NAME: string
     API_GATEWAY_URL: string
     BIRTH: {


### PR DESCRIPTION
In Niue, it is likely going to  be necessary to hide a page in the form from a Field Agent.

The following conditional can be added to a group to hide the entire page from this user type:

```
conditionals: [
    {
      action: 'hide',
      expression: `window.config.USER_SYSTEM_ROLE==='FIELD_AGENT'`
    }
  ]
```

I had wanted to just check userDetails, but that prop isnt available to the group conditionals at present.  It is available to only field conditionals.