### PR TITLE
Mongoose package required in migration service

### DIFF
--- a/packages/migration/package.json
+++ b/packages/migration/package.json
@@ -31,6 +31,7 @@
     "lodash": "^4.17.21",
     "migrate-mongo": "^9.0.0",
     "minio": "^7.0.30",
+    "mongoose": "^6.6.1",
     "uuid": "^3.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Getting this bug:

```
ERROR: Could not migrate up 20230602090436-update-identifier-with-system.js: Cannot find package 'mongoose' imported from /usr/src/app/packages/migration/build/dist/src/migrations/hearth/20230602090436-update-identifier-with-system.js Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'mongoose' imported from /usr/src/app/packages/migration/build/dist/src/migrations/hearth/20230602090436-update-identifier-with-system.js
```