### PR TITLE
allow sorting searchEvents by multiple fields

### DIFF
--- a/packages/gateway/src/features/search/root-resolvers.ts
+++ b/packages/gateway/src/features/search/root-resolvers.ts
@@ -72,7 +72,8 @@ export const resolvers: GQLResolver = {
         count,
         skip,
         sortColumn,
-        sort = 'desc'
+        sort = 'desc',
+        sortBy
       },
       { headers: authHeader }
     ) {
@@ -159,6 +160,11 @@ export const resolvers: GQLResolver = {
         }
         if (sortColumn) {
           searchCriteria.sortColumn = sortColumn
+        }
+        if (sortBy) {
+          searchCriteria.sortBy = sortBy.map((sort) => ({
+            [sort.column]: sort.order
+          }))
         }
 
         searchCriteria.parameters = { ...advancedSearchParameters }

--- a/packages/gateway/src/features/search/schema.graphql
+++ b/packages/gateway/src/features/search/schema.graphql
@@ -124,6 +124,11 @@ type EventProgressSet {
   progressReport: EventProgressData
 }
 
+input SortBy {
+  column: String!
+  order: String!
+}
+
 type Query {
   searchEvents(
     userId: String
@@ -132,6 +137,7 @@ type Query {
     skip: Int
     sort: String
     sortColumn: String
+    sortBy: [SortBy!]
   ): EventSearchResultSet
   getEventsWithProgress(
     declarationJurisdictionId: String

--- a/packages/gateway/src/features/search/utils.ts
+++ b/packages/gateway/src/features/search/utils.ts
@@ -18,6 +18,7 @@ export interface ISearchCriteria {
   parameters: GQLAdvancedSearchParametersInput
   sort?: string
   sortColumn?: string
+  sortBy?: Array<Record<string, string>>
   size?: number
   from?: number
   createdBy?: string

--- a/packages/gateway/src/graphql/schema.d.ts
+++ b/packages/gateway/src/graphql/schema.d.ts
@@ -474,6 +474,11 @@ export interface GQLAdvancedSearchParametersInput {
   compositionType?: Array<string | null>
 }
 
+export interface GQLSortBy {
+  column: string
+  order: string
+}
+
 export interface GQLEventProgressResultSet {
   results?: Array<GQLEventProgressSet | null>
   totalItems?: number
@@ -2540,6 +2545,7 @@ export interface QueryToSearchEventsArgs {
   skip?: number
   sort?: string
   sortColumn?: string
+  sortBy?: Array<GQLSortBy>
 }
 export interface QueryToSearchEventsResolver<TParent = any, TResult = any> {
   (

--- a/packages/gateway/src/graphql/schema.graphql
+++ b/packages/gateway/src/graphql/schema.graphql
@@ -131,6 +131,7 @@ type Query {
     skip: Int
     sort: String
     sortColumn: String
+    sortBy: [SortBy!]
   ): EventSearchResultSet
   getEventsWithProgress(
     declarationJurisdictionId: String
@@ -604,6 +605,11 @@ input AdvancedSearchParametersInput {
   informantDoBEnd: String
   informantIdentifier: String
   compositionType: [String]
+}
+
+input SortBy {
+  column: String!
+  order: String!
 }
 
 type EventProgressResultSet {

--- a/packages/search/src/features/search/service.ts
+++ b/packages/search/src/features/search/service.ts
@@ -27,10 +27,12 @@ export function formatSearchParams(
     createdBy = '',
     from = 0,
     size = DEFAULT_SIZE,
-    sort = SortOrder.ASC,
     sortColumn = 'dateOfDeclaration',
+    sortBy,
     parameters
   } = searchPayload
+
+  const sort = sortBy ?? [{ [sortColumn]: searchPayload.sort ?? SortOrder.ASC }]
 
   return {
     index: OPENCRVS_INDEX_NAME,
@@ -39,7 +41,7 @@ export function formatSearchParams(
     size,
     body: {
       query: advancedQueryBuilder(parameters, createdBy, isExternalSearch),
-      sort: [{ [sortColumn]: sort }]
+      sort
     }
   }
 }

--- a/packages/search/src/features/search/types.ts
+++ b/packages/search/src/features/search/types.ts
@@ -86,8 +86,12 @@ export interface IAdvancedSearchParam {
 
 export interface ISearchCriteria {
   parameters: IAdvancedSearchParam
-  sort?: string
+  /** Sort direction */
+  sort?: SortOrder
+  /** Column to be sorted by */
   sortColumn?: string
+  /** Overrides sort & sortColumn if sorting by multiple attributes is requested */
+  sortBy?: Array<Record<string, SortOrder>>
   size?: number
   from?: number
   createdBy?: string


### PR DESCRIPTION
https://github.com/opencrvs/opencrvs-core/issues/5837

Allows inputting multiple fields to event search so that DCI API can support multiple sorted fields. This is backwards compatible with sort / sortColumn -style of sorting.