### PR TITLE
Add a new field type 'HIDDEN' for hard coded values

### DIFF
--- a/packages/client/src/components/form/FormFieldGenerator.tsx
+++ b/packages/client/src/components/form/FormFieldGenerator.tsx
@@ -87,7 +87,8 @@ import {
   INidVerificationButton,
   DIVIDER,
   HEADING3,
-  SUBSECTION_HEADER
+  SUBSECTION_HEADER,
+  HIDDEN
 } from '@client/forms'
 import { getValidationErrorsForForm, Errors } from '@client/forms/validation'
 import { InputField } from '@client/components/form/InputField'
@@ -634,6 +635,15 @@ const GeneratedInputField = React.memo<GeneratedInputFieldProps>(
       )
     }
 
+    if (fieldDefinition.type === HIDDEN) {
+      return (
+        <input
+          type="hidden"
+          {...inputProps}
+          value={inputProps.value as string}
+        />
+      )
+    }
     return (
       <InputField {...inputFieldProps}>
         <TextInput

--- a/packages/client/src/forms/index.ts
+++ b/packages/client/src/forms/index.ts
@@ -45,6 +45,7 @@ export const TEL = 'TEL'
 export const NUMBER = 'NUMBER'
 export const BIG_NUMBER = 'BIG_NUMBER'
 export const RADIO_GROUP = 'RADIO_GROUP'
+export const HIDDEN = 'HIDDEN'
 export const RADIO_GROUP_WITH_NESTED_FIELDS = 'RADIO_GROUP_WITH_NESTED_FIELDS'
 export const INFORMATIVE_RADIO_GROUP = 'INFORMATIVE_RADIO_GROUP'
 export const CHECKBOX_GROUP = 'CHECKBOX_GROUP'
@@ -566,6 +567,9 @@ export interface ITextFormField extends IFormFieldBase {
   maxLength?: number
   dependency?: string
 }
+export interface IHiddenFormField extends IFormFieldBase {
+  type: typeof HIDDEN
+}
 
 export interface ITelFormField extends IFormFieldBase {
   type: typeof TEL
@@ -711,6 +715,7 @@ export type IFormField =
   | ITelFormField
   | INumberFormField
   | IBigNumberFormField
+  | IHiddenFormField
   | ISelectFormFieldWithOptions
   | ISelectFormFieldWithDynamicOptions
   | IFormFieldWithDynamicDefinitions
@@ -1062,6 +1067,9 @@ export interface Ii18nTextFormField extends Ii18nFormFieldBase {
   type: typeof TEXT
   maxLength?: number
 }
+export interface Ii18nHiddenFormField extends Ii18nFormFieldBase {
+  type: typeof HIDDEN
+}
 export interface Ii18nTelFormField extends Ii18nFormFieldBase {
   type: typeof TEL
   isSmallSized?: boolean
@@ -1192,6 +1200,7 @@ export interface Ii18nTimeFormField extends Ii18nFormFieldBase {
 export type Ii18nFormField =
   | Ii18nTextFormField
   | Ii18nTelFormField
+  | Ii18nHiddenFormField
   | Ii18nNumberFormField
   | Ii18nBigNumberFormField
   | Ii18nSelectFormField

--- a/packages/client/src/forms/utils.ts
+++ b/packages/client/src/forms/utils.ts
@@ -44,7 +44,9 @@ import {
   ISelectFormFieldWithOptions,
   NID_VERIFICATION_BUTTON,
   INidVerificationButton,
-  BULLET_LIST
+  BULLET_LIST,
+  HIDDEN,
+  Ii18nHiddenFormField
 } from '@client/forms'
 import { IntlShape, MessageDescriptor } from 'react-intl'
 import {
@@ -121,6 +123,10 @@ export const internationaliseFieldObject = (
     unit: field.unit && intl.formatMessage(field.unit),
     description: field.description && intl.formatMessage(field.description),
     placeholder: field.placeholder && intl.formatMessage(field.placeholder)
+  }
+
+  if (base.type === HIDDEN) {
+    return base as Ii18nHiddenFormField
   }
 
   if (

--- a/packages/client/src/views/CorrectionForm/utils.ts
+++ b/packages/client/src/views/CorrectionForm/utils.ts
@@ -39,7 +39,8 @@ import {
   CHECKBOX,
   ICheckboxFormField,
   SUBSECTION_HEADER,
-  DIVIDER
+  DIVIDER,
+  HIDDEN
 } from '@client/forms'
 import { IDeclaration, SUBMISSION_STATUS } from '@client/declarations'
 import { getValidationErrorsForForm } from '@client/forms/validation'
@@ -603,6 +604,9 @@ export function isVisibleField(
   draft: IDeclaration,
   offlineResources: IOfflineData
 ) {
+  if (field.type === HIDDEN) {
+    return false
+  }
   const conditionalActions = getConditionalActionsForField(
     field,
     draft.data[section.id] || {},

--- a/packages/client/src/views/RegisterForm/review/ReviewSection.tsx
+++ b/packages/client/src/views/RegisterForm/review/ReviewSection.tsx
@@ -72,7 +72,8 @@ import {
   NID_VERIFICATION_BUTTON,
   WARNING,
   SUBSECTION_HEADER,
-  DIVIDER
+  DIVIDER,
+  HIDDEN
 } from '@client/forms'
 import { Event } from '@client/utils/gateway'
 import {
@@ -864,6 +865,11 @@ class ReviewSectionComp extends React.Component<FullProps, State> {
 
   isVisibleField(field: IFormField, section: IFormSection) {
     const { draft, offlineCountryConfiguration } = this.props
+
+    if (field.type === HIDDEN) {
+      return false
+    }
+
     const conditionalActions = getConditionalActionsForField(
       field,
       draft.data[section.id] || {},


### PR DESCRIPTION
In Cameroon, for child's place of birth we only show fields for
- Municipality
- Locality

And no "Country". For us this means that in Record audit, Place of birth we were only able to show `<Municipality>, `. This hidden input allows us to include new values to the form data without showing the field in review or in the form. I'm pretty sure it's useful for others as well