### PR TITLE
Allow HTML elements to be used in PARAGRAPH type form fields

### DIFF
--- a/docker-compose.deps.yml
+++ b/docker-compose.deps.yml
@@ -57,5 +57,5 @@ services:
     restart: unless-stopped
 
   minio:
-    image: quay.io/minio/minio:RELEASE.2022-11-11T03-44-20Z.fips
+    image: quay.io/minio/minio:RELEASE.2023-09-16T01-01-47Z.fips
     restart: unless-stopped

--- a/packages/client/src/components/form/FormFieldGenerator.tsx
+++ b/packages/client/src/components/form/FormFieldGenerator.tsx
@@ -495,15 +495,19 @@ const GeneratedInputField = React.memo<GeneratedInputFieldProps>(
       return <Heading3>{fieldDefinition.label}</Heading3>
     }
     if (fieldDefinition.type === PARAGRAPH) {
-      const label = fieldDefinition.label as unknown as MessageDescriptor
+      const label = fieldDefinition.label as unknown as MessageDescriptor & {
+        values: Record<string, string>
+      }
+      const values = label.values || {}
 
       const message = intl.formatMessage(label, {
-        [fieldDefinition.name]: value as string
+        ...values,
+        [fieldDefinition.name]: value as any
       })
 
       return (
         <Text variant={fieldDefinition.fontVariant ?? 'reg16'} element="p">
-          <span dangerouslySetInnerHTML={{ __html: message }}></span>
+          <span dangerouslySetInnerHTML={{ __html: message }} />
         </Text>
       )
     }

--- a/packages/client/src/components/form/FormFieldGenerator.tsx
+++ b/packages/client/src/components/form/FormFieldGenerator.tsx
@@ -497,14 +497,13 @@ const GeneratedInputField = React.memo<GeneratedInputFieldProps>(
     if (fieldDefinition.type === PARAGRAPH) {
       const label = fieldDefinition.label as unknown as MessageDescriptor
 
+      const message = intl.formatMessage(label, {
+        [fieldDefinition.name]: value as string
+      })
+
       return (
         <Text variant={fieldDefinition.fontVariant ?? 'reg16'} element="p">
-          <FormattedMessage
-            {...label}
-            values={{
-              [fieldDefinition.name]: value as any
-            }}
-          />
+          <span dangerouslySetInnerHTML={{ __html: message }}></span>
         </Text>
       )
     }


### PR DESCRIPTION
We wanted to include a link to in one of our form pages and found this to be possible just by using the paragraph input type. It should be completely safe to render the HTML as it's coming from the country config and is defined by the SIs.

```
fields: [
  {
    name: 'supportingDocs',
    type: 'PARAGRAPH',
    label: {
      defaultMessage:
        'Click {link} to print page 2 of the Municipal Form No. 102 (supporting docs)',
      values: {
        link: '<a target="_blank" href="https://drive.google.com/file/d/1XWPVW2zQ6X1fL93-RE1plaXZVpVS_Wh3/view">here</a>'
      },
      description: 'Supporting documents link text',
      id: 'form.section.documents.birth.supportingDocsLinkText'
    },
    initialValue: '',
    validator: [],
    conditionals: []
  },
```