### PR TITLE
Remove FIELD_AGENT as informantType options when user is REGISTRATION

### DIFF
--- a/packages/client/src/components/form/FormFieldGenerator.tsx
+++ b/packages/client/src/components/form/FormFieldGenerator.tsx
@@ -981,7 +981,8 @@ class FormSectionComponent extends React.Component<Props> {
                   options: getFieldOptions(
                     field as ISelectFormFieldWithOptions,
                     values,
-                    offlineCountryConfig
+                    offlineCountryConfig,
+                    draftData
                   )
                 } as ISelectFormFieldWithOptions)
               : field.type === SELECT_WITH_DYNAMIC_OPTIONS
@@ -991,7 +992,8 @@ class FormSectionComponent extends React.Component<Props> {
                   options: getFieldOptions(
                     field as ISelectFormFieldWithDynamicOptions,
                     values,
-                    offlineCountryConfig
+                    offlineCountryConfig,
+                    draftData
                   )
                 } as ISelectFormFieldWithOptions)
               : field.type === FIELD_WITH_DYNAMIC_DEFINITIONS

--- a/packages/client/src/forms/certificate/fieldDefinitions/collectorSection.ts
+++ b/packages/client/src/forms/certificate/fieldDefinitions/collectorSection.ts
@@ -542,13 +542,17 @@ export const collectDeathCertificateFormSection: IFormSection = {
           ],
           conditionals: [conditionals.iDType]
         },
+        /*
+         * @customization - this was made as in Cameroon we always want the document id label to say "Document ID" and not reflect the previously
+         * selected document type
+         */
         {
           name: 'iD',
           type: FIELD_WITH_DYNAMIC_DEFINITIONS,
           dynamicDefinitions: {
             label: {
               dependency: 'iDType',
-              labelMapper: identityNameMapper
+              labelMapper: (): MessageDescriptor => formMessages.iD
             },
             type: {
               kind: 'dynamic',
@@ -604,22 +608,25 @@ export const collectDeathCertificateFormSection: IFormSection = {
               validators
             )
           ]
-        },
-        {
-          name: 'relationship',
-          type: TEXT,
-          label: formMessages.informantsRelationWithDeceased,
-          required: true,
-          initialValue: '',
-          validator: [
-            fieldValidationDescriptorToValidationFunction(
-              {
-                operation: 'requiredBasic'
-              },
-              validators
-            )
-          ]
         }
+        /*
+         * @customization - this was made as in Cameroon we don't want relationShip field
+         */
+        // {
+        //   name: 'relationship',
+        //   type: TEXT,
+        //   label: formMessages.informantsRelationWithDeceased,
+        //   required: true,
+        //   initialValue: '',
+        //   validator: [
+        //     fieldValidationDescriptorToValidationFunction(
+        //       {
+        //         operation: 'requiredBasic'
+        //       },
+        //       validators
+        //     )
+        //   ]
+        // }
       ]
     },
     {

--- a/packages/client/src/forms/utils.ts
+++ b/packages/client/src/forms/utils.ts
@@ -349,7 +349,7 @@ export const getFieldOptions = (
       // eslint-disable-next-line no-eval
       const conditionEvaluator = eval(field.optionCondition!)
       return field.options.filter((field) =>
-        conditionEvaluator(field, values, draftData)
+        conditionEvaluator({field, values, draftData})
       )
     }
 

--- a/packages/client/src/forms/utils.ts
+++ b/packages/client/src/forms/utils.ts
@@ -341,13 +341,16 @@ export const getVisibleGroupFields = (group: IFormSectionGroup) => {
 export const getFieldOptions = (
   field: ISelectFormFieldWithOptions | ISelectFormFieldWithDynamicOptions,
   values: IFormSectionData,
-  offlineCountryConfig: IOfflineData
+  offlineCountryConfig: IOfflineData,
+  draftData?: IFormData
 ) => {
   if (field.type === SELECT_WITH_OPTIONS) {
     if (field.optionCondition) {
       // eslint-disable-next-line no-eval
       const conditionEvaluator = eval(field.optionCondition!)
-      return field.options.filter(conditionEvaluator)
+      return field.options.filter((field) =>
+        conditionEvaluator(field, values, draftData)
+      )
     }
 
     return field.options

--- a/packages/client/src/views/RegisterForm/RegisterForm.tsx
+++ b/packages/client/src/views/RegisterForm/RegisterForm.tsx
@@ -110,9 +110,6 @@ import { client } from '@client/utils/apolloClient'
 import { Stack, ToggleMenu } from '@client/../../components/lib'
 import { useModal } from '@client/hooks/useModal'
 import { Text } from '@opencrvs/components/lib/Text'
-import { EVENT_TYPE } from '../../../../metrics/src/features/metrics/utils'
-import { SystemRole } from '../../utils/gateway'
-
 const Notice = styled.div`
   background: ${({ theme }) => theme.colors.primary};
   box-shadow: 0 0 12px 0 rgba(0, 0, 0, 0.11);
@@ -1377,71 +1374,6 @@ function findFirstVisibleSection(sections: IFormSection[]) {
   return sections.filter(({ viewType }) => viewType !== 'hidden')[0]
 }
 
-/*
- * @customization - this function was made as in Cameroon we want to remove FIELD_AGENT options in informantType when
- * user is REGISTRATION_AGENT
- */
-function updateInformantTypeOptionByUserSystemRole(
-  fields: IFormField[],
-  declaration: IDeclaration,
-  userDetails?: UserDetails | null
-) {
-  const {
-    event,
-    registrationStatus,
-    data: { history }
-  } = declaration
-
-  if (event === 'birth' || event === 'death') {
-    if (!registrationStatus) {
-      return fields.map((item) => {
-        if (item.name === 'informantType') {
-          if (userDetails?.systemRole === ROLE_REGISTRATION_AGENT) {
-            const currentItem = item as ISelectFormFieldWithOptions
-            return {
-              ...currentItem,
-              options: currentItem?.options?.filter(
-                ({ value }) => value !== 'FIELD_AGENT'
-              )
-            }
-          }
-        }
-
-        return item
-      })
-    } else {
-      const historyDeclared = history?.find(
-        (r: any) => r.regStatus === SUBMISSION_STATUS.DECLARED && !r.action
-      )
-
-      if (historyDeclared) {
-        const {
-          user: { id }
-        } = historyDeclared
-        if (userDetails?.id === id) {
-          return fields.map((item) => {
-            if (item.name === 'informantType') {
-              if (userDetails?.systemRole === ROLE_REGISTRATION_AGENT) {
-                const currentItem = item as ISelectFormFieldWithOptions
-                return {
-                  ...currentItem,
-                  options: currentItem?.options?.filter(
-                    ({ value }) => value !== 'FIELD_AGENT'
-                  )
-                }
-              }
-            }
-
-            return item
-          })
-        }
-      }
-    }
-  }
-
-  return fields
-}
-
 function mapStateToProps(state: IStoreState, props: IFormProps & RouteProps) {
   const { match, registerForm, declaration } = props
   const sectionId =
@@ -1471,18 +1403,8 @@ function mapStateToProps(state: IStoreState, props: IFormProps & RouteProps) {
       ) > -1) ||
     false
 
-  /*
-   * @customization - Apply updateInformantTypeOptionByUserSystemRole function to remove FIELD_AGENT options in informantType when
-   * user is REGISTRATION_AGENT
-   */
-  const activeSectionGroupUpdated = updateInformantTypeOptionByUserSystemRole(
-    activeSectionGroup.fields,
-    declaration,
-    userDetails
-  )
-
   const fields = replaceInitialValues(
-    activeSectionGroupUpdated,
+    activeSectionGroup.fields,
     declaration.data[activeSection.id] || {},
     declaration.data,
     userDetails

--- a/packages/client/src/views/RegisterForm/RegisterForm.tsx
+++ b/packages/client/src/views/RegisterForm/RegisterForm.tsx
@@ -1409,8 +1409,7 @@ function updateInformantTypeOptionByUserSystemRole(
 
         return item
       })
-    }
-    if (registrationStatus === SUBMISSION_STATUS.DECLARED) {
+    } else {
       const historyDeclared = history?.find(
         (r: any) => r.regStatus === SUBMISSION_STATUS.DECLARED && !r.action
       )


### PR DESCRIPTION
This PR corrects the display of the ID document label according to the select option of the ID type and also allows the FIELD_AGENT option to be removed from the choice of informantType when the user is REGISTRATION_AGENT.