### PR TITLE
Turn `declarationMap` on for commons and components package

### DIFF
--- a/packages/commons/tsconfig.json
+++ b/packages/commons/tsconfig.json
@@ -19,11 +19,9 @@
     "strictNullChecks": true,
     "noUnusedLocals": true,
     "types": ["jest", "fhir"],
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "declarationMap": true
   },
   "include": ["src/**/*.ts", "typings"],
-  "exclude": [
-    "node_modules",
-    "build"
-  ]
+  "exclude": ["node_modules", "build"]
 }

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -23,7 +23,8 @@
     "strictNullChecks": true,
     "suppressImplicitAnyIndexErrors": true,
     "noUnusedLocals": false,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "declarationMap": true
   },
   "include": [
     "src/**/*.tsx",


### PR DESCRIPTION
We mostly try to go to the actual source files for these two packages. Prior one for the type defintions and later for the source component files