### PR TITLE
Opencrvs confirm button remains inactive

### DIFF
--- a/packages/client/src/forms/utils.ts
+++ b/packages/client/src/forms/utils.ts
@@ -349,7 +349,7 @@ export const getFieldOptions = (
       // eslint-disable-next-line no-eval
       const conditionEvaluator = eval(field.optionCondition!)
       return field.options.filter((field) =>
-        conditionEvaluator({ field, values, draftData })
+        conditionEvaluator({ field, values, declaration: draftData })
       )
     }
 

--- a/packages/client/src/forms/utils.ts
+++ b/packages/client/src/forms/utils.ts
@@ -349,7 +349,7 @@ export const getFieldOptions = (
       // eslint-disable-next-line no-eval
       const conditionEvaluator = eval(field.optionCondition!)
       return field.options.filter((field) =>
-        conditionEvaluator({field, values, draftData})
+        conditionEvaluator({ field, values, draftData })
       )
     }
 

--- a/packages/client/src/views/SysAdmin/Team/user/userCreation/CreateNewUser.tsx
+++ b/packages/client/src/views/SysAdmin/Team/user/userCreation/CreateNewUser.tsx
@@ -157,11 +157,11 @@ class CreateNewUserComponent extends React.Component<WithApolloClient<Props>> {
       return this.renderLoadingPage()
     }
 
-    if (section.viewType === 'form') {
+    if (section?.viewType === 'form') {
       return <UserForm {...this.props} />
     }
 
-    if (section.viewType === 'preview') {
+    if (section?.viewType === 'preview') {
       return (
         <UserReviewForm
           client={this.props.client as ApolloClient<any>}
@@ -210,14 +210,18 @@ function getNextSectionIds(
 
 const mapStateToProps = (state: IStoreState, props: Props) => {
   const sectionId =
-    props.match.params.sectionId || state.userForm.userForm!.sections[0].id
+    props.match.params.sectionId || state.userForm.userForm?.sections[0].id
 
-  const section = state.userForm.userForm!.sections.find(
+  const section = state.userForm.userForm?.sections.find(
     (section) => section.id === sectionId
   ) as IFormSection
 
   if (!section) {
-    throw new Error(`No section found ${sectionId}`)
+    return {
+      sectionId,
+      userId: props.match.params.userId,
+      submitting: state.userForm.submitting
+    }
   }
 
   let formData = { ...state.userForm.userFormData }

--- a/packages/client/src/views/SysAdmin/Team/user/userCreation/UserReviewForm.tsx
+++ b/packages/client/src/views/SysAdmin/Team/user/userCreation/UserReviewForm.tsx
@@ -148,27 +148,34 @@ class UserReviewFormComponent extends React.Component<
           sections.push({ title: intl.formatMessage(field.label), items: [] })
         } else if (field && sections.length > 0) {
           if (field.name === 'username' && !this.getValue(field)) return
+
           let label =
             field.type === SIMPLE_DOCUMENT_UPLOADER ? (
-              <DocumentUploaderContainer>
-                <SimpleDocumentUploader
-                  label={intl.formatMessage(field.label)}
-                  disableDeleteInPreview={true}
-                  name={field.name}
-                  onComplete={(file) => {
-                    this.props.modify({
-                      ...this.props.formData,
-                      [field.name]: file
-                    })
-                  }}
-                  allowedDocType={field.allowedDocType}
-                  files={
-                    this.props.formData[
-                      field.name
-                    ] as unknown as IAttachmentValue
-                  }
-                />
-              </DocumentUploaderContainer>
+              <>
+                {this.props.formData[field.name] ? (
+                  <DocumentUploaderContainer>
+                    <SimpleDocumentUploader
+                      label={intl.formatMessage(field.label)}
+                      disableDeleteInPreview={true}
+                      name={field.name}
+                      onComplete={(file) => {
+                        this.props.modify({
+                          ...this.props.formData,
+                          [field.name]: file
+                        })
+                      }}
+                      allowedDocType={field.allowedDocType}
+                      files={
+                        this.props.formData[
+                          field.name
+                        ] as unknown as IAttachmentValue
+                      }
+                    />
+                  </DocumentUploaderContainer>
+                ) : (
+                  intl.formatMessage(field.label)
+                )}
+              </>
             ) : (
               intl.formatMessage(field.label)
             )


### PR DESCRIPTION
This PR can be used to upload a user's signature by forcing the scenario in which the validate button is activated.