### PR TITLE
Fix certificate content svg multiline

### DIFF
--- a/packages/client/src/views/PrintCertificate/PDFUtils.ts
+++ b/packages/client/src/views/PrintCertificate/PDFUtils.ts
@@ -195,9 +195,11 @@ export async function previewCertificate(
     offlineResource,
     intl,
     optionalData
-  ).getDataUrl((pdf: string) => {
-    callBack(pdf)
-  })
+  ).then((pdf) =>
+    pdf.getDataUrl((pdf: string) => {
+      callBack(pdf)
+    })
+  )
 }
 
 export async function printCertificate(


### PR DESCRIPTION
Fix Certificate Content Svg Multiline: The foreignObject [SVG] element includes elements from a different XML namespace. In the context of a browser. It can handle more attributes as customizing CSS properties element. 