### PR TITLE
Add support for passing intl and other context variables to custom handlebar helpers

### DIFF
--- a/packages/client/src/forms/handlebarHelpers.ts
+++ b/packages/client/src/forms/handlebarHelpers.ts
@@ -9,13 +9,25 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 
-import { referenceApi } from '@client/utils/referenceApi'
+import {
+  LoadHandlebarHelpersResponse,
+  referenceApi
+} from '@client/utils/referenceApi'
 import * as Handlebars from 'handlebars'
 
-export let handlebarHelpers: Record<string, Handlebars.HelperDelegate>
+export let handlebarHelpers: LoadHandlebarHelpersResponse
 
 export async function initHandlebarHelpers() {
   handlebarHelpers = await referenceApi.importHandlebarHelpers()
+}
+
+export function getHandlebarHelpers() {
+  if (!handlebarHelpers) {
+    throw new Error(
+      'Handlebar helpers were requested before initialization. This should never happen.'
+    )
+  }
+  return handlebarHelpers
 }
 
 export function registerHandlebarHelpers() {

--- a/packages/client/src/forms/handlebarHelpers.ts
+++ b/packages/client/src/forms/handlebarHelpers.ts
@@ -13,9 +13,8 @@ import {
   LoadHandlebarHelpersResponse,
   referenceApi
 } from '@client/utils/referenceApi'
-import * as Handlebars from 'handlebars'
 
-export let handlebarHelpers: LoadHandlebarHelpersResponse
+let handlebarHelpers: LoadHandlebarHelpersResponse
 
 export async function initHandlebarHelpers() {
   handlebarHelpers = await referenceApi.importHandlebarHelpers()
@@ -28,15 +27,4 @@ export function getHandlebarHelpers() {
     )
   }
   return handlebarHelpers
-}
-
-export function registerHandlebarHelpers() {
-  if (handlebarHelpers) {
-    for (const funcName of Object.keys(handlebarHelpers)) {
-      const func = handlebarHelpers[funcName]
-      if (typeof func === 'function') {
-        Handlebars.registerHelper(funcName, func)
-      }
-    }
-  }
 }

--- a/packages/client/src/setupTests.ts
+++ b/packages/client/src/setupTests.ts
@@ -93,6 +93,13 @@ vi.doMock('@client/forms/user/fieldDefinitions/createUser', () => ({
   createUserForm: mockOfflineData.forms.userForm
 }))
 
+vi.mock('@client/forms/handlebarHelpers', async () => {
+  return {
+    initHandlebarHelpers: () => Promise.resolve(),
+    getHandlebarHelpers: () => ({})
+  }
+})
+
 vi.mock('@client/forms/conditionals', async () => {
   const actual = (await vi.importActual('@client/forms/conditionals')) as any
   return {

--- a/packages/client/src/utils/referenceApi.ts
+++ b/packages/client/src/utils/referenceApi.ts
@@ -15,6 +15,7 @@ import { ILocation } from '@client/offline/reducer'
 import { getToken } from '@client/utils/authUtils'
 import { Event, System } from '@client/utils/gateway'
 import { Validator } from '@client/forms/validators'
+import { IntlShape } from 'react-intl'
 export interface ILocationDataResponse {
   [locationId: string]: ILocation
 }
@@ -203,17 +204,25 @@ export async function importConditionals(): Promise<LoadConditionalsResponse> {
   return conditionals
 }
 
+type InjectedUtilities = {
+  intl: IntlShape
+}
+
 export type LoadHandlebarHelpersResponse = Record<
   string,
-  Handlebars.HelperDelegate
+  (injectedUtilities: InjectedUtilities) => Handlebars.HelperDelegate
 >
-async function importHandlebarHelpers(): Promise<LoadHandlebarHelpersResponse> {
-  // https://github.com/rollup/plugins/tree/master/packages/dynamic-import-vars#limitations
-  const handlebars = await import(
-    /* @vite-ignore */ `${window.config.COUNTRY_CONFIG_URL}/handlebars.js`
-  )
 
-  return handlebars
+async function importHandlebarHelpers(): Promise<LoadHandlebarHelpersResponse> {
+  try {
+    // https://github.com/rollup/plugins/tree/master/packages/dynamic-import-vars#limitations
+    const handlebars = await import(
+      /* @vite-ignore */ `${window.config.COUNTRY_CONFIG_URL}/handlebars.js`
+    )
+    return handlebars
+  } catch (error) {
+    return {}
+  }
 }
 
 async function loadContent(): Promise<IContentResponse> {

--- a/packages/client/src/views/PrintCertificate/PDFUtils.ts
+++ b/packages/client/src/views/PrintCertificate/PDFUtils.ts
@@ -31,7 +31,10 @@ import { fetchImageAsBase64 } from '@client/utils/imageUtils'
 import { getOfflineData } from '@client/offline/selectors'
 import isValid from 'date-fns/isValid'
 import format from 'date-fns/format'
-import { registerHandlebarHelpers } from '@client/forms/handlebarHelpers'
+import {
+  getHandlebarHelpers,
+  registerHandlebarHelpers
+} from '@client/forms/handlebarHelpers'
 
 type TemplateDataType = string | MessageDescriptor | Array<string>
 function isMessageDescriptor(
@@ -98,7 +101,13 @@ export function executeHandlebarsTemplate(
     },
     cache
   )
-  registerHandlebarHelpers()
+
+  const customHelpers = getHandlebarHelpers()
+
+  for (const helperName of Object.keys(customHelpers)) {
+    const helper = customHelpers[helperName]({ intl })
+    Handlebars.registerHelper(helperName, helper)
+  }
 
   Handlebars.registerHelper(
     'intl',

--- a/packages/client/src/views/PrintCertificate/PDFUtils.ts
+++ b/packages/client/src/views/PrintCertificate/PDFUtils.ts
@@ -31,10 +31,7 @@ import { fetchImageAsBase64 } from '@client/utils/imageUtils'
 import { getOfflineData } from '@client/offline/selectors'
 import isValid from 'date-fns/isValid'
 import format from 'date-fns/format'
-import {
-  getHandlebarHelpers,
-  registerHandlebarHelpers
-} from '@client/forms/handlebarHelpers'
+import { getHandlebarHelpers } from '@client/forms/handlebarHelpers'
 
 type TemplateDataType = string | MessageDescriptor | Array<string>
 function isMessageDescriptor(

--- a/packages/client/src/views/PrintCertificate/PDFUtils.ts
+++ b/packages/client/src/views/PrintCertificate/PDFUtils.ts
@@ -102,6 +102,13 @@ export function executeHandlebarsTemplate(
   const customHelpers = getHandlebarHelpers()
 
   for (const helperName of Object.keys(customHelpers)) {
+    /*
+     * Note for anyone adding new context variables to handlebar helpers:
+     * Everything you expose to country config's here will become API surface area,
+     * This means that countries will become dependant on it and it will be hard to remove or rename later on.
+     * If you need to expose the full record, please consider only exposing the specific values you know are needed.
+     * Otherwise what happens is that we lose the ability to refactor and remove things later on.
+     */
     const helper = customHelpers[helperName]({ intl })
     Handlebars.registerHelper(helperName, helper)
   }


### PR DESCRIPTION
Example usage in country config would now be 

```ts
import * as Handlebars from 'handlebars'
import { type IntlShape } from 'react-intl'

type HelperProps = { intl: IntlShape }

export function myIntlHelper({ intl }: HelperProps): Handlebars.HelperDelegate {
  return function (this: any, args: string[]) {
    const idParts = args.slice(0, -1)
    if (idParts.some((part) => part === undefined)) {
      return ''
    }

    const id = idParts.join('.')

    return intl.formatMessage({
      id,
      defaultMessage: 'Missing translation for ' + id
    })
  }
}
```