### PR TITLE
fix: don't resolve Patient.address.extension

### DIFF
--- a/packages/search/src/features/records/service.ts
+++ b/packages/search/src/features/records/service.ts
@@ -51,6 +51,7 @@ export class RecordNotFoundError extends Error {
 function checkForUnresolvedReferences(bundle: Bundle) {
   const EXCLUDED_PATHS = [
     'Location.partOf.reference',
+    'Patient.address.extension',
     'Composition.relatesTo.targetReference.reference',
     'CompositionHistory.relatesTo.targetReference.reference'
   ]


### PR DESCRIPTION
Fixes download failing on develop due to `Unresolved reference found: Location/foo Make sure to add a join to getFHIRBundleWithRecordID query so that all resources of the records are returned Resource: Bundle` 