### PR TITLE
ocrvs-6126 Introduce a new handlebar "printInAdvance"

### DIFF
--- a/packages/client/src/views/PrintCertificate/ReviewCertificateAction.tsx
+++ b/packages/client/src/views/PrintCertificate/ReviewCertificateAction.tsx
@@ -54,8 +54,7 @@ import {
   getEventDate,
   isFreeOfCost,
   calculatePrice,
-  getRegisteredDate,
-  getRegistrarSignatureHandlebarName
+  getRegisteredDate
 } from './utils'
 import { getOfflineData } from '@client/offline/selectors'
 import { countries } from '@client/utils/countries'
@@ -351,10 +350,6 @@ function mapStatetoProps(
   const draft = getDraft(declarations, registrationId, eventType)
   const event = getEvent(draft.event)
   const offlineCountryConfig = getOfflineData(state)
-  const signatureKey = getRegistrarSignatureHandlebarName(
-    offlineCountryConfig,
-    event
-  )
 
   return {
     event,
@@ -365,11 +360,7 @@ function mapStatetoProps(
         ...draft.data,
         template: {
           ...draft.data.template,
-          [signatureKey]:
-            !draft.data.template?.[signatureKey] ||
-            isCertificateForPrintInAdvance(draft)
-              ? ''
-              : draft.data.template[signatureKey]
+          ...(isCertificateForPrintInAdvance(draft) && { printInAdvance: true })
         }
       }
     },

--- a/packages/client/src/views/PrintCertificate/utils.ts
+++ b/packages/client/src/views/PrintCertificate/utils.ts
@@ -8,12 +8,7 @@
  *
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
-import {
-  IFormData,
-  IFormSectionGroup,
-  IRadioGroupWithNestedFieldsFormField,
-  ISelectOption
-} from '@client/forms'
+import { IFormData, IFormSectionGroup, ISelectOption } from '@client/forms'
 import { Event } from '@client/utils/gateway'
 import { dynamicMessages } from '@client/i18n/messages/views/certificate'
 import { getAvailableLanguages } from '@client/i18n/utils'
@@ -275,25 +270,6 @@ export function isCertificateForPrintInAdvance(
     return true
   }
   return false
-}
-
-export function getRegistrarSignatureHandlebarName(
-  offlineCountryConfig: IOfflineData,
-  event: Event
-) {
-  const svgCode =
-    offlineCountryConfig.templates.certificates![event]?.definition
-  const html = document.createElement('html')
-  html.innerHTML = String(svgCode)
-  const certificateImages = html.querySelectorAll('image')
-  const signatureImage = Array.from(certificateImages).find(
-    (image) => image.getAttribute('data-content') === 'signature'
-  )
-  const handlebarText =
-    signatureImage?.getAttribute('href') ||
-    signatureImage?.getAttribute('xlink:href') ||
-    ''
-  return handlebarText?.match(/^{{(\w+)}}$/)?.[1] || ''
 }
 
 export function filterPrintInAdvancedOption(collectionForm: IFormSectionGroup) {


### PR DESCRIPTION
When in the Print in Advance flow, core now exposes a new handlebar "printInAdvance" with a boolean value, which country implementations can check in their certificates to hide particulars fields from showing up in it. For example, registrar's name/signature can be conditionally hidden in the certificates for print in advance using this handlebar.

N.B. Currently farajaland repo is not using this new handlebar