### PR TITLE
OCRVS-6022:  Allow null values for user mobile and emailForNotification when creating users but still check for uniqueness

### DIFF
--- a/packages/migration/src/migrations/user-mgnt/20231106130956-email-mobile-unique-index.ts
+++ b/packages/migration/src/migrations/user-mgnt/20231106130956-email-mobile-unique-index.ts
@@ -1,0 +1,47 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+
+import { Db, MongoClient } from 'mongodb'
+
+export const up = async (db: Db, client: MongoClient) => {
+  const session = client.startSession()
+  try {
+    await session.withTransaction(async () => {
+      // eslint-disable-next-line no-console
+      console.log('Updating indices for collection: users')
+      await db
+        .collection('users')
+        .createIndex(
+          { emailForNotification: 1 },
+          { unique: true, sparse: true }
+        )
+      await db
+        .collection('users')
+        .createIndex({ mobile: 1 }, { unique: true, sparse: true })
+    })
+  } finally {
+    await session.endSession()
+  }
+}
+
+export const down = async (db: Db, client: MongoClient) => {
+  const session = client.startSession()
+  try {
+    await session.withTransaction(async () => {
+      await db.collection('users').dropIndex({ emailForNotification: 1 } as any)
+      await db.collection('users').dropIndex({ mobile: 1 } as any)
+    })
+  } catch (error) {
+    console.error('Error occurred while dropping the index:', error)
+  } finally {
+    await session.endSession()
+  }
+}

--- a/packages/user-mgnt/src/model/user.ts
+++ b/packages/user-mgnt/src/model/user.ts
@@ -298,7 +298,7 @@ const userSchema = new Schema({
   identifiers: [IdentifierSchema],
   email: { type: String },
   emailForNotification: { type: String, unique: true, sparse: true },
-  mobile: { type: String, unique: true },
+  mobile: { type: String, unique: true, sparse: true },
   passwordHash: { type: String, required: true },
   oldPasswordHash: { type: String },
   salt: { type: String, required: true },


### PR DESCRIPTION
When creating a user user-mgnt was not checking for uniqueness for emailForNotification without an index.

Also if mobile was not a required field, you couldnt submit it empty without the sparse:true flag and an index forcing users to enter in a mobile number regardless.

Tested in seeding and in the UI