### PR TITLE
Fix input field Number when correcting a declaration (#6180)

### DIFF
--- a/packages/client/graphql.schema.json
+++ b/packages/client/graphql.schema.json
@@ -313,6 +313,18 @@
             "deprecationReason": null
           },
           {
+            "name": "partOf",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "postalCode",
             "description": null,
             "type": {
@@ -531,6 +543,18 @@
             "deprecationReason": null
           },
           {
+            "name": "childIdentifier",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "childLastName",
             "description": null,
             "args": [],
@@ -554,6 +578,18 @@
                 "name": "String",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "contactEmail",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -1271,6 +1307,18 @@
             "deprecationReason": null
           },
           {
+            "name": "childIdentifier",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "childLastName",
             "description": null,
             "type": {
@@ -1293,6 +1341,18 @@
                 "name": "String",
                 "ofType": null
               }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "contactEmail",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -2702,7 +2762,7 @@
             "description": null,
             "type": {
               "kind": "ENUM",
-              "name": "AttachmentStatus",
+              "name": "AttachmentInputStatus",
               "ofType": null
             },
             "defaultValue": null,
@@ -2764,32 +2824,26 @@
       },
       {
         "kind": "ENUM",
-        "name": "AttachmentStatus",
+        "name": "AttachmentInputStatus",
         "description": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
         "enumValues": [
           {
-            "name": "AMENDED",
+            "name": "approved",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "ENTERED_IN_ERROR",
+            "name": "deleted",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "FINAL",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "PRELIMINARY",
+            "name": "validated",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -3051,6 +3105,18 @@
         "fields": [
           {
             "name": "childGender",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "childIdentifier",
             "description": null,
             "args": [],
             "type": {
@@ -5271,7 +5337,7 @@
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "String",
+                "name": "FieldValue",
                 "ofType": null
               }
             },
@@ -5287,7 +5353,7 @@
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "String",
+                "name": "FieldValue",
                 "ofType": null
               }
             },
@@ -6527,7 +6593,7 @@
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -6575,7 +6641,7 @@
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -6591,7 +6657,7 @@
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -7552,6 +7618,16 @@
       },
       {
         "kind": "SCALAR",
+        "name": "FieldValue",
+        "description": "String, Number or Boolean",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "SCALAR",
         "name": "Float",
         "description": "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).",
         "fields": null,
@@ -8272,6 +8348,22 @@
         "description": null,
         "fields": [
           {
+            "name": "value",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "FieldValue",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "valueCode",
             "description": null,
             "args": [],
@@ -8289,22 +8381,6 @@
           },
           {
             "name": "valueId",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "valueString",
             "description": null,
             "args": [],
             "type": {
@@ -8988,7 +9064,7 @@
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -9036,7 +9112,7 @@
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -9052,7 +9128,7 @@
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -9068,7 +9144,7 @@
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -9084,7 +9160,7 @@
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -9996,7 +10072,7 @@
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -10012,7 +10088,7 @@
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -10028,7 +10104,7 @@
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -10044,7 +10120,7 @@
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -10060,7 +10136,7 @@
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -10076,7 +10152,7 @@
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -10092,7 +10168,7 @@
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -16310,6 +16386,26 @@
                 "deprecationReason": null
               },
               {
+                "name": "sortBy",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "SortBy",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "sortColumn",
                 "description": null,
                 "type": {
@@ -17953,6 +18049,18 @@
             "deprecationReason": null
           },
           {
+            "name": "contactEmail",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "contactNumber",
             "description": null,
             "args": [],
@@ -19537,6 +19645,49 @@
               "kind": "SCALAR",
               "name": "String",
               "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "SortBy",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "column",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "order",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "defaultValue": null,
             "isDeprecated": false,

--- a/packages/client/src/forms/utils.ts
+++ b/packages/client/src/forms/utils.ts
@@ -687,20 +687,16 @@ export const isDateField = (
   return field.type === DATE
 }
 
-export const stringifyFieldValue = (
+export const serializeFieldValue = (
   field: IFormField,
   fieldValue: IFormFieldValue,
   sectionData: IFormSectionData
-): string => {
-  if (!fieldValue) {
-    return ''
-  }
-
+) => {
   if (isDateField(field, sectionData)) {
     return fieldValue.toString()
   }
 
-  return fieldValue.toString()
+  return fieldValue
 }
 
 export const getSelectedRadioOptionWithNestedFields = (

--- a/packages/client/src/tests/schema.graphql
+++ b/packages/client/src/tests/schema.graphql
@@ -536,8 +536,8 @@ input CorrectionRejectionInput {
 input CorrectionValueInput {
   section: String!
   fieldName: String!
-  oldValue: String!
-  newValue: String!
+  oldValue: FieldValue!
+  newValue: FieldValue!
 }
 
 type CountryLogo {
@@ -567,6 +567,7 @@ input CurrencyInput {
 }
 
 scalar Date
+scalar FieldValue
 
 type Death {
   REGISTRATION_TARGET: Int
@@ -849,7 +850,7 @@ enum ImageFit {
 type InputOutput {
   valueCode: String!
   valueId: String!
-  valueString: String!
+  value: String!
 }
 
 type IntegratedSystem {

--- a/packages/client/src/utils/gateway.ts
+++ b/packages/client/src/utils/gateway.ts
@@ -32,6 +32,7 @@ export type Scalars = {
   Int: number
   Float: number
   Date: any
+  FieldValue: any
   Map: any
 }
 
@@ -65,6 +66,7 @@ export type AddressInput = {
   district?: InputMaybe<Scalars['String']>
   from?: InputMaybe<Scalars['Date']>
   line?: InputMaybe<Array<Scalars['String']>>
+  partOf?: InputMaybe<Scalars['String']>
   postalCode?: InputMaybe<Scalars['String']>
   state?: InputMaybe<Scalars['String']>
   text?: InputMaybe<Scalars['String']>
@@ -95,8 +97,10 @@ export type AdvancedSeachParameters = {
   childDoBStart?: Maybe<Scalars['String']>
   childFirstNames?: Maybe<Scalars['String']>
   childGender?: Maybe<Scalars['String']>
+  childIdentifier?: Maybe<Scalars['String']>
   childLastName?: Maybe<Scalars['String']>
   compositionType?: Maybe<Array<Maybe<Scalars['String']>>>
+  contactEmail?: Maybe<Scalars['String']>
   contactNumber?: Maybe<Scalars['String']>
   dateOfEvent?: Maybe<Scalars['String']>
   dateOfEventEnd?: Maybe<Scalars['String']>
@@ -158,10 +162,11 @@ export type AdvancedSearchParametersInput = {
   childDoBStart?: InputMaybe<Scalars['String']>
   childFirstNames?: InputMaybe<Scalars['String']>
   childGender?: InputMaybe<Scalars['String']>
+  childIdentifier?: InputMaybe<Scalars['String']>
   childLastName?: InputMaybe<Scalars['String']>
   compositionType?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
-  contactNumber?: InputMaybe<Scalars['String']>
   contactEmail?: InputMaybe<Scalars['String']>
+  contactNumber?: InputMaybe<Scalars['String']>
   dateOfEvent?: InputMaybe<Scalars['String']>
   dateOfEventEnd?: InputMaybe<Scalars['String']>
   dateOfEventStart?: InputMaybe<Scalars['String']>
@@ -290,18 +295,17 @@ export type AttachmentInput = {
   data?: InputMaybe<Scalars['String']>
   description?: InputMaybe<Scalars['String']>
   originalFileName?: InputMaybe<Scalars['String']>
-  status?: InputMaybe<AttachmentStatus>
+  status?: InputMaybe<AttachmentInputStatus>
   subject?: InputMaybe<Scalars['String']>
   systemFileName?: InputMaybe<Scalars['String']>
   type?: InputMaybe<Scalars['String']>
   uri?: InputMaybe<Scalars['String']>
 }
 
-export enum AttachmentStatus {
-  Amended = 'AMENDED',
-  EnteredInError = 'ENTERED_IN_ERROR',
-  Final = 'FINAL',
-  Preliminary = 'PRELIMINARY'
+export enum AttachmentInputStatus {
+  Approved = 'approved',
+  Deleted = 'deleted',
+  Validated = 'validated'
 }
 
 export type AuditLogItemBase = {
@@ -334,6 +338,7 @@ export type Birth = {
 export type BirthEventSearchSet = EventSearchSet & {
   __typename?: 'BirthEventSearchSet'
   childGender?: Maybe<Scalars['String']>
+  childIdentifier?: Maybe<Scalars['String']>
   childName?: Maybe<Array<Maybe<HumanName>>>
   dateOfBirth?: Maybe<Scalars['Date']>
   fatherDateOfBirth?: Maybe<Scalars['String']>
@@ -560,8 +565,8 @@ export type CorrectionRejectionInput = {
 
 export type CorrectionValueInput = {
   fieldName: Scalars['String']
-  newValue: Scalars['String']
-  oldValue: Scalars['String']
+  newValue: Scalars['FieldValue']
+  oldValue: Scalars['FieldValue']
   section: Scalars['String']
 }
 
@@ -707,9 +712,9 @@ export type DuplicatesInfo = {
 
 export type Estimation = {
   __typename?: 'Estimation'
+  femaleEstimation: Scalars['Float']
   locationId: Scalars['String']
   locationLevel: Scalars['String']
-  femaleEstimation: Scalars['Float']
   maleEstimation: Scalars['Float']
   totalEstimation: Scalars['Float']
 }
@@ -895,9 +900,9 @@ export enum ImageFit {
 
 export type InputOutput = {
   __typename?: 'InputOutput'
+  value: Scalars['FieldValue']
   valueCode: Scalars['String']
   valueId: Scalars['String']
-  valueString: Scalars['String']
 }
 
 export type IntegratedSystem = {
@@ -970,13 +975,13 @@ export type LocationStatisticsResponse = {
 
 export type LocationWiseEstimationMetric = {
   __typename?: 'LocationWiseEstimationMetric'
-  estimated: Scalars['Int']
+  estimated: Scalars['Float']
   locationId: Scalars['String']
   locationName: Scalars['String']
-  total: Scalars['Int']
-  within1Year: Scalars['Int']
-  within5Years: Scalars['Int']
-  withinTarget: Scalars['Int']
+  total: Scalars['Float']
+  within1Year: Scalars['Float']
+  within5Years: Scalars['Float']
+  withinTarget: Scalars['Float']
 }
 
 export type LoginBackground = {
@@ -1082,13 +1087,13 @@ export type MixedTotalMetricsResult =
 
 export type MonthWiseEstimationMetric = {
   __typename?: 'MonthWiseEstimationMetric'
-  estimated: Scalars['Int']
-  month: Scalars['Int']
-  total: Scalars['Int']
-  within1Year: Scalars['Int']
-  within5Years: Scalars['Int']
-  withinTarget: Scalars['Int']
-  year: Scalars['Int']
+  estimated: Scalars['Float']
+  month: Scalars['Float']
+  total: Scalars['Float']
+  within1Year: Scalars['Float']
+  within5Years: Scalars['Float']
+  withinTarget: Scalars['Float']
+  year: Scalars['Float']
 }
 
 export type Mutation = {
@@ -1854,6 +1859,7 @@ export type QuerySearchEventsArgs = {
   count?: InputMaybe<Scalars['Int']>
   skip?: InputMaybe<Scalars['Int']>
   sort?: InputMaybe<Scalars['String']>
+  sortBy?: InputMaybe<Array<SortBy>>
   sortColumn?: InputMaybe<Scalars['String']>
   userId?: InputMaybe<Scalars['String']>
 }
@@ -2028,6 +2034,7 @@ export type RegistrationSearchSet = {
   __typename?: 'RegistrationSearchSet'
   assignment?: Maybe<AssignmentData>
   comment?: Maybe<Scalars['String']>
+  contactEmail?: Maybe<Scalars['String']>
   contactNumber?: Maybe<Scalars['String']>
   contactRelationship?: Maybe<Scalars['String']>
   createdAt?: Maybe<Scalars['String']>
@@ -2194,6 +2201,11 @@ export type Signature = {
 export type SignatureInput = {
   data: Scalars['String']
   type?: InputMaybe<Scalars['String']>
+}
+
+export type SortBy = {
+  column: Scalars['String']
+  order: Scalars['String']
 }
 
 export enum Status {
@@ -3005,6 +3017,7 @@ export type SearchEventsQuery = {
             __typename?: 'RegistrationSearchSet'
             status?: string | null
             contactNumber?: string | null
+            contactEmail?: string | null
             trackingId?: string | null
             registrationNumber?: string | null
             registeredLocationId?: string | null
@@ -3054,6 +3067,7 @@ export type SearchEventsQuery = {
             __typename?: 'RegistrationSearchSet'
             status?: string | null
             contactNumber?: string | null
+            contactEmail?: string | null
             trackingId?: string | null
             registrationNumber?: string | null
             registeredLocationId?: string | null
@@ -3109,6 +3123,7 @@ export type SearchEventsQuery = {
             __typename?: 'RegistrationSearchSet'
             status?: string | null
             contactNumber?: string | null
+            contactEmail?: string | null
             trackingId?: string | null
             registrationNumber?: string | null
             registeredLocationId?: string | null
@@ -3790,13 +3805,13 @@ export type FetchBirthRegistrationForReviewQuery = {
         __typename?: 'InputOutput'
         valueCode: string
         valueId: string
-        valueString: string
+        value: any
       } | null> | null
       output?: Array<{
         __typename?: 'InputOutput'
         valueCode: string
         valueId: string
-        valueString: string
+        value: any
       } | null> | null
       certificates?: Array<{
         __typename?: 'Certificate'
@@ -4106,13 +4121,13 @@ export type FetchBirthRegistrationForCertificateQuery = {
         __typename?: 'InputOutput'
         valueCode: string
         valueId: string
-        valueString: string
+        value: any
       } | null> | null
       output?: Array<{
         __typename?: 'InputOutput'
         valueCode: string
         valueId: string
-        valueString: string
+        value: any
       } | null> | null
       certificates?: Array<{
         __typename?: 'Certificate'
@@ -4330,31 +4345,127 @@ export type FetchDeathRegistrationForReviewQuery = {
     father?: {
       __typename?: 'Person'
       id?: string | null
+      birthDate?: string | null
+      maritalStatus?: string | null
+      occupation?: string | null
+      detailsExist?: boolean | null
+      reasonNotApplying?: string | null
+      ageOfIndividualInYears?: number | null
+      exactDateOfBirthUnknown?: boolean | null
+      dateOfMarriage?: any | null
+      educationalAttainment?: string | null
+      nationality?: Array<string | null> | null
       name?: Array<{
         __typename?: 'HumanName'
         use?: string | null
         firstNames?: string | null
         familyName?: string | null
+      } | null> | null
+      identifier?: Array<{
+        __typename?: 'IdentityType'
+        id?: string | null
+        type?: string | null
+        otherType?: string | null
+        fieldsModifiedByIdentity?: Array<string | null> | null
+      } | null> | null
+      address?: Array<{
+        __typename?: 'Address'
+        type?: string | null
+        line?: Array<string | null> | null
+        district?: string | null
+        state?: string | null
+        city?: string | null
+        postalCode?: string | null
+        country?: string | null
+      } | null> | null
+      telecom?: Array<{
+        __typename?: 'ContactPoint'
+        system?: string | null
+        value?: string | null
       } | null> | null
     } | null
     mother?: {
       __typename?: 'Person'
       id?: string | null
+      birthDate?: string | null
+      maritalStatus?: string | null
+      occupation?: string | null
+      detailsExist?: boolean | null
+      reasonNotApplying?: string | null
+      ageOfIndividualInYears?: number | null
+      exactDateOfBirthUnknown?: boolean | null
+      dateOfMarriage?: any | null
+      educationalAttainment?: string | null
+      nationality?: Array<string | null> | null
       name?: Array<{
         __typename?: 'HumanName'
         use?: string | null
         firstNames?: string | null
         familyName?: string | null
       } | null> | null
+      identifier?: Array<{
+        __typename?: 'IdentityType'
+        id?: string | null
+        type?: string | null
+        otherType?: string | null
+        fieldsModifiedByIdentity?: Array<string | null> | null
+      } | null> | null
+      address?: Array<{
+        __typename?: 'Address'
+        type?: string | null
+        line?: Array<string | null> | null
+        district?: string | null
+        state?: string | null
+        city?: string | null
+        postalCode?: string | null
+        country?: string | null
+      } | null> | null
+      telecom?: Array<{
+        __typename?: 'ContactPoint'
+        system?: string | null
+        value?: string | null
+      } | null> | null
     } | null
     spouse?: {
       __typename?: 'Person'
       id?: string | null
+      birthDate?: string | null
+      maritalStatus?: string | null
+      occupation?: string | null
+      detailsExist?: boolean | null
+      reasonNotApplying?: string | null
+      ageOfIndividualInYears?: number | null
+      exactDateOfBirthUnknown?: boolean | null
+      dateOfMarriage?: any | null
+      educationalAttainment?: string | null
+      nationality?: Array<string | null> | null
       name?: Array<{
         __typename?: 'HumanName'
         use?: string | null
         firstNames?: string | null
         familyName?: string | null
+      } | null> | null
+      identifier?: Array<{
+        __typename?: 'IdentityType'
+        id?: string | null
+        type?: string | null
+        otherType?: string | null
+        fieldsModifiedByIdentity?: Array<string | null> | null
+      } | null> | null
+      address?: Array<{
+        __typename?: 'Address'
+        type?: string | null
+        line?: Array<string | null> | null
+        district?: string | null
+        state?: string | null
+        city?: string | null
+        postalCode?: string | null
+        country?: string | null
+      } | null> | null
+      telecom?: Array<{
+        __typename?: 'ContactPoint'
+        system?: string | null
+        value?: string | null
       } | null> | null
     } | null
     medicalPractitioner?: {
@@ -4527,13 +4638,13 @@ export type FetchDeathRegistrationForReviewQuery = {
         __typename?: 'InputOutput'
         valueCode: string
         valueId: string
-        valueString: string
+        value: any
       } | null> | null
       output?: Array<{
         __typename?: 'InputOutput'
         valueCode: string
         valueId: string
-        valueString: string
+        value: any
       } | null> | null
       certificates?: Array<{
         __typename?: 'Certificate'
@@ -4826,13 +4937,13 @@ export type FetchDeathRegistrationForCertificationQuery = {
         __typename?: 'InputOutput'
         valueCode: string
         valueId: string
-        valueString: string
+        value: any
       } | null> | null
       output?: Array<{
         __typename?: 'InputOutput'
         valueCode: string
         valueId: string
-        valueString: string
+        value: any
       } | null> | null
       certificates?: Array<{
         __typename?: 'Certificate'
@@ -5277,13 +5388,13 @@ export type FetchMarriageRegistrationForReviewQuery = {
         __typename?: 'InputOutput'
         valueCode: string
         valueId: string
-        valueString: string
+        value: any
       } | null> | null
       output?: Array<{
         __typename?: 'InputOutput'
         valueCode: string
         valueId: string
-        valueString: string
+        value: any
       } | null> | null
       certificates?: Array<{
         __typename?: 'Certificate'
@@ -5614,13 +5725,13 @@ export type FetchMarriageRegistrationForCertificateQuery = {
         __typename?: 'InputOutput'
         valueCode: string
         valueId: string
-        valueString: string
+        value: any
       } | null> | null
       output?: Array<{
         __typename?: 'InputOutput'
         valueCode: string
         valueId: string
-        valueString: string
+        value: any
       } | null> | null
       certificates?: Array<{
         __typename?: 'Certificate'
@@ -8811,13 +8922,13 @@ export type FetchViewRecordByCompositionQuery = {
             __typename?: 'InputOutput'
             valueCode: string
             valueId: string
-            valueString: string
+            value: any
           } | null> | null
           output?: Array<{
             __typename?: 'InputOutput'
             valueCode: string
             valueId: string
-            valueString: string
+            value: any
           } | null> | null
           certificates?: Array<{
             __typename?: 'Certificate'
@@ -8932,31 +9043,127 @@ export type FetchViewRecordByCompositionQuery = {
         father?: {
           __typename?: 'Person'
           id?: string | null
+          birthDate?: string | null
+          maritalStatus?: string | null
+          occupation?: string | null
+          detailsExist?: boolean | null
+          reasonNotApplying?: string | null
+          ageOfIndividualInYears?: number | null
+          exactDateOfBirthUnknown?: boolean | null
+          dateOfMarriage?: any | null
+          educationalAttainment?: string | null
+          nationality?: Array<string | null> | null
           name?: Array<{
             __typename?: 'HumanName'
             use?: string | null
             firstNames?: string | null
             familyName?: string | null
+          } | null> | null
+          identifier?: Array<{
+            __typename?: 'IdentityType'
+            id?: string | null
+            type?: string | null
+            otherType?: string | null
+            fieldsModifiedByIdentity?: Array<string | null> | null
+          } | null> | null
+          address?: Array<{
+            __typename?: 'Address'
+            type?: string | null
+            line?: Array<string | null> | null
+            district?: string | null
+            state?: string | null
+            city?: string | null
+            postalCode?: string | null
+            country?: string | null
+          } | null> | null
+          telecom?: Array<{
+            __typename?: 'ContactPoint'
+            system?: string | null
+            value?: string | null
           } | null> | null
         } | null
         mother?: {
           __typename?: 'Person'
           id?: string | null
+          birthDate?: string | null
+          maritalStatus?: string | null
+          occupation?: string | null
+          detailsExist?: boolean | null
+          reasonNotApplying?: string | null
+          ageOfIndividualInYears?: number | null
+          exactDateOfBirthUnknown?: boolean | null
+          dateOfMarriage?: any | null
+          educationalAttainment?: string | null
+          nationality?: Array<string | null> | null
           name?: Array<{
             __typename?: 'HumanName'
             use?: string | null
             firstNames?: string | null
             familyName?: string | null
           } | null> | null
+          identifier?: Array<{
+            __typename?: 'IdentityType'
+            id?: string | null
+            type?: string | null
+            otherType?: string | null
+            fieldsModifiedByIdentity?: Array<string | null> | null
+          } | null> | null
+          address?: Array<{
+            __typename?: 'Address'
+            type?: string | null
+            line?: Array<string | null> | null
+            district?: string | null
+            state?: string | null
+            city?: string | null
+            postalCode?: string | null
+            country?: string | null
+          } | null> | null
+          telecom?: Array<{
+            __typename?: 'ContactPoint'
+            system?: string | null
+            value?: string | null
+          } | null> | null
         } | null
         spouse?: {
           __typename?: 'Person'
           id?: string | null
+          birthDate?: string | null
+          maritalStatus?: string | null
+          occupation?: string | null
+          detailsExist?: boolean | null
+          reasonNotApplying?: string | null
+          ageOfIndividualInYears?: number | null
+          exactDateOfBirthUnknown?: boolean | null
+          dateOfMarriage?: any | null
+          educationalAttainment?: string | null
+          nationality?: Array<string | null> | null
           name?: Array<{
             __typename?: 'HumanName'
             use?: string | null
             firstNames?: string | null
             familyName?: string | null
+          } | null> | null
+          identifier?: Array<{
+            __typename?: 'IdentityType'
+            id?: string | null
+            type?: string | null
+            otherType?: string | null
+            fieldsModifiedByIdentity?: Array<string | null> | null
+          } | null> | null
+          address?: Array<{
+            __typename?: 'Address'
+            type?: string | null
+            line?: Array<string | null> | null
+            district?: string | null
+            state?: string | null
+            city?: string | null
+            postalCode?: string | null
+            country?: string | null
+          } | null> | null
+          telecom?: Array<{
+            __typename?: 'ContactPoint'
+            system?: string | null
+            value?: string | null
           } | null> | null
         } | null
         medicalPractitioner?: {
@@ -9094,13 +9301,13 @@ export type FetchViewRecordByCompositionQuery = {
             __typename?: 'InputOutput'
             valueCode: string
             valueId: string
-            valueString: string
+            value: any
           } | null> | null
           output?: Array<{
             __typename?: 'InputOutput'
             valueCode: string
             valueId: string
-            valueString: string
+            value: any
           } | null> | null
           certificates?: Array<{
             __typename?: 'Certificate'
@@ -9406,13 +9613,13 @@ export type FetchViewRecordByCompositionQuery = {
             __typename?: 'InputOutput'
             valueCode: string
             valueId: string
-            valueString: string
+            value: any
           } | null> | null
           output?: Array<{
             __typename?: 'InputOutput'
             valueCode: string
             valueId: string
-            valueString: string
+            value: any
           } | null> | null
           certificates?: Array<{
             __typename?: 'Certificate'

--- a/packages/client/src/views/DataProvider/birth/queries.ts
+++ b/packages/client/src/views/DataProvider/birth/queries.ts
@@ -283,12 +283,12 @@ export const GET_BIRTH_REGISTRATION_FOR_REVIEW = gql`
         input {
           valueCode
           valueId
-          valueString
+          value
         }
         output {
           valueCode
           valueId
-          valueString
+          value
         }
         certificates {
           hasShowedVerifiedDocument
@@ -556,12 +556,12 @@ export const GET_BIRTH_REGISTRATION_FOR_CERTIFICATE = gql`
         input {
           valueCode
           valueId
-          valueString
+          value
         }
         output {
           valueCode
           valueId
-          valueString
+          value
         }
         certificates {
           hasShowedVerifiedDocument

--- a/packages/client/src/views/DataProvider/death/queries.ts
+++ b/packages/client/src/views/DataProvider/death/queries.ts
@@ -348,12 +348,12 @@ export const GET_DEATH_REGISTRATION_FOR_REVIEW = gql`
         input {
           valueCode
           valueId
-          valueString
+          value
         }
         output {
           valueCode
           valueId
-          valueString
+          value
         }
         certificates {
           hasShowedVerifiedDocument
@@ -607,12 +607,12 @@ export const GET_DEATH_REGISTRATION_FOR_CERTIFICATION = gql`
         input {
           valueCode
           valueId
-          valueString
+          value
         }
         output {
           valueCode
           valueId
-          valueString
+          value
         }
         certificates {
           hasShowedVerifiedDocument

--- a/packages/client/src/views/DataProvider/marriage/queries.ts
+++ b/packages/client/src/views/DataProvider/marriage/queries.ts
@@ -288,12 +288,12 @@ const GET_MARRIAGE_REGISTRATION_FOR_REVIEW = gql`
         input {
           valueCode
           valueId
-          valueString
+          value
         }
         output {
           valueCode
           valueId
-          valueString
+          value
         }
         certificates {
           hasShowedVerifiedDocument
@@ -579,12 +579,12 @@ const GET_MARRIAGE_REGISTRATION_FOR_CERTIFICATE = gql`
         input {
           valueCode
           valueId
-          valueString
+          value
         }
         output {
           valueCode
           valueId
-          valueString
+          value
         }
         certificates {
           hasShowedVerifiedDocument

--- a/packages/client/src/views/RecordAudit/ActionDetailsModal.tsx
+++ b/packages/client/src/views/RecordAudit/ActionDetailsModal.tsx
@@ -302,10 +302,8 @@ const ActionDetailsModalListTable = ({
       ) as IFormSection
 
       if (section.id === 'documents') {
-        item.valueString = EMPTY_STRING
-        editedValue.valueString = intl.formatMessage(
-          dynamicConstantsMessages.updated
-        )
+        item.value = EMPTY_STRING
+        editedValue.value = intl.formatMessage(dynamicConstantsMessages.updated)
       }
 
       const indexes = item?.valueId?.split('.')
@@ -326,18 +324,8 @@ const ActionDetailsModalListTable = ({
 
         result.push({
           item: getItemName(section.name, fieldObj.label),
-          original: getFieldValue(
-            item.valueString,
-            fieldObj,
-            offlineData,
-            intl
-          ),
-          edit: getFieldValue(
-            editedValue.valueString,
-            fieldObj,
-            offlineData,
-            intl
-          )
+          original: getFieldValue(item.value, fieldObj, offlineData, intl),
+          edit: getFieldValue(editedValue.value, fieldObj, offlineData, intl)
         })
       } else {
         const [parentField] = indexes
@@ -350,18 +338,8 @@ const ActionDetailsModalListTable = ({
 
         result.push({
           item: getItemName(section.name, fieldObj.label),
-          original: getFieldValue(
-            item.valueString,
-            fieldObj,
-            offlineData,
-            intl
-          ),
-          edit: getFieldValue(
-            editedValue.valueString,
-            fieldObj,
-            offlineData,
-            intl
-          )
+          original: getFieldValue(item.value, fieldObj, offlineData, intl),
+          edit: getFieldValue(editedValue.value, fieldObj, offlineData, intl)
         })
       }
     })

--- a/packages/client/src/views/ReviewCorrection/ReviewCorrection.tsx
+++ b/packages/client/src/views/ReviewCorrection/ReviewCorrection.tsx
@@ -619,15 +619,7 @@ function applyCorrectionToData(record: IDeclaration) {
     (acc: Record<string, Record<string, IFormFieldValue>>, curr: any) => {
       acc[curr.valueCode] = acc[curr.valueCode] || {}
 
-      switch (typeof record.data[curr.valueCode]?.[curr.valueId]) {
-        case 'number':
-          acc[curr.valueCode][curr.valueId] = Number(curr.valueString)
-          break
-
-        default:
-          acc[curr.valueCode][curr.valueId] = curr.valueString
-          break
-      }
+      acc[curr.valueCode][curr.valueId] = curr.value
 
       return acc
     },
@@ -657,7 +649,7 @@ function applyCorrectionToData(record: IDeclaration) {
     requester: correctionRequestTask.requester!,
     values: correctionRequestTask.input.map((input) => ({
       fieldName: input!.valueId,
-      newValue: input!.valueString,
+      newValue: input!.value!,
       section: input!.valueCode,
       oldValue: (record.data[input!.valueCode][input!.valueId] || '').toString()
     }))

--- a/packages/client/src/views/ViewRecord/query.ts
+++ b/packages/client/src/views/ViewRecord/query.ts
@@ -110,12 +110,12 @@ export const FETCH_VIEW_RECORD_BY_COMPOSITION = gql`
         input {
           valueCode
           valueId
-          valueString
+          value
         }
         output {
           valueCode
           valueId
-          valueString
+          value
         }
         certificates {
           hasShowedVerifiedDocument

--- a/packages/gateway/src/features/registration/schema.graphql
+++ b/packages/gateway/src/features/registration/schema.graphql
@@ -139,7 +139,7 @@ type DuplicatesInfo {
 type InputOutput {
   valueCode: String!
   valueId: String!
-  valueString: String!
+  value: FieldValue!
 }
 
 type IntegratedSystem {
@@ -337,8 +337,8 @@ type MarriageRegistration implements EventRegistration { # -> Composition
 input CorrectionValueInput {
   section: String!
   fieldName: String!
-  oldValue: String!
-  newValue: String!
+  oldValue: FieldValue!
+  newValue: FieldValue!
 }
 
 input CorrectionInput {

--- a/packages/gateway/src/features/registration/type-resolvers.ts
+++ b/packages/gateway/src/features/registration/type-resolvers.ts
@@ -102,6 +102,7 @@ import {
 
 import { Context } from '@gateway/graphql/context'
 import * as validateUUID from 'uuid-validate'
+import { TaskInput } from 'fhir/r3'
 
 function findRelatedPerson(
   patientCode:
@@ -1296,6 +1297,18 @@ export const typeResolvers: GQLResolver = {
           encounterParticipant.period.start) ||
         null
       )
+    }
+  },
+  InputOutput: {
+    value: (inputOutput: TaskInput) => {
+      if (inputOutput.valueBoolean !== undefined) {
+        return inputOutput.valueBoolean
+      }
+      if (inputOutput.valueInteger !== undefined) {
+        return inputOutput.valueInteger
+      }
+
+      return inputOutput.valueString
     }
   },
   History: {

--- a/packages/gateway/src/graphql/common.graphql
+++ b/packages/gateway/src/graphql/common.graphql
@@ -8,6 +8,7 @@
 # Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
 # automatically map from FHIR
 
+scalar FieldValue
 scalar Date
 scalar Map
 

--- a/packages/gateway/src/graphql/config.ts
+++ b/packages/gateway/src/graphql/config.ts
@@ -9,7 +9,12 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 import { mapSchema, getDirective, MapperKind } from '@graphql-tools/utils'
-import { defaultFieldResolver, GraphQLSchema } from 'graphql'
+import {
+  Kind,
+  GraphQLScalarType,
+  defaultFieldResolver,
+  GraphQLSchema
+} from 'graphql'
 
 import { resolvers as certificateResolvers } from '@gateway/features/certificate/root-resolvers'
 import { resolvers as locationRootResolvers } from '@gateway/features/location/root-resolvers'
@@ -88,7 +93,43 @@ const resolvers: StringIndexed<IResolvers> = merge(
   bookmarkAdvancedSearchResolvers as IResolvers,
   informantSMSNotificationResolvers as IResolvers,
   informantSMSNotiTypeResolvers as IResolvers,
-  OIDPUserInfoResolvers as IResolvers
+  OIDPUserInfoResolvers as IResolvers,
+  {
+    FieldValue: new GraphQLScalarType({
+      name: 'FieldValue',
+      description: 'String, Number or Boolean',
+      serialize(value) {
+        if (!['string', 'number', 'boolean'].includes(typeof value)) {
+          throw new Error('Value must be either a String, Boolean or an number')
+        }
+
+        return value
+      },
+      parseValue(value) {
+        if (!['string', 'number', 'boolean'].includes(typeof value)) {
+          throw new Error('Value must be either a String, Boolean or an number')
+        }
+
+        return value
+      },
+      parseLiteral(ast) {
+        switch (ast.kind) {
+          case Kind.INT:
+            return parseInt(ast.value, 10)
+          case Kind.FLOAT:
+            return parseFloat(ast.value)
+          case Kind.BOOLEAN:
+            return ast.value
+          case Kind.STRING:
+            return ast.value
+          default:
+            throw new Error(
+              'Value must be either a String, Boolean or an number'
+            )
+        }
+      }
+    })
+  }
 )
 
 export const getExecutableSchema = (): GraphQLSchema => {

--- a/packages/gateway/src/graphql/schema.d.ts
+++ b/packages/gateway/src/graphql/schema.d.ts
@@ -1210,8 +1210,8 @@ export interface GQLCorrectionPaymentInput {
 export interface GQLCorrectionValueInput {
   section: string
   fieldName: string
-  oldValue: string
-  newValue: string
+  oldValue: GQLFieldValue
+  newValue: GQLFieldValue
 }
 
 export interface GQLFHIRIDMap {
@@ -1479,7 +1479,7 @@ export interface GQLComment {
 export interface GQLInputOutput {
   valueCode: string
   valueId: string
-  valueString: string
+  value: GQLFieldValue
 }
 
 export interface GQLPayment {
@@ -1751,6 +1751,8 @@ export const enum GQLPaymentOutcomeType {
   ERROR = 'ERROR',
   PARTIAL = 'PARTIAL'
 }
+
+export type GQLFieldValue = any
 
 export interface GQLObservationFHIRIDS {
   maleDependentsOfDeceased?: string
@@ -2030,6 +2032,7 @@ export interface GQLResolver {
   EventProgressData?: GQLEventProgressDataTypeResolver
   WebhookPermission?: GQLWebhookPermissionTypeResolver
   OIDPUserAddress?: GQLOIDPUserAddressTypeResolver
+  FieldValue?: GraphQLScalarType
   BirthFee?: GQLBirthFeeTypeResolver
   DeathFee?: GQLDeathFeeTypeResolver
   MarriageFee?: GQLMarriageFeeTypeResolver
@@ -9497,7 +9500,7 @@ export interface CommentToCreatedAtResolver<TParent = any, TResult = any> {
 export interface GQLInputOutputTypeResolver<TParent = any> {
   valueCode?: InputOutputToValueCodeResolver<TParent>
   valueId?: InputOutputToValueIdResolver<TParent>
-  valueString?: InputOutputToValueStringResolver<TParent>
+  value?: InputOutputToValueResolver<TParent>
 }
 
 export interface InputOutputToValueCodeResolver<TParent = any, TResult = any> {
@@ -9518,10 +9521,7 @@ export interface InputOutputToValueIdResolver<TParent = any, TResult = any> {
   ): TResult
 }
 
-export interface InputOutputToValueStringResolver<
-  TParent = any,
-  TResult = any
-> {
+export interface InputOutputToValueResolver<TParent = any, TResult = any> {
   (
     parent: TParent,
     args: {},

--- a/packages/gateway/src/graphql/schema.graphql
+++ b/packages/gateway/src/graphql/schema.graphql
@@ -1328,8 +1328,8 @@ input CorrectionPaymentInput {
 input CorrectionValueInput {
   section: String!
   fieldName: String!
-  oldValue: String!
-  newValue: String!
+  oldValue: FieldValue!
+  newValue: FieldValue!
 }
 
 input FHIRIDMap {
@@ -1597,7 +1597,7 @@ type Comment {
 type InputOutput {
   valueCode: String!
   valueId: String!
-  valueString: String!
+  value: FieldValue!
 }
 
 type Payment {
@@ -1868,6 +1868,8 @@ enum PaymentOutcomeType {
   ERROR
   PARTIAL
 }
+
+scalar FieldValue
 
 input ObservationFHIRIDS {
   maleDependentsOfDeceased: String

--- a/packages/search/src/elasticsearch/utils.ts
+++ b/packages/search/src/elasticsearch/utils.ts
@@ -92,7 +92,7 @@ export interface ICorrection {
   section: string
   fieldName: string
   oldValue: string
-  newValue: string
+  newValue: string | number | boolean
 }
 
 export interface IAssignment {
@@ -442,15 +442,23 @@ function updateOperationHistoryWithCorrection(
     for (let i = 0; i < task.input.length; i += 1) {
       const section = task.input[i].valueCode || ''
       const fieldName = task.input[i].valueId || ''
-      const oldValue = task.input[i].valueString || ''
-      const newValue = task.output[i].valueString || ''
+      const oldValue =
+        task.input[i].valueString ||
+        task.output[i].valueInteger?.toString() ||
+        ''
+      const newValueString = task.output[i].valueString
+      const newValueNumber = task.output[i].valueInteger
 
-      operationHistory.correction?.push({
+      const payload: ICorrection = {
         section,
         fieldName,
         oldValue,
-        newValue
-      })
+        newValue: (newValueNumber !== undefined
+          ? newValueNumber
+          : newValueString)! // On of these the values always exist
+      }
+
+      operationHistory.correction?.push(payload)
     }
   }
 }

--- a/packages/workflow/src/records/correction-request.ts
+++ b/packages/workflow/src/records/correction-request.ts
@@ -38,8 +38,8 @@ export const CorrectionRequestInput = z.object({
     z.object({
       section: z.string(),
       fieldName: z.string(),
-      oldValue: z.string(),
-      newValue: z.string()
+      oldValue: z.union([z.string(), z.number(), z.boolean()]),
+      newValue: z.union([z.string(), z.number(), z.boolean()])
     })
   ),
   reason: z.string(),

--- a/packages/workflow/src/records/fhir.ts
+++ b/packages/workflow/src/records/fhir.ts
@@ -29,6 +29,22 @@ import {
   CorrectionRequestPaymentInput
 } from './correction-request'
 
+function getFHIRValueField(value: unknown) {
+  if (typeof value === 'string') {
+    return { valueString: value }
+  }
+
+  if (typeof value === 'number') {
+    return { valueInteger: value }
+  }
+
+  if (typeof value === 'boolean') {
+    return { valueBoolean: value }
+  }
+
+  throw new Error('Invalid value type')
+}
+
 export function createCorrectionProofOfLegalCorrectionDocument(
   subjectReference: URNReference,
   attachmentURL: string,
@@ -254,7 +270,7 @@ export function createCorrectedTask(
           }
         ]
       },
-      valueString: update.newValue
+      ...getFHIRValueField(update.newValue)
     })),
     reason: {
       text: correctionDetails.reason,
@@ -356,7 +372,7 @@ export function createCorrectionRequestTask(
           }
         ]
       },
-      valueString: update.newValue
+      ...getFHIRValueField(update.newValue)
     })),
     reason: {
       text: correctionDetails.reason,


### PR DESCRIPTION
We noticed a bug happening when user requested a correction with non-string fields. When the changes eventually got applied, an "age" field for instance would have a string value that caused gateway type validations to fail.

PR implements a generic value field in GraphQA so that correction can describe different fields without having to cast to string
