### PR TITLE
feat: return part-of from gateway addresses

### DIFF
--- a/packages/commons/src/fhir/index.ts
+++ b/packages/commons/src/fhir/index.ts
@@ -13,7 +13,7 @@ import { ValidRecord } from '../record'
 import { Nominal } from '../nominal'
 import { UUID } from '../uuid'
 import { Encounter, SavedEncounter } from './encounter'
-import { Extension } from './extension'
+import { Extension, KnownExtensionType } from './extension'
 import { Patient } from './patient'
 import { CompositionSection, SavedCompositionSection } from './composition'
 import { SavedTask, Task, TaskHistory } from './task'
@@ -144,8 +144,11 @@ export type StrictBundle<T extends Resource[]> = Omit<Bundle, 'entry'> & {
   entry: { [Property in keyof T]: BundleEntry<T[Property]> }
 }
 
-export type Address = Omit<fhir3.Address, 'type'> & {
+export type Address = Omit<fhir3.Address, 'type' | 'extension'> & {
   type?: fhir3.Address['type'] | 'SECONDARY_ADDRESS' | 'PRIMARY_ADDRESS'
+  extension?: Array<
+    KnownExtensionType['http://opencrvs.org/specs/extension/part-of']
+  >
 }
 
 export type BusinessStatus = Omit<fhir3.CodeableConcept, 'coding'> & {

--- a/packages/gateway/src/features/registration/type-resolvers.ts
+++ b/packages/gateway/src/features/registration/type-resolvers.ts
@@ -97,7 +97,8 @@ import {
   isTaskOrTaskHistory,
   isURLReference,
   resourceIdentifierToUUID,
-  urlReferenceToUUID
+  urlReferenceToUUID,
+  Address
 } from '@opencrvs/commons/types'
 
 import { Context } from '@gateway/graphql/context'
@@ -221,6 +222,16 @@ export const typeResolvers: GQLResolver = {
           return location.name
         })
       )
+    },
+    partOf: (address: Address) => {
+      if (!address.extension) return null
+
+      const partOfExtension = findExtension(
+        `${OPENCRVS_SPECIFICATION_URL}extension/part-of`,
+        address.extension
+      )
+
+      return partOfExtension?.valueReference?.reference?.split('/')?.[1] ?? null
     }
   },
   Person: {

--- a/packages/gateway/src/graphql/common.graphql
+++ b/packages/gateway/src/graphql/common.graphql
@@ -255,6 +255,7 @@ type Address { # -> Address (mostly the same property name except:)
   country: String
   from: Date # -> .period.start
   to: Date # -> .period.end
+  partOf: String
 }
 
 enum AuthorizationStatus {

--- a/packages/gateway/src/graphql/schema.d.ts
+++ b/packages/gateway/src/graphql/schema.d.ts
@@ -924,6 +924,7 @@ export interface GQLAddress {
   country?: string
   from?: GQLDate
   to?: GQLDate
+  partOf?: string
 }
 
 export interface GQLAttachment {
@@ -7663,6 +7664,7 @@ export interface GQLAddressTypeResolver<TParent = any> {
   country?: AddressToCountryResolver<TParent>
   from?: AddressToFromResolver<TParent>
   to?: AddressToToResolver<TParent>
+  partOf?: AddressToPartOfResolver<TParent>
 }
 
 export interface AddressToUseResolver<TParent = any, TResult = any> {
@@ -7783,6 +7785,15 @@ export interface AddressToFromResolver<TParent = any, TResult = any> {
 }
 
 export interface AddressToToResolver<TParent = any, TResult = any> {
+  (
+    parent: TParent,
+    args: {},
+    context: Context,
+    info: GraphQLResolveInfo
+  ): TResult
+}
+
+export interface AddressToPartOfResolver<TParent = any, TResult = any> {
   (
     parent: TParent,
     args: {},

--- a/packages/gateway/src/graphql/schema.graphql
+++ b/packages/gateway/src/graphql/schema.graphql
@@ -1066,6 +1066,7 @@ type Address {
   country: String
   from: Date
   to: Date
+  partOf: String
 }
 
 type Attachment {


### PR DESCRIPTION
This allows us to return the home location of mother/father when querying for births in dci-crvs-api.
Related PR: https://github.com/opencrvs/dci-crvs-api/pull/132 