### PR TITLE
Print declaration : remove blank space after header (CTRL + P) and open in new tab

### DIFF
--- a/packages/client/src/navigation/index.ts
+++ b/packages/client/src/navigation/index.ts
@@ -689,7 +689,7 @@ export function goToOrganisationView(userDetails: UserDetails) {
 }
 
 export function goToPrintRecordView(declarationId: string) {
-  return push(formatUrl(PRINT_RECORD, { declarationId }))
+  window.open(`/print-record/${declarationId}`, '_blank')
 }
 export type INavigationState = undefined
 

--- a/packages/client/src/views/PrintRecord/Body.tsx
+++ b/packages/client/src/views/PrintRecord/Body.tsx
@@ -99,7 +99,7 @@ const DocumentTypeBox = styled.div`
 
 const AvoidBreak = styled.div`
   @media print {
-    break-inside: avoid;
+    page-break-after: avoid;
   }
 `
 

--- a/packages/client/src/views/PrintRecord/PrintRecord.tsx
+++ b/packages/client/src/views/PrintRecord/PrintRecord.tsx
@@ -40,6 +40,12 @@ const Container = styled.div`
 const Content = styled.div`
   max-width: 1024px;
 `
+
+const AvoidBreak = styled.div`
+  @media print {
+    page-break-after: avoid;
+  }
+`
 export function PrintRecord() {
   const languages = useSelector(getLanguages)
   const offlineData = useSelector(getOfflineData)
@@ -68,30 +74,32 @@ export function PrintRecord() {
   return (
     <Container>
       <Content>
-        <Header
-          logoSrc={offlineData.config.COUNTRY_LOGO.file}
-          title={formatMessage(intls, reviewMessages.govtName)}
-          heading={formatMessage(
-            intls,
-            printRecordMessages.civilRegistrationCentre
-          )}
-          subject={formatMessage(
-            intls,
-            reviewMessages.headerSubjectWithoutName,
-            {
-              eventType: declaration.event
+        <AvoidBreak>
+          <Header
+            logoSrc={offlineData.config.COUNTRY_LOGO.file}
+            title={formatMessage(intls, reviewMessages.govtName)}
+            heading={formatMessage(
+              intls,
+              printRecordMessages.civilRegistrationCentre
+            )}
+            subject={formatMessage(
+              intls,
+              reviewMessages.headerSubjectWithoutName,
+              {
+                eventType: declaration.event
+              }
+            )}
+            info={
+              declaration.data?.registration?.trackingId
+                ? {
+                    label: formatMessage(intls, constantsMessages.trackingId),
+                    value: declaration.data.registration.trackingId as string
+                  }
+                : undefined
             }
-          )}
-          info={
-            declaration.data?.registration?.trackingId
-              ? {
-                  label: formatMessage(intls, constantsMessages.trackingId),
-                  value: declaration.data.registration.trackingId as string
-                }
-              : undefined
-          }
-          subjectColor={getEventwiseSubjectColor(declaration.event)}
-        />
+            subjectColor={getEventwiseSubjectColor(declaration.event)}
+          />
+        </AvoidBreak>
         <Body declaration={declaration} intls={intls} />
       </Content>
     </Container>


### PR DESCRIPTION
This PR remove blank space after header when we want to print declaration (CTRL + P) and also open new tab when you click "print declaration".