### PR TITLE
update password copy to suggest a 12 character long passphrase

### DIFF
--- a/packages/client/src/i18n/messages/user.ts
+++ b/packages/client/src/i18n/messages/user.ts
@@ -431,7 +431,7 @@ const messagesToDefine: IUserMessages = {
   },
   passwordCaseCharacteristicsForPasswordUpdateForm: {
     id: 'password.cases',
-    defaultMessage: 'Contain upper and lower cases',
+    defaultMessage: 'At least one upper and lower case character',
     description: 'Password validation'
   },
   passwordNumberCharacteristicsForPasswordUpdateForm: {

--- a/packages/client/src/i18n/messages/user.ts
+++ b/packages/client/src/i18n/messages/user.ts
@@ -349,8 +349,7 @@ const messagesToDefine: IUserMessages = {
     id: 'settings.changePassword'
   },
   changePasswordMessage: {
-    defaultMessage:
-      'We recommend you create a unique password - one that you don’t use for another website or app. Note. You can’t reuse your old password once you change it.',
+    defaultMessage: `Create a unique password - one that you don't use for other websites or applications. A secure and easy to remember passphrase could include three random words, while avoiding the use of personal info.`,
     description: 'Password change message',
     id: 'misc.newPass.instruction'
   },

--- a/packages/client/src/i18n/messages/views/userSetup.ts
+++ b/packages/client/src/i18n/messages/views/userSetup.ts
@@ -105,8 +105,7 @@ const messagesToDefine: IUserSetupMessages = {
     id: 'misc.newPass.header'
   },
   instruction: {
-    defaultMessage:
-      'We recommend you create a unique password - one that you don’t use for another website or app. Note. You can’t reuse your old password once you change it.',
+    defaultMessage: `Create a unique password - one that you don't use for other websites or applications. A secure and easy to remember passphrase could include three random words, while avoiding the use of personal info.`,
     description: 'New Password instruction',
     id: 'misc.newPass.instruction'
   },

--- a/packages/client/src/i18n/messages/views/userSetup.ts
+++ b/packages/client/src/i18n/messages/views/userSetup.ts
@@ -90,7 +90,7 @@ const messagesToDefine: IUserSetupMessages = {
     id: 'password.label.confirm'
   },
   hasCases: {
-    defaultMessage: 'Contain upper and lower cases',
+    defaultMessage: 'At least one upper and lower case character',
     description: 'Password validation',
     id: 'password.cases'
   },

--- a/packages/client/src/tests/languages.json
+++ b/packages/client/src/tests/languages.json
@@ -844,7 +844,7 @@
         "misc.notif.processingText": "{num} declaration processing...",
         "misc.notif.sorryError": "Sorry! Something went wrong",
         "misc.notif.userFormSuccess": "New user created",
-        "password.cases": "Contain upper and lower cases",
+        "password.cases": "At least one upper and lower case character",
         "password.label.current": "Current password",
         "password.label.confirm": "Confirm password",
         "password.label.new": "New password",

--- a/packages/client/src/tests/languages.json
+++ b/packages/client/src/tests/languages.json
@@ -837,7 +837,7 @@
         "settings.user.label.assignedOffice": "Assigned office",
         "misc.session.expired": "Your session has expired. Please login again.",
         "misc.newPass.header": "Choose a new password",
-        "misc.newPass.instruction": "We recommend you create a unique password - one that you don’t use for another website or app. Note. You can’t reuse your old password once you change it.",
+        "misc.newPass.instruction": "Create a unique password - one that you don't use for other websites or applications. A secure and easy to remember passphrase could include three random words, while avoiding the use of personal info.",
         "misc.notif.declarationsSynced": "As you have connectivity, we can synchronize your declarations.",
         "misc.notif.draftsSaved": "Your draft has been saved",
         "misc.notif.outboxText": "Outbox({num})",

--- a/packages/client/src/views/Settings/PasswordChangeModal.tsx
+++ b/packages/client/src/views/Settings/PasswordChangeModal.tsx
@@ -153,7 +153,7 @@ class PasswordChangeModalComp extends React.Component<IFullProps, State> {
   }
   validateLength = (value: string) => {
     this.setState(() => ({
-      validLength: value.length >= 8
+      validLength: value.length >= 12
     }))
   }
   validateNumber = (value: string) => {
@@ -335,9 +335,9 @@ class PasswordChangeModalComp extends React.Component<IFullProps, State> {
                         messages.passwordLengthCharacteristicsForPasswordUpdateForm,
                         {
                           min: intl.formatMessage({
-                            defaultMessage: '8',
+                            defaultMessage: '12',
                             description: 'Minimum length password',
-                            id: 'number.eight'
+                            id: 'number.twelve'
                           })
                         }
                       )}
@@ -404,9 +404,9 @@ class PasswordChangeModalComp extends React.Component<IFullProps, State> {
                     messages.passwordLengthCharacteristicsForPasswordUpdateForm,
                     {
                       min: intl.formatMessage({
-                        defaultMessage: '8',
+                        defaultMessage: '12',
                         description: 'Minimum length password',
-                        id: 'number.eight'
+                        id: 'number.twelve'
                       })
                     }
                   )}

--- a/packages/client/src/views/UserSetup/CreatePassword.tsx
+++ b/packages/client/src/views/UserSetup/CreatePassword.tsx
@@ -177,7 +177,7 @@ export function CreatePassword({ setupData, goToStep }: IProps) {
                 {validLength && <TickOn />}
                 {!validLength && <TickOff />}
                 <span>
-                  {intl.formatMessage(messages.minLength, { min: 8 })}
+                  {intl.formatMessage(messages.minLength, { min: 12 })}
                 </span>
               </div>
               <div>

--- a/packages/login/src/i18n/messages/views/resetCredentialsForm.ts
+++ b/packages/login/src/i18n/messages/views/resetCredentialsForm.ts
@@ -94,7 +94,7 @@ const messagesToDefine = {
   },
   passwordCaseCharacteristicsForPasswordUpdateForm: {
     id: 'password.cases',
-    defaultMessage: 'Contain upper and lower cases',
+    defaultMessage: 'At least one upper and lower case character',
     description: 'Password validation'
   },
   passwordNumberCharacteristicsForPasswordUpdateForm: {

--- a/packages/login/src/i18n/messages/views/resetCredentialsForm.ts
+++ b/packages/login/src/i18n/messages/views/resetCredentialsForm.ts
@@ -84,8 +84,7 @@ const messagesToDefine = {
   },
   passwordUpdateFormBodySubheader: {
     id: 'misc.newPass.instruction',
-    defaultMessage:
-      'We recommend you create a unique password - one that you don’t use for another website or app. Note. You can’t reuse your old password once you change it.',
+    defaultMessage: `Create a unique password - one that you don't use for other websites or applications. A secure and easy to remember passphrase could include three random words, while avoiding the use of personal info.`,
     description: 'New Password instruction'
   },
   passwordLengthCharacteristicsForPasswordUpdateForm: {

--- a/packages/login/src/views/resetCredentialsForm/updatePasswordForm.tsx
+++ b/packages/login/src/views/resetCredentialsForm/updatePasswordForm.tsx
@@ -95,7 +95,7 @@ class UpdatePasswordComponent extends React.Component<IFullProps, State> {
   }
   validateLength = (value: string) => {
     this.setState(() => ({
-      validLength: value.length >= 8
+      validLength: value.length >= 12
     }))
   }
   validateNumber = (value: string) => {
@@ -264,7 +264,7 @@ class UpdatePasswordComponent extends React.Component<IFullProps, State> {
                     <span>
                       {intl.formatMessage(
                         messages.passwordLengthCharacteristicsForPasswordUpdateForm,
-                        { min: 8 }
+                        { min: 12 }
                       )}
                     </span>
                   </div>


### PR DESCRIPTION
Increases the security of a password change, by increasing it to 12 characters.

Farajaland PR: https://github.com/opencrvs/opencrvs-farajaland/pull/867

- [x] update the 12 char length validation
- [x] update the client/login copy
- [x] update the copy in Farajaland as well