### PR TITLE
Add and configure Trivy for security scans

### DIFF
--- a/.github/workflows/build-images-from-branch.yml
+++ b/.github/workflows/build-images-from-branch.yml
@@ -74,7 +74,28 @@ jobs:
 
       - name: Build ${{ matrix.service }}
         run: |
+          export VERSION="${{ needs.base.outputs.version }}"
           echo ${{ matrix.service }}
-          export VERSION=`git log -1 --pretty=format:%h`
           docker-compose build ${{ matrix.service }}
           docker-compose push ${{ matrix.service }}
+
+  security-scans:
+    needs: [base, build]
+    strategy:
+      fail-fast: false
+      matrix:
+        service: ${{ fromJSON(needs.base.outputs.services) }}
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            trivy.yaml
+            .trivyignore.yaml
+          sparse-checkout-cone-mode: false
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'opencrvs/ocrvs-${{ matrix.service }}:${{ needs.base.outputs.version }}'
+          trivy-config: trivy.yaml

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -7,7 +7,7 @@
 #
 # Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
 
-name: Lint and run unit tests
+name: Lint, run unit tests and security scans
 
 on: [pull_request]
 
@@ -110,3 +110,16 @@ jobs:
       - name: Run Unit Test
         if: steps.check-scripts.outputs.skip != 'true' && steps.check-scripts.outputs.skip-test != 'true'
         run: cd ${{ matrix.package }} && yarn test
+
+  security-scans:
+    needs: setup
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Run Trivy vulnerability scanner in fs mode
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          trivy-config: trivy.yaml

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -85,3 +85,24 @@ jobs:
           export VERSION=${{ github.event.inputs.release_version }}
           docker-compose build ${{ matrix.service }}
           docker-compose push ${{ matrix.service }}
+
+  security-scans:
+    needs: [base, build]
+    strategy:
+      fail-fast: false
+      matrix:
+        service: ${{ fromJSON(needs.base.outputs.services) }}
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            trivy.yaml
+            .trivyignore.yaml
+          sparse-checkout-cone-mode: false
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'opencrvs/ocrvs-${{ matrix.service }}:${{ needs.base.outputs.version }}'
+          trivy-config: trivy.yaml

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,43 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# OpenCRVS is also distributed under the terms of the Civil Registration
+# & Healthcare Disclaimer located at http://opencrvs.org/license.
+#
+# Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+misconfigurations:
+  - id: AVD-DS-0002
+    statement: Non-root users in nginx and metabase images to be addressed in follow up PR
+    paths:
+      - 'packages/client/Dockerfile'
+      - 'packages/components/Dockerfile'
+      - 'packages/dashboards/Dockerfile'
+      - 'packages/login/Dockerfile'
+      - 'packages/scheduler/Dockerfile'
+      - '/usr/local/share/.cache'
+vulnerabilities:
+  - id: CVE-2023-46233
+    statement: only applies to SHA-1 usage - should still be patched though
+  - id: CVE-2023-52079
+    statement: msgpackr vulnerable to dos
+  - id: CVE-2024-23331
+    statement: Vites vuln only applicable to server.fs.deny
+  - id: CVE-2020-8231
+    statement: curl vuln scheduler - low prio
+  - id: CVE-2022-42003
+    statement: Dashboards vulns (java libs)
+  - id: CVE-2022-42004
+    statement: Dashboards vulns (java libs)
+  - id: CVE-2022-3509
+    statement: Dashboards vulns (java libs)
+  - id: CVE-2022-3510
+    statement: Dashboards vulns (java libs)
+  - id: CVE-2022-35010
+    statement: Dashboards vulns (java libs)
+  - id: CVE-2023-24998
+    statement: Dashboards vulns (java libs)
+  - id: CVE-2023-32697
+    statement: Dashboards vulns (java libs)
+  - id: CVE-2022-1471
+    statement: Dashboards vulns (java libs)

--- a/packages/auth/Dockerfile
+++ b/packages/auth/Dockerfile
@@ -2,6 +2,8 @@ FROM node:gallium-alpine
 
 WORKDIR /app
 
+RUN apk update && apk upgrade
+
 COPY . .
 
 RUN rm -rf /app/packages/*
@@ -16,5 +18,10 @@ RUN yarn build
 
 WORKDIR /app/packages/auth
 RUN yarn build
+
+# FIXME: to be replaced later with whole build running as node
+RUN chown -R node:node /app
+
+USER node
 
 CMD yarn start:prod

--- a/packages/client/Dockerfile
+++ b/packages/client/Dockerfile
@@ -3,6 +3,8 @@
 FROM node:gallium-alpine
 WORKDIR /app
 
+RUN apk update && apk upgrade
+
 COPY . .
 
 # Remove packages we don't need to speed up yarn install
@@ -14,7 +16,7 @@ COPY packages/components /app/packages/components
 COPY packages/commons /app/packages/commons
 COPY packages/gateway /app/packages/gateway
 
-RUN apk update && apk add make python3 g++
+RUN apk update && apk upgrade && apk add --no-cache make python3 g++
 
 RUN yarn install
 
@@ -32,6 +34,7 @@ RUN yarn build
 
 FROM nginx
 
+RUN apt-get update && apt-get upgrade -y
 
 COPY --from=0 /app/packages/client/build/ /usr/share/nginx/html/
 

--- a/packages/components/Dockerfile
+++ b/packages/components/Dockerfile
@@ -3,6 +3,8 @@
 FROM node:gallium-alpine
 WORKDIR /app
 
+RUN apk update && apk upgrade
+
 COPY . .
 
 # Remove packages we don't need to speed up yarn install
@@ -11,7 +13,7 @@ RUN rm -rf /app/packages/*
 # Copy packages
 COPY packages/components /app/packages/components
 
-RUN apk update && apk add make python3 g++
+RUN apk update && apk upgrade && apk add --no-cache make python3 g++
 RUN yarn install
 
 # Build components
@@ -22,6 +24,8 @@ RUN yarn build-storybook
 # Step 2. Build the actual image
 
 FROM nginx
+
+RUN apt-get update && apt-get upgrade -y
 
 ARG HOST
 ARG COUNTRY_CONFIG_URL

--- a/packages/config/Dockerfile
+++ b/packages/config/Dockerfile
@@ -2,6 +2,8 @@ FROM node:gallium-alpine
 
 WORKDIR /app
 
+RUN apk update && apk upgrade
+
 COPY . .
 
 RUN rm -rf /app/packages/*
@@ -16,5 +18,10 @@ RUN yarn build
 
 WORKDIR /app/packages/config
 RUN yarn build
+
+# FIXME: to be replaced later with whole build running as node
+RUN chown -R node:node /app
+
+USER node
 
 CMD yarn start:prod

--- a/packages/config/src/handlers/forms/validation.ts
+++ b/packages/config/src/handlers/forms/validation.ts
@@ -420,7 +420,7 @@ const form = z.object({
     .refine(
       (sections) =>
         sections.filter(({ id }) =>
-          REQUIRED_SECTIONS.includes(id as typeof REQUIRED_SECTIONS[number])
+          REQUIRED_SECTIONS.includes(id as (typeof REQUIRED_SECTIONS)[number])
         ).length >= 2,
       {
         message: `${REQUIRED_SECTIONS.map((sec) => `"${sec}"`).join(

--- a/packages/dashboards/Dockerfile
+++ b/packages/dashboards/Dockerfile
@@ -11,6 +11,6 @@ ENV MB_DB_FILE=/data/metabase/metabase.mv.db
 ENV OPENCRVS_ENVIRONMENT_CONFIGURATION_SQL_FILE=/environment-configuration.sql
 
 # Install envsubst
-RUN apk update && apk add gettext
+RUN apk update && apk upgrade && apk add --no-cache gettext
 
 ENTRYPOINT ["/bin/sh", "/run.sh"]

--- a/packages/documents/Dockerfile
+++ b/packages/documents/Dockerfile
@@ -2,6 +2,8 @@ FROM node:gallium-alpine
 
 WORKDIR /app
 
+RUN apk update && apk upgrade
+
 COPY . .
 
 RUN rm -rf /app/packages/*
@@ -16,5 +18,10 @@ RUN yarn build
 
 WORKDIR /app/packages/documents
 RUN yarn build
+
+# FIXME: to be replaced later with whole build running as node
+RUN chown -R node:node /app
+
+USER node
 
 CMD yarn start:prod

--- a/packages/gateway/Dockerfile
+++ b/packages/gateway/Dockerfile
@@ -2,6 +2,8 @@ FROM node:gallium-alpine
 
 WORKDIR /app
 
+RUN apk update && apk upgrade
+
 COPY . .
 
 RUN rm -rf /app/packages/*
@@ -16,5 +18,10 @@ RUN yarn build
 
 WORKDIR /app/packages/gateway
 RUN yarn build
+
+# FIXME: to be replaced later with whole build running as node
+RUN chown -R node:node /app
+
+USER node
 
 CMD yarn start:prod

--- a/packages/login/Dockerfile
+++ b/packages/login/Dockerfile
@@ -12,7 +12,7 @@ RUN rm -rf /app/packages/*
 COPY packages/login /app/packages/login
 COPY packages/components /app/packages/components
 
-RUN apk update && apk add make python3 g++
+RUN apk update && apk upgrade && apk add --no-cache make python3 g++
 
 RUN yarn install
 
@@ -31,6 +31,7 @@ RUN yarn build
 
 FROM nginx
 
+RUN apt-get update && apt-get upgrade -y
 
 COPY --from=0 /app/packages/login/build/ /usr/share/nginx/html/
 

--- a/packages/metrics/Dockerfile
+++ b/packages/metrics/Dockerfile
@@ -2,6 +2,8 @@ FROM node:gallium-alpine
 
 WORKDIR /app
 
+RUN apk update && apk upgrade
+
 COPY . .
 
 RUN rm -rf /app/packages/*
@@ -16,5 +18,10 @@ RUN yarn build
 
 WORKDIR /app/packages/metrics
 RUN yarn build
+
+# FIXME: to be replaced later with whole build running as node
+RUN chown -R node:node /app
+
+USER node
 
 CMD yarn start:prod

--- a/packages/migration/Dockerfile
+++ b/packages/migration/Dockerfile
@@ -1,6 +1,8 @@
 FROM node:gallium-alpine
 WORKDIR /app
 
+RUN apk update && apk upgrade
+
 ## Add the wait script to the image
 ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.9.0/wait /app/wait
 RUN chmod +x /app/wait
@@ -18,5 +20,10 @@ RUN yarn install
 RUN yarn build
 
 WORKDIR /app/packages/migration
+
+# FIXME: to be replaced later with whole build running as node
+RUN chown -R node:node /app
+
+USER node
 
 CMD /app/wait && yarn start:prod

--- a/packages/notification/Dockerfile
+++ b/packages/notification/Dockerfile
@@ -2,6 +2,8 @@ FROM node:gallium-alpine
 
 WORKDIR /app
 
+RUN apk update && apk upgrade
+
 COPY . .
 
 RUN rm -rf /app/packages/*
@@ -16,5 +18,10 @@ RUN yarn build
 
 WORKDIR /app/packages/notification
 RUN yarn build
+
+# FIXME: to be replaced later with whole build running as node
+RUN chown -R node:node /app
+
+USER node
 
 CMD yarn start:prod

--- a/packages/scheduler/Dockerfile
+++ b/packages/scheduler/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.9
 
 # Install required packages
-RUN apk add --update --no-cache bash curl coreutils mongodb mongodb-tools
+RUN apk update && apk upgrade && apk add --update --no-cache bash curl coreutils mongodb mongodb-tools
 
 WORKDIR /usr/scheduler
 

--- a/packages/search/Dockerfile
+++ b/packages/search/Dockerfile
@@ -2,6 +2,8 @@ FROM node:gallium-alpine
 
 WORKDIR /app
 
+RUN apk update && apk upgrade
+
 COPY . .
 
 RUN rm -rf /app/packages/*
@@ -16,5 +18,10 @@ RUN yarn build
 
 WORKDIR /app/packages/search
 RUN yarn build
+
+# FIXME: to be replaced later with whole build running as node
+RUN chown -R node:node /app
+
+USER node
 
 CMD yarn start:prod

--- a/packages/user-mgnt/Dockerfile
+++ b/packages/user-mgnt/Dockerfile
@@ -2,6 +2,8 @@ FROM node:gallium-alpine
 
 WORKDIR /app
 
+RUN apk update && apk upgrade
+
 COPY . .
 
 RUN rm -rf /app/packages/*
@@ -16,5 +18,10 @@ RUN yarn build
 
 WORKDIR /app/packages/user-mgnt
 RUN yarn build
+
+# FIXME: to be replaced later with whole build running as node
+RUN chown -R node:node /app
+
+USER node
 
 CMD yarn start:prod

--- a/packages/webhooks/Dockerfile
+++ b/packages/webhooks/Dockerfile
@@ -2,6 +2,8 @@ FROM node:gallium-alpine
 
 WORKDIR /app
 
+RUN apk update && apk upgrade
+
 COPY . .
 
 RUN rm -rf /app/packages/*
@@ -16,5 +18,10 @@ RUN yarn build
 
 WORKDIR /app/packages/webhooks
 RUN yarn build
+
+# FIXME: to be replaced later with whole build running as node
+RUN chown -R node:node /app
+
+USER node
 
 CMD yarn start:prod

--- a/packages/workflow/Dockerfile
+++ b/packages/workflow/Dockerfile
@@ -2,6 +2,8 @@ FROM node:gallium-alpine
 
 WORKDIR /app
 
+RUN apk update && apk upgrade
+
 COPY . .
 
 RUN rm -rf /app/packages/*
@@ -16,5 +18,10 @@ RUN yarn build
 
 WORKDIR /app/packages/workflow
 RUN yarn build
+
+# FIXME: to be replaced later with whole build running as node
+RUN chown -R node:node /app
+
+USER node
 
 CMD yarn start:prod

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -16,7 +16,7 @@ scan:
     - .secrets
     - data
     - development-environment
-    - sequece-diagrams
+    - sequence-diagrams
     - usr/local/share/.cache/yarn/v6/
   scanners:
     - vuln

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,0 +1,27 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# OpenCRVS is also distributed under the terms of the Civil Registration
+# & Healthcare Disclaimer located at http://opencrvs.org/license.
+#
+# Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+exit-code: 1
+severity:
+  - HIGH
+  - CRITICAL
+scan:
+  skip-dirs:
+    - node_modules
+    - .secrets
+    - data
+    - development-environment
+    - sequece-diagrams
+    - usr/local/share/.cache/yarn/v6/
+  scanners:
+    - vuln
+    - misconfig
+    - secret
+ignorefile: .trivyignore.yaml
+vulnerability:
+  ignore-unfixed: true


### PR DESCRIPTION
Add [trivy](https://trivy.dev) to be able to:

- Check packages for known vulnerabilities
- Check for any potential misconfigurations in configs
- Check that licenses are properly matching

Runs both in CI and CD - idea being that CD runs it agains the build images and CI just for the repo.

Theres a `.trivyignore.yaml` for tuning findings. Currently couple HIGH and one CRITICAL but none of them seem too applicable to our use case.

Example from [build pipeline](https://github.com/opencrvs/opencrvs-core/actions/runs/7800090618/job/21272357025)


Also:

- Use `node` user where we can (to make `trivy` happy about it but its also a nice security practice)
- Pull latest OS packages with `apt-get upgrade` or equivalent during builds