### PR TITLE
Unassign fix

### DIFF
--- a/packages/client/src/views/RecordAudit/RecordAudit.tsx
+++ b/packages/client/src/views/RecordAudit/RecordAudit.tsx
@@ -46,7 +46,8 @@ import {
   IDeclaration,
   SUBMISSION_STATUS,
   DOWNLOAD_STATUS,
-  modifyDeclaration
+  modifyDeclaration,
+  writeDeclaration
 } from '@client/declarations'
 import { IStoreState } from '@client/store'
 import { GQLEventSearchSet } from '@opencrvs/gateway/src/graphql/schema'
@@ -245,12 +246,15 @@ function ReinstateButton({
           ? REINSTATE_BIRTH_DECLARATION
           : REINSTATE_DEATH_DECLARATION
       }
-      onCompleted={() => {
+      // update the store and indexDb with the latest status of the declaration
+      onCompleted={(data) => {
         refetchDeclarationInfo?.()
         dispatch(
-          modifyDeclaration({
+          writeDeclaration({
             ...declaration,
-            submissionStatus: ''
+            submissionStatus: '',
+            registrationStatus: data.markEventAsReinstated
+              ?.registrationStatus as string
           })
         )
       }}

--- a/packages/client/src/workqueue/reducer.ts
+++ b/packages/client/src/workqueue/reducer.ts
@@ -167,7 +167,7 @@ async function getFilteredDeclarations(
       (dec) =>
         dec &&
         hasStatusChanged(dec, savedDeclarations) &&
-        isNotSubmitting(dec, savedDeclarations)
+        isNotSubmittingOrDownloading(dec, savedDeclarations)
     )
     .map((dec) => savedDeclarations.find((d) => d.id === dec?.id))
     .filter((maybeDeclaration): maybeDeclaration is IDeclaration =>
@@ -235,13 +235,16 @@ async function getWorkqueueOfCurrentUser(): Promise<string> {
   return JSON.stringify(currentUserWorkqueue)
 }
 
-function isNotSubmitting(
+function isNotSubmittingOrDownloading(
   workqueueDeclaration: GQLEventSearchSet,
   savedDeclarations: IDeclaration[]
 ) {
   const declarationInStore = savedDeclarations.find(
     (dec) => dec.id === workqueueDeclaration.id
   )!
+  if (declarationInStore?.downloadStatus === DOWNLOAD_STATUS.DOWNLOADING)
+    return false
+
   if (declarationInStore?.submissionStatus)
     return !Boolean(
       [


### PR DESCRIPTION
1. When we first download multiple declarations, we enqueue the declarations for being downloaded and create `declaration.data = {}` in the state. Then when the `UPDATE_REGISTRAR_WORKQUEUE_SUCCESS` is dispatched, we were checking `hasStatusChanged` & `isNotSubmitting`. And since the `declaration.data` is empty the `hasStatusChanged` function compares `undefined !== workqueueDeclarationStatus`. Thus it finds that the status of the declaration has changed. So here, now we check `isNotSubmittingOrDownloading`.

2. When we reinstate a declaration it is not removed from the declarationState. Thus it stays assigned after the reinstating action is complete. And since we compare the workqueue data's status with the status of the declaration in store, we get a scenario like, `ARCHIVED !== DECLARED`(Current status, the status in the store was not used to change). And for that, after reinstating, if one were to click any workqueue tabs, they would find a toast about them being unassigned from the reinstated declaration. So, now we update the declaration in the store with the previous registration status, that we get from the query and use write declaration. (Since modify declaration does not update the indexDb) And now it shouldn't find the status has changed and also the declaration stays assigned like it used to be. 