### PR TITLE
[State Transitions] Fix task creation taking previous status and encounter into account

### DIFF
--- a/packages/workflow/src/records/fhir.ts
+++ b/packages/workflow/src/records/fhir.ts
@@ -1163,8 +1163,9 @@ function createNewTaskResource(
 ): SavedTask {
   return {
     resourceType: 'Task',
-    status: 'accepted',
+    status: previousTask.status ?? 'accepted',
     intent: 'proposal',
+    ...(previousTask.encounter && { encounter: previousTask.encounter }),
     code: previousTask.code,
     focus: previousTask.focus,
     id: previousTask.id,


### PR DESCRIPTION
We use `status` and `encounter` of task for the correction flow. So for new task creation, we keep the previous ones.