### PR TITLE
fix(security): ignore metabase vulnerability errors until v0.49

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -41,3 +41,11 @@ vulnerabilities:
     statement: Dashboards vulns (java libs)
   - id: CVE-2022-1471
     statement: Dashboards vulns (java libs)
+  - id: CVE-2024-25710
+    statement: Metabase v0.46 vulnerability (remove when v0.49 is released)
+  - id: CVE-2024-26308
+    statement: Metabase v0.46 vulnerability (remove when v0.49 is released)
+  - id: CVE-2024-22201
+    statement: Metabase v0.46 vulnerability (remove when v0.49 is released)
+  - id: CVE-2023-36478
+    statement: Metabase v0.46 vulnerability (remove when v0.49 is released)


### PR DESCRIPTION
Ignores the Metabase vulnerability errors until we upgrade to v0.49 where they will be fixed. 

https://github.com/opencrvs/opencrvs-core/actions/runs/8265986110/job/22613148216
Trivy has passed here