### PR TITLE
comp: Adds full width options to Button

### DIFF
--- a/packages/components/src/Button/Button.styles.ts
+++ b/packages/components/src/Button/Button.styles.ts
@@ -11,7 +11,7 @@
 
 import { css } from 'styled-components'
 
-export const base = css`
+export const base = ({ fullWidth }: { fullWidth?: boolean }) => css`
   ${({ theme }) => theme.fonts.bold16};
   display: inline-flex;
   justify-content: center;
@@ -27,6 +27,11 @@ export const base = css`
   opacity: 1;
   margin: 0;
   background: transparent;
+
+  ${fullWidth &&
+  css`
+    width: 100%;
+  `}
 
   svg {
     height: 24px;
@@ -205,7 +210,7 @@ export const medium = css`
 
 export const large = css`
   ${({ theme }) => theme.fonts.bold18};
-  height: 48px;
+  height: 54px;
   padding: 0 16px;
 
   svg {

--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -30,6 +30,8 @@ type ButtonModifier = 'disabled' | 'loading'
 interface ButtonCustomization extends React.HTMLAttributes<HTMLButtonElement> {
   /** Size of the button */
   size?: ButtonSize
+  /** Size of the button */
+  fullWidth?: boolean
   /** Element the button renders as */
   element?: 'a' | 'button'
   /** Button type */
@@ -72,6 +74,7 @@ const StyledButton = styled.button.withConfig({
 
 export const Button = ({
   size = 'medium',
+  fullWidth,
   element = 'button',
   type,
   loading,
@@ -81,6 +84,7 @@ export const Button = ({
   return (
     <StyledButton
       size={size}
+      fullWidth={fullWidth}
       variant={type}
       loading={loading}
       as={element}


### PR DESCRIPTION
Testing cherry-picking commits from form-elements branch. 

This PR adds a fullWidth prop to Button. So we can do things like so in the futue:

<img width="564" alt="image" src="https://github.com/opencrvs/opencrvs-core/assets/46478402/dfa13023-d43e-4555-9040-3c0319021275">

