### PR TITLE
[HOTFIX] Implementation changes due schema changes

### DIFF
--- a/packages/notification/src/features/email/service..ts
+++ b/packages/notification/src/features/email/service..ts
@@ -93,7 +93,8 @@ async function findOldestNotificationQueueRecord() {
 async function dispatch(record: NotificationQueueRecord) {
   return notifyCountryConfig(
     {
-      email: 'allUserNotification'
+      email: 'allUserNotification',
+      sms: 'allUserNotification'
     },
     { email: record.bcc[0], bcc: record.bcc.slice(1) },
     'user',


### PR DESCRIPTION
Due to recent notification schema changes in Farajaland as part of mass email PR, the existing calls to the notification endpoint were responding 400. So, in the farajaland PR https://github.com/opencrvs/opencrvs-farajaland/pull/976 the schema is reverted back to the previous one and this core change is applied to comply with the reverted schema.