### PR TITLE
Upgrade all actions to Ubuntu 22.04 and lock the version

### DIFF
--- a/.github/workflows/build-images-from-branch.yml
+++ b/.github/workflows/build-images-from-branch.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   base:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         if: github.event_name == 'workflow_dispatch'
@@ -56,7 +56,7 @@ jobs:
     strategy:
       matrix:
         service: ${{ fromJSON(needs.base.outputs.services) }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         if: github.event_name == 'workflow_dispatch'
@@ -85,7 +85,7 @@ jobs:
       fail-fast: false
       matrix:
         service: ${{ fromJSON(needs.base.outputs.services) }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/cd-manual-e2e.yml
+++ b/.github/workflows/cd-manual-e2e.yml
@@ -32,7 +32,7 @@ on:
 jobs:
   manual-deploy-staging-e2e:
     environment: staging
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 120
     steps:
       - name: Checking out git repo

--- a/.github/workflows/create-backup-data-action.yml
+++ b/.github/workflows/create-backup-data-action.yml
@@ -35,7 +35,7 @@ on:
 jobs:
   backup:
     environment: production
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       BACKUP_HOST: farajaland-${{ github.event.inputs.backup_environment }}.opencrvs.org
       SRC_HOST: farajaland.opencrvs.org

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -13,7 +13,7 @@ on: [pull_request]
 
 jobs:
   setup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
 
@@ -30,7 +30,7 @@ jobs:
 
   test:
     needs: setup
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -114,7 +114,7 @@ jobs:
 
   security-scans:
     needs: setup
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   base:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: trstringer/manual-approval@v1
         with:
@@ -63,7 +63,7 @@ jobs:
     strategy:
       matrix:
         service: ${{ fromJSON(needs.base.outputs.services) }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         if: github.event_name == 'workflow_dispatch'
@@ -92,7 +92,7 @@ jobs:
       fail-fast: false
       matrix:
         service: ${{ fromJSON(needs.base.outputs.services) }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/reset-env-action.yml
+++ b/.github/workflows/reset-env-action.yml
@@ -25,7 +25,7 @@ on:
 jobs:
   clear:
     environment: ${{ github.event.inputs.environment }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       ENV: ${{ github.event.inputs.environment }}
       REPLICAS: ${{ github.event.inputs.replicas }}

--- a/.github/workflows/trigger-e2e.yml
+++ b/.github/workflows/trigger-e2e.yml
@@ -1,3 +1,11 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# OpenCRVS is also distributed under the terms of the Civil Registration
+# & Healthcare Disclaimer located at http://opencrvs.org/license.
+#
+# Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
 name: Trigger E2E
 
 on:
@@ -7,7 +15,7 @@ on:
   workflow_dispatch:
 jobs:
   e2e:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/github-script@v6
         with:


### PR DESCRIPTION
First step of https://github.com/opencrvs/opencrvs-core/issues/6519

- Upgrade all versions of containers to latest LTS (22.04)
- Lock the version to ^^ so we dont float and all runs are predictable

No breakage expected, especially since many places already got on 22.04 due to latest
