### PR TITLE
fix: remove trailing slash from FHIR_URL

### DIFF
--- a/packages/config/src/config/constants.ts
+++ b/packages/config/src/config/constants.ts
@@ -34,7 +34,7 @@ export const CERT_PUBLIC_KEY_PATH =
   '../../.secrets/public-key.pem'
 export const PRODUCTION = process.env.NODE_ENV === 'production'
 export const QA_ENV = process.env.QA_ENV || false
-export const FHIR_URL = process.env.FHIR_URL || 'http://localhost:3447/fhir/'
+export const FHIR_URL = process.env.FHIR_URL || 'http://localhost:3447/fhir'
 
 // Check if the token has been invalided in the auth service before it has expired
 // This needs to be a string to make it easy to pass as an ENV var.

--- a/packages/config/src/handlers/locations/hierarchy.ts
+++ b/packages/config/src/handlers/locations/hierarchy.ts
@@ -13,8 +13,7 @@ import { ServerRoute } from '@hapi/hapi'
 import { FHIR_URL } from '@config/config/constants'
 
 async function fetchLocation(locationId: string) {
-  const url = new URL(`Location/${locationId}`, FHIR_URL)
-  const res = await fetch(url, {
+  const res = await fetch(`${FHIR_URL}/Location/${locationId}`, {
     headers: {
       'Content-Type': 'application/fhir+json'
     }


### PR DESCRIPTION
The base in URL doesn't support pathname so had to resolve the URL manually.