### PR TITLE
chore: ignore metabase vulnerability

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -40,10 +40,12 @@ vulnerabilities:
   - id: CVE-2022-1471
     statement: Dashboards vulns (java libs)
   - id: CVE-2024-25710
-    statement: Metabase v0.46 vulnerability (remove when v0.49 is released)
+    statement: Metabase v0.46 vulnerability, fixed in Metabase v0.49
   - id: CVE-2024-26308
-    statement: Metabase v0.46 vulnerability (remove when v0.49 is released)
+    statement: Metabase v0.46 vulnerability, fixed in Metabase v0.49
   - id: CVE-2024-22201
-    statement: Metabase v0.46 vulnerability (remove when v0.49 is released)
+    statement: Metabase v0.46 vulnerability, fixed in Metabase v0.49
   - id: CVE-2023-36478
-    statement: Metabase v0.46 vulnerability (remove when v0.49 is released)
+    statement: Metabase v0.46 vulnerability, fixed in Metabase v0.49
+  - id: CVE-2024-21634
+    statement: Metabase v0.46 vulnerability, fixed in Metabase v0.49


### PR DESCRIPTION
tested running trivy for v0.49 and the error isn't there anymore