### PR TITLE
Fix Check for valid date to handle incomplete marriage declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 - In review page, Eliminating the 'No supporting documents' and 'upload' prompts when documents are already uploaded [#6231] (https://github.com/opencrvs/opencrvs-core/issues/6231)
 - Fix Registrar of any location should be able to review a correction request [#6247](https://github.com/opencrvs/opencrvs-core/issues/6247)
 - Fix issues of invisible inputs when navigating from can't login link in login page [#6163](https://github.com/opencrvs/opencrvs-core/issues/6163)
+- Fix Check for valid date to handle incomplete marriage declarations [#7017](https://github.com/opencrvs/opencrvs-core/issues/7017)
 
 ## Refactor
 

--- a/packages/client/src/forms/register/mappings/event-specific-fields/marriage/query/event-mappings.ts
+++ b/packages/client/src/forms/register/mappings/event-specific-fields/marriage/query/event-mappings.ts
@@ -9,7 +9,10 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 import { IFormField, IFormData } from '@client/forms'
-import { formatPlainDate } from '@client/utils/date-formatting'
+import {
+  formatPlainDate,
+  isValidPlainDate
+} from '@client/utils/date-formatting'
 
 export const marriageDateToFieldTransformation =
   (alternativeSectionIds?: string[]) =>
@@ -67,8 +70,7 @@ export const marriageDateFormatTransformation =
       queryValue = queryData[fromSectionIds].dateOfMarriage
     }
 
-    const date = new Date(queryValue)
-    if (!Number.isNaN(date.getTime())) {
+    if (isValidPlainDate(queryValue)) {
       const prevLocale = window.__localeId__
       window.__localeId__ = locale
 


### PR DESCRIPTION
Updated logic to use `isValidPlainDate` function to check date values, ensuring that null or invalid date values do not cause issues. This change allows the retrieval of incomplete marriage declarations even when the date of marriage is missing.