### PR TITLE
Fix: Reset pagination to page 1 when location changes

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -40,10 +40,12 @@ vulnerabilities:
   - id: CVE-2022-1471
     statement: Dashboards vulns (java libs)
   - id: CVE-2024-25710
-    statement: Metabase v0.46 vulnerability (remove when v0.49 is released)
+    statement: Metabase v0.46 vulnerability, fixed in Metabase v0.49
   - id: CVE-2024-26308
-    statement: Metabase v0.46 vulnerability (remove when v0.49 is released)
+    statement: Metabase v0.46 vulnerability, fixed in Metabase v0.49
   - id: CVE-2024-22201
-    statement: Metabase v0.46 vulnerability (remove when v0.49 is released)
+    statement: Metabase v0.46 vulnerability, fixed in Metabase v0.49
   - id: CVE-2023-36478
-    statement: Metabase v0.46 vulnerability (remove when v0.49 is released)
+    statement: Metabase v0.46 vulnerability, fixed in Metabase v0.49
+  - id: CVE-2024-21634
+    statement: Metabase v0.46 vulnerability, fixed in Metabase v0.49

--- a/packages/client/src/views/RegisterForm/RegisterForm.tsx
+++ b/packages/client/src/views/RegisterForm/RegisterForm.tsx
@@ -1103,6 +1103,7 @@ class RegisterFormView extends React.Component<FullProps, State> {
                             intl.formatMessage(activeSection.title))
                         }
                         showTitleOnMobile={true}
+                        bottomActionDirection="column"
                         bottomActionButtons={
                           [
                             nextSectionGroup && (

--- a/packages/client/src/views/SysAdmin/Team/user/UserList.tsx
+++ b/packages/client/src/views/SysAdmin/Team/user/UserList.tsx
@@ -84,6 +84,8 @@ import { getLocalizedLocationName } from '@client/utils/locationUtils'
 import { HOME } from '@client/navigation/routes'
 
 const DEFAULT_FIELD_AGENT_LIST_SIZE = 10
+const DEFAULT_PAGE_NUMBER = 1
+
 const { useState } = React
 
 const UserTable = styled(BodyContent)`
@@ -269,7 +271,8 @@ function UserListComponent(props: IProps) {
     selectedUser: null
   })
 
-  const [currentPageNumber, setCurrentPageNumber] = useState<number>(1)
+  const [currentPageNumber, setCurrentPageNumber] =
+    useState<number>(DEFAULT_PAGE_NUMBER)
   const recordCount = DEFAULT_FIELD_AGENT_LIST_SIZE * currentPageNumber
   const searchedLocation: ILocation | undefined = offlineOffices.find(
     ({ id }) => locationId === id
@@ -633,6 +636,7 @@ function UserListComponent(props: IProps) {
           selectedLocationId={locationId}
           onChangeLocation={(locationId) => {
             props.goToTeamUserList(locationId)
+            setCurrentPageNumber(DEFAULT_PAGE_NUMBER)
           }}
           requiredLocationTypes={'CRVS_OFFICE'}
         />


### PR DESCRIPTION
Ensure the currentPageNumber is reset to 1 whenever the location parameter changes to avoid issues where no data is found and the table and pagination components disappear.