### PR TITLE
fix: only run prettier for staged graphql files

### DIFF
--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -106,7 +106,10 @@
     "typescript": "4.9.5"
   },
   "lint-staged": {
-    "src/**/*.{ts,graphql}": [
+    "src/**/*.{graphql}": [
+      "prettier --write"
+    ],
+    "src/**/*.{ts}": [
       "prettier --write",
       "eslint -c .eslintrc.js --fix"
     ]


### PR DESCRIPTION
eslint ignores the "files" path provided in the config if it's run on an individual file. Therefore, when lint-staged pipes the grapql files to the eslint command it returns an error.