### PR TITLE
fix: mongo aggregate query hitting the memory limit

### DIFF
--- a/packages/search/src/features/records/service.ts
+++ b/packages/search/src/features/records/service.ts
@@ -379,13 +379,26 @@ function joinFromResourcesIdToResourceIdentifier(
         }
       }
     },
+    /*
+     * If resourceIds is empty, $lookup considers it being a subset of everything and joins the entire `from` collection.
+     * To workaround, set the array to be not-empty to not join anything.
+     */
+    {
+      $addFields: {
+        resourceIds: {
+          $cond: {
+            if: { $eq: ['$resourceIds', []] },
+            then: ['_EMPTY_'],
+            else: '$resourceIds'
+          }
+        }
+      }
+    },
     {
       $lookup: {
         from: collectionToJoin,
-        let: { resourceIds: '$resourceIds' },
-        pipeline: [
-          { $match: { $expr: { $in: [`$${foreignField}`, '$$resourceIds'] } } }
-        ],
+        localField: `resourceIds`,
+        foreignField,
         as: 'joinResult'
       }
     },

--- a/packages/search/src/features/records/service.ts
+++ b/packages/search/src/features/records/service.ts
@@ -382,8 +382,10 @@ function joinFromResourcesIdToResourceIdentifier(
     {
       $lookup: {
         from: collectionToJoin,
-        localField: `resourceIds`,
-        foreignField,
+        let: { resourceIds: '$resourceIds' },
+        pipeline: [
+          { $match: { $expr: { $in: [`$${foreignField}`, '$$resourceIds'] } } }
+        ],
         as: 'joinResult'
       }
     },


### PR DESCRIPTION
## Problem

The MongoDB aggregate query's maximum size is 16 MB. The aggregate within it grows too large as the $lookup joins the full DocumentReference -collection to it. This happens if `resourceIds` is empty, as $lookup considers it to be a subset of everything and joins everything to it.

![image](https://github.com/opencrvs/opencrvs-core/assets/1322608/3ee3ca17-a2a9-4283-9b58-4f7f18ad2ed3)

## Solution

Don't allow `resourceIds` to be empty, add a placeholder value if it is.