### PR TITLE
fix: memoization causing cache invalidation issues with locations

### DIFF
--- a/packages/config/src/services/hearth.ts
+++ b/packages/config/src/services/hearth.ts
@@ -10,10 +10,9 @@
  */
 import { Location, SavedBundle } from '@opencrvs/commons/types'
 import { FHIR_URL } from '@config/config/constants'
-import { memoize } from 'lodash'
 import { joinURL } from '@opencrvs/commons'
 
-export const fetchLocations = memoize(async () => {
+export const fetchLocations = async () => {
   const allLocationsUrl = joinURL(FHIR_URL, `Location?_count=0&status=active`)
   const response = await fetch(allLocationsUrl)
 
@@ -23,7 +22,7 @@ export const fetchLocations = memoize(async () => {
 
   const bundle = (await response.json()) as SavedBundle<Location>
   return bundle.entry.map(({ resource }) => resource)
-})
+}
 
 export const fetchFromHearth = async <T = any>(
   suffix: string,


### PR DESCRIPTION
## Problem

If locations were updated or the database was cleared, the services might memoize locations incorrectly.

## Solution

Remove the memoize from fetchLocations. It's a pre-mature optimization, as we haven't faced performance issues before adding this.