### PR TITLE
chore: ignore braces vulnerability issue

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -49,3 +49,5 @@ vulnerabilities:
     statement: Metabase v0.46 vulnerability, fixed in Metabase v0.49
   - id: CVE-2024-21634
     statement: Metabase v0.46 vulnerability, fixed in Metabase v0.49
+  - id: CVE-2024-4068
+    statement: Transitive dependency of lint-staged, jest and msw. Not running in production. Likely fixed by upgrading.


### PR DESCRIPTION
Why do we have it?
```
info Has been hoisted to "braces"
info Reasons this module exists
   - "workspace-aggregator-1bc5bc23-ff24-435a-bd4c-0e2022fe4ae6" depends on it
   - Hoisted from "_project_#micromatch#braces"
   - Hoisted from "_project_#@opencrvs#login#msw#chokidar#braces"
info Disk size without dependencies: "80KB"
info Disk size with unique dependencies: "104KB"
info Disk size with transitive dependencies: "244KB"
info Number of shared dependencies: 4
=> Found "lint-staged#braces@2.3.2"
info Reasons this module exists
   - "_project_#lint-staged#micromatch" depends on it
   - Hoisted from "_project_#lint-staged#micromatch#braces"
info Disk size without dependencies: "120KB"
info Disk size with unique dependencies: "1.47MB"
info Disk size with transitive dependencies: "3.98MB"
info Number of shared dependencies: 28
=> Found "sane#braces@2.3.2"
info Reasons this module exists
   - "_project_#jest-haste-map#sane#micromatch" depends on it
   - Hoisted from "_project_#jest-haste-map#sane#micromatch#braces"
info Disk size without dependencies: "120KB"
info Disk size with unique dependencies: "1.47MB"
info Disk size with transitive dependencies: "3.98MB"
info Number of shared dependencies: 28
Done in 1.66s.
```

chokidar and micromatch are transitive dependencies of jest, lint-staged and msw. Even if we used it in production, [it seems to be a non-issue](https://github.com/paulmillr/chokidar/issues/1314#issuecomment-2118003506). Braces will get updated when we upgrade our development dependencies.