### PR TITLE
chore: deprecate admin UI menu items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@
 
   We are dropping support for 'agentDefault' to be used as initial value for SELECT_WITH_DYNAMIC_OPTIONS type of fields. The country config package now must return the form with prepopulated initial values to show default addresses. [#6871](https://github.com/opencrvs/opencrvs-core/issues/6871)
 
-- #### Remove system admin UI items: Application, Certificates, User roles, Communications / Informant notifications
+- #### Remove system admin UI items: Application, Certificates, User roles, Informant notifications
 
   We have now moved to configuring these items directly from country configuration repository.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@
 
   We are dropping support for 'agentDefault' to be used as initial value for SELECT_WITH_DYNAMIC_OPTIONS type of fields. The country config package now must return the form with prepopulated initial values to show default addresses. [#6871](https://github.com/opencrvs/opencrvs-core/issues/6871)
 
+- #### Remove system admin UI items: Application, Certificates, User roles, Communications / Informant notifications
+
+  We have now moved to configuring these items directly from country configuration repository.
+
 ## New features
 
 - Add loading spinners before JavaScript bundle has loaded for both login and client

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -47,8 +47,6 @@ import { AppStore } from './store'
 import { CorrectionForm, CorrectionReviewForm } from './views/CorrectionForm'
 import { VerifyCorrector } from './views/CorrectionForm/VerifyCorrector'
 import { RecordAudit } from './views/RecordAudit/RecordAudit'
-import { ApplicationConfig } from './views/SysAdmin/Config/Application'
-import { CertificatesConfig } from './views/SysAdmin/Config/Certificates'
 import { UserList } from './views/SysAdmin/Team/user/UserList'
 import { SystemList } from './views/SysAdmin/Config/Systems/Systems'
 import VSExport from './views/SysAdmin/Vsexports/VSExport'
@@ -62,11 +60,9 @@ import { Leaderboards } from '@client/views/Performance/Leaderboards'
 import { PerformanceDashboard } from '@client/views/Performance/Dashboard'
 import { SystemRoleType } from '@client/utils/gateway'
 import { AdministrativeLevels } from '@client/views/Organisation/AdministrativeLevels'
-import InformantNotification from '@client/views/SysAdmin/Communications/InformantSMSNotification/InformantSMSNotification'
 import { VerifyCertificatePage } from '@client/views/VerifyCertificate/VerifyCertificatePage'
 import { IssueCertificate } from '@client/views/IssueCertificate/IssueCertificate'
 import { IssuePayment } from '@client/views/IssueCertificate/IssueCollectorForm/IssuePayment'
-import UserRoles from '@client/views/SysAdmin/Config/UserRoles/UserRoles'
 import { OIDPVerificationCallback } from './views/OIDPVerificationCallback/OIDPVerificationCallback'
 import { ApolloProvider } from '@client/utils/ApolloProvider'
 import { Home } from '@client/views/OfficeHome/Home'
@@ -262,24 +258,6 @@ export function App(props: IAppProps) {
                                               roles={[
                                                 SystemRoleType.NationalSystemAdmin
                                               ]}
-                                              path={routes.CERTIFICATE_CONFIG}
-                                              component={CertificatesConfig}
-                                            />
-                                            <ProtectedRoute
-                                              exact
-                                              roles={[
-                                                SystemRoleType.NationalSystemAdmin
-                                              ]}
-                                              path={
-                                                routes.INFORMANT_NOTIFICATION
-                                              }
-                                              component={InformantNotification}
-                                            />
-                                            <ProtectedRoute
-                                              exact
-                                              roles={[
-                                                SystemRoleType.NationalSystemAdmin
-                                              ]}
                                               path={routes.ALL_USER_EMAIL}
                                               component={AllUserEmail}
                                             />
@@ -304,22 +282,6 @@ export function App(props: IAppProps) {
                                                 routes.ADVANCED_SEARCH_RESULT
                                               }
                                               component={AdvancedSearchResult}
-                                            />
-                                            <ProtectedRoute
-                                              exact
-                                              roles={[
-                                                SystemRoleType.NationalSystemAdmin
-                                              ]}
-                                              path={routes.APPLICATION_CONFIG}
-                                              component={ApplicationConfig}
-                                            />
-                                            <ProtectedRoute
-                                              exact
-                                              roles={[
-                                                SystemRoleType.NationalSystemAdmin
-                                              ]}
-                                              path={routes.USER_ROLES_CONFIG}
-                                              component={UserRoles}
                                             />
                                             <ProtectedRoute
                                               path={

--- a/packages/client/src/components/interface/Navigation.test.tsx
+++ b/packages/client/src/components/interface/Navigation.test.tsx
@@ -109,8 +109,6 @@ describe('Navigation for national system admin related tests', () => {
     expect(testComponent.exists('#navigation_config_main')).toBeTruthy()
     testComponent.find('#navigation_config_main').hostNodes().simulate('click')
     testComponent.update()
-    expect(testComponent.exists('#navigation_application')).toBeTruthy()
-    expect(testComponent.exists('#navigation_certificate')).toBeTruthy()
   })
 
   it('No application related tabs', async () => {

--- a/packages/client/src/components/interface/Navigation.tsx
+++ b/packages/client/src/components/interface/Navigation.tsx
@@ -19,11 +19,8 @@ import { navigationMessages } from '@client/i18n/messages/views/navigation'
 import {
   goToAdvancedSearchResult,
   goToAllUserEmail,
-  goToApplicationConfig,
-  goToCertificateConfig,
   goToDashboardView,
   goToHomeTab,
-  goToInformantNotification,
   goToLeaderBoardsView,
   goToOrganisationView,
   goToPerformanceStatistics,
@@ -31,7 +28,6 @@ import {
   goToSettings,
   goToSystemList,
   goToTeamView,
-  goToUserRolesConfig,
   goToVSExport
 } from '@client/navigation'
 import { ADVANCED_SEARCH_RESULT } from '@client/navigation/routes'
@@ -223,10 +219,7 @@ interface IProps {
 
 interface IDispatchProps {
   goToHomeTab: typeof goToHomeTab
-  goToCertificateConfigAction: typeof goToCertificateConfig
   goToVSExportsAction: typeof goToVSExport
-  goToUserRolesConfigAction: typeof goToUserRolesConfig
-  goToApplicationConfigAction: typeof goToApplicationConfig
   goToAdvancedSearchResultAction: typeof goToAdvancedSearchResult
   redirectToAuthentication: typeof redirectToAuthentication
   goToPerformanceViewAction: typeof goToPerformanceView
@@ -239,7 +232,6 @@ interface IDispatchProps {
   goToPerformanceStatistics: typeof goToPerformanceStatistics
   updateRegistrarWorkqueue: typeof updateRegistrarWorkqueue
   setAdvancedSearchParam: typeof setAdvancedSearchParam
-  goToInformantNotification: typeof goToInformantNotification
   goToAllUserEmail: typeof goToAllUserEmail
 }
 
@@ -303,11 +295,8 @@ const NavigationView = (props: IFullProps) => {
     enableMenuSelection = true,
     loadWorkqueueStatuses = true,
     activeMenuItem,
-    goToCertificateConfigAction,
-    goToUserRolesConfigAction,
     goToVSExportsAction,
     goToSystemViewAction,
-    goToApplicationConfigAction,
     goToAdvancedSearchResultAction,
     navigationWidth,
     workqueue,
@@ -321,7 +310,6 @@ const NavigationView = (props: IFullProps) => {
     goToPerformanceStatistics,
     goToDashboardView,
     goToLeaderBoardsView,
-    goToInformantNotification,
     goToAllUserEmail,
     className
   } = props
@@ -721,54 +709,17 @@ const NavigationView = (props: IFullProps) => {
                       />
                       {(isConfigExpanded ||
                         configTab.includes(activeMenuItem)) && (
-                        <>
-                          <NavigationSubItem
-                            label={intl.formatMessage(
-                              navigationMessages[WORKQUEUE_TABS.application]
-                            )}
-                            id={`navigation_${WORKQUEUE_TABS.application}`}
-                            onClick={goToApplicationConfigAction}
-                            isSelected={
-                              enableMenuSelection &&
-                              activeMenuItem === WORKQUEUE_TABS.application
-                            }
-                          />
-                          <NavigationSubItem
-                            label={intl.formatMessage(
-                              navigationMessages[WORKQUEUE_TABS.certificate]
-                            )}
-                            id={`navigation_${WORKQUEUE_TABS.certificate}`}
-                            onClick={goToCertificateConfigAction}
-                            isSelected={
-                              enableMenuSelection &&
-                              activeMenuItem === WORKQUEUE_TABS.certificate
-                            }
-                          />
-
-                          <NavigationSubItem
-                            id={`navigation_${WORKQUEUE_TABS.systems}`}
-                            label={intl.formatMessage(
-                              navigationMessages[WORKQUEUE_TABS.systems]
-                            )}
-                            onClick={goToSystemViewAction}
-                            isSelected={
-                              enableMenuSelection &&
-                              activeMenuItem === WORKQUEUE_TABS.systems
-                            }
-                          />
-
-                          <NavigationSubItem
-                            id={`navigation_${WORKQUEUE_TABS.userRoles}`}
-                            label={intl.formatMessage(
-                              navigationMessages[WORKQUEUE_TABS.userRoles]
-                            )}
-                            onClick={goToUserRolesConfigAction}
-                            isSelected={
-                              enableMenuSelection &&
-                              activeMenuItem === WORKQUEUE_TABS.userRoles
-                            }
-                          />
-                        </>
+                        <NavigationSubItem
+                          id={`navigation_${WORKQUEUE_TABS.systems}`}
+                          label={intl.formatMessage(
+                            navigationMessages[WORKQUEUE_TABS.systems]
+                          )}
+                          onClick={goToSystemViewAction}
+                          isSelected={
+                            enableMenuSelection &&
+                            activeMenuItem === WORKQUEUE_TABS.systems
+                          }
+                        />
                       )}
                     </>
                   )}
@@ -802,33 +753,17 @@ const NavigationView = (props: IFullProps) => {
                       />
                       {(isCommunationExpanded ||
                         conmmunicationTab.includes(activeMenuItem)) && (
-                        <>
-                          <NavigationSubItem
-                            label={intl.formatMessage(
-                              navigationMessages[
-                                WORKQUEUE_TABS.informantNotification
-                              ]
-                            )}
-                            id={`navigation_${WORKQUEUE_TABS.informantNotification}`}
-                            onClick={goToInformantNotification}
-                            isSelected={
-                              enableMenuSelection &&
-                              activeMenuItem ===
-                                WORKQUEUE_TABS.informantNotification
-                            }
-                          />
-                          <NavigationSubItem
-                            label={intl.formatMessage(
-                              navigationMessages[WORKQUEUE_TABS.emailAllUsers]
-                            )}
-                            id={`navigation_${WORKQUEUE_TABS.emailAllUsers}`}
-                            onClick={goToAllUserEmail}
-                            isSelected={
-                              enableMenuSelection &&
-                              activeMenuItem === WORKQUEUE_TABS.emailAllUsers
-                            }
-                          />
-                        </>
+                        <NavigationSubItem
+                          label={intl.formatMessage(
+                            navigationMessages[WORKQUEUE_TABS.emailAllUsers]
+                          )}
+                          id={`navigation_${WORKQUEUE_TABS.emailAllUsers}`}
+                          onClick={goToAllUserEmail}
+                          isSelected={
+                            enableMenuSelection &&
+                            activeMenuItem === WORKQUEUE_TABS.emailAllUsers
+                          }
+                        />
                       )}
                     </>
                   )}
@@ -1027,9 +962,6 @@ export const Navigation = connect<
   IStoreState
 >(mapStateToProps, {
   goToHomeTab,
-  goToCertificateConfigAction: goToCertificateConfig,
-  goToUserRolesConfigAction: goToUserRolesConfig,
-  goToApplicationConfigAction: goToApplicationConfig,
   goToAdvancedSearchResultAction: goToAdvancedSearchResult,
   goToVSExportsAction: goToVSExport,
   goToPerformanceViewAction: goToPerformanceView,
@@ -1043,7 +975,6 @@ export const Navigation = connect<
   goToPerformanceStatistics,
   goToLeaderBoardsView,
   goToDashboardView,
-  goToInformantNotification,
   goToAllUserEmail
 })(injectIntl(withRouter(NavigationView)))
 


### PR DESCRIPTION
https://github.com/opencrvs/opencrvs-core/issues/6975

Deprecated items in Admin UI that can now be configured directly from the country configuration. This helps us maintain the configuration options. Due to our experience in country installations, we've noticed that the functional configuration needs technical knowledge, which is required anyway when configuring forms in country configuration. 

Note that this pull request doesn't remove the stale code left behind of these views. Some parts of the application like advanced search depend on some of the admin UI code, so it's being done in a separate PR https://github.com/opencrvs/opencrvs-core/issues/7156