### PR TITLE
chore: force Renovate to use Semantic Commits

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "extends": [
     "config:recommended",
     "monorepo:lerna",
-    ":semanticCommitsDisabled"
+    ":semanticCommits"
   ],
   "lockFileMaintenance": {
     "enabled": true

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    "monorepo:lerna"
+    "monorepo:lerna",
+    ":semanticCommitsDisabled"
   ],
   "lockFileMaintenance": {
     "enabled": true


### PR DESCRIPTION
## Changes:

- Add `":semanticCommits"` preset to Renovate's `extends` array [^1]

## Context:

We want Renovate to _always_ use Semantic Commits style:

- https://github.com/renovatebot/renovate/discussions/29676

### What to do if you later _don't_ want Semantic Commits

If in the future, you want Renovate to automatically detect Semantic Commits, you can change the line to `:semanticCommitsDisabled`
[^1]: [Renovate docs, manually enabling or disabling semantic commits](https://docs.renovatebot.com/semantic-commits/#manually-enabling-or-disabling-semantic-commits)