### PR TITLE
chore: handle `ws` security error

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -52,4 +52,4 @@ vulnerabilities:
   - id: CVE-2024-4068
     statement: Transitive dependency of lint-staged, jest and msw. Not running in production. Likely fixed by upgrading.
   - id: CVE-2024-37890
-    statement: "ws" vulnerability, transitive dependency of jest, storybook, graphql-codegen, not running in production.
+    statement: ws vulnerability, transitive dependency of jest, storybook, graphql-codegen, not running in production.

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -51,3 +51,5 @@ vulnerabilities:
     statement: Metabase v0.46 vulnerability, fixed in Metabase v0.49
   - id: CVE-2024-4068
     statement: Transitive dependency of lint-staged, jest and msw. Not running in production. Likely fixed by upgrading.
+  - id: CVE-2024-37890
+    statement: "ws" vulnerability, transitive dependency of jest, storybook, graphql-codegen, not running in production.


### PR DESCRIPTION
```
➜  client git:(ignore-trivy-again) yarn why ws
yarn why v1.22.19
[1/4] 🤔  Why do we have the module "ws"...?
[2/4] 🚚  Initialising dependency graph...
warning Resolution field "@types/react@18.3.1" is incompatible with requested version "@types/react@^16"
[3/4] 🔍  Finding dependency...
[4/4] 🚡  Calculating file sizes...
=> Found "ws@8.13.0"
info Has been hoisted to "ws"
info Reasons this module exists
   - "workspace-aggregator-28f9bf1d-42ec-4629-bbea-390756f234dd" depends on it
   - Hoisted from "_project_#@opencrvs#client#@graphql-codegen#cli#@graphql-tools#url-loader#@graphql-tools#executor-graphql-ws#ws"
   - Hoisted from "_project_#@opencrvs#client#@graphql-codegen#cli#@graphql-tools#url-loader#@graphql-tools#executor-legacy-ws#ws"
info Disk size without dependencies: "180KB"
info Disk size with unique dependencies: "180KB"
info Disk size with transitive dependencies: "180KB"
info Number of shared dependencies: 0
=> Found "@storybook/core-server#ws@8.14.2"
info This module exists because "_project_#@opencrvs#components#@storybook#core-server" depends on it.
=> Found "@graphql-tools/url-loader#ws@8.14.2"
info This module exists because "_project_#@opencrvs#client#@graphql-codegen#cli#@graphql-tools#url-loader" depends on it.
=> Found "puppeteer-core#ws@6.2.2"
info This module exists because "_project_#@opencrvs#components#storybook#@storybook#cli#puppeteer-core" depends on it.
info Disk size without dependencies: "136KB"
info Disk size with unique dependencies: "164KB"
info Disk size with transitive dependencies: "164KB"
info Number of shared dependencies: 1
=> Found "jsdom#ws@7.5.9"
info This module exists because "_project_#@opencrvs#auth#jest#@jest#core#jest-config#jest-environment-jsdom#jsdom" depends on it.
info Disk size without dependencies: "168KB"
info Disk size with unique dependencies: "168KB"
info Disk size with transitive dependencies: "168KB"
info Number of shared dependencies: 0
✨  Done in 0.68s.
```
Only used by **jest** (tests), **storybook** (component library examples page) and **graphql-codegen** (ran in development) so it's not a production issue.