### PR TITLE
Explicitly define 3.3 as compose file versions

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -6,7 +6,7 @@
 # & Healthcare Disclaimer located at http://opencrvs.org/license.
 #
 # Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
-
+version: '3.3'
 services:
   client:
     environment:

--- a/docker-compose.demo-deps.yml
+++ b/docker-compose.demo-deps.yml
@@ -6,7 +6,7 @@
 # & Healthcare Disclaimer located at http://opencrvs.org/license.
 #
 # Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
-
+version: '3.3'
 services:
   # For dependencies, expose ports locally for dev
   mongo1:

--- a/docker-compose.deps.yml
+++ b/docker-compose.deps.yml
@@ -6,6 +6,7 @@
 # & Healthcare Disclaimer located at http://opencrvs.org/license.
 #
 # Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+version: '3.3'
 volumes:
   metricbeat:
 services:

--- a/docker-compose.dev-deps.yml
+++ b/docker-compose.dev-deps.yml
@@ -6,7 +6,7 @@
 # & Healthcare Disclaimer located at http://opencrvs.org/license.
 #
 # Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
-
+version: '3.3'
 services:
   # For dependencies, expose ports locally for dev
   mongo1:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,7 +6,7 @@
 # & Healthcare Disclaimer located at http://opencrvs.org/license.
 #
 # Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
-
+version: '3.3'
 services:
   # Expose dev secrets as a plain volume - these will use docker secrets in staging and prod
   auth:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@
 # & Healthcare Disclaimer located at http://opencrvs.org/license.
 #
 # Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
-
+version: '3.3'
 services:
   base:
     image: opencrvs/ocrvs-base:${VERSION}


### PR DESCRIPTION
This is to fix the following error in deployments

```
Updating docker swarm stack with new compose files
version mismatched between two composefiles : 3.12 and 3.3
error Command failed with exit code 1.
```