### PR TITLE
fix: increase rate limit on team searches

### DIFF
--- a/packages/gateway/src/features/user/root-resolvers.ts
+++ b/packages/gateway/src/features/user/root-resolvers.ts
@@ -41,7 +41,7 @@ import { rateLimitedResolver } from '@gateway/rate-limit'
 export const resolvers: GQLResolver = {
   Query: {
     getUser: rateLimitedResolver(
-      { requestsPerMinute: 10 },
+      { requestsPerMinute: 20 },
       async (_, { userId }, { dataSources }) => {
         const user = await dataSources.usersAPI.getUserById(userId!)
         return user
@@ -49,21 +49,21 @@ export const resolvers: GQLResolver = {
     ),
 
     getUserByMobile: rateLimitedResolver(
-      { requestsPerMinute: 10 },
+      { requestsPerMinute: 20 },
       async (_, { mobile }, { dataSources }) => {
         return dataSources.usersAPI.getUserByMobile(mobile!)
       }
     ),
 
     getUserByEmail: rateLimitedResolver(
-      { requestsPerMinute: 10 },
+      { requestsPerMinute: 20 },
       (_, { email }, { dataSources }) => {
         return dataSources.usersAPI.getUserByEmail(email!)
       }
     ),
 
     searchUsers: rateLimitedResolver(
-      { requestsPerMinute: 10 },
+      { requestsPerMinute: 20 },
       async (
         _,
         {
@@ -124,7 +124,7 @@ export const resolvers: GQLResolver = {
     ),
 
     searchFieldAgents: rateLimitedResolver(
-      { requestsPerMinute: 10 },
+      { requestsPerMinute: 20 },
       async (
         _,
         {


### PR DESCRIPTION
Due to QA [running into the rate limit](https://github.com/opencrvs/opencrvs-core/issues/5930) with the team page, we can increase the limit from 10 to 20. It should still be quite slow for brute-forcing attacks, although it allows a bit more flexibility for `a.mweene` `b.mweene` `c.mweene` ... `k.mweene` types of brute-force attacks where the attacker might already know something about the user.

Bruteforce attacks in general should be fairly well mitigated though, as they need a JWT, and VPN access.