### PR TITLE
fix: bad requests in elastic search when there is no mapping

### DIFF
--- a/packages/search/src/features/search/service.test.ts
+++ b/packages/search/src/features/search/service.test.ts
@@ -147,7 +147,9 @@ describe('elasticsearch params formatter', () => {
             ]
           }
         },
-        sort: [{ dateOfDeclaration: 'asc' }]
+        sort: [
+          { dateOfDeclaration: { order: 'asc', unmapped_type: 'keyword' } }
+        ]
       }
     })
   })
@@ -205,7 +207,9 @@ describe('elasticsearch params formatter', () => {
             ]
           }
         },
-        sort: [{ dateOfDeclaration: 'asc' }]
+        sort: [
+          { dateOfDeclaration: { order: 'asc', unmapped_type: 'keyword' } }
+        ]
       }
     })
   })

--- a/packages/search/src/features/search/service.ts
+++ b/packages/search/src/features/search/service.ts
@@ -30,7 +30,14 @@ export async function formatSearchParams(
     parameters
   } = searchPayload
 
-  const sort = sortBy ?? [{ [sortColumn]: searchPayload.sort ?? SortOrder.ASC }]
+  const sort = sortBy ?? [
+    {
+      [sortColumn]: {
+        order: searchPayload.sort ?? SortOrder.ASC,
+        unmapped_type: 'keyword'
+      }
+    }
+  ]
   const query = await advancedQueryBuilder(
     parameters,
     createdBy,
@@ -60,7 +67,7 @@ export const advancedSearch = async (
     })
   } catch (error) {
     if (error.statusCode === 400) {
-      logger.error('Search: bad request')
+      logger.error(`ElasticSearch: bad request. Error: ${error.message}`)
     } else {
       logger.error('Search error: ', error)
     }


### PR DESCRIPTION
When we have no records in ElasticSearch, first load of the application always give an error to console:
```
[10:38:11.030] ERROR: ElasticSearch: bad request. Error: search_phase_execution_exception: [query_shard_exception] Reason: No mapping found for [dateOfDeclaration] in order to sort on
```
As it's an non-issue and gets fixed when first declaration is made, it should be ignored from console. ElasticSearch offers a "unmapped_type", which maps the field to any type we want if it doesn't exist. I set it to "keyword" as it's the default we use in the search fields. I amended the search request to include that, unless the advanced `sortBy` is used.

