### PR TITLE
fix: date of certification not being visible on death

### DIFF
--- a/packages/client/src/utils/gateway.ts
+++ b/packages/client/src/utils/gateway.ts
@@ -5172,7 +5172,6 @@ export type FetchMarriageRegistrationForReviewQuery = {
       __typename?: 'History'
       otherReason?: string | null
       requester?: string | null
-      requesterOther?: string | null
       hasShowedVerifiedDocument?: boolean | null
       noSupportingDocumentationRequired?: boolean | null
       date?: any | null
@@ -5532,7 +5531,6 @@ export type FetchMarriageRegistrationForCertificateQuery = {
       __typename?: 'History'
       otherReason?: string | null
       requester?: string | null
-      requesterOther?: string | null
       hasShowedVerifiedDocument?: boolean | null
       date?: any | null
       action?: RegAction | null
@@ -7408,106 +7406,6 @@ export type EmailAllUsersQuery = {
   } | null
 }
 
-export type ToggleInformantSmsNotificationMutationVariables = Exact<{
-  smsNotifications?: InputMaybe<
-    Array<SmsNotificationInput> | SmsNotificationInput
-  >
-}>
-
-export type ToggleInformantSmsNotificationMutation = {
-  __typename?: 'Mutation'
-  toggleInformantSMSNotification?: Array<{
-    __typename?: 'SMSNotification'
-    id?: string | null
-    name: string
-    enabled: boolean
-    updatedAt: string
-    createdAt: string
-  }> | null
-}
-
-export type GetInformantSmsNotificationsQueryVariables = Exact<{
-  [key: string]: never
-}>
-
-export type GetInformantSmsNotificationsQuery = {
-  __typename?: 'Query'
-  informantSMSNotifications?: Array<{
-    __typename?: 'SMSNotification'
-    id?: string | null
-    name: string
-    enabled: boolean
-    updatedAt: string
-    createdAt: string
-  }> | null
-}
-
-export type UpdateApplicationConfigMutationVariables = Exact<{
-  applicationConfig?: InputMaybe<ApplicationConfigurationInput>
-}>
-
-export type UpdateApplicationConfigMutation = {
-  __typename?: 'Mutation'
-  updateApplicationConfig?: {
-    __typename?: 'ApplicationConfiguration'
-    APPLICATION_NAME?: string | null
-    NID_NUMBER_PATTERN?: string | null
-    PHONE_NUMBER_PATTERN?: string | null
-    DATE_OF_BIRTH_UNKNOWN?: boolean | null
-    INFORMANT_SIGNATURE_REQUIRED?: boolean | null
-    USER_NOTIFICATION_DELIVERY_METHOD?: string | null
-    INFORMANT_NOTIFICATION_DELIVERY_METHOD?: string | null
-    LOGIN_BACKGROUND?: {
-      __typename?: 'LoginBackground'
-      backgroundColor?: string | null
-      backgroundImage?: string | null
-      imageFit?: ImageFit | null
-    } | null
-    COUNTRY_LOGO?: {
-      __typename?: 'CountryLogo'
-      fileName?: string | null
-      file?: string | null
-    } | null
-    CURRENCY?: {
-      __typename?: 'Currency'
-      languagesAndCountry?: Array<string | null> | null
-      isoCode?: string | null
-    } | null
-    BIRTH?: {
-      __typename?: 'Birth'
-      REGISTRATION_TARGET?: number | null
-      LATE_REGISTRATION_TARGET?: number | null
-      PRINT_IN_ADVANCE?: boolean | null
-      FEE?: {
-        __typename?: 'BirthFee'
-        ON_TIME?: number | null
-        LATE?: number | null
-        DELAYED?: number | null
-      } | null
-    } | null
-    DEATH?: {
-      __typename?: 'Death'
-      REGISTRATION_TARGET?: number | null
-      PRINT_IN_ADVANCE?: boolean | null
-      FEE?: {
-        __typename?: 'DeathFee'
-        ON_TIME?: number | null
-        DELAYED?: number | null
-      } | null
-    } | null
-    MARRIAGE?: {
-      __typename?: 'Marriage'
-      REGISTRATION_TARGET?: number | null
-      PRINT_IN_ADVANCE?: boolean | null
-      FEE?: {
-        __typename?: 'MarriageFee'
-        ON_TIME?: number | null
-        DELAYED?: number | null
-      } | null
-    } | null
-  } | null
-}
-
 export type RegisterSystemMutationVariables = Exact<{
   system?: InputMaybe<SystemInput>
 }>
@@ -8086,6 +7984,7 @@ export type FetchRecordDetailsForVerificationQuery = {
           __typename?: 'History'
           action?: RegAction | null
           regStatus?: RegStatus | null
+          date?: any | null
           user?: {
             __typename?: 'User'
             primaryOffice?: {
@@ -8147,6 +8046,7 @@ export type FetchRecordDetailsForVerificationQuery = {
           __typename?: 'History'
           action?: RegAction | null
           regStatus?: RegStatus | null
+          date?: any | null
           user?: {
             __typename?: 'User'
             primaryOffice?: {

--- a/packages/client/src/views/VerifyCertificate/VerifyCertificatePage.tsx
+++ b/packages/client/src/views/VerifyCertificate/VerifyCertificatePage.tsx
@@ -168,13 +168,13 @@ const TimeOutState = () => {
 const isBirthRegistration = (
   data: RegistrationToBeVerified
 ): data is BirthRegistration => {
-  return data?.registration?.type === RegistrationType.Birth
+  return data.registration?.type === RegistrationType.Birth
 }
 
 const isDeathRegistration = (
   data: RegistrationToBeVerified
 ): data is DeathRegistration => {
-  return data?.registration?.type === RegistrationType.Death
+  return data.registration?.type === RegistrationType.Death
 }
 
 export function VerifyCertificatePage() {

--- a/packages/client/src/views/VerifyCertificate/VerifyCertificatePage.tsx
+++ b/packages/client/src/views/VerifyCertificate/VerifyCertificatePage.tsx
@@ -38,8 +38,6 @@ import formatDate, { formatPlainDate } from '@client/utils/date-formatting'
 import {
   BirthRegistration,
   DeathRegistration,
-  History,
-  RecordDetails,
   RegistrationType,
   RegStatus
 } from '@client/utils/gateway'
@@ -47,10 +45,12 @@ import { useTimeout } from '@client/hooks/useTimeout'
 import { goToHome } from '@client/navigation'
 import { EMPTY_STRING } from '@client/utils/constants'
 import { compact } from 'lodash'
-import { useVerificationRecordDetails } from './useVerificationRecordDetails'
+import {
+  RegistrationToBeVerified,
+  useVerificationRecordDetails
+} from './useVerificationRecordDetails'
 import { useLocationIntl } from '@client/hooks/useLocationIntl'
 import { generateFullAddress } from '@client/utils/locationUtils'
-import { SUBMISSION_STATUS } from '@client/declarations'
 
 const Container = styled.div<{ size: string; checking: boolean }>`
   position: relative;
@@ -166,15 +166,15 @@ const TimeOutState = () => {
 }
 
 const isBirthRegistration = (
-  data: RecordDetails
+  data: RegistrationToBeVerified
 ): data is BirthRegistration => {
-  return data.registration?.type === RegistrationType.Birth
+  return data?.registration?.type === RegistrationType.Birth
 }
 
 const isDeathRegistration = (
-  data: RecordDetails
+  data: RegistrationToBeVerified
 ): data is DeathRegistration => {
-  return data.registration?.type === RegistrationType.Death
+  return data?.registration?.type === RegistrationType.Death
 }
 
 export function VerifyCertificatePage() {
@@ -214,7 +214,7 @@ export function VerifyCertificatePage() {
     blank?.close()
   }
 
-  const getFullName = (data: RecordDetails) => {
+  const getFullName = (data: RegistrationToBeVerified) => {
     if (isBirthRegistration(data)) {
       return (
         data.child?.name?.[0]?.firstNames +
@@ -223,7 +223,7 @@ export function VerifyCertificatePage() {
       )
     }
 
-    if (data.registration?.type === RegistrationType.Death) {
+    if (isDeathRegistration(data)) {
       return (
         data.deceased?.name?.[0]?.firstNames +
         ' ' +
@@ -232,7 +232,7 @@ export function VerifyCertificatePage() {
     }
   }
 
-  const getDateOfBirthOrOfDeceased = (data: RecordDetails) => {
+  const getDateOfBirthOrOfDeceased = (data: RegistrationToBeVerified) => {
     if (isBirthRegistration(data) && data.child?.birthDate) {
       return formatPlainDate(data.child.birthDate)
     }
@@ -242,23 +242,19 @@ export function VerifyCertificatePage() {
     return undefined
   }
 
-  const getGender = (data: RecordDetails) => {
+  const getGender = (data: RegistrationToBeVerified) => {
     if (isBirthRegistration(data)) return data.child?.gender
     if (isDeathRegistration(data)) return data.deceased?.gender
   }
 
-  const getLastCertifiedDate = (data: RecordDetails) => {
+  const getLastCertifiedDate = (data: RegistrationToBeVerified) => {
     // find first certified action from history sorted in ascending order by time
-    return (
-      data.history &&
-      data.history.find(
-        (item) => item?.regStatus?.toString() === SUBMISSION_STATUS.CERTIFIED
-      )
-    )?.date
+    return data.history?.find((item) => item?.regStatus === RegStatus.Certified)
+      ?.date
   }
 
   // This function currently supports upto two location levels
-  const getLocation = (data: RecordDetails) => {
+  const getLocation = (data: RegistrationToBeVerified) => {
     const location = data.eventLocation
 
     if (location?.type === 'HEALTH_FACILITY') {
@@ -291,10 +287,9 @@ export function VerifyCertificatePage() {
       .join(', ')
   }
 
-  const getRegistarData = (data: RecordDetails) => {
+  const getRegistarData = (data: RegistrationToBeVerified) => {
     const history = compact(data.history).find(
-      ({ action, regStatus }: History) =>
-        !action && regStatus === RegStatus.Registered
+      ({ action, regStatus }) => !action && regStatus === RegStatus.Registered
     )
 
     return {

--- a/packages/client/src/views/VerifyCertificate/useVerificationRecordDetails.ts
+++ b/packages/client/src/views/VerifyCertificate/useVerificationRecordDetails.ts
@@ -10,7 +10,7 @@
  */
 
 import { gql, useQuery } from '@apollo/client'
-import { Query } from '@client/utils/gateway'
+import { FetchRecordDetailsForVerificationQuery } from '@client/utils/gateway'
 import { useParams } from 'react-router'
 
 const FETCH_RECORD_DETAILS_FOR_VERIFICATION = gql`
@@ -98,6 +98,7 @@ const FETCH_RECORD_DETAILS_FOR_VERIFICATION = gql`
         history {
           action
           regStatus
+          date
           user {
             primaryOffice {
               hierarchy {
@@ -123,7 +124,7 @@ export const useVerificationRecordDetails = () => {
     loading,
     error,
     data: queryData
-  } = useQuery<Pick<Query, 'fetchRecordDetailsForVerification'>>(
+  } = useQuery<FetchRecordDetailsForVerificationQuery>(
     FETCH_RECORD_DETAILS_FOR_VERIFICATION,
     {
       variables: { id: declarationId },
@@ -134,3 +135,7 @@ export const useVerificationRecordDetails = () => {
 
   return { loading, error, data }
 }
+
+export type RegistrationToBeVerified = NonNullable<
+  FetchRecordDetailsForVerificationQuery['fetchRecordDetailsForVerification']
+>


### PR DESCRIPTION
#7064

* adds `date` to the death history query
* run generate-gateway-types
* tie the view types into the queried types to have stricter type-safety