### PR TITLE
fix: allow fonts from country config

### DIFF
--- a/infrastructure/nginx-default.conf
+++ b/infrastructure/nginx-default.conf
@@ -44,7 +44,7 @@ add_header X-Permitted-Cross-Domain-Policies master-only;
 # I need to change our application code so we can increase security by disabling 'unsafe-inline' 'unsafe-eval'
 # directives for css and js(if you have inline css or js, you will need to keep it too).
 # more: http://www.html5rocks.com/en/tutorials/security/content-security-policy/#inline-code-considered-harmful
-add_header Content-Security-Policy "default-src 'self' {{CONTENT_SECURITY_POLICY_WILDCARD}} *.sentry.io/ sentry.io/; font-src fonts.gstatic.com; object-src 'none'; script-src 'self' 'unsafe-eval' blob: https: http: storage.googleapis.com/workbox-cdn/ sentry.io/api/embed/error-page/; style-src 'self' fonts.googleapis.com 'unsafe-inline'; img-src 'self' data: http: https: ";
+add_header Content-Security-Policy "default-src 'self' {{CONTENT_SECURITY_POLICY_WILDCARD}} *.sentry.io/ sentry.io/; font-src fonts.gstatic.com {{CONTENT_SECURITY_POLICY_WILDCARD}}; object-src 'none'; script-src 'self' 'unsafe-eval' blob: https: http: storage.googleapis.com/workbox-cdn/ sentry.io/api/embed/error-page/; style-src 'self' fonts.googleapis.com 'unsafe-inline'; img-src 'self' data: http: https: ";
 
 server {
     listen       80;


### PR DESCRIPTION
#7303

Content policy didn't allow fetching fonts from country config. I added the wildcard to the fonts as well and deployed this to farajaland-dev. Seems to be working there.

![image](https://github.com/opencrvs/opencrvs-core/assets/1322608/6c3d6071-5196-4fe8-a0ac-ebf90cf093b8)
