### PR TITLE
Restore docker branch caching

### DIFF
--- a/.github/workflows/build-images-from-branch.yml
+++ b/.github/workflows/build-images-from-branch.yml
@@ -59,13 +59,15 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push base image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           file: packages/Dockerfile.base
           context: .
           push: true
-          tags: 'opencrvs/ocrvs-base:${{ steps.set-version-and-branch.outputs.version }}'
-          cache-from: type=registry,ref=opencrvs/ocrvs-base:${{ steps.set-version-and-branch.outputs.version }}
+          tags: |
+            opencrvs/ocrvs-base:${{ steps.set-version-and-branch.outputs.version }}
+            opencrvs/ocrvs-base:${{ steps.set-version-and-branch.outputs.branch }}
+          cache-from: type=registry,ref=opencrvs/ocrvs-base:${{ steps.set-version-and-branch.outputs.branch }}
           cache-to: type=inline
 
     outputs:
@@ -96,16 +98,19 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           file: packages/${{ matrix.service }}/Dockerfile
           build-args: |
             VERSION=${{ needs.base.outputs.version }}
+            BRANCH=${{ needs.base.outputs.branch }}
           push: true
           context: .
           tags: |
             opencrvs/ocrvs-${{ matrix.service }}:${{ needs.base.outputs.version }}
             opencrvs/ocrvs-${{ matrix.service }}:${{ needs.base.outputs.branch }}
+          cache-from: type=registry,ref=opencrvs/ocrvs-${{ matrix.service }}:${{ needs.base.outputs.branch }}
+          cache-to: type=inline
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.23.0

--- a/packages/Dockerfile.base
+++ b/packages/Dockerfile.base
@@ -15,4 +15,8 @@ COPY --chown=node:node yarn.lock .
 RUN yarn install --production --frozen-lockfile
 
 COPY --chown=node:node packages/commons /app/packages/commons
-RUN cd packages/commons && yarn install --frozen-lockfile && yarn build
+
+WORKDIR /app/packages/commons
+
+RUN yarn install --frozen-lockfile
+RUN yarn build

--- a/packages/auth/Dockerfile
+++ b/packages/auth/Dockerfile
@@ -1,5 +1,5 @@
-ARG  VERSION=dev
-FROM opencrvs/ocrvs-base:${VERSION}
+ARG  BRANCH=develop
+FROM opencrvs/ocrvs-base:${BRANCH}
 
 USER node
 

--- a/packages/client/Dockerfile
+++ b/packages/client/Dockerfile
@@ -1,5 +1,5 @@
-ARG  VERSION=dev
-FROM opencrvs/ocrvs-base:${VERSION}
+ARG  BRANCH=develop
+FROM opencrvs/ocrvs-base:${BRANCH}
 
 USER node
 

--- a/packages/components/Dockerfile
+++ b/packages/components/Dockerfile
@@ -1,5 +1,5 @@
-ARG  VERSION=dev
-FROM opencrvs/ocrvs-base:${VERSION}
+ARG  BRANCH=develop
+FROM opencrvs/ocrvs-base:${BRANCH}
 
 USER node
 

--- a/packages/config/Dockerfile
+++ b/packages/config/Dockerfile
@@ -1,5 +1,5 @@
-ARG  VERSION=dev
-FROM opencrvs/ocrvs-base:${VERSION}
+ARG  BRANCH=develop
+FROM opencrvs/ocrvs-base:${BRANCH}
 
 USER node
 

--- a/packages/documents/Dockerfile
+++ b/packages/documents/Dockerfile
@@ -1,5 +1,5 @@
-ARG  VERSION=dev
-FROM opencrvs/ocrvs-base:${VERSION}
+ARG  BRANCH=develop
+FROM opencrvs/ocrvs-base:${BRANCH}
 
 USER node
 

--- a/packages/gateway/Dockerfile
+++ b/packages/gateway/Dockerfile
@@ -1,5 +1,5 @@
-ARG  VERSION=dev
-FROM opencrvs/ocrvs-base:${VERSION}
+ARG  BRANCH=develop
+FROM opencrvs/ocrvs-base:${BRANCH}
 
 USER node
 

--- a/packages/login/Dockerfile
+++ b/packages/login/Dockerfile
@@ -1,5 +1,5 @@
-ARG  VERSION=dev
-FROM opencrvs/ocrvs-base:${VERSION}
+ARG  BRANCH=develop
+FROM opencrvs/ocrvs-base:${BRANCH}
 
 USER node
 

--- a/packages/metrics/Dockerfile
+++ b/packages/metrics/Dockerfile
@@ -1,5 +1,5 @@
-ARG  VERSION=dev
-FROM opencrvs/ocrvs-base:${VERSION}
+ARG  BRANCH=develop
+FROM opencrvs/ocrvs-base:${BRANCH}
 
 USER node
 

--- a/packages/migration/Dockerfile
+++ b/packages/migration/Dockerfile
@@ -1,5 +1,5 @@
-ARG  VERSION=dev
-FROM opencrvs/ocrvs-base:${VERSION}
+ARG  BRANCH=develop
+FROM opencrvs/ocrvs-base:${BRANCH}
 
 USER node
 

--- a/packages/notification/Dockerfile
+++ b/packages/notification/Dockerfile
@@ -1,5 +1,5 @@
-ARG  VERSION=dev
-FROM opencrvs/ocrvs-base:${VERSION}
+ARG  BRANCH=develop
+FROM opencrvs/ocrvs-base:${BRANCH}
 
 USER node
 

--- a/packages/search/Dockerfile
+++ b/packages/search/Dockerfile
@@ -1,5 +1,5 @@
-ARG  VERSION=dev
-FROM opencrvs/ocrvs-base:${VERSION}
+ARG  BRANCH=develop
+FROM opencrvs/ocrvs-base:${BRANCH}
 
 USER node
 

--- a/packages/user-mgnt/Dockerfile
+++ b/packages/user-mgnt/Dockerfile
@@ -1,5 +1,5 @@
-ARG  VERSION=dev
-FROM opencrvs/ocrvs-base:${VERSION}
+ARG  BRANCH=develop
+FROM opencrvs/ocrvs-base:${BRANCH}
 
 USER node
 

--- a/packages/webhooks/Dockerfile
+++ b/packages/webhooks/Dockerfile
@@ -1,5 +1,5 @@
-ARG  VERSION=dev
-FROM opencrvs/ocrvs-base:${VERSION}
+ARG  BRANCH=develop
+FROM opencrvs/ocrvs-base:${BRANCH}
 
 USER node
 

--- a/packages/workflow/Dockerfile
+++ b/packages/workflow/Dockerfile
@@ -1,5 +1,5 @@
-ARG  VERSION=dev
-FROM opencrvs/ocrvs-base:${VERSION}
+ARG  BRANCH=develop
+FROM opencrvs/ocrvs-base:${BRANCH}
 
 USER node
 


### PR DESCRIPTION
- Upgrade to `docker/build-push-action` to v6 to get summaries ( see more at https://github.com/docker/build-push-action/releases )
- Bring back caching based on current branch (could also potentially test later multi source caching with eg. always develop in addition)
- Change `VERSION` used for this purpose to `BRANCH` to avoid overlap in existing usage