### PR TITLE
Remove deprecated version from compose files

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -6,7 +6,6 @@
 # & Healthcare Disclaimer located at http://opencrvs.org/license.
 #
 # Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
-version: '3.3'
 services:
   client:
     environment:

--- a/docker-compose.demo-deps.yml
+++ b/docker-compose.demo-deps.yml
@@ -6,7 +6,6 @@
 # & Healthcare Disclaimer located at http://opencrvs.org/license.
 #
 # Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
-version: '3.3'
 services:
   # For dependencies, expose ports locally for dev
   mongo1:

--- a/docker-compose.deps.yml
+++ b/docker-compose.deps.yml
@@ -6,7 +6,6 @@
 # & Healthcare Disclaimer located at http://opencrvs.org/license.
 #
 # Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
-version: '3.3'
 volumes:
   metricbeat:
 services:

--- a/docker-compose.dev-deps.yml
+++ b/docker-compose.dev-deps.yml
@@ -6,7 +6,6 @@
 # & Healthcare Disclaimer located at http://opencrvs.org/license.
 #
 # Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
-version: '3.3'
 services:
   # For dependencies, expose ports locally for dev
   mongo1:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,7 +6,6 @@
 # & Healthcare Disclaimer located at http://opencrvs.org/license.
 #
 # Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
-version: '3.3'
 services:
   # Expose dev secrets as a plain volume - these will use docker secrets in staging and prod
   auth:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,6 @@
 # & Healthcare Disclaimer located at http://opencrvs.org/license.
 #
 # Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
-version: '3.3'
 services:
   base:
     image: opencrvs/ocrvs-base:${VERSION}


### PR DESCRIPTION
Current compose V2 spec (yes, its very confusing how we are at V2 vs previously 3.x versions..) deprecated and removed usage of `version`. 

Even though this is still accepted as value its

- Validated to match (which can cause issue in cases of mismatch)
- Throwing warnings due to deprecation

Combination means it does nothing but potentially causes issues :)


See more details here https://docs.docker.com/compose/intro/history/

and explicit note about `version` in the spec here https://github.com/compose-spec/compose-spec/blob/master/04-version-and-name.md