### PR TITLE
chore!: remove deprecated inputFieldWidth

### DIFF
--- a/packages/client/src/components/form/FormFieldGenerator.tsx
+++ b/packages/client/src/components/form/FormFieldGenerator.tsx
@@ -502,10 +502,6 @@ const GeneratedInputField = React.memo<GeneratedInputFieldProps>(
       )
     }
     if (fieldDefinition.type === NUMBER) {
-      let inputFieldWidth = fieldDefinition.inputFieldWidth
-      if (fieldDefinition?.inputWidth) {
-        inputFieldWidth = fieldDefinition.inputWidth + 'px'
-      }
       return (
         <InputField {...inputFieldProps}>
           <TextInput
@@ -527,7 +523,6 @@ const GeneratedInputField = React.memo<GeneratedInputFieldProps>(
             onWheel={(event: React.WheelEvent<HTMLInputElement>) => {
               event.currentTarget.blur()
             }}
-            inputFieldWidth={inputFieldWidth}
           />
         </InputField>
       )

--- a/packages/client/src/forms/index.ts
+++ b/packages/client/src/forms/index.ts
@@ -580,7 +580,6 @@ export interface INumberFormField extends IFormFieldBase {
   type: typeof NUMBER
   step?: number
   max?: number
-  inputFieldWidth?: string
   inputWidth?: number
   maxLength?: number
 }
@@ -1086,7 +1085,6 @@ export interface Ii18nNumberFormField extends Ii18nFormFieldBase {
   type: typeof NUMBER
   step?: number
   max?: number
-  inputFieldWidth?: string
   inputWidth?: number
   maxLength?: number
 }

--- a/packages/client/src/tests/forms.json
+++ b/packages/client/src/tests/forms.json
@@ -476,8 +476,7 @@
                       "operation": "bundleFieldToSectionFieldTransformer",
                       "parameters": []
                     }
-                  },
-                  "inputFieldWidth": "78px"
+                  }
                 },
                 {
                   "name": "placeOfBirthTitle",
@@ -1011,8 +1010,7 @@
                       "expression": "((values.informantType===\"MOTHER\") || (values.informantType===\"FATHER\") || (!values.informantType))"
                     }
                   ],
-                  "postfix": "years",
-                  "inputFieldWidth": "78px"
+                  "postfix": "years"
                 },
                 {
                   "name": "nationality",
@@ -2403,8 +2401,7 @@
                       "expression": "!values.exactDateOfBirthUnknown || !values.detailsExist"
                     }
                   ],
-                  "postfix": "years",
-                  "inputFieldWidth": "78px"
+                  "postfix": "years"
                 },
                 {
                   "name": "firstNamesEng",
@@ -2934,8 +2931,7 @@
                       "expression": "!values.exactDateOfBirthUnknown || (!values.detailsExist)"
                     }
                   ],
-                  "postfix": "years",
-                  "inputFieldWidth": "78px"
+                  "postfix": "years"
                 },
                 {
                   "name": "firstNamesEng",
@@ -3808,8 +3804,7 @@
                       "expression": "!values.exactDateOfBirthUnknown"
                     }
                   ],
-                  "postfix": "years",
-                  "inputFieldWidth": "78px"
+                  "postfix": "years"
                 },
                 {
                   "name": "firstNamesEng",
@@ -4786,8 +4781,7 @@
                       "expression": "!values.exactDateOfBirthUnknown"
                     }
                   ],
-                  "postfix": "years",
-                  "inputFieldWidth": "78px"
+                  "postfix": "years"
                 },
                 {
                   "name": "nationality",
@@ -6704,8 +6698,7 @@
                       "expression": "(!values.informantType || values.informantType === \"BRIDE\" || values.informantType === \"GROOM\")"
                     }
                   ],
-                  "postfix": "years",
-                  "inputFieldWidth": "78px"
+                  "postfix": "years"
                 },
                 {
                   "name": "nationality",
@@ -8080,8 +8073,7 @@
                       "expression": "!values.exactDateOfBirthUnknown"
                     }
                   ],
-                  "postfix": "years",
-                  "inputFieldWidth": "78px"
+                  "postfix": "years"
                 },
                 {
                   "name": "nationality",
@@ -9333,8 +9325,7 @@
                       "expression": "!values.exactDateOfBirthUnknown"
                     }
                   ],
-                  "postfix": "years",
-                  "inputFieldWidth": "78px"
+                  "postfix": "years"
                 },
                 {
                   "name": "nationality",

--- a/packages/client/src/views/SysAdmin/Config/Systems/Systems.tsx
+++ b/packages/client/src/views/SysAdmin/Config/Systems/Systems.tsx
@@ -528,7 +528,6 @@ export function SystemList() {
                   value={newClientName}
                   onChange={onChangeClientName}
                   error={false}
-                  inputFieldWidth="100%"
                 />
               </InputField>
             </Field>

--- a/packages/components/src/TextInput/TextInput.tsx
+++ b/packages/components/src/TextInput/TextInput.tsx
@@ -19,7 +19,6 @@ export interface ICustomProps {
   autocomplete?: boolean
   isSmallSized?: boolean // Deprecated
   isDisabled?: boolean
-  inputFieldWidth?: string // Deprecated
   hasPrefix?: boolean
   hasPostfix?: boolean
   prefix?: React.ReactNode | string


### PR DESCRIPTION
We removed the usage of the deprecated `inputFieldWidth` field from countryconfig here: https://github.com/opencrvs/opencrvs-countryconfig/pull/201

This PR deprecates them core entirely