### PR TITLE
fix: bring back certificate & notification config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 
   We are dropping support for 'agentDefault' to be used as initial value for SELECT_WITH_DYNAMIC_OPTIONS type of fields. The country config package now must return the form with prepopulated initial values to show default addresses. [#6871](https://github.com/opencrvs/opencrvs-core/issues/6871)
 
-- #### Remove system admin UI items: Application, Certificates, User roles, Informant notifications
+- #### Remove system admin UI items: Application, User roles
 
   We have now moved to configuring these items directly from country configuration repository.
 

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -47,6 +47,7 @@ import { AppStore } from './store'
 import { CorrectionForm, CorrectionReviewForm } from './views/CorrectionForm'
 import { VerifyCorrector } from './views/CorrectionForm/VerifyCorrector'
 import { RecordAudit } from './views/RecordAudit/RecordAudit'
+import { CertificatesConfig } from './views/SysAdmin/Config/Certificates'
 import { UserList } from './views/SysAdmin/Team/user/UserList'
 import { SystemList } from './views/SysAdmin/Config/Systems/Systems'
 import VSExport from './views/SysAdmin/Vsexports/VSExport'
@@ -60,6 +61,7 @@ import { Leaderboards } from '@client/views/Performance/Leaderboards'
 import { PerformanceDashboard } from '@client/views/Performance/Dashboard'
 import { SystemRoleType } from '@client/utils/gateway'
 import { AdministrativeLevels } from '@client/views/Organisation/AdministrativeLevels'
+import InformantNotification from '@client/views/SysAdmin/Communications/InformantSMSNotification/InformantSMSNotification'
 import { VerifyCertificatePage } from '@client/views/VerifyCertificate/VerifyCertificatePage'
 import { IssueCertificate } from '@client/views/IssueCertificate/IssueCertificate'
 import { IssuePayment } from '@client/views/IssueCertificate/IssueCollectorForm/IssuePayment'
@@ -252,6 +254,24 @@ export function App(props: IAppProps) {
                                                 routes.REGISTRAR_HOME_TAB_PAGE
                                               }
                                               component={OfficeHome}
+                                            />
+                                            <ProtectedRoute
+                                              exact
+                                              roles={[
+                                                SystemRoleType.NationalSystemAdmin
+                                              ]}
+                                              path={routes.CERTIFICATE_CONFIG}
+                                              component={CertificatesConfig}
+                                            />
+                                            <ProtectedRoute
+                                              exact
+                                              roles={[
+                                                SystemRoleType.NationalSystemAdmin
+                                              ]}
+                                              path={
+                                                routes.INFORMANT_NOTIFICATION
+                                              }
+                                              component={InformantNotification}
                                             />
                                             <ProtectedRoute
                                               exact

--- a/packages/client/src/components/interface/Navigation.test.tsx
+++ b/packages/client/src/components/interface/Navigation.test.tsx
@@ -109,6 +109,7 @@ describe('Navigation for national system admin related tests', () => {
     expect(testComponent.exists('#navigation_config_main')).toBeTruthy()
     testComponent.find('#navigation_config_main').hostNodes().simulate('click')
     testComponent.update()
+    expect(testComponent.exists('#navigation_certificate')).toBeTruthy()
   })
 
   it('No application related tabs', async () => {

--- a/packages/client/src/components/interface/Navigation.tsx
+++ b/packages/client/src/components/interface/Navigation.tsx
@@ -19,8 +19,10 @@ import { navigationMessages } from '@client/i18n/messages/views/navigation'
 import {
   goToAdvancedSearchResult,
   goToAllUserEmail,
+  goToCertificateConfig,
   goToDashboardView,
   goToHomeTab,
+  goToInformantNotification,
   goToLeaderBoardsView,
   goToOrganisationView,
   goToPerformanceStatistics,
@@ -219,6 +221,7 @@ interface IProps {
 
 interface IDispatchProps {
   goToHomeTab: typeof goToHomeTab
+  goToCertificateConfigAction: typeof goToCertificateConfig
   goToVSExportsAction: typeof goToVSExport
   goToAdvancedSearchResultAction: typeof goToAdvancedSearchResult
   redirectToAuthentication: typeof redirectToAuthentication
@@ -232,6 +235,7 @@ interface IDispatchProps {
   goToPerformanceStatistics: typeof goToPerformanceStatistics
   updateRegistrarWorkqueue: typeof updateRegistrarWorkqueue
   setAdvancedSearchParam: typeof setAdvancedSearchParam
+  goToInformantNotification: typeof goToInformantNotification
   goToAllUserEmail: typeof goToAllUserEmail
 }
 
@@ -295,6 +299,7 @@ const NavigationView = (props: IFullProps) => {
     enableMenuSelection = true,
     loadWorkqueueStatuses = true,
     activeMenuItem,
+    goToCertificateConfigAction,
     goToVSExportsAction,
     goToSystemViewAction,
     goToAdvancedSearchResultAction,
@@ -310,6 +315,7 @@ const NavigationView = (props: IFullProps) => {
     goToPerformanceStatistics,
     goToDashboardView,
     goToLeaderBoardsView,
+    goToInformantNotification,
     goToAllUserEmail,
     className
   } = props
@@ -709,17 +715,30 @@ const NavigationView = (props: IFullProps) => {
                       />
                       {(isConfigExpanded ||
                         configTab.includes(activeMenuItem)) && (
-                        <NavigationSubItem
-                          id={`navigation_${WORKQUEUE_TABS.systems}`}
-                          label={intl.formatMessage(
-                            navigationMessages[WORKQUEUE_TABS.systems]
-                          )}
-                          onClick={goToSystemViewAction}
-                          isSelected={
-                            enableMenuSelection &&
-                            activeMenuItem === WORKQUEUE_TABS.systems
-                          }
-                        />
+                        <>
+                          <NavigationSubItem
+                            label={intl.formatMessage(
+                              navigationMessages[WORKQUEUE_TABS.certificate]
+                            )}
+                            id={`navigation_${WORKQUEUE_TABS.certificate}`}
+                            onClick={goToCertificateConfigAction}
+                            isSelected={
+                              enableMenuSelection &&
+                              activeMenuItem === WORKQUEUE_TABS.certificate
+                            }
+                          />
+                          <NavigationSubItem
+                            id={`navigation_${WORKQUEUE_TABS.systems}`}
+                            label={intl.formatMessage(
+                              navigationMessages[WORKQUEUE_TABS.systems]
+                            )}
+                            onClick={goToSystemViewAction}
+                            isSelected={
+                              enableMenuSelection &&
+                              activeMenuItem === WORKQUEUE_TABS.systems
+                            }
+                          />
+                        </>
                       )}
                     </>
                   )}
@@ -753,17 +772,33 @@ const NavigationView = (props: IFullProps) => {
                       />
                       {(isCommunationExpanded ||
                         conmmunicationTab.includes(activeMenuItem)) && (
-                        <NavigationSubItem
-                          label={intl.formatMessage(
-                            navigationMessages[WORKQUEUE_TABS.emailAllUsers]
-                          )}
-                          id={`navigation_${WORKQUEUE_TABS.emailAllUsers}`}
-                          onClick={goToAllUserEmail}
-                          isSelected={
-                            enableMenuSelection &&
-                            activeMenuItem === WORKQUEUE_TABS.emailAllUsers
-                          }
-                        />
+                        <>
+                          <NavigationSubItem
+                            label={intl.formatMessage(
+                              navigationMessages[
+                                WORKQUEUE_TABS.informantNotification
+                              ]
+                            )}
+                            id={`navigation_${WORKQUEUE_TABS.informantNotification}`}
+                            onClick={goToInformantNotification}
+                            isSelected={
+                              enableMenuSelection &&
+                              activeMenuItem ===
+                                WORKQUEUE_TABS.informantNotification
+                            }
+                          />
+                          <NavigationSubItem
+                            label={intl.formatMessage(
+                              navigationMessages[WORKQUEUE_TABS.emailAllUsers]
+                            )}
+                            id={`navigation_${WORKQUEUE_TABS.emailAllUsers}`}
+                            onClick={goToAllUserEmail}
+                            isSelected={
+                              enableMenuSelection &&
+                              activeMenuItem === WORKQUEUE_TABS.emailAllUsers
+                            }
+                          />
+                        </>
                       )}
                     </>
                   )}
@@ -962,6 +997,7 @@ export const Navigation = connect<
   IStoreState
 >(mapStateToProps, {
   goToHomeTab,
+  goToCertificateConfigAction: goToCertificateConfig,
   goToAdvancedSearchResultAction: goToAdvancedSearchResult,
   goToVSExportsAction: goToVSExport,
   goToPerformanceViewAction: goToPerformanceView,
@@ -975,6 +1011,7 @@ export const Navigation = connect<
   goToPerformanceStatistics,
   goToLeaderBoardsView,
   goToDashboardView,
+  goToInformantNotification,
   goToAllUserEmail
 })(injectIntl(withRouter(NavigationView)))
 

--- a/packages/client/src/views/SysAdmin/Config/Certificates/Certificates.test.tsx
+++ b/packages/client/src/views/SysAdmin/Config/Certificates/Certificates.test.tsx
@@ -31,8 +31,6 @@ const fetch = createFetchMock(vi)
 fetch.enableMocks()
 
 enum MENU_ITEM {
-  PREVIEW,
-  PRINT,
   DOWNLOAD,
   UPLOAD
 }
@@ -229,37 +227,6 @@ describe('ConfigHome page when already has uploaded certificate template', async
         setTimeout(resolve, 200)
       })
       expect(updateCertificateMutationSpy).toBeCalledTimes(1)
-    })
-
-    it('should render preview certificate template when clicked on preview', async () => {
-      await clickOnMenuItem(testComponent, 'birth', MENU_ITEM.PREVIEW)
-
-      await waitForElement(testComponent, '#preview_image_field')
-
-      expect(
-        testComponent.find('#preview_image_field').hostNodes()
-      ).toHaveLength(1)
-    })
-
-    it('should go back from preview page if click on back arrow', async () => {
-      await clickOnMenuItem(testComponent, 'birth', MENU_ITEM.PREVIEW)
-      await waitForElement(testComponent, '#preview_image_field')
-      testComponent.find('#preview_close').hostNodes().simulate('click')
-      testComponent.update()
-
-      expect(
-        testComponent.find('#preview_image_field').hostNodes()
-      ).toHaveLength(0)
-    })
-
-    it('should call print certificate after clicking print', async () => {
-      await clickOnMenuItem(testComponent, 'birth', MENU_ITEM.PRINT)
-      testComponent.update()
-      await new Promise((resolve) => {
-        setTimeout(resolve, 200)
-      })
-
-      expect(printCertificateSpy).toBeCalledTimes(1)
     })
 
     it('should download preview certificate', async () => {

--- a/packages/client/src/views/SysAdmin/Config/Certificates/Certificates.tsx
+++ b/packages/client/src/views/SysAdmin/Config/Certificates/Certificates.tsx
@@ -207,41 +207,6 @@ class CertificatesConfigComponent extends React.Component<Props, State> {
   ) {
     const menuItems = [
       {
-        label: intl.formatMessage(buttonMessages.preview),
-        handler: async () => {
-          const dummyTemplateData = getDummyCertificateTemplateData(
-            event,
-            this.props.registerForm
-          )
-
-          svgCode = executeHandlebarsTemplate(
-            svgCode,
-            dummyTemplateData,
-            this.props.state
-          )
-          const linkSource = `data:${SVGFile.type};base64,${window.btoa(
-            svgCode
-          )}`
-          this.setState({
-            eventName: event,
-            previewImage: { type: SVGFile.type, data: linkSource }
-          })
-        }
-      },
-      {
-        label: intl.formatMessage(buttonMessages.print),
-        handler: async () => {
-          await printDummyCertificate(
-            event,
-            this.props.registerForm,
-            intl,
-            this.props.userDetails as UserDetails,
-            this.props.offlineResources,
-            this.props.state
-          )
-        }
-      },
-      {
         label: intl.formatMessage(messages.downloadTemplate),
         handler: () => {
           downloadFile(SVGFile.type, svgCode, svgFilename)
@@ -621,21 +586,6 @@ class CertificatesConfigComponent extends React.Component<Props, State> {
                 />
               }
             >
-              <>
-                {intl.formatMessage(messages.listDetails)}
-                <Link
-                  id="certificate-instructions-link"
-                  onClick={() => {
-                    window.open(
-                      'https://documentation.opencrvs.org/setup/4.-functional-configuration/4.4-configure-a-certificate-template',
-                      '_blank',
-                      'noopener,noreferrer'
-                    )
-                  }}
-                >
-                  {intl.formatMessage(messages.listDetailsQsn)}
-                </Link>
-              </>
               <TabContent
                 item={
                   CertificateSection.items.find(


### PR DESCRIPTION
I removed both the `preview` & `print` options from the action menu
Also removed the short description in the certificates page as it contained a broken link to documentation
![bring-back-certificate-config](https://github.com/user-attachments/assets/f70c8dd1-590c-42b2-b76f-802ee7fecbdd)
