### PR TITLE
Get cherry picked commits based on git log results against base sha

### DIFF
--- a/.github/workflows/auto-pr-to-release.yml
+++ b/.github/workflows/auto-pr-to-release.yml
@@ -113,12 +113,6 @@ jobs:
 
           # Fetch and checkout the release branch
           git fetch --all --unshallow
-          git log ${{ env.HEAD_BRANCH }}
-          git fetch origin ${{ env.HEAD_BRANCH }} --unshallow
-          echo "New logs"
-          git log ${{ env.HEAD_BRANCH }}
-          git status
-
           git checkout ${{ env.RELEASE_BRANCH }}
 
           # Create a new branch for the PR

--- a/.github/workflows/auto-pr-to-release.yml
+++ b/.github/workflows/auto-pr-to-release.yml
@@ -137,7 +137,8 @@ jobs:
             # If cherry-pick fails, create a placeholder commit
             echo "Cherry-pick failed. Creating placeholder commit."
 
-            GIT_LOG_ONELINE_OUTPUT=$(git log --oneline --no-decorate $COMMIT_RANGE)
+            # -- Is needed to make unambigious we are referring to branches rather than files. Happens when branch has "/"
+            GIT_LOG_ONELINE_OUTPUT=$(git log --oneline --no-decorate --no-merges $COMMIT_RANGE --)
 
             git reset --hard
             git commit --allow-empty -m "Placeholder commit for PR #${{ env.PR_ID }}"
@@ -162,7 +163,7 @@ jobs:
             \`\`\`
 
 
-            **Individual commits:**
+            **Individual commits without merges:**
             \`\`\`
             $GIT_LOG_ONELINE_OUTPUT
             \`\`\`

--- a/.github/workflows/auto-pr-to-release.yml
+++ b/.github/workflows/auto-pr-to-release.yml
@@ -120,8 +120,10 @@ jobs:
 
           echo "First commit: ${{ env.FIRST_COMMIT_SHA }}"
           echo "Latest commit: ${{ env.LATEST_COMMIT_SHA }}"
+          echo "Release branch: ${{ env.RELEASE_BRANCH }}"
+          echo "Head branch: ${{ env.HEAD_BRANCH }}"
           # NOTE: git cherry-pick range needs ~ to include the FIRST_COMMIT_SHA (https://stackoverflow.com/questions/1994463/how-to-cherry-pick-a-range-of-commits-and-merge-them-into-another-branch)
-          COMMIT_RANGE="${{ env.FIRST_COMMIT_SHA }}~..${{ env.LATEST_COMMIT_SHA }}"
+          COMMIT_RANGE="${{ env.RELEASE_BRANCH }}~..${{ env.HEAD_BRANCH }}"
 
           if [ "${{ env.FIRST_COMMIT_SHA }}" == "${{ env.LATEST_COMMIT_SHA }}" ]; then
             COMMIT_RANGE=${{ env.FIRST_COMMIT_SHA }}

--- a/.github/workflows/auto-pr-to-release.yml
+++ b/.github/workflows/auto-pr-to-release.yml
@@ -107,7 +107,6 @@ jobs:
           # Fetch and checkout the release branch
           git fetch --all
 
-          git fetch origin ${{ env.HEAD_BRANCH }}:${{ env.HEAD_BRANCH }}
           git checkout ${{ env.RELEASE_BRANCH }}
 
           # Create a new branch for the PR

--- a/.github/workflows/auto-pr-to-release.yml
+++ b/.github/workflows/auto-pr-to-release.yml
@@ -118,20 +118,20 @@ jobs:
 
           COMMIT_RANGE="${{ env.BASE_SHA }}..${{ env.HEAD_BRANCH }}"
 
-          echo "Commit range: $COMMIT_RANGE"
+          echo "Commit range: ${COMMIT_RANGE}"
 
-          NON_MERGE_COMMITS=$(git log --reverse --no-merges --pretty=format:"%h" $COMMIT_RANGE -- | xargs)
+          NON_MERGE_COMMITS=$(git log ${COMMIT_RANGE} --reverse --no-merges --pretty=format:"%h" -- | xargs)
 
           echo "Ordered non-merge commits: $NON_MERGE_COMMITS"
 
           # Attempt to cherry-pick the commits from the original PR
-          CHERRY_PICK_OUTPUT=$(git cherry-pick $NON_MERGE_COMMITS 2>&1) || {
+          CHERRY_PICK_OUTPUT=$(git cherry-pick ${NON_MERGE_COMMITS} 2>&1) || {
             git cherry-pick --abort || true
             # If cherry-pick fails, create a placeholder commit
             echo "Cherry-pick failed. Creating placeholder commit."
 
             # -- Is needed to make unambigious we are referring to branches rather than files. Happens when branch has "/"
-            GIT_LOG_ONELINE_OUTPUT=$(git log --oneline --no-decorate --no-merges $COMMIT_RANGE --)
+            GIT_LOG_ONELINE_OUTPUT=$(git log --oneline --no-decorate --no-merges ${COMMIT_RANGE} --)
 
             git reset --hard
             git commit --allow-empty -m "Placeholder commit for PR #${{ env.PR_ID }}"

--- a/.github/workflows/auto-pr-to-release.yml
+++ b/.github/workflows/auto-pr-to-release.yml
@@ -113,6 +113,10 @@ jobs:
 
           # Fetch and checkout the release branch
           git fetch --all
+          git log ${{ env.HEAD_BRANCH }}
+          git fetch origin ${{ env.HEAD_BRANCH }}
+          echo "New logs"
+          git log ${{ env.HEAD_BRANCH }}
 
           git checkout ${{ env.RELEASE_BRANCH }}
 

--- a/.github/workflows/auto-pr-to-release.yml
+++ b/.github/workflows/auto-pr-to-release.yml
@@ -25,6 +25,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Setup SSH
+        if: ${{ env.ACT }}
+        run: |
+          echo "${{ secrets.SSH_PRIVATE_KEY_PROD }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+
       - name: Checkout repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/auto-pr-to-release.yml
+++ b/.github/workflows/auto-pr-to-release.yml
@@ -112,11 +112,12 @@ jobs:
           git config advice.mergeConflict false
 
           # Fetch and checkout the release branch
-          git fetch --all
+          git fetch --all --unshallow
           git log ${{ env.HEAD_BRANCH }}
-          git fetch origin ${{ env.HEAD_BRANCH }}
+          git fetch origin ${{ env.HEAD_BRANCH }} --unshallow
           echo "New logs"
           git log ${{ env.HEAD_BRANCH }}
+          git status
 
           git checkout ${{ env.RELEASE_BRANCH }}
 

--- a/.github/workflows/auto-pr-to-release.yml
+++ b/.github/workflows/auto-pr-to-release.yml
@@ -33,7 +33,7 @@ jobs:
         id: get_pr_details_dispatch
         run: |
           PR_NUMBER=${{ github.event.inputs.pr_number }}
-          PR_DATA=$(gh pr view $PR_NUMBER --json number,headRefName,baseRefName,mergedBy,mergeCommit,author,milestone,title --jq '{number: .number, headRefName: .headRefName, baseRefName: .baseRefName, merger: .mergedBy.login, author: .author.login, milestone: .milestone.title, title: .title}')
+          PR_DATA=$(gh pr view $PR_NUMBER --json number,headRefName,baseRefName,mergedBy,mergeCommit,author,milestone,title,base --jq '{number: .number, headRefName: .headRefName, baseRefName: .baseRefName, merger: .mergedBy.login, author: .author.login, milestone: .milestone.title, title: .title, baseSha: .base.sha}')
           echo "PR_ID=$(echo $PR_DATA | jq -r '.number')" >> $GITHUB_ENV
           echo "PR_AUTHOR=$(echo $PR_DATA | jq -r '.author')" >> $GITHUB_ENV
           echo "PR_MERGER=$(echo $PR_DATA | jq -r '.merger')" >> $GITHUB_ENV
@@ -41,7 +41,7 @@ jobs:
           echo "BASE_BRANCH=$(echo $PR_DATA | jq -r '.baseRefName')" >> $GITHUB_ENV
           echo "HEAD_BRANCH=$(echo $PR_DATA | jq -r '.headRefName')" >> $GITHUB_ENV
           echo "PR_TITLE=$(echo $PR_DATA | jq -r '.title')" >> $GITHUB_ENV
-          echo "BASE_SHA=${{ github.event.pull_request.base.sha }}" >> $GITHUB_ENV
+          echo "BASE_SHA=$(echo $PR_DATA | jq -r '.baseSha')" >> $GITHUB_ENV
 
           LATEST_COMMIT_SHA=$(gh pr view $PR_NUMBER --json commits --jq '.commits[-1].oid')
           FIRST_COMMIT_SHA=$(gh pr view $PR_NUMBER --json commits --jq '.commits[0].oid')

--- a/.github/workflows/auto-pr-to-release.yml
+++ b/.github/workflows/auto-pr-to-release.yml
@@ -112,6 +112,8 @@ jobs:
 
           # Fetch and checkout the release branch
           git fetch --all
+
+          git fetch origin ${{ env.HEAD_BRANCH }}:${{ env.HEAD_BRANCH }}
           git checkout ${{ env.RELEASE_BRANCH }}
 
           # Create a new branch for the PR
@@ -120,10 +122,9 @@ jobs:
 
           echo "First commit: ${{ env.FIRST_COMMIT_SHA }}"
           echo "Latest commit: ${{ env.LATEST_COMMIT_SHA }}"
-          echo "Release branch: ${{ env.RELEASE_BRANCH }}"
-          echo "Head branch: ${{ env.HEAD_BRANCH }}"
+
           # NOTE: git cherry-pick range needs ~ to include the FIRST_COMMIT_SHA (https://stackoverflow.com/questions/1994463/how-to-cherry-pick-a-range-of-commits-and-merge-them-into-another-branch)
-          COMMIT_RANGE="${{ env.RELEASE_BRANCH }}~..${{ env.HEAD_BRANCH }}"
+          COMMIT_RANGE="$NEW_BRANCH~..${{ env.HEAD_BRANCH }}"
 
           if [ "${{ env.FIRST_COMMIT_SHA }}" == "${{ env.LATEST_COMMIT_SHA }}" ]; then
             COMMIT_RANGE=${{ env.FIRST_COMMIT_SHA }}

--- a/.github/workflows/auto-pr-to-release.yml
+++ b/.github/workflows/auto-pr-to-release.yml
@@ -114,7 +114,7 @@ jobs:
           git checkout -b $NEW_BRANCH
 
           echo "HEAD_BRANCH: ${{ env.HEAD_BRANCH }}"
-          echo "BASE_SHA": ${{ env.BASE_SHA }}"
+          echo "BASE_SHA: ${{ env.BASE_SHA }}"
 
           COMMIT_RANGE="${{ env.BASE_SHA }}..${{ env.HEAD_BRANCH }}"
 

--- a/.github/workflows/auto-pr-to-release.yml
+++ b/.github/workflows/auto-pr-to-release.yml
@@ -25,13 +25,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Setup SSH
-        if: ${{ env.ACT }}
-        run: |
-          echo "${{ secrets.SSH_PRIVATE_KEY_PROD }}" > ~/.ssh/id_rsa
-          chmod 600 ~/.ssh/id_rsa
-          ssh-keyscan github.com >> ~/.ssh/known_hosts
-
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -122,7 +115,7 @@ jobs:
           echo "HEAD_BRANCH: ${{ env.HEAD_BRANCH }}"
           echo "BASE_SHA: ${{ env.BASE_SHA }}"
 
-          COMMIT_RANGE="${{ env.BASE_SHA }}..${{ env.HEAD_BRANCH }}"
+          COMMIT_RANGE="${{ env.BASE_SHA }}..origin/${{ env.HEAD_BRANCH }}"
 
           echo "Commit range: ${COMMIT_RANGE}"
 

--- a/.github/workflows/auto-pr-to-release.yml
+++ b/.github/workflows/auto-pr-to-release.yml
@@ -129,9 +129,6 @@ jobs:
             # If cherry-pick fails, create a placeholder commit
             echo "Cherry-pick failed. Creating placeholder commit."
 
-            # -- Is needed to make unambigious we are referring to branches rather than files. Happens when branch has "/"
-            GIT_LOG_ONELINE_OUTPUT=$(git log --oneline --no-decorate --no-merges ${COMMIT_RANGE} --)
-
             git reset --hard
             git commit --allow-empty -m "Placeholder commit for PR #${{ env.PR_ID }}"
 

--- a/.github/workflows/auto-pr-to-release.yml
+++ b/.github/workflows/auto-pr-to-release.yml
@@ -33,20 +33,17 @@ jobs:
         id: get_pr_details_dispatch
         run: |
           PR_NUMBER=${{ github.event.inputs.pr_number }}
-          PR_DATA=$(gh pr view $PR_NUMBER --json number,headRefName,baseRefName,mergedBy,mergeCommit,author,milestone,title,base --jq '{number: .number, headRefName: .headRefName, baseRefName: .baseRefName, merger: .mergedBy.login, author: .author.login, milestone: .milestone.title, title: .title, baseSha: .base.sha}')
-          echo "PR_ID=$(echo $PR_DATA | jq -r '.number')" >> $GITHUB_ENV
-          echo "PR_AUTHOR=$(echo $PR_DATA | jq -r '.author')" >> $GITHUB_ENV
-          echo "PR_MERGER=$(echo $PR_DATA | jq -r '.merger')" >> $GITHUB_ENV
-          echo "MILESTONE=$(echo $PR_DATA | jq -r '.milestone')" >> $GITHUB_ENV
-          echo "BASE_BRANCH=$(echo $PR_DATA | jq -r '.baseRefName')" >> $GITHUB_ENV
-          echo "HEAD_BRANCH=$(echo $PR_DATA | jq -r '.headRefName')" >> $GITHUB_ENV
-          echo "PR_TITLE=$(echo $PR_DATA | jq -r '.title')" >> $GITHUB_ENV
-          echo "BASE_SHA=$(echo $PR_DATA | jq -r '.baseSha')" >> $GITHUB_ENV
-
-          LATEST_COMMIT_SHA=$(gh pr view $PR_NUMBER --json commits --jq '.commits[-1].oid')
-          FIRST_COMMIT_SHA=$(gh pr view $PR_NUMBER --json commits --jq '.commits[0].oid')
-          echo "LATEST_COMMIT_SHA=${LATEST_COMMIT_SHA}" >> $GITHUB_ENV
-          echo "FIRST_COMMIT_SHA=${FIRST_COMMIT_SHA}" >> $GITHUB_ENV
+          PR_DATA=$(curl -s -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/opencrvs/opencrvs-core/pulls/$PR_NUMBER)
+          # printf escapes the newlines in the JSON, so we can use jq to parse output such as:
+          # "body": "![image](https://github.com/user-attachments/assets/8eee5bcf-7692-490f-a19f-576623e09961)\r\n",
+          echo "PR_ID=$(printf '%s' $PR_DATA | jq -r '.number')" >> $GITHUB_ENV
+          echo "PR_AUTHOR=$(printf '%s' $PR_DATA | jq -r '.user.login')" >> $GITHUB_ENV
+          echo "PR_MERGER=$(printf '%s' $PR_DATA | jq -r '.merged_by.login')" >> $GITHUB_ENV
+          echo "MILESTONE=$(printf '%s' $PR_DATA | jq -r '.milestone.title')" >> $GITHUB_ENV
+          echo "BASE_BRANCH=$(printf '%s' $PR_DATA | jq -r '.base.ref')" >> $GITHUB_ENV
+          echo "HEAD_BRANCH=$(printf '%s' $PR_DATA | jq -r '.head.ref')" >> $GITHUB_ENV
+          echo "PR_TITLE=$(printf '%s' $PR_DATA | jq -r '.title')" >> $GITHUB_ENV
+          echo "BASE_SHA=$(printf '%s' $PR_DATA | jq -r '.base.sha')" >> $GITHUB_ENV
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -62,11 +59,6 @@ jobs:
           echo "HEAD_BRANCH=${{ github.event.pull_request.head.ref }}" >> $GITHUB_ENV
           echo "PR_TITLE=${{ github.event.pull_request.title }}" >> $GITHUB_ENV
           echo "BASE_SHA=${{ github.event.pull_request.base.sha }}" >> $GITHUB_ENV
-
-          LATEST_COMMIT_SHA=$(gh pr view $PR_NUMBER --json commits --jq '.commits[-1].oid')
-          FIRST_COMMIT_SHA=$(gh pr view $PR_NUMBER --json commits --jq '.commits[0].oid')
-          echo "LATEST_COMMIT_SHA=${LATEST_COMMIT_SHA}" >> $GITHUB_ENV
-          echo "FIRST_COMMIT_SHA=${FIRST_COMMIT_SHA}" >> $GITHUB_ENV
 
           PR_DETAILS=$(gh pr view $PR_NUMBER --json mergedBy)
           MERGED_BY_LOGIN=$(echo "$PR_DETAILS" | jq -r '.mergedBy.login')

--- a/.github/workflows/auto-pr-to-release.yml
+++ b/.github/workflows/auto-pr-to-release.yml
@@ -41,6 +41,7 @@ jobs:
           echo "BASE_BRANCH=$(echo $PR_DATA | jq -r '.baseRefName')" >> $GITHUB_ENV
           echo "HEAD_BRANCH=$(echo $PR_DATA | jq -r '.headRefName')" >> $GITHUB_ENV
           echo "PR_TITLE=$(echo $PR_DATA | jq -r '.title')" >> $GITHUB_ENV
+          echo "BASE_SHA=${{ github.event.pull_request.base.sha }}" >> $GITHUB_ENV
 
           LATEST_COMMIT_SHA=$(gh pr view $PR_NUMBER --json commits --jq '.commits[-1].oid')
           FIRST_COMMIT_SHA=$(gh pr view $PR_NUMBER --json commits --jq '.commits[0].oid')
@@ -60,6 +61,7 @@ jobs:
           echo "BASE_BRANCH=${{ github.event.pull_request.base.ref }}" >> $GITHUB_ENV
           echo "HEAD_BRANCH=${{ github.event.pull_request.head.ref }}" >> $GITHUB_ENV
           echo "PR_TITLE=${{ github.event.pull_request.title }}" >> $GITHUB_ENV
+          echo "BASE_SHA=${{ github.event.pull_request.base.sha }}" >> $GITHUB_ENV
 
           LATEST_COMMIT_SHA=$(gh pr view $PR_NUMBER --json commits --jq '.commits[-1].oid')
           FIRST_COMMIT_SHA=$(gh pr view $PR_NUMBER --json commits --jq '.commits[0].oid')
@@ -120,20 +122,19 @@ jobs:
           NEW_BRANCH="auto-pr-${{ env.RELEASE_BRANCH }}-${{ env.PR_ID }}-$RANDOM"
           git checkout -b $NEW_BRANCH
 
-          echo "First commit: ${{ env.FIRST_COMMIT_SHA }}"
-          echo "Latest commit: ${{ env.LATEST_COMMIT_SHA }}"
+          echo "HEAD_BRANCH: ${{ env.HEAD_BRANCH }}"
+          echo "BASE_SHA": ${{ env.BASE_SHA }}"
 
-          # NOTE: git cherry-pick range needs ~ to include the FIRST_COMMIT_SHA (https://stackoverflow.com/questions/1994463/how-to-cherry-pick-a-range-of-commits-and-merge-them-into-another-branch)
-          COMMIT_RANGE="$NEW_BRANCH~..${{ env.HEAD_BRANCH }}"
-
-          if [ "${{ env.FIRST_COMMIT_SHA }}" == "${{ env.LATEST_COMMIT_SHA }}" ]; then
-            COMMIT_RANGE=${{ env.FIRST_COMMIT_SHA }}
-          fi
+          COMMIT_RANGE="${{ env.BASE_SHA }}..${{ env.HEAD_BRANCH }}"
 
           echo "Commit range: $COMMIT_RANGE"
 
+          NON_MERGE_COMMITS=$(git log --reverse --no-merges --pretty=format:"%h" $COMMIT_RANGE -- | xargs)
+
+          echo "Ordered non-merge commits: $NON_MERGE_COMMITS"
+
           # Attempt to cherry-pick the commits from the original PR
-          CHERRY_PICK_OUTPUT=$(git cherry-pick $COMMIT_RANGE 2>&1) || {
+          CHERRY_PICK_OUTPUT=$(git cherry-pick $NON_MERGE_COMMITS 2>&1) || {
             git cherry-pick --abort || true
             # If cherry-pick fails, create a placeholder commit
             echo "Cherry-pick failed. Creating placeholder commit."
@@ -160,14 +161,9 @@ jobs:
 
             git checkout $NEW_BRANCH
             git reset --hard HEAD~1  # Remove placeholder commit
-            git cherry-pick $COMMIT_RANGE
+            git cherry-pick $NON_MERGE_COMMITS
             \`\`\`
 
-
-            **Individual commits without merges:**
-            \`\`\`
-            $GIT_LOG_ONELINE_OUTPUT
-            \`\`\`
             "
           }
 


### PR DESCRIPTION
See initial discussion: https://github.com/opencrvs/opencrvs-core/pull/7397

Problems:
1. When feature branch includes merge commits (e.g. someone merges develop in to keep branch up-to-date) automation will fail
2. It's not completely safe to ignore the merge commits if they happen to include some meaningful changes for the release (Hopefully we can ignore this?)
3. If one includes merge commits the resulting set will end up with unrelated commits (https://github.com/opencrvs/opencrvs-core/compare/auto-pr-release-v1.6.0-7344-10229-test vs https://github.com/opencrvs/opencrvs-core/pull/7394)

Initial suggestions:
- In order for this to work we should either a) knowingly ignore the merges b) enforce rebasing of develop on feature branches
- If we go with a) we might not want to use ranges but rather get the commit hashes `git log branchA..banchB --no-merges  --pretty=format:"%h"  --` and pick them individually


Final solution:
- Utilise `base.sha` to get just the right commits that were added in feature branch compared to base branch
- Filter out merge commits through `git log` to make automation pass more likely