### PR TITLE
fix(vulnerability): resolve fast-xml-parser to 4.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "react-signature-canvas": "^1.0.6"
   },
   "resolutions": {
-    "@types/react": "18.3.1"
+    "@types/react": "18.3.1",
+    "fast-xml-parser": "4.4.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13519,17 +13519,10 @@ fast-url-parser@1.1.3, fast-url-parser@^1.1.3:
   dependencies:
     punycode "^1.3.2"
 
-fast-xml-parser@4.2.5:
-  version "4.2.5"
-  resolved "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz"
-  integrity sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==
-  dependencies:
-    strnum "^1.0.5"
-
-fast-xml-parser@^4.1.3, fast-xml-parser@^4.2.2:
-  version "4.3.2"
-  resolved "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.3.2.tgz"
-  integrity sha512-rmrXUXwbJedoXkStenj1kkljNF7ugn5ZjR9FJcwmCfcCbtOMDghPajbc+Tck6vE6F5XsDmx+Pr2le9fw8+pXBg==
+fast-xml-parser@4.2.5, fast-xml-parser@4.4.1, fast-xml-parser@^4.1.3, fast-xml-parser@^4.2.2:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz#86dbf3f18edf8739326447bcaac31b4ae7f6514f"
+  integrity sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==
   dependencies:
     strnum "^1.0.5"
 


### PR DESCRIPTION
specific version `@4.2.5` is used through 

```
└─┬ @opencrvs/metrics@1.5.0 -> ./packages/metrics
  └─┬ mongodb@4.17.2
    └─┬ @aws-sdk/credential-providers@3.433.0
      └─┬ @aws-sdk/client-sts@3.433.0
        └── fast-xml-parser@4.2.5
```

Which in our case should not be a problem since we are not using aws. Other dependencies accept ^4.x.x