### PR TITLE
Fix/missing operation history

### DIFF
--- a/packages/commons/src/fhir/task.ts
+++ b/packages/commons/src/fhir/task.ts
@@ -227,6 +227,7 @@ export function sortTasksDescending<T extends { lastModified: string }>(
     )
   })
 }
+
 export const findTaskHistories = (
   bundle: Bundle,
   sort = sortTasksAscending
@@ -239,6 +240,15 @@ export const findTaskHistories = (
       .map(({ resource }) => resource)
   )
 }
+
+export const findAllTasks = (bundle: Bundle, sort = sortTasksAscending) =>
+  sort(
+    bundle.entry
+      .filter((entry): entry is BundleEntry<Task | TaskHistory> =>
+        isTaskOrTaskHistory(entry.resource)
+      )
+      .map(({ resource }) => resource)
+  )
 
 export const findFirstTaskHistory = (bundle: Bundle) =>
   findTaskHistories(bundle).at(0)

--- a/packages/search/src/elasticsearch/utils.ts
+++ b/packages/search/src/elasticsearch/utils.ts
@@ -21,7 +21,6 @@ import {
   searchForDeathDuplicates
 } from '@search/features/registration/deduplicate/service'
 import {
-  findTaskHistories,
   getBusinessStatus,
   SavedBundle,
   SavedOffice,
@@ -29,7 +28,8 @@ import {
   SavedTask,
   SearchDocument,
   validStatusMapping,
-  IOperationHistory
+  IOperationHistory,
+  findAllTasks
 } from '@opencrvs/commons/types'
 import { findName } from '@search/features/fhir/fhir-utils'
 
@@ -199,11 +199,17 @@ export async function getCreatedBy(compositionId: string) {
   return results?.body?.hits?.hits[0]?._source?.createdBy
 }
 
+/**
+ * Compose operation histories from a bundle.
+ *
+ * Include both the latest Task and TaskHistory. Otherwise the latest task will be missing.
+ * e.g. When field agent sends a declaration for review, and registrar approves it with changes.
+ */
 export const composeOperationHistories = (bundle: SavedBundle) => {
-  const taskHistories = findTaskHistories(bundle)
-  return taskHistories.map((taskHistory) => ({
-    operationType: getBusinessStatus(taskHistory),
-    operatedOn: taskHistory.lastModified
+  const tasks = findAllTasks(bundle)
+  return tasks.map((task) => ({
+    operationType: getBusinessStatus(task),
+    operatedOn: task.lastModified
   }))
 }
 

--- a/packages/workflow/src/config/routes.ts
+++ b/packages/workflow/src/config/routes.ts
@@ -84,7 +84,7 @@ export const getRoutes = () => {
       handler: downloadRecordHandler,
       config: {
         tags: ['api'],
-        description: 'Create record endpoint'
+        description: 'Download record endpoint'
       }
     },
     {


### PR DESCRIPTION
https://github.com/orgs/opencrvs/projects/4/views/2?pane=issue&itemId=68678339

Issue:
1. Field agent sends birth event for review
2. Local registrar changes the details and registers the event
3. register timestamp does not appear

Fix:
Do not filter out task type from index, since register might not get indexed.




<img width="1245" alt="Screenshot 2024-08-15 at 15 24 09" src="https://github.com/user-attachments/assets/3c53083d-149a-415d-9f43-cd3b9ce17db1">


Related test case: https://github.com/opencrvs/opencrvs-farajaland/pull/1092

