### PR TITLE
fix: date range edit not being clickable in advanced search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,6 +205,7 @@ Follow the descriptions in the migration notes to re-provision all servers safel
 - Update Content-Security-Policy to allow loading fonts from country configuration [#7296](https://github.com/opencrvs/opencrvs-core/pull/7296)
 - Fix frontend crashing on 'Registration by Status' under performance due to missing translations [#7129](https://github.com/opencrvs/opencrvs-core/pull/7129)
 - Fix email of practitioner to be saved in hearth. A migration is added to correct the email of practitoiner in existing db. [7315](https://github.com/opencrvs/opencrvs-core/pull/7315)
+- Fix EDIT not working 4 DateRangePickerForFormField [7485](https://github.com/opencrvs/opencrvs-core/pull/7485)
 
 ## [1.3.4](https://github.com/opencrvs/opencrvs-core/compare/v1.3.3...v1.3.4)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,7 +205,7 @@ Follow the descriptions in the migration notes to re-provision all servers safel
 - Update Content-Security-Policy to allow loading fonts from country configuration [#7296](https://github.com/opencrvs/opencrvs-core/pull/7296)
 - Fix frontend crashing on 'Registration by Status' under performance due to missing translations [#7129](https://github.com/opencrvs/opencrvs-core/pull/7129)
 - Fix email of practitioner to be saved in hearth. A migration is added to correct the email of practitoiner in existing db. [7315](https://github.com/opencrvs/opencrvs-core/pull/7315)
-- Fix EDIT not working 4 DateRangePickerForFormField [7485](https://github.com/opencrvs/opencrvs-core/pull/7485)
+- Fix inaccessible and only partly visible "Edit" button in "Advanced Search" - feature's date range list [7485](https://github.com/opencrvs/opencrvs-core/pull/7485)
 
 ## [1.3.4](https://github.com/opencrvs/opencrvs-core/compare/v1.3.3...v1.3.4)
 

--- a/packages/client/src/components/DateRangePickerForFormField.tsx
+++ b/packages/client/src/components/DateRangePickerForFormField.tsx
@@ -94,14 +94,9 @@ function DateRangePickerForFormFieldComponent(props: IDateRangePickerProps) {
     })
   }
 
-  const isValidDateRange =
-    props.value.rangeStart !== undefined && props.value.rangeEnd !== undefined
   const dateRangeLabel =
-    formatDateRangeLabel(props.value.rangeStart, props.value.rangeEnd) || ''
-
-  const linkLabel = isValidDateRange
-    ? intl.formatMessage(buttonMessages.edit)
-    : intl.formatMessage(buttonMessages.exactDateUnknown)
+    formatDateRangeLabel(props.value.rangeStart, props.value.rangeEnd) ||
+    intl.formatMessage(buttonMessages.exactDateUnknown)
 
   return (
     <DateRangePickerContainer>
@@ -115,22 +110,25 @@ function DateRangePickerForFormFieldComponent(props: IDateRangePickerProps) {
         disabled={props.value.isDateRangeActive}
       />
       <DateRangeBody>
-        {isValidDateRange && (
+        {props.value.isDateRangeActive && (
           <Checkbox
             name={props.inputProps.id + 'date_range_toggle'}
             label={dateRangeLabel || ''}
             value={''}
             selected={props.value.isDateRangeActive || false}
             onChange={handleDateRangeActiveChange}
-          ></Checkbox>
+          />
         )}
 
         <Link
           id={props.inputProps.id + '-date_range_button'}
           onClick={handleLinkOnClick}
         >
-          {linkLabel}
+          {props.value.isDateRangeActive
+            ? intl.formatMessage(buttonMessages.edit)
+            : intl.formatMessage(buttonMessages.exactDateUnknown)}
         </Link>
+
         {modalVisible && (
           <DateRangePicker
             startDate={

--- a/packages/components/src/Checkbox/Checkbox.tsx
+++ b/packages/components/src/Checkbox/Checkbox.tsx
@@ -17,7 +17,7 @@ const Label = styled.label<{ disabled?: boolean }>`
   flex-direction: row;
   gap: 12px;
   border-radius: 4px;
-  width: 100%;
+  width: auto;
   padding: 8px 8px;
   align-items: center;
   isolation: isolate;
@@ -85,7 +85,7 @@ const Check = styled.span<{ size?: string; disabled?: boolean }>`
 
 const Input = styled.input`
   position: absolute;
-  width: 100%;
+  width: auto;
   height: 40px;
   opacity: 0;
   z-index: 2;


### PR DESCRIPTION
The logic for toggling between range and exact date was not working as
expected, and the CheckBox's label was overlapping over the 'edit' link

https://github.com/opencrvs/opencrvs-core/issues/7417