### PR TITLE
fix(registration-list): use time property instead of date for safer date format generation

### DIFF
--- a/packages/client/src/utils/date-formatting.ts
+++ b/packages/client/src/utils/date-formatting.ts
@@ -106,11 +106,15 @@ export const convertAgeToDate = (age: string): string => {
   return format(subYears(new Date(), Number(age)), 'yyyy-MM-dd')
 }
 
-export default function formatDate(date: Date | number, formatStr = 'PP') {
+export default function formatDate(
+  date: Date | number,
+  formatStr = 'PP',
+  locale?: string
+) {
   if (!isValid(date)) {
     return ''
   }
   return format(date, formatStr, {
-    locale: locales[window.__localeId__]
+    locale: locales[locale ?? window.__localeId__]
   })
 }

--- a/packages/client/src/utils/gateway.ts
+++ b/packages/client/src/utils/gateway.ts
@@ -7849,76 +7849,82 @@ export type GetRegistrationsListByFilterQueryVariables = Exact<{
   size: Scalars['Int']
 }>
 
+export type RegistrationsListByLocationFilter = {
+  __typename: 'TotalMetricsByLocation'
+  total?: number | null
+  results: Array<{
+    __typename?: 'EventMetricsByLocation'
+    total: number
+    late: number
+    delayed: number
+    home: number
+    healthFacility: number
+    location: { __typename?: 'Location'; name?: string | null }
+  }>
+}
+
+export type RegistrationsListByRegistrarFilter = {
+  __typename: 'TotalMetricsByRegistrar'
+  total?: number | null
+  results: Array<{
+    __typename?: 'EventMetricsByRegistrar'
+    total: number
+    late: number
+    delayed: number
+    registrarPractitioner?: {
+      __typename?: 'User'
+      id: string
+      systemRole: SystemRoleType
+      role: {
+        __typename?: 'Role'
+        _id: string
+        labels: Array<{
+          __typename?: 'RoleLabel'
+          lang: string
+          label: string
+        }>
+      }
+      primaryOffice?: {
+        __typename?: 'Location'
+        name?: string | null
+        id: string
+      } | null
+      name: Array<{
+        __typename?: 'HumanName'
+        firstNames?: string | null
+        familyName?: string | null
+        use?: string | null
+      }>
+      avatar?: {
+        __typename?: 'Avatar'
+        type: string
+        data: string
+      } | null
+    } | null
+  }>
+}
+
+export type RegistrationsListByTimeFilter = {
+  __typename: 'TotalMetricsByTime'
+  total?: number | null
+  results: Array<{
+    __typename?: 'EventMetricsByTime'
+    total: number
+    delayed: number
+    late: number
+    home: number
+    healthFacility: number
+    month: string
+    time: string
+  }>
+}
+
 export type GetRegistrationsListByFilterQuery = {
   __typename?: 'Query'
   getRegistrationsListByFilter?:
-    | {
-        __typename: 'TotalMetricsByLocation'
-        total?: number | null
-        results: Array<{
-          __typename?: 'EventMetricsByLocation'
-          total: number
-          late: number
-          delayed: number
-          home: number
-          healthFacility: number
-          location: { __typename?: 'Location'; name?: string | null }
-        }>
-      }
-    | {
-        __typename: 'TotalMetricsByRegistrar'
-        total?: number | null
-        results: Array<{
-          __typename?: 'EventMetricsByRegistrar'
-          total: number
-          late: number
-          delayed: number
-          registrarPractitioner?: {
-            __typename?: 'User'
-            id: string
-            systemRole: SystemRoleType
-            role: {
-              __typename?: 'Role'
-              _id: string
-              labels: Array<{
-                __typename?: 'RoleLabel'
-                lang: string
-                label: string
-              }>
-            }
-            primaryOffice?: {
-              __typename?: 'Location'
-              name?: string | null
-              id: string
-            } | null
-            name: Array<{
-              __typename?: 'HumanName'
-              firstNames?: string | null
-              familyName?: string | null
-              use?: string | null
-            }>
-            avatar?: {
-              __typename?: 'Avatar'
-              type: string
-              data: string
-            } | null
-          } | null
-        }>
-      }
-    | {
-        __typename: 'TotalMetricsByTime'
-        total?: number | null
-        results: Array<{
-          __typename?: 'EventMetricsByTime'
-          total: number
-          delayed: number
-          late: number
-          home: number
-          healthFacility: number
-          month: string
-          time: string
-        }>
-      }
+    | RegistrationsListByLocationFilter
+    | RegistrationsListByRegistrarFilter
+    | RegistrationsListByTimeFilter
     | null
 }
 

--- a/packages/client/src/views/Performance/RegistrationsList.test.tsx
+++ b/packages/client/src/views/Performance/RegistrationsList.test.tsx
@@ -71,7 +71,7 @@ describe('Registrations List test', () => {
                   late: 0,
                   home: 0,
                   healthFacility: 0,
-                  month: 'November-2022',
+                  month: '2022-11-01',
                   time: '1667239200000',
                   __typename: 'EventMetricsByTime'
                 },
@@ -81,7 +81,7 @@ describe('Registrations List test', () => {
                   late: 2,
                   home: 1,
                   healthFacility: 12,
-                  month: 'October-2022',
+                  month: '2022-10-01',
                   time: '1664560800000',
                   __typename: 'EventMetricsByTime'
                 },
@@ -91,7 +91,7 @@ describe('Registrations List test', () => {
                   late: 0,
                   home: 0,
                   healthFacility: 2,
-                  month: 'September-2022',
+                  month: '2022-09-01',
                   time: '1661968800000',
                   __typename: 'EventMetricsByTime'
                 },
@@ -101,7 +101,7 @@ describe('Registrations List test', () => {
                   late: 0,
                   home: 0,
                   healthFacility: 0,
-                  month: 'August-2022',
+                  month: '2022-08-01',
                   time: '1659290400000',
                   __typename: 'EventMetricsByTime'
                 },
@@ -111,7 +111,7 @@ describe('Registrations List test', () => {
                   late: 0,
                   home: 0,
                   healthFacility: 0,
-                  month: 'July-2022',
+                  month: '2022-07-01',
                   time: '1656612000000',
                   __typename: 'EventMetricsByTime'
                 },
@@ -121,7 +121,7 @@ describe('Registrations List test', () => {
                   late: 0,
                   home: 0,
                   healthFacility: 0,
-                  month: 'June-2022',
+                  month: '2022-06-01',
                   time: '1654020000000',
                   __typename: 'EventMetricsByTime'
                 },
@@ -131,7 +131,7 @@ describe('Registrations List test', () => {
                   late: 0,
                   home: 0,
                   healthFacility: 0,
-                  month: 'May-2022',
+                  month: '2022-05-01',
                   time: '1651341600000',
                   __typename: 'EventMetricsByTime'
                 },
@@ -141,7 +141,7 @@ describe('Registrations List test', () => {
                   late: 0,
                   home: 0,
                   healthFacility: 0,
-                  month: 'April-2022',
+                  month: '2022-04-01',
                   time: '1648749600000',
                   __typename: 'EventMetricsByTime'
                 },
@@ -151,7 +151,7 @@ describe('Registrations List test', () => {
                   late: 0,
                   home: 0,
                   healthFacility: 0,
-                  month: 'March-2022',
+                  month: '2022-03-01',
                   time: '1646071200000',
                   __typename: 'EventMetricsByTime'
                 },
@@ -161,7 +161,7 @@ describe('Registrations List test', () => {
                   late: 0,
                   home: 0,
                   healthFacility: 0,
-                  month: 'February-2022',
+                  month: '2022-02-01',
                   time: '1643652000000',
                   __typename: 'EventMetricsByTime'
                 }

--- a/packages/client/src/views/Performance/RegistrationsList.tsx
+++ b/packages/client/src/views/Performance/RegistrationsList.tsx
@@ -20,7 +20,6 @@ import {
   goToFieldAgentList,
   goToPerformanceHome,
   goToRegistrationsList,
-  IDynamicValues,
   goToUserProfile,
   goToTeamUserList
 } from '@client/navigation'
@@ -53,8 +52,7 @@ import { Content, ContentSize } from '@opencrvs/components/lib/Content'
 import { SortArrow } from '@opencrvs/components/lib/icons'
 import { Pagination } from '@opencrvs/components/lib/Pagination'
 import { Table } from '@opencrvs/components/lib/Table'
-import type { GQLMixedTotalMetricsResult } from '@client/utils/gateway-deprecated-do-not-use'
-import { get, orderBy } from 'lodash'
+import { orderBy } from 'lodash'
 import { parse } from 'query-string'
 import React from 'react'
 import { injectIntl, WrappedComponentProps } from 'react-intl'
@@ -64,7 +62,7 @@ import ReactTooltip from 'react-tooltip'
 import styled from 'styled-components'
 import { Link } from '@opencrvs/components/lib/Link'
 import { useAuthorization } from '@client/hooks/useAuthorization'
-import formatDate, { formatLongDate } from '@client/utils/date-formatting'
+import formatDate from '@client/utils/date-formatting'
 
 const ToolTipContainer = styled.span`
   text-align: center;

--- a/packages/client/src/views/Performance/RegistrationsList.tsx
+++ b/packages/client/src/views/Performance/RegistrationsList.tsx
@@ -491,7 +491,7 @@ function RegistrationListComponent(props: IProps) {
     return {
       ...result,
       // Time is epoch but returned as a string
-      month: formatDate(+result.time, 'MMMM yyyy', intl.locale),
+      month: formatDate(new Date(result.month), 'MMMM yyyy', intl.locale),
       total: String(result.total),
       delayed: showWithTooltip(result.total, result.delayed, 'delayed', index),
       delayed_num: getPercentage(result.total, result.delayed),

--- a/packages/client/src/views/Performance/RegistrationsList.tsx
+++ b/packages/client/src/views/Performance/RegistrationsList.tsx
@@ -29,7 +29,11 @@ import { ILocation } from '@client/offline/reducer'
 import { getOfflineData } from '@client/offline/selectors'
 import { IStoreState } from '@client/store'
 import {
+  GetRegistrationsListByFilterQuery,
   QueryGetRegistrationsListByFilterArgs,
+  RegistrationsListByLocationFilter,
+  RegistrationsListByRegistrarFilter,
+  RegistrationsListByTimeFilter,
   RegistrationType
 } from '@client/utils/gateway'
 import { generateLocations } from '@client/utils/locationUtils'
@@ -60,7 +64,7 @@ import ReactTooltip from 'react-tooltip'
 import styled from 'styled-components'
 import { Link } from '@opencrvs/components/lib/Link'
 import { useAuthorization } from '@client/hooks/useAuthorization'
-import { formatLongDate } from '@client/utils/date-formatting'
+import formatDate, { formatLongDate } from '@client/utils/date-formatting'
 
 const ToolTipContainer = styled.span`
   text-align: center;
@@ -395,139 +399,145 @@ function RegistrationListComponent(props: IProps) {
     )
   }
 
-  function getContent(data?: GQLMixedTotalMetricsResult) {
-    const content = { ...data } as IDynamicValues
-    let finalContent: IDynamicValues[] = []
+  const getTableContentByRegistrar = (
+    result: RegistrationsListByRegistrarFilter['results'][0],
+    index: number
+  ) => ({
+    ...result,
+    name: (
+      <Stack>
+        <AvatarSmall
+          name={
+            result.registrarPractitioner?.name
+              ? getName(result.registrarPractitioner.name, 'en')
+              : ''
+          }
+          avatar={result.registrarPractitioner?.avatar}
+        />
+        <>
+          {!isPerformanceManager ? (
+            <Link
+              font="bold14"
+              onClick={() => {
+                props.goToUserProfile(String(result.registrarPractitioner?.id))
+              }}
+            >
+              {result.registrarPractitioner?.name
+                ? getName(result.registrarPractitioner.name, 'en')
+                : ''}
+            </Link>
+          ) : (
+            String(
+              result.registrarPractitioner?.name
+                ? getName(result.registrarPractitioner.name, 'en')
+                : ''
+            )
+          )}
+        </>
+      </Stack>
+    ),
+    location: (
+      <>
+        {!isPerformanceManager ? (
+          <Link
+            font="bold14"
+            onClick={() => {
+              props.goToTeamUserList(
+                result.registrarPractitioner?.primaryOffice?.id as string
+              )
+            }}
+          >
+            {result.registrarPractitioner?.primaryOffice?.name}
+          </Link>
+        ) : (
+          String(result.registrarPractitioner?.primaryOffice?.name)
+        )}
+      </>
+    ),
+    systemRole: getFieldAgentTypeLabel(
+      result.registrarPractitioner?.systemRole as string
+    ),
+    total: String(result.total),
+    delayed: showWithTooltip(result.total, result.delayed, 'delayed', index),
+    delayed_num: getPercentage(result.total, result.delayed),
+    late: showWithTooltip(result.total, result.late, 'late', index),
+    late_num: getPercentage(result.total, result.late)
+  })
 
-    if (content.__typename === RESULT_TYPE.by_registrar) {
-      finalContent = content.results.map(
-        (result: IDynamicValues, index: number) => ({
-          ...result,
-          name: (
-            <Stack>
-              <AvatarSmall
-                name={
-                  result.registrarPractitioner.name
-                    ? getName(result.registrarPractitioner.name, 'en')
-                    : ''
-                }
-                avatar={result.registrarPractitioner.avatar}
-              />
-              <>
-                {!isPerformanceManager ? (
-                  <Link
-                    font="bold14"
-                    onClick={() => {
-                      props.goToUserProfile(
-                        String(result.registrarPractitioner.id)
-                      )
-                    }}
-                  >
-                    {result.registrarPractitioner.name
-                      ? getName(result.registrarPractitioner.name, 'en')
-                      : ''}
-                  </Link>
-                ) : (
-                  String(
-                    result.registrarPractitioner.name
-                      ? getName(result.registrarPractitioner.name, 'en')
-                      : ''
-                  )
-                )}
-              </>
-            </Stack>
-          ),
-          location: (
-            <>
-              {!isPerformanceManager ? (
-                <Link
-                  font="bold14"
-                  onClick={() => {
-                    props.goToTeamUserList(
-                      result.registrarPractitioner.primaryOffice?.id as string
-                    )
-                  }}
-                >
-                  {result.registrarPractitioner.primaryOffice.name}
-                </Link>
-              ) : (
-                String(result.registrarPractitioner.primaryOffice.name)
-              )}
-            </>
-          ),
-          systemRole: getFieldAgentTypeLabel(
-            result.registrarPractitioner.systemRole
-          ),
-          total: String(result.total),
-          delayed: showWithTooltip(
-            result.total,
-            result.delayed,
-            'delayed',
-            index
-          ),
-          delayed_num: getPercentage(result.total, result.delayed),
-          late: showWithTooltip(result.total, result.late, 'late', index),
-          late_num: getPercentage(result.total, result.late)
-        })
-      )
-    } else if (content.__typename === RESULT_TYPE.by_location) {
-      finalContent = content.results.map(
-        (result: IDynamicValues, index: number) => ({
-          ...result,
-          location: result.location.name,
-          total: String(result.total),
-          delayed: showWithTooltip(
-            result.total,
-            result.delayed,
-            'delayed',
-            index
-          ),
-          delayed_num: getPercentage(result.total, result.delayed),
-          late: showWithTooltip(result.total, result.late, 'late', index),
-          late_num: getPercentage(result.total, result.late),
-          home: showWithTooltip(result.total, result.home, 'home', index),
-          home_num: getPercentage(result.total, result.home),
-          healthFacility: showWithTooltip(
-            result.total,
-            result.healthFacility,
-            'healthFacility',
-            index
-          ),
-          healthFacility_num: getPercentage(result.total, result.healthFacility)
-        })
-      )
-    } else if (content.__typename === RESULT_TYPE.by_time) {
-      finalContent = content.results.map(
-        (result: IDynamicValues, index: number) => ({
-          ...result,
-          month: formatLongDate(
-            new Date(result.month).toISOString(),
-            intl.locale,
-            'MMMM yyyy'
-          ),
-          total: String(result.total),
-          delayed: showWithTooltip(
-            result.total,
-            result.delayed,
-            'delayed',
-            index
-          ),
-          delayed_num: getPercentage(result.total, result.delayed),
-          late: showWithTooltip(result.total, result.late, 'late', index),
-          late_num: getPercentage(result.total, result.late),
-          home: showWithTooltip(result.total, result.home, 'home', index),
-          home_num: getPercentage(result.total, result.home),
-          healthFacility: showWithTooltip(
-            result.total,
-            result.healthFacility,
-            'healthFacility',
-            index
-          ),
-          healthFacility_num: getPercentage(result.total, result.healthFacility)
-        })
-      )
+  const getTableContentByLocation = (
+    result: RegistrationsListByLocationFilter['results'][0],
+    index: number
+  ) => ({
+    ...result,
+    location: result.location.name,
+    total: String(result.total),
+    delayed: showWithTooltip(result.total, result.delayed, 'delayed', index),
+    delayed_num: getPercentage(result.total, result.delayed),
+    late: showWithTooltip(result.total, result.late, 'late', index),
+    late_num: getPercentage(result.total, result.late),
+    home: showWithTooltip(result.total, result.home, 'home', index),
+    home_num: getPercentage(result.total, result.home),
+    healthFacility: showWithTooltip(
+      result.total,
+      result.healthFacility,
+      'healthFacility',
+      index
+    ),
+    healthFacility_num: getPercentage(result.total, result.healthFacility)
+  })
+
+  const getTableContentByTime = (
+    result: RegistrationsListByTimeFilter['results'][0],
+    index: number
+  ) => {
+    return {
+      ...result,
+      // Time is epoch but returned as a string
+      month: formatDate(+result.time, 'MMMM yyyy', intl.locale),
+      total: String(result.total),
+      delayed: showWithTooltip(result.total, result.delayed, 'delayed', index),
+      delayed_num: getPercentage(result.total, result.delayed),
+      late: showWithTooltip(result.total, result.late, 'late', index),
+      late_num: getPercentage(result.total, result.late),
+      home: showWithTooltip(result.total, result.home, 'home', index),
+      home_num: getPercentage(result.total, result.home),
+      healthFacility: showWithTooltip(
+        result.total,
+        result.healthFacility,
+        'healthFacility',
+        index
+      ),
+      healthFacility_num: getPercentage(result.total, result.healthFacility)
     }
-    return orderBy(finalContent, [columnToBeSort], [sortOrder[columnToBeSort]])
+  }
+
+  function getContent(
+    content?: GetRegistrationsListByFilterQuery['getRegistrationsListByFilter']
+  ) {
+    if (!content) {
+      return []
+    }
+
+    const orderRows = (
+      rows: Array<
+        ReturnType<
+          | typeof getTableContentByTime
+          | typeof getTableContentByLocation
+          | typeof getTableContentByRegistrar
+        >
+      >
+    ) => orderBy(rows, [columnToBeSort], [sortOrder[columnToBeSort]])
+
+    switch (content.__typename) {
+      case RESULT_TYPE.by_registrar:
+        return orderRows(content.results.map(getTableContentByRegistrar))
+      case RESULT_TYPE.by_location:
+        return orderRows(content.results.map(getTableContentByLocation))
+      case RESULT_TYPE.by_time:
+        return orderRows(content.results.map(getTableContentByTime))
+      default:
+        return []
+    }
   }
 
   const options: (IPerformanceSelectOption & { disabled?: boolean })[] = [
@@ -668,7 +678,7 @@ function RegistrationListComponent(props: IProps) {
           </>
         }
       >
-        <Query
+        <Query<GetRegistrationsListByFilterQuery>
           query={FETCH_REGISTRATIONS}
           variables={queryVariables}
           fetchPolicy={'no-cache'}
@@ -684,15 +694,15 @@ function RegistrationListComponent(props: IProps) {
                     )}
                     isLoading={true}
                     columns={getColumns()}
-                    content={getContent(
-                      data && data.getRegistrationsListByFilter
-                    )}
+                    content={getContent(data?.getRegistrationsListByFilter)}
                   />
                   <GenericErrorToast />
                 </>
               )
             } else {
-              const totalData = get(data, 'getRegistrationsListByFilter.total')
+              const registrationCount =
+                data?.getRegistrationsListByFilter?.total ?? 0
+
               return (
                 <>
                   <TableDiv>
@@ -705,20 +715,20 @@ function RegistrationListComponent(props: IProps) {
                       isLoading={loading}
                       disableScrollOnOverflow={true}
                       columns={getColumns()}
-                      content={getContent(
-                        data && data.getRegistrationsListByFilter
-                      )}
-                      totalItems={totalData}
+                      content={getContent(data?.getRegistrationsListByFilter)}
+                      totalItems={registrationCount}
                       currentPage={currentPage}
                       pageSize={recordCount}
                       highlightRowOnMouseOver
                       noPagination={true}
                     />
                   </TableDiv>
-                  {totalData > DEFAULT_PAGE_SIZE && (
+                  {registrationCount > DEFAULT_PAGE_SIZE && (
                     <Pagination
                       currentPage={currentPage}
-                      totalPages={Math.ceil(totalData / DEFAULT_PAGE_SIZE)}
+                      totalPages={Math.ceil(
+                        registrationCount / DEFAULT_PAGE_SIZE
+                      )}
                       onPageChange={(cp: number) => {
                         props.goToRegistrationsList(
                           timeStart,

--- a/packages/metrics/src/features/totalMetrics/handler.ts
+++ b/packages/metrics/src/features/totalMetrics/handler.ts
@@ -226,16 +226,18 @@ export async function totalMetricsByTime(
   const event = request.query[EVENT]
   const skip = request.query[SKIP]
   const size = request.query[SIZE]
+
   const registrationsByGroup = await fetchRegistrationsGroupByTime(
     timeStart,
     timeEnd,
     event,
     locationId
   )
+
   const registrations = registrationsByGroup
 
   registrations.forEach((registration) => {
-    registration.month = format(new Date(registration.time), 'MMMM yyyy')
+    registration.month = format(new Date(registration.time), 'yyyy-MM-dd')
   })
 
   const months = uniqBy(registrations, 'month').map((item) => item.month)
@@ -292,6 +294,7 @@ export async function totalMetricsByTime(
     })
   })
 
+  console.log(results)
   return {
     total: results.length,
     results: results.splice(skip, size)

--- a/packages/metrics/src/features/totalMetrics/handler.ts
+++ b/packages/metrics/src/features/totalMetrics/handler.ts
@@ -294,7 +294,6 @@ export async function totalMetricsByTime(
     })
   })
 
-  console.log(results)
   return {
     total: results.length,
     results: results.splice(skip, size)


### PR DESCRIPTION
https://github.com/orgs/opencrvs/projects/4/views/2?pane=issue&itemId=74602069

What happens:
Depending on language and browser settings the registration list view might crash when given english date inputs e.g. ('July 2024')

How it was fixed:
Use the epoch time property from the same payload.


![date-fix](https://github.com/user-attachments/assets/6de8ceb5-db00-4ef6-a9b7-c2a9d7c85b50)

- Improve types and split code