### PR TITLE
fix: keep `family` field as optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@
 
 ## 1.6.0 Release candidate
 
+## Improvements
+
+- Internally we were storing the `family` name field as a required property which was limiting what how you could capture the name of a person in the forms. Now we are storing it as an optional property which would make more flexible.
+
 ### Breaking changes
 
 - **Gateways searchEvents API updated** `operationHistories` only returns `operationType` & `operatedOn` due to the other fields being unused in OpenCRVS

--- a/packages/commons/src/fhir/patient.ts
+++ b/packages/commons/src/fhir/patient.ts
@@ -41,7 +41,7 @@ export type Patient = WithStrictExtensions<
 
 export type OpenCRVSPatientName = Omit<fhir3.HumanName, 'use' | 'family'> & {
   use: string
-  family: string[]
+  family?: string[]
 }
 
 export const SUPPORTED_PATIENT_IDENTIFIER_CODES = [

--- a/packages/notification/src/features/utils.ts
+++ b/packages/notification/src/features/utils.ts
@@ -93,7 +93,7 @@ export function getInformantName(
   if (!name) {
     error(record, 'name not found in informant patient resource')
   }
-  return [name.given?.join(' '), name.family.join(' ')].join(' ').trim()
+  return [name.given?.join(' '), name.family?.join(' ')].join(' ').trim()
 }
 
 export function getPersonName(
@@ -117,7 +117,7 @@ export function getPersonName(
   if (!name) {
     error(record, `name not found in patient resource for ${compositionCode}`)
   }
-  return [name.given?.join(' '), name.family.join(' ')].join(' ').trim()
+  return [name.given?.join(' '), name.family?.join(' ')].join(' ').trim()
 }
 
 export function getRegistrationLocation(

--- a/packages/notification/src/features/utilsForPartiallyCompletedRecord.ts
+++ b/packages/notification/src/features/utilsForPartiallyCompletedRecord.ts
@@ -48,7 +48,7 @@ export function getInformantName(record: InProgressRecord | RejectedRecord) {
   if (!name) {
     return
   }
-  return [name.given?.join(' '), name.family.join(' ')].join(' ').trim()
+  return [name.given?.join(' '), name.family?.join(' ')].join(' ').trim()
 }
 
 export function getContactPhoneNo(record: InProgressRecord | RejectedRecord) {


### PR DESCRIPTION
https://github.com/opencrvs/opencrvs-core/blob/4ee08fbab548b0c3f191406d57f7222d63ebd713/packages/commons/src/fhir/patient.ts#L42-L45
With this type we are basically saying that family (i.e. "lastName") will always be there. And although we also mentioned this on our form definitions here: https://github.com/opencrvs/opencrvs-countryconfig/blob/develop/src/form/birth/index.ts#L189 but Uganda doesn't want that and have made it to be an optional field.

Anyway we also say that the "firstName" is a required field but our types don't really reflect that tbh (as I mentioned above we've only made "family" field to be a required field but not the "given" (i.e. firstName) field).

Now when I'm trying to register a declaration in Uganda without providing lastName for informant, this line throws an error: https://github.com/opencrvs/opencrvs-core/blob/4ee08fbab548b0c3f191406d57f7222d63ebd713/packages/notification/src/features/utils.ts#L96 as we are trying to access "family.join" but family is undefined.