### PR TITLE
fix: add the missing location details to a newly created declaration which was causing advanced search to break

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 ## Bug fixes
 
 - On slow connections or in rare corner cases, it was possible that the same record got saved to the database twice. This was caused by a bug in how the unique technical identifier we generate were stored as FHIR. The backend now ensures every record is submitted only once. [#7477](https://github.com/opencrvs/opencrvs-core/issues/7477)
+- When a declaration(birth/death) is created the event location information was not being parsed to ElasticSearch which caused the Advanced search feature to not work when searching for records by event location.[7494](https://github.com/opencrvs/opencrvs-core/issues/7494)
 
 ## 1.5.0 (TBD)
 

--- a/packages/workflow/src/records/fhir.ts
+++ b/packages/workflow/src/records/fhir.ts
@@ -51,7 +51,8 @@ import {
   RegistrationStatus,
   getResourceFromBundleById,
   TransactionResponse,
-  TaskIdentifierSystem
+  TaskIdentifierSystem,
+  Location
 } from '@opencrvs/commons/types'
 import { FHIR_URL } from '@workflow/constants'
 import fetch from 'node-fetch'
@@ -1448,6 +1449,27 @@ export async function getTaskHistory(taskId: string): Promise<Bundle<Task>> {
   if (!res.ok) {
     throw new Error(
       `Fetching task history from Hearth failed with [${res.status}] body: ${res.statusText}`
+    )
+  }
+
+  return res.json()
+}
+
+export async function getLocationsById(
+  locationIds: Array<string>
+): Promise<Bundle<Location>> {
+  const res = await fetch(
+    new URL(`/fhir/Location?_id=${locationIds.join(',')}`, FHIR_URL).href,
+    {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/fhir+json'
+      }
+    }
+  )
+  if (!res.ok) {
+    throw new Error(
+      `Fetching locations from Hearth failed with [${res.status}] body: ${res.statusText}`
     )
   }
 


### PR DESCRIPTION
The event location information was missing in the bundle that gets sent to ElasticSearch fot newly created declarations, this caused Advanced Search not to work when searching by event location

https://github.com/opencrvs/opencrvs-core/issues/7494