### PR TITLE
fix(migration): prevent update from over-running existing values

### DIFF
--- a/packages/migration/src/migrations/hearth/20230612060923-update-patient-identifier-with-codeableconcept.ts
+++ b/packages/migration/src/migrations/hearth/20230612060923-update-patient-identifier-with-codeableconcept.ts
@@ -84,7 +84,7 @@ export const up = async (db: Db, client: MongoClient) => {
               },
               {
                 $set: {
-                  'identifier.$[].type': {
+                  'identifier.$.type': {
                     coding: updatedCoding
                   }
                 }


### PR DESCRIPTION
Issue:
When `identifier` includes ids of different `type`, migration will result on renaming all the types based on the first one on the list.

INPUT:
```
[
  {
    "id": BRN-123",
    "type": "BIRTH_REGISTRATION_NUMBER",
    "otherType": null
  },
  {
    "id": "NI-123",
    "type": "NATIONAL_ID",
    "otherType": null
  }
]
```

OUPUT:
```
[
  {
    "id": BRN-123",
    "type": "BIRTH_REGISTRATION_NUMBER",
    "otherType": null
  },
  {
    "id": "NI-123",
    "type": "BIRTH_REGISTRATION_NUMBER",
    "otherType": null
  }
]
```

Fix:
- Update only the first match
- Assumes there aren't multiple ids of same type within the array.



