### PR TITLE
fix: Refactor bundleIncludesLocationResources() function logic to properly check if location resources are included in a bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@
 - When any user's role was updated, incorrect role was shown for that user's actions in the history section of a declaration's record audit page. [#7495](https://github.com/opencrvs/opencrvs-core/issues/7495)
 - When a user updates a marriage declaration editing the signature of the bride, groom, witness one or witness two, handle the changed value of the signature properly. [#7462](https://github.com/opencrvs/opencrvs-core/issues/7462)
 - Registration agent was unable to download declarations that were previously corrected by registrar. [#7582](https://github.com/opencrvs/opencrvs-core/issues/7582)
+- The internal function we used to check if all the location references listed in the encounter are included in the bundle had incorrect logic which resulted in location details missing in ElasticSearch which broke Advanced search. [7494](https://github.com/opencrvs/opencrvs-core/issues/7494)
 
 ## 1.5.0 (TBD)
 

--- a/packages/workflow/src/records/handler/create.test.ts
+++ b/packages/workflow/src/records/handler/create.test.ts
@@ -18,13 +18,30 @@ import {
   SavedBundle,
   SavedTask,
   TransactionResponse,
-  URLReference
+  URLReference,
+  SavedLocation
 } from '@opencrvs/commons/types'
+import { UUID } from '@opencrvs/commons'
 
 const existingTaskBundle: SavedBundle<SavedTask> = {
   resourceType: 'Bundle',
   type: 'document',
   entry: []
+}
+
+const existingLocationBundle: SavedBundle<SavedLocation> = {
+  resourceType: 'Bundle',
+  type: 'document',
+  entry: [
+    {
+      resource: {
+        resourceType: 'Location',
+        id: '146251e9-df90-4068-82b0-27d8f979e8e2' as UUID
+      },
+      fullUrl:
+        'http://localhost:3447/fhir/Location/146251e9-df90-4068-82b0-27d8f979e8e2/_history/e79c368d-f8e4-49b7-8573-d885e11ebb47' as URLReference
+    }
+  ]
 }
 
 describe('Create record endpoint', () => {
@@ -117,6 +134,12 @@ describe('Create record endpoint', () => {
           ]
         }
         return res(ctx.json(responseBundle))
+      })
+    )
+
+    mswServer.use(
+      rest.get('http://localhost:3447/fhir/Location', (_, res, ctx) => {
+        return res(ctx.json(existingLocationBundle))
       })
     )
 

--- a/packages/workflow/src/records/handler/create.ts
+++ b/packages/workflow/src/records/handler/create.ts
@@ -157,14 +157,18 @@ async function resolveLocationsForEncounter(
 
 function bundleIncludesLocationResources(record: Saved<Bundle>) {
   const encounter = findEncounterFromRecord(record)
-  const locationIds =
+  const encounterLocationIds =
     encounter?.location?.map(
       ({ location }) => location.reference.split('/')[1]
     ) || []
 
-  return record.entry
-    .filter(({ resource }) => resource.resourceType == 'Location')
-    .every(({ resource }) => locationIds?.includes(resource.id))
+  const bundleLocations = record.entry.filter(
+    ({ resource }) => resource.resourceType == 'Location'
+  )
+
+  return encounterLocationIds.every((locationId) =>
+    bundleLocations.some((location) => location.id === locationId)
+  )
 }
 
 async function createRecord(


### PR DESCRIPTION
The logic to check if a bundle contains the require location resource
was incorrect, it's fixed now by checking that all the encounter locations
exist a resources in the bundle

https://github.com/opencrvs/opencrvs-core/issues/7494