### PR TITLE
fix: exclude `UNASSIGNED_EXTENSION_URL` from the extension list of correctedTask

### DIFF
--- a/packages/workflow/src/records/fhir.ts
+++ b/packages/workflow/src/records/fhir.ts
@@ -52,7 +52,6 @@ import {
   getResourceFromBundleById,
   TransactionResponse,
   TaskIdentifierSystem,
-  UNASSIGNED_EXTENSION_URL,
   Location
 } from '@opencrvs/commons/types'
 import { FHIR_URL } from '@workflow/constants'
@@ -614,9 +613,6 @@ export function createCorrectedTask(
       {
         url: MAKE_CORRECTION_EXTENSION_URL,
         valueString: 'REGISTERED'
-      },
-      {
-        url: UNASSIGNED_EXTENSION_URL
       }
     ],
     input: correctionDetails.values.map((update) => ({


### PR DESCRIPTION
Revert "fix: include `UNASSIGNED_EXTENSION_URL` in the extension list of correctedTask"
This reverts commit dd2a7638b03cee51ef81b950601fc5fb26c2d2c1.