### PR TITLE
fix(v1.7.0): Modify location builder so it does not edit health facilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 
 ## Bug fixes
 
-- TBC
+- Fix health facilities missing from dropdown after correcting a record address [#7528](https://github.com/opencrvs/opencrvs-core/issues/7528)
 
 ## 1.6.0 Release candidate
 

--- a/packages/commons/src/fhir/location.ts
+++ b/packages/commons/src/fhir/location.ts
@@ -120,3 +120,7 @@ export function isHealthFacility(
 ): location is HealthFacility {
   return location.type?.coding?.[0].code === 'HEALTH_FACILITY'
 }
+
+export function getLocationType(location: Location): string | undefined {
+  return location.type?.coding?.[0].code
+}

--- a/packages/commons/src/fhir/transformers/utils.ts
+++ b/packages/commons/src/fhir/transformers/utils.ts
@@ -65,7 +65,11 @@ import {
   findEntryFromBundle
 } from '..'
 
-import { CompositionSectionTitleByCode, PartialBy } from '../../types'
+import {
+  CompositionSectionTitleByCode,
+  isHealthFacility,
+  PartialBy
+} from '../../types'
 import {
   DOWNLOADED_EXTENSION_URL,
   EVENT_TYPE,
@@ -333,14 +337,7 @@ export function selectOrCreateLocationRefResource(
 
   if (!encounter.location) {
     // create location
-    const locationRef = getUUID()
-    const locationEntry = createLocationResource(locationRef)
-    fhirBundle.entry.push(locationEntry)
-    encounter.location = []
-    encounter.location.push({
-      location: { reference: `urn:uuid:${locationRef}` as URNReference }
-    })
-    return locationEntry.resource
+    return createNewLocation(fhirBundle, encounter)
   }
 
   if (!encounter.location || !encounter.location[0]) {
@@ -358,6 +355,22 @@ export function selectOrCreateLocationRefResource(
       'Location referenced from encounter section not found in FHIR bundle'
     )
   }
+
+  if (isHealthFacility(locationEntry.resource)) {
+    return createNewLocation(fhirBundle, encounter)
+  }
+
+  return locationEntry.resource
+}
+
+function createNewLocation(fhirBundle: Bundle, encounter: Encounter): Location {
+  const locationRef = getUUID()
+  const locationEntry = createLocationResource(locationRef)
+  fhirBundle.entry.push(locationEntry)
+  encounter.location = []
+  encounter.location.push({
+    location: { reference: `urn:uuid:${locationRef}` as URNReference }
+  })
   return locationEntry.resource
 }
 


### PR DESCRIPTION
Cause of issue:

When a correction to a birth or death record was made from HEALTH_FACILITY to another type, instead of creating a new location, the original facility resource was edited. 
This changed the type to PRIVATE_HOME or OTHER so when the facility dropdown is populated, the value is filtered out as it is no longer a HEALTH_FACILITY.

fixes: https://github.com/opencrvs/opencrvs-core/issues/7528