### PR TITLE
chore(e2e): output step summary after triggering

### DIFF
--- a/.github/workflows/trigger-e2e-environment.yml
+++ b/.github/workflows/trigger-e2e-environment.yml
@@ -27,7 +27,8 @@ jobs:
     if: ${{ !contains(github.actor, 'bot') && github.event.pull_request.head.repo.fork == false }}
     runs-on: ubuntu-22.04
     outputs:
-      runId: ${{ steps.dispatch_e2e.outputs.runId }}
+      run_id: ${{ steps.dispatch_e2e.outputs.run_id }}
+      deployment_link: ${{ steps.print-links.outputs.deployment_link }}
     steps:
       - uses: actions/checkout@v3
 
@@ -109,17 +110,23 @@ jobs:
               console.log(`Captured runId: ${runId}`);
 
               // Set the runId as an output
-              core.setOutput('runId', runId);
+              core.setOutput('run_id', runId);
             } else {
               throw new Error('No workflow run found.');
             }
 
       - name: Print link to E2E workflow run
+        id: print-links
         run: |
-          echo "See your E2E deployment run details here: https://github.com/opencrvs/e2e/actions/runs/${{ steps.dispatch_e2e.outputs.runId }}" >> $GITHUB_STEP_SUMMARY
+          E2E_RUN_LINK="https://github.com/opencrvs/e2e/actions/runs/${{ steps.dispatch_e2e.outputs.run_id }}"
+          DEPLOYMENT_LINK="https://${{ steps.dispatch_e2e.outputs.stack }}.opencrvs.dev"
+
+          echo "See your E2E deployment run details here: $E2E_RUN_LINK" >> $GITHUB_STEP_SUMMARY
           echo "All deployments & E2E of this environment you can see here: https://github.com/opencrvs/e2e/deployments/${{ steps.dispatch_e2e.outputs.stack }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "If everything goes alright, you should see your stack getting deployed here: https://${{ steps.dispatch_e2e.outputs.stack }}.opencrvs.dev" >> $GITHUB_STEP_SUMMARY
+          echo "If everything goes alright, you should see your stack getting deployed here: $DEPLOYMENT_LINK" >> $GITHUB_STEP_SUMMARY
+
+          echo "::set-output name=e2e_run_link::$E2E_RUN_LINK"
 
   listen-e2e:
     needs: trigger-e2e
@@ -132,20 +139,9 @@ jobs:
           script: |
             const owner = 'opencrvs';
             const repo = 'e2e';
-            const runId = ${{ needs.trigger-e2e.outputs.runId }};
+            const runId = ${{ needs.trigger-e2e.outputs.run_id }};
             const prNumber = ${{ github.event.pull_request.number }};
-
-            function slugify(str) {
-              return str
-                .toLowerCase()
-                .replace(/[^\w\s-]/g, '')
-                .trim()
-                .replace(/\s+/g, '-')
-                .replace(/-+/g, '-')
-                .substr(0, 35);
-            }
-            const branchName = slugify('${{ env.BRANCH_NAME }}');
-            const deployMessage = `Your environment is deployed to https://${branchName}.opencrvs.dev.`;
+            const deployMessage = `Your environment is deployed to ${{ needs.trigger-e2e.outputs.deployment_link }}`;
 
             let deployJobCompleted = false;
 
@@ -220,7 +216,7 @@ jobs:
           script: |
             const owner = 'opencrvs';
             const repo = 'e2e';
-            const runId = ${{ steps.dispatch_e2e.outputs.runId }};
+            const runId = ${{ needs.trigger-e2e.outputs.run_id }};
             let status = 'in_progress';
 
             while (status === 'in_progress' || status === 'queued') {

--- a/.github/workflows/trigger-e2e-environment.yml
+++ b/.github/workflows/trigger-e2e-environment.yml
@@ -126,7 +126,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "If everything goes alright, you should see your stack getting deployed here: $DEPLOYMENT_LINK" >> $GITHUB_STEP_SUMMARY
 
-          echo "::set-output name=e2e_run_link::$E2E_RUN_LINK"
+          echo "deployment_link=$DEPLOYMENT_LINK" >> $GITHUB_OUTPUT
 
   listen-e2e:
     needs: trigger-e2e

--- a/.github/workflows/trigger-e2e-environment.yml
+++ b/.github/workflows/trigger-e2e-environment.yml
@@ -23,7 +23,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  e2e:
+  trigger-e2e:
     if: ${{ !contains(github.actor, 'bot') && github.event.pull_request.head.repo.fork == false }}
     runs-on: ubuntu-22.04
     steps:
@@ -119,6 +119,10 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "If everything goes alright, you should see your stack getting deployed here: https://${{ steps.dispatch_e2e.outputs.stack }}.opencrvs.dev" >> $GITHUB_STEP_SUMMARY
 
+  listen-e2e:
+    needs: trigger-e2e
+    runs-on: ubuntu-22.04
+    steps:
       - name: Wait for Environment Deployment (Deploy Job)
         uses: actions/github-script@v7
         with:
@@ -126,7 +130,7 @@ jobs:
           script: |
             const owner = 'opencrvs';
             const repo = 'e2e';
-            const runId = ${{ steps.dispatch_e2e.outputs.runId }};
+            const runId = ${{ needs.trigger-e2e.outputs.runId }};
             const prNumber = ${{ github.event.pull_request.number }};
 
             function slugify(str) {

--- a/.github/workflows/trigger-e2e-environment.yml
+++ b/.github/workflows/trigger-e2e-environment.yml
@@ -26,6 +26,8 @@ jobs:
   trigger-e2e:
     if: ${{ !contains(github.actor, 'bot') && github.event.pull_request.head.repo.fork == false }}
     runs-on: ubuntu-22.04
+    outputs:
+      runId: ${{ steps.dispatch_e2e.outputs.runId }}
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Splits the E2E action into two steps to allow outputting step summary after the trigger-e2e step. This step summary has a link to the E2E environment to debug so it's useful to have it visible.