### PR TITLE
fix: label param in required error messages

### DIFF
--- a/packages/client/src/views/RegisterForm/review/ReviewSection.tsx
+++ b/packages/client/src/views/RegisterForm/review/ReviewSection.tsx
@@ -894,7 +894,7 @@ class ReviewSectionComp extends React.Component<FullProps, State> {
       <RequiredField id={`required_label_${section.id}_${field.name}`}>
         {field.ignoreFieldLabelOnErrorMessage ||
           (field.previewGroup &&
-            this.props.intl.formatMessage(field.label) + ' ')}
+            this.props.intl.formatMessage(field.label, field.labelParam) + ' ')}
         {this.props.intl.formatMessage(
           errorsOnField.message,
           errorsOnField.props


### PR DESCRIPTION
Before          |  After
:-------------------------:|:-------------------------:
![image](https://github.com/user-attachments/assets/5cd73583-1fba-435c-91b6-3869df6e8542)  |  ![image](https://github.com/user-attachments/assets/a5d575be-031d-4c15-93aa-fbf939f41ca8)


