### PR TITLE
fix: notification content

### DIFF
--- a/packages/notification/src/features/sentForUpdates/handler.ts
+++ b/packages/notification/src/features/sentForUpdates/handler.ts
@@ -14,6 +14,7 @@ import { sendNotification } from '@notification/features/sms/utils'
 import { messageKeys } from '@notification/i18n/messages'
 import {
   getOfficeName,
+  getPersonName,
   getRegistrationLocation
 } from '@notification/features/utils'
 import {
@@ -41,7 +42,8 @@ export async function birthSentForUpdatesNotification(
       trackingId: getTrackingId(rejectedRecord),
       crvsOffice: getOfficeName(rejectedRecord),
       registrationLocation: getRegistrationLocation(rejectedRecord),
-      informantName: getInformantName(rejectedRecord)
+      informantName: getInformantName(rejectedRecord),
+      name: getPersonName(rejectedRecord, 'child')
     }
   )
   return h.response().code(200)
@@ -66,7 +68,8 @@ export async function deathSentForUpdatesNotification(
       trackingId: getTrackingId(rejectedRecord),
       crvsOffice: getOfficeName(rejectedRecord),
       registrationLocation: getRegistrationLocation(rejectedRecord),
-      informantName: getInformantName(rejectedRecord)
+      informantName: getInformantName(rejectedRecord),
+      name: getPersonName(rejectedRecord, 'deceased')
     }
   )
   return h.response().code(200)

--- a/packages/notification/src/features/utils.ts
+++ b/packages/notification/src/features/utils.ts
@@ -51,7 +51,7 @@ export function getContactEmail(
 }
 
 function error(
-  record: ReadyForReviewRecord | RegisteredRecord,
+  record: ReadyForReviewRecord | RegisteredRecord | RejectedRecord,
   message: string
 ): never {
   const task = getTaskFromSavedBundle(record)
@@ -97,7 +97,7 @@ export function getInformantName(
 }
 
 export function getPersonName(
-  record: ReadyForReviewRecord | RegisteredRecord,
+  record: ReadyForReviewRecord | RegisteredRecord | RejectedRecord,
   personType: 'deceased' | 'child'
 ) {
   const compositionCode: Extract<

--- a/packages/notification/src/features/utils.ts
+++ b/packages/notification/src/features/utils.ts
@@ -117,6 +117,7 @@ export function getPersonName(
   if (!name) {
     error(record, `name not found in patient resource for ${compositionCode}`)
   }
+  // the trim used in given name handles the case when a country does not have middlename
   return [name.given?.join(' ').trim(), name.family].join(' ').trim()
 }
 


### PR DESCRIPTION
birth/death rejection notification requires a name in notification payload
https://github.com/opencrvs/opencrvs-countryconfig/blob/release-v1.6.0/src/translations/notification.csv#L6