### PR TITLE
fix(migration): introduce conditionality and continue indexing on failure

### DIFF
--- a/packages/migration/src/migrations/hearth/20220822085901-rejected-declarations-started-by.ts
+++ b/packages/migration/src/migrations/hearth/20220822085901-rejected-declarations-started-by.ts
@@ -79,7 +79,7 @@ async function getCompositionIdToStartedByMap(
     if (startedByMap.has(compositionId)) return
     startedByMap.set(
       compositionId,
-      extractId(task.extension[0].valueReference.reference)
+      extractId(task.extension[0]?.valueReference.reference)
     )
   })
   return startedByMap

--- a/packages/migration/src/migrations/hearth/20221017133354-restore-supporting-document.ts
+++ b/packages/migration/src/migrations/hearth/20221017133354-restore-supporting-document.ts
@@ -56,7 +56,7 @@ export const up = async (db: Db, client: MongoClient) => {
           const immediatePrevComp = compositionHistory[correctionIndex - 1]
           const hasDocumentSection = immediatePrevComp?.section?.find(
             (section: fhir.CompositionSection) =>
-              section?.code?.coding?.[0].code === 'supporting-documents'
+              section?.code?.coding?.[0]?.code === 'supporting-documents'
           )
           if (hasDocumentSection) {
             await db

--- a/packages/migration/src/migrations/hearth/20221031131452-add_practioner_id_event_registrations.ts
+++ b/packages/migration/src/migrations/hearth/20221031131452-add_practioner_id_event_registrations.ts
@@ -52,7 +52,7 @@ async function migrateRegistrations(measurement: string, db: Db) {
 
     await writePoints(updatedPoints)
 
-    const startTime = registrations[0].time?.getNanoTime()
+    const startTime = registrations[0]?.time?.getNanoTime()
     const endTime = registrations[registrations.length - 1].time?.getNanoTime()
 
     const deleteQuery = `DELETE FROM ${measurement} WHERE registrarPractitionerId = '' AND time >= ${startTime} AND time <= ${endTime}`
@@ -110,7 +110,7 @@ const getUpdatedPoints = async (
           )
         }
 
-        let id: string = ''
+        let id = ''
         if (
           practitionerExtension &&
           practitionerExtension.valueReference &&

--- a/packages/migration/src/migrations/hearth/20221110092434-add_identifiers_DOB_gender_location.ts
+++ b/packages/migration/src/migrations/hearth/20221110092434-add_identifiers_DOB_gender_location.ts
@@ -52,7 +52,8 @@ export const up = async (db: Db, client: MongoClient) => {
           const body = {}
           const compositionDoc =
             (await compositionCursor.next()) as unknown as fhir.Composition
-          await setInformantDeceasedAndLocationDetails(db, body, compositionDoc)
+
+          await setInformantDeceasedAndLocationDetails(db, body, compositionDoc) // <-- this one throws the error
         }
         skip += limit
         processedDocCount += count
@@ -157,16 +158,18 @@ async function setInformantDeceasedAndLocationDetails(
     )
 
     if (encounterDoc.length > 0) {
-      const locationId = encounterDoc[0].location[0].location.reference.replace(
-        'Location/',
-        ''
-      )
+      const locationId =
+        encounterDoc[0]?.location?.[0]?.location?.reference?.replace(
+          'Location/',
+          ''
+        )
 
-      const locationDoc = await getCollectionDocuments(
-        db,
-        COLLECTION_NAMES.LOCATION,
-        [locationId]
-      )
+      const locationDoc = locationId
+        ? await getCollectionDocuments(db, COLLECTION_NAMES.LOCATION, [
+            locationId
+          ])
+        : []
+
       if (locationDoc.length > 0) {
         const address: fhir.Address = locationDoc[0].address
         if (address) {

--- a/packages/migration/src/migrations/hearth/20221110092434-add_identifiers_DOB_gender_location.ts
+++ b/packages/migration/src/migrations/hearth/20221110092434-add_identifiers_DOB_gender_location.ts
@@ -53,7 +53,7 @@ export const up = async (db: Db, client: MongoClient) => {
           const compositionDoc =
             (await compositionCursor.next()) as unknown as fhir.Composition
 
-          await setInformantDeceasedAndLocationDetails(db, body, compositionDoc) // <-- this one throws the error
+          await setInformantDeceasedAndLocationDetails(db, body, compositionDoc)
         }
         skip += limit
         processedDocCount += count

--- a/packages/migration/src/migrations/hearth/20221128065238-migrate-documents-to-minio.ts
+++ b/packages/migration/src/migrations/hearth/20221128065238-migrate-documents-to-minio.ts
@@ -38,7 +38,7 @@ export const up = async (db: Db, client: MongoClient) => {
         )
         while (await documentCursor.hasNext()) {
           const document = await documentCursor.next()
-          const fileData = document?.content[0]?.attachment?.data
+          const fileData = document?.content?.[0]?.attachment?.data
           if (fileData && isBase64FileString(fileData)) {
             const refUrl = await uploadBase64ToMinio(fileData)
             if (refUrl) {

--- a/packages/migration/src/migrations/hearth/20221128065238-migrate-documents-to-minio.ts
+++ b/packages/migration/src/migrations/hearth/20221128065238-migrate-documents-to-minio.ts
@@ -38,7 +38,7 @@ export const up = async (db: Db, client: MongoClient) => {
         )
         while (await documentCursor.hasNext()) {
           const document = await documentCursor.next()
-          const fileData = document?.content[0].attachment.data
+          const fileData = document?.content[0]?.attachment?.data
           if (fileData && isBase64FileString(fileData)) {
             const refUrl = await uploadBase64ToMinio(fileData)
             if (refUrl) {

--- a/packages/migration/src/migrations/hearth/20230127063226-update-practitioner-role.ts
+++ b/packages/migration/src/migrations/hearth/20230127063226-update-practitioner-role.ts
@@ -105,8 +105,8 @@ export const up = async (db: Db, client: MongoClient) => {
 
           if (hasSystemTypes) {
             const typeCode = practitionerRole.code?.find(
-              (c) => c.coding?.[0].system === systemTypes
-            )?.coding?.[0].code
+              (c) => c.coding?.[0]?.system === systemTypes
+            )?.coding?.[0]?.code
             await db
               .collection('PractitionerRole')
               .updateOne(

--- a/packages/migration/src/migrations/hearth/20230221105416-create-performance-views.ts
+++ b/packages/migration/src/migrations/hearth/20230221105416-create-performance-views.ts
@@ -766,7 +766,9 @@ export const up = async (db: Db, client: MongoClient) => {
           $project: {
             _id: { $concat: [{ $toString: '$id' }, '_', '$daysInYear.date'] },
             name: 1,
-            date: { $dateFromString: { dateString: '$daysInYear.date' } },
+            date: {
+              $dateFromString: { dateString: '$daysInYear.date', onError: null }
+            },
             estimatedNumberOfBirths: '$daysInYear.estimatedNumberOfBirths',
             event: 'Birth'
           }

--- a/packages/migration/src/migrations/hearth/20230221105416-create-performance-views.ts
+++ b/packages/migration/src/migrations/hearth/20230221105416-create-performance-views.ts
@@ -452,10 +452,16 @@ export const up = async (db: Db, client: MongoClient) => {
             districtName: '$district.name',
             stateName: '$state.name',
             createdAt: {
-              $dateFromString: { dateString: '$firstTask.lastModified' }
+              $dateFromString: {
+                dateString: '$firstTask.lastModified',
+                onError: new Date(0).toISOString()
+              }
             },
             registeredAt: {
-              $dateFromString: { dateString: '$registerTask.lastModified' }
+              $dateFromString: {
+                dateString: '$registerTask.lastModified',
+                onError: new Date(0).toISOString()
+              }
             },
             status: '$latestTask.businessStatus.coding.code',
             childsAgeInDaysAtDeclaration: 1,
@@ -631,7 +637,10 @@ export const up = async (db: Db, client: MongoClient) => {
             stateName: '$state.name',
             event: 'Birth',
             createdAt: {
-              $dateFromString: { dateString: '$lastModified' }
+              $dateFromString: {
+                dateString: '$lastModified',
+                onError: new Date(0).toISOString()
+              }
             }
           }
         },

--- a/packages/migration/src/migrations/hearth/20230221105416-create-performance-views.ts
+++ b/packages/migration/src/migrations/hearth/20230221105416-create-performance-views.ts
@@ -452,16 +452,10 @@ export const up = async (db: Db, client: MongoClient) => {
             districtName: '$district.name',
             stateName: '$state.name',
             createdAt: {
-              $dateFromString: {
-                dateString: '$firstTask.lastModified',
-                onError: new Date(0).toISOString()
-              }
+              $dateFromString: { dateString: '$firstTask.lastModified' }
             },
             registeredAt: {
-              $dateFromString: {
-                dateString: '$registerTask.lastModified',
-                onError: new Date(0).toISOString()
-              }
+              $dateFromString: { dateString: '$registerTask.lastModified' }
             },
             status: '$latestTask.businessStatus.coding.code',
             childsAgeInDaysAtDeclaration: 1,
@@ -637,10 +631,7 @@ export const up = async (db: Db, client: MongoClient) => {
             stateName: '$state.name',
             event: 'Birth',
             createdAt: {
-              $dateFromString: {
-                dateString: '$lastModified',
-                onError: new Date(0).toISOString()
-              }
+              $dateFromString: { dateString: '$lastModified' }
             }
           }
         },
@@ -776,7 +767,7 @@ export const up = async (db: Db, client: MongoClient) => {
             _id: { $concat: [{ $toString: '$id' }, '_', '$daysInYear.date'] },
             name: 1,
             date: {
-              $dateFromString: { dateString: '$daysInYear.date', onError: null }
+              $dateFromString: { dateString: '$daysInYear.date' }
             },
             estimatedNumberOfBirths: '$daysInYear.estimatedNumberOfBirths',
             event: 'Birth'

--- a/packages/migration/src/migrations/hearth/20230328065851-change-certified-status-to-issused.ts
+++ b/packages/migration/src/migrations/hearth/20230328065851-change-certified-status-to-issused.ts
@@ -67,7 +67,7 @@ export const up = async (db: Db, client: MongoClient) => {
             const operationHistoriesData =
               searchResult &&
               searchResult.body.hits.hits.length > 0 &&
-              searchResult.body.hits.hits[0]._source?.operationHistories
+              searchResult.body.hits.hits?.[0]?._source?.operationHistories
             const lastOperationHistory =
               operationHistoriesData &&
               operationHistoriesData.length > 0 &&

--- a/packages/migration/src/migrations/hearth/20230328065851-change-certified-status-to-issused.ts
+++ b/packages/migration/src/migrations/hearth/20230328065851-change-certified-status-to-issused.ts
@@ -65,9 +65,7 @@ export const up = async (db: Db, client: MongoClient) => {
             const searchResult = await searchByCompositionId(compositionId)
 
             const operationHistoriesData =
-              searchResult &&
-              searchResult.body.hits.hits.length > 0 &&
-              searchResult.body.hits.hits?.[0]?._source?.operationHistories
+              searchResult?.body?.hits?.hits?.[0]?._source?.operationHistories
             const lastOperationHistory =
               operationHistoriesData &&
               operationHistoriesData.length > 0 &&

--- a/packages/migration/src/migrations/hearth/20230602120944-populate-valid-locationid.ts
+++ b/packages/migration/src/migrations/hearth/20230602120944-populate-valid-locationid.ts
@@ -144,14 +144,14 @@ async function updateEventLocationIdOrJurisdictionIds(db: Db, elasticDoc: any) {
         ''
       )
 
-    const locationDoc = await getCollectionDocuments(
-      db,
-      COLLECTION_NAMES.LOCATION,
-      [locationId]
-    )
+    const locationDoc = locationId
+      ? await getCollectionDocuments(db, COLLECTION_NAMES.LOCATION, [
+          locationId
+        ])
+      : []
 
     if (locationDoc.length > 0) {
-      if (locationDoc?.[0]?.type?.coding?.[0]?.code === 'HEALTH_FACILITY') {
+      if (locationDoc[0].type?.coding?.[0]?.code === 'HEALTH_FACILITY') {
         body.eventLocationId = locationDoc[0]?.id
       } else {
         const address = locationDoc[0]?.address

--- a/packages/migration/src/migrations/hearth/20230602120944-populate-valid-locationid.ts
+++ b/packages/migration/src/migrations/hearth/20230602120944-populate-valid-locationid.ts
@@ -138,10 +138,11 @@ async function updateEventLocationIdOrJurisdictionIds(db: Db, elasticDoc: any) {
   )
 
   if (encounterDoc.length > 0) {
-    const locationId = encounterDoc[0].location[0].location.reference.replace(
-      'Location/',
-      ''
-    )
+    const locationId =
+      encounterDoc[0]?.location?.[0]?.location?.reference?.replace(
+        'Location/',
+        ''
+      )
 
     const locationDoc = await getCollectionDocuments(
       db,
@@ -150,10 +151,10 @@ async function updateEventLocationIdOrJurisdictionIds(db: Db, elasticDoc: any) {
     )
 
     if (locationDoc.length > 0) {
-      if (locationDoc[0].type.coding[0].code === 'HEALTH_FACILITY') {
-        body.eventLocationId = locationDoc[0].id
+      if (locationDoc?.[0]?.type?.coding?.[0]?.code === 'HEALTH_FACILITY') {
+        body.eventLocationId = locationDoc[0]?.id
       } else {
-        const address = locationDoc[0].address
+        const address = locationDoc[0]?.address
         if (address) {
           const eventJurisdictionIds: string[] = []
           address.state && eventJurisdictionIds.push(address.state)

--- a/packages/migration/src/migrations/hearth/20230602120944-populate-valid-locationid.ts
+++ b/packages/migration/src/migrations/hearth/20230602120944-populate-valid-locationid.ts
@@ -151,10 +151,11 @@ async function updateEventLocationIdOrJurisdictionIds(db: Db, elasticDoc: any) {
       : []
 
     if (locationDoc.length > 0) {
-      if (locationDoc[0].type?.coding?.[0]?.code === 'HEALTH_FACILITY') {
-        body.eventLocationId = locationDoc[0]?.id
+      const firstLocationDoc = locationDoc[0]
+      if (firstLocationDoc.type?.coding?.[0]?.code === 'HEALTH_FACILITY') {
+        body.eventLocationId = firstLocationDoc.id
       } else {
-        const address = locationDoc[0]?.address
+        const address = firstLocationDoc.address
         if (address) {
           const eventJurisdictionIds: string[] = []
           address.state && eventJurisdictionIds.push(address.state)

--- a/packages/migration/src/migrations/hearth/20231123125224-deceased-birth-date.ts
+++ b/packages/migration/src/migrations/hearth/20231123125224-deceased-birth-date.ts
@@ -50,7 +50,7 @@ export const up = async (db: Db, client: MongoClient) => {
         })
       let processed = 0
       for await (const patient of patientIterator) {
-        const age = parseInt(patient.extension[0].valueString, 10)
+        const age = parseInt(patient.extension?.[0]?.valueString, 10)
         const birthDate = subYears(new Date(patient.deceasedDateTime), age)
         db.collection('Patient').updateOne(
           { id: patient.id },

--- a/packages/search/src/features/reindex/reindex.ts
+++ b/packages/search/src/features/reindex/reindex.ts
@@ -62,6 +62,8 @@ export const reindex = async () => {
     }
   })
 
+  const droppedCompositionIds: string[] = []
+
   await client.helpers.bulk(
     {
       retries: 3,
@@ -74,19 +76,25 @@ export const reindex = async () => {
         }
       }),
       onDrop(doc) {
-        console.log('dropping id', doc.document.compositionId)
+        droppedCompositionIds.push(doc.document.compositionId)
       }
     },
     {
       meta: true
     }
   )
+
   const t2 = performance.now()
   logger.info(
     `Finished reindexing to ${index} in ${((t2 - t1) / 1000).toFixed(
       2
     )} seconds`
   )
+
+  if (droppedCompositionIds.length) {
+    logger.warn(`Could not index ${droppedCompositionIds.length} document(s)`)
+    logger.warn(droppedCompositionIds.join(', '))
+  }
 
   return { index }
 }

--- a/packages/search/src/features/reindex/reindex.ts
+++ b/packages/search/src/features/reindex/reindex.ts
@@ -92,8 +92,8 @@ export const reindex = async () => {
   )
 
   if (droppedCompositionIds.length) {
-    logger.warn(`Could not index ${droppedCompositionIds.length} document(s)`)
-    logger.warn(droppedCompositionIds.join(', '))
+    logger.error(`Could not index ${droppedCompositionIds.length} document(s)`)
+    logger.error(droppedCompositionIds.join(', '))
   }
 
   return { index }

--- a/packages/search/src/features/reindex/reindex.ts
+++ b/packages/search/src/features/reindex/reindex.ts
@@ -74,9 +74,7 @@ export const reindex = async () => {
         }
       }),
       onDrop(doc) {
-        throw new Error(
-          `Document ${doc.document.compositionId} couldn't be inserted`
-        )
+        console.log('dropping id', doc.document.compositionId)
       }
     },
     {


### PR DESCRIPTION
Issue:
When running migrations, we assume arrays always contain at least one item. This results to failure during the process.

Fix:
Introduce conditional checks to remaining files, even if they might work without 99% of the time.

____
Issue:
Reindexing throws an error when single document fails to be indexed to elasticsearch.
Most likely the implicit schema that gets created prevents some of the items being added.

Fix:
Allow elasticsearch to drop the documents but keep track of them.


