### PR TITLE
fix: use URL constructor to build the url

### DIFF
--- a/packages/config/src/handlers/forms/formsHandler.ts
+++ b/packages/config/src/handlers/forms/formsHandler.ts
@@ -32,7 +32,8 @@ export default async function getForm(
   h: Hapi.ResponseToolkit
 ) {
   const token = request.headers.authorization
-  const response = await fetch(`${env.COUNTRY_CONFIG_URL}/forms`, {
+  const url = new URL('forms', env.COUNTRY_CONFIG_URL)
+  const response = await fetch(url, {
     headers: {
       Authorization: token
     }
@@ -40,7 +41,7 @@ export default async function getForm(
 
   if (response.status !== 200) {
     logger.error(
-      `Core failed to fetch form definition from ${env.COUNTRY_CONFIG_URL}/forms. Check country config logs for more details`
+      `Core failed to fetch form definition from ${url.href}. Check country config logs for more details`
     )
 
     return h.response().code(500)


### PR DESCRIPTION
There was an extra `/` in the url that was being hit when running in dev mode.