### PR TITLE
(User roles) fix: update registration list type

### DIFF
--- a/packages/client/graphql.schema.json
+++ b/packages/client/graphql.schema.json
@@ -5645,9 +5645,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "OBJECT",
-              "name": "User",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/packages/client/src/tests/schema.graphql
+++ b/packages/client/src/tests/schema.graphql
@@ -1902,7 +1902,7 @@ type User {
   email: String
   status: Status!
   underInvestigation: Boolean
-  primaryOffice: Location
+  primaryOffice: Location!
   localRegistrar: LocalRegistrar
   identifier: Identifier
   signature: Signature

--- a/packages/client/src/utils/gateway.ts
+++ b/packages/client/src/utils/gateway.ts
@@ -677,7 +677,7 @@ export type EventMetricsByRegistrar = {
   __typename?: 'EventMetricsByRegistrar'
   delayed: Scalars['Int']
   late: Scalars['Int']
-  registrarPractitioner?: Maybe<User>
+  registrarPractitioner: User
   total: Scalars['Int']
 }
 
@@ -7337,7 +7337,7 @@ export type RegistrationsListByRegistrarFilter = {
     total: number
     late: number
     delayed: number
-    registrarPractitioner?: {
+    registrarPractitioner: {
       __typename?: 'User'
       id: string
       role: {
@@ -7349,11 +7349,11 @@ export type RegistrationsListByRegistrarFilter = {
           label: string
         }>
       }
-      primaryOffice?: {
+      primaryOffice: {
         __typename?: 'Location'
         name?: string | null
         id: string
-      } | null
+      }
       name: Array<{
         __typename?: 'HumanName'
         firstNames?: string | null
@@ -7365,7 +7365,7 @@ export type RegistrationsListByRegistrarFilter = {
         type: string
         data: string
       } | null
-    } | null
+    }
   }>
 }
 

--- a/packages/gateway/src/features/metrics/schema.graphql
+++ b/packages/gateway/src/features/metrics/schema.graphql
@@ -16,7 +16,7 @@ type EventMetrics {
 }
 
 type EventMetricsByRegistrar {
-  registrarPractitioner: User
+  registrarPractitioner: User!
   total: Int!
   late: Int!
   delayed: Int!

--- a/packages/gateway/src/graphql/schema.d.ts
+++ b/packages/gateway/src/graphql/schema.d.ts
@@ -1341,7 +1341,7 @@ export interface GQLAdvancedSeachParameters {
 }
 
 export interface GQLEventMetricsByRegistrar {
-  registrarPractitioner?: GQLUser
+  registrarPractitioner: GQLUser
   total: number
   late: number
   delayed: number

--- a/packages/gateway/src/graphql/schema.graphql
+++ b/packages/gateway/src/graphql/schema.graphql
@@ -1435,7 +1435,7 @@ type AdvancedSeachParameters {
 }
 
 type EventMetricsByRegistrar {
-  registrarPractitioner: User
+  registrarPractitioner: User!
   total: Int!
   late: Int!
   delayed: Int!


### PR DESCRIPTION
This fixes a typescript error on the `RegistrationList` component where `canReadUser(result.registrarPractitioner)`, this `registrarPractitioner` can be `undefined`.