### PR TITLE
fix: make all triggers of a specific http request touched on request change

### DIFF
--- a/packages/client/src/components/form/Button.tsx
+++ b/packages/client/src/components/form/Button.tsx
@@ -57,6 +57,16 @@ export function ButtonField(props: ButtonFieldProps) {
     isCompleted
   }) => {
     if (isCompleted) {
+      /**
+       * Form can have buttons having the same triggers. For example, if a button works as an id
+       * generator and is required, then it prevents the user in review page to submit the declaration
+       * without clicking it, which is fine. But if a problem occurs in the id generating server, then
+       * the user can never submit the form and the flow is blocked forever. To avoid this scenario and
+       * to keep the user experience smooth, a conditional button with the exact same trigger and with identical
+       * appearance of the generator button is shown with the error message that trigger gets after the request.
+       * This button is not required.
+       * The UX is shown in the screen capture: https://github.com/opencrvs/opencrvs-core/pull/7822#issue-2608396705
+       */
       const fieldsHavingSameTrigger = fields.filter(
         (f) => isFieldButton(f) && f.options.trigger === trigger.name
       )

--- a/packages/client/src/components/form/Button.tsx
+++ b/packages/client/src/components/form/Button.tsx
@@ -22,7 +22,7 @@ import { useSelector } from 'react-redux'
 import { getOfflineData } from '@client/offline/selectors'
 import { getUserDetails } from '@client/profile/profileSelectors'
 import { useHttp } from './http'
-import { handleUnsupportedIcon } from '@client/forms/utils'
+import { handleUnsupportedIcon, isFieldButton } from '@client/forms/utils'
 
 interface ButtonFieldProps extends Omit<ButtonProps, 'type'> {
   fieldDefinition: Ii18nButtonFormField
@@ -57,7 +57,11 @@ export function ButtonField(props: ButtonFieldProps) {
     isCompleted
   }) => {
     if (isCompleted) {
-      setFieldTouched(fieldDefinition.name)
+      const fieldsHavingSameTrigger = fields.filter(
+        (f) => isFieldButton(f) && f.options.trigger === trigger.name
+      )
+
+      fieldsHavingSameTrigger.forEach((f) => setFieldTouched(f.name))
     }
     setFieldValue(trigger.name, { loading, data, error } as IFormFieldValue)
   }


### PR DESCRIPTION
For some reason if the http endpoint is not working, then the user may want to enter value into another input for a manual intervention. But in that case the fetch button should not be mandatory and should not block submission of the record. Thus as a workaround, a solution can be applied where there would be two fetch buttons with same appearance, one of them is required, the other one is not. When there is an error, the required one can be kept hidden and the optional one is shown disabled. But prior to this change the latter button was not touched. This change make all triggers that point to the same http request touched on request resolved.

https://github.com/user-attachments/assets/2bd44d36-750f-48dd-a455-b85bd8d7e2e6

