### PR TITLE
fix(upload): Fix total documents size limit calculation

### DIFF
--- a/packages/client/src/components/form/DocumentUploadField/DocumentUploaderWithOption.tsx
+++ b/packages/client/src/components/form/DocumentUploadField/DocumentUploaderWithOption.tsx
@@ -221,11 +221,17 @@ export const DocumentUploaderWithOption = (props: IFullProps) => {
       (option: ISelectOption) => option.value === documentType
     )
 
+    const options = { ...defaultOptions }
+    const resizedImage =
+      Boolean(options.maxSizeMB) &&
+      bytesToMB(uploadedImage.size) > options.maxSizeMB &&
+      (await imageCompression(uploadedImage, options))
+
     const newDocument: IFileValue = {
       optionValues,
-      type: uploadedImage.type,
+      type: resizedImage.type || uploadedImage.type,
       data: fileAsBase64.toString(),
-      fileSize: uploadedImage.size
+      fileSize: resizedImage.size || uploadedImage.size
     }
 
     props.onComplete([...props.files, newDocument])


### PR DESCRIPTION
This is a fix for the issue https://github.com/opencrvs/opencrvs-core/issues/7840 : Incorrect File Size Calculation During Upload for Compressed Files in Birth Registration