### PR TITLE
fix(rate-limit): use the value of an object key, instead of the key itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 - Handle label params used in form inputs when rendering in action details modal
 - **Staged files getting reset on precommit hook failure** We were running lint-staged separately on each package using lerna which potentially created a race condition causing staged changes to get lost on failure. Now we are running lint-staged directly without depending on lerna. **_This is purely a DX improvement without affecting any functionality of the system_**
 - Fix `informantType` missing in template object which prevented rendering informant relationship data in the certificates [#5952](https://github.com/opencrvs/opencrvs-core/issues/5952)
+- Fix users hitting rate limit when multiple users authenticated the same time with different usernames [#7728](https://github.com/opencrvs/opencrvs-core/issues/7728)
 
 ### Breaking changes
 
@@ -64,6 +65,7 @@
 - **Gateways searchEvents API updated** `operationHistories` only returns `operationType` & `operatedOn` due to the other fields being unused in OpenCRVS
 - **Config changes to review/preview and signatures** Core used to provide review/preview section by default which are now removed and need to be provided from countryconfig. The signature field definitions (e.g. informant signature, bride signature etc.) were hard coded in core which also have now been removed. The signatures can now be added through the review/preview sections defined in countryconfig just like any other field. You can use the following section definition as the default which is without any additional fields. We highly recommend checking out our reference country repository which has the signature fields in its review/preview sections
 - `hasChildLocation` query has been removed from gateway. We have created the query `isLeafLevelLocation` instead which is more descriptive on its intended use.
+
 ```
 {
   id: 'preview',

--- a/packages/gateway/src/rate-limit.test.ts
+++ b/packages/gateway/src/rate-limit.test.ts
@@ -240,7 +240,7 @@ describe('Rate limit', () => {
     return expect(() => Promise.all(resolverCalls)).not.toThrowError()
   })
 
-  it.only('handles multiple users authenticating with different usernames', async () => {
+  it('handles multiple users authenticating with different usernames', async () => {
     const server = await createServer()
 
     // okay to go through 10 times

--- a/packages/gateway/src/rate-limit.ts
+++ b/packages/gateway/src/rate-limit.ts
@@ -105,14 +105,17 @@ export const rateLimitedRoute =
     const key = pathOptionsForKey!.find(
       (path) => get(payload, path) !== undefined
     )
+    const value = payload[key!]
 
-    if (!key) {
-      throw new Error("Couldn't find a rate limiting key in payload")
+    if (!value) {
+      throw new Error(
+        "Couldn't find the value for a rate limiting key in payload"
+      )
     }
 
     return withRateLimit(
       {
-        key: `${key}:${route}`,
+        key: `${value}:${route}`,
         requestsPerMinute
       },
       fn

--- a/packages/gateway/src/rate-limit.ts
+++ b/packages/gateway/src/rate-limit.ts
@@ -105,7 +105,7 @@ export const rateLimitedRoute =
     const key = pathOptionsForKey!.find(
       (path) => get(payload, path) !== undefined
     )
-    const value = payload[key!]
+    const value = get(payload, key!)
 
     if (!value) {
       throw new Error(


### PR DESCRIPTION
With this payload to `/auth/authenticate`
```
{ username: 'test.user', password: 'test' }
```
the cached rate-limiting key was `username:/auth/authenticate`.
It's supposed to be `test.user:/auth/authenticate`.