### PR TITLE
fix: include all child location in `getStatusWiseRegistrationCountHandler` (#7917)

### DIFF
--- a/packages/search/src/features/search/handler.test.ts
+++ b/packages/search/src/features/search/handler.test.ts
@@ -16,6 +16,8 @@ import { ICountQueryParam } from './handler'
 import { SearchDocument } from '@opencrvs/commons'
 import * as searchService from './service'
 import { OPENCRVS_INDEX_NAME } from '@search/constants'
+import * as fetchAny from 'jest-fetch-mock'
+const fetch = fetchAny as fetchAny.FetchMock
 
 jest.setTimeout(100000)
 
@@ -118,6 +120,7 @@ describe('Verify handlers', () => {
     it('Should return 200 for valid payload', async () => {
       const t = await setupTestCases(setup, { scope: ['register'] })
 
+      fetch.mockResponses([JSON.stringify([{ id: '123' }]), { status: 200 }])
       const res = await t.callStatusWiseRegistrationCount({
         declarationJurisdictionId: '123',
         status: ['REGISTERED']

--- a/packages/search/src/features/search/handler.ts
+++ b/packages/search/src/features/search/handler.ts
@@ -13,7 +13,8 @@ import {
   logger,
   SearchDocument,
   EVENT,
-  getSearchTotalCount
+  getSearchTotalCount,
+  UUID
 } from '@opencrvs/commons'
 import { badRequest, internal } from '@hapi/boom'
 import { DEFAULT_SIZE, advancedSearch } from '@search/features/search/service'
@@ -33,6 +34,7 @@ import {
   searchForBirthDuplicates
 } from '@search/features/registration/deduplicate/service'
 import { capitalize } from 'lodash'
+import { resolveLocationChildren } from './location'
 
 type IAssignmentPayload = {
   compositionId: string
@@ -138,9 +140,12 @@ export async function getStatusWiseRegistrationCountHandler(
       }
     ]
     if (payload.declarationJurisdictionId) {
+      const leafLevelJurisdictionIds = await resolveLocationChildren(
+        payload.declarationJurisdictionId as UUID
+      )
       matchRules.push({
-        match: {
-          declarationJurisdictionIds: payload.declarationJurisdictionId
+        terms: {
+          'declarationJurisdictionIds.keyword': leafLevelJurisdictionIds
         }
       })
     }


### PR DESCRIPTION
* fix: include all child location in `getStatusWiseRegistrationCountHandler`

* fix: unit test

* refactor: include children location directly to matchRules

* fix: use terms for matchRule

* fix: test: remove one http response

* chore: remove comment