### PR TITLE
add a waiting state for continue (button) to next form section with HTTP field event fetching

### DIFF
--- a/packages/client/src/components/form/Button.tsx
+++ b/packages/client/src/components/form/Button.tsx
@@ -31,6 +31,7 @@ interface ButtonFieldProps extends Omit<ButtonProps, 'type'> {
   draftData: IFormData
   setFieldValue: (name: string, value: IFormFieldValue) => void
   setFieldTouched: (name: string, isTouched?: boolean) => void
+  onWaitingRequiredStateChanged?: (shouldWaitTriggeredEventCompletion: boolean) => void
 }
 
 export function ButtonField(props: ButtonFieldProps) {
@@ -41,6 +42,7 @@ export function ButtonField(props: ButtonFieldProps) {
     setFieldTouched,
     values,
     draftData,
+    onWaitingRequiredStateChanged,
     ...buttonProps
   } = props
   const { icon, loadingLabel, buttonLabel } = fieldDefinition
@@ -55,8 +57,9 @@ export function ButtonField(props: ButtonFieldProps) {
     error,
     loading,
     isCompleted
-  }) => {
+  }) => {    
     if (isCompleted) {
+      onWaitingRequiredStateChanged?.(false)
       /**
        * Form can have buttons having the same triggers. For example, if a button works as an id
        * generator and is required, then it prevents the user in review page to submit the declaration
@@ -91,6 +94,7 @@ export function ButtonField(props: ButtonFieldProps) {
       ? loadingLabel
       : buttonLabel
   const onClick = () => {
+    fieldDefinition.options.shouldWaitTriggeredEventCompletion && onWaitingRequiredStateChanged?.(true)
     call()
   }
   return (

--- a/packages/client/src/components/form/FormFieldGenerator.tsx
+++ b/packages/client/src/components/form/FormFieldGenerator.tsx
@@ -188,6 +188,7 @@ type GeneratedInputFieldProps = {
   draftData: IFormData
   disabled?: boolean
   onUploadingStateChanged?: (isUploading: boolean) => void
+  onWaitingRequiredStateChanged?: (shouldWaitTriggeredEventCompletion: boolean) => void
   requiredErrorMessage?: MessageDescriptor
   setFieldTouched: (name: string, isTouched?: boolean) => void
 } & Omit<IDispatchProps, 'writeDeclaration'>
@@ -208,6 +209,7 @@ const GeneratedInputField = React.memo<GeneratedInputFieldProps>(
     disabled,
     dynamicDispatch,
     onUploadingStateChanged,
+    onWaitingRequiredStateChanged,
     setFieldTouched,
     requiredErrorMessage,
     fields,
@@ -698,6 +700,7 @@ const GeneratedInputField = React.memo<GeneratedInputFieldProps>(
             setFieldValue={setFieldValue}
             disabled={disabled}
             setFieldTouched={setFieldTouched}
+            onWaitingRequiredStateChanged={onWaitingRequiredStateChanged}
           />
         </InputField>
       )
@@ -785,6 +788,7 @@ interface IFormSectionProps {
   onSetTouched?: (func: ISetTouchedFunction) => void
   requiredErrorMessage?: MessageDescriptor
   onUploadingStateChanged?: (isUploading: boolean) => void
+  onWaitingRequiredStateChanged?: (shouldWaitTriggeredEventCompletion: boolean) => void
   initialValues?: IAdvancedSearchFormState
 }
 
@@ -960,7 +964,8 @@ class FormSectionComponent extends React.Component<Props> {
       draftData,
       userDetails,
       setValues,
-      dynamicDispatch
+      dynamicDispatch,
+      onWaitingRequiredStateChanged
     } = this.props
 
     const language = this.props.intl.locale
@@ -1159,6 +1164,7 @@ class FormSectionComponent extends React.Component<Props> {
                       draftData={draftData}
                       disabled={isFieldDisabled}
                       dynamicDispatch={dynamicDispatch}
+                      onWaitingRequiredStateChanged={onWaitingRequiredStateChanged}
                     />
                   )}
                 </Field>
@@ -1222,6 +1228,9 @@ class FormSectionComponent extends React.Component<Props> {
                             onUploadingStateChanged={
                               this.props.onUploadingStateChanged
                             }
+                            onWaitingRequiredStateChanged={
+                              this.props.onWaitingRequiredStateChanged
+                            }
                           />
                         )}
                       </FastField>
@@ -1258,6 +1267,7 @@ class FormSectionComponent extends React.Component<Props> {
                       values={values}
                       draftData={draftData}
                       dynamicDispatch={dynamicDispatch}
+                      onWaitingRequiredStateChanged={onWaitingRequiredStateChanged}
                     />
                   )}
                 </Field>
@@ -1292,6 +1302,9 @@ class FormSectionComponent extends React.Component<Props> {
                         disabled={isFieldDisabled}
                         onUploadingStateChanged={
                           this.props.onUploadingStateChanged
+                        }
+                        onWaitingRequiredStateChanged={
+                          this.props.onWaitingRequiredStateChanged
                         }
                       />
                     )

--- a/packages/client/src/forms/index.ts
+++ b/packages/client/src/forms/index.ts
@@ -740,6 +740,7 @@ export interface IHttpFormField extends IFormFieldBase {
     headers: Record<string, string>
     body: Record<string, any>
   } & Omit<Request, 'body' | 'headers'>
+  shouldWaitTriggeredEventCompletion?: boolean
 }
 export interface IButtonFormField extends IFormFieldBase {
   type: typeof BUTTON
@@ -749,6 +750,7 @@ export interface IButtonFormField extends IFormFieldBase {
   options: {
     trigger: string
     shouldHandleLoadingState?: boolean
+    shouldWaitTriggeredEventCompletion?: boolean
   }
 }
 
@@ -1269,6 +1271,7 @@ export interface Ii18nHttpFormField extends Ii18nFormFieldBase {
     headers: Record<string, string>
     body: Record<string, any>
   } & Omit<Request, 'body' | 'headers'>
+  shouldWaitTriggeredEventCompletion?: boolean
 }
 
 export interface Ii18nButtonFormField extends Ii18nFormFieldBase {
@@ -1279,6 +1282,7 @@ export interface Ii18nButtonFormField extends Ii18nFormFieldBase {
   options: {
     trigger: string
     shouldHandleLoadingState?: boolean
+    shouldWaitTriggeredEventCompletion?: boolean
   }
 }
 

--- a/packages/client/src/views/RegisterForm/RegisterForm.tsx
+++ b/packages/client/src/views/RegisterForm/RegisterForm.tsx
@@ -197,6 +197,7 @@ type State = {
   showConfirmationModal: boolean
   confirmDeleteDeclarationModal: boolean
   isFileUploading: boolean
+  shouldWaitTriggeredEventCompletion: boolean
   startTime: number
   selectedDuplicateComId: string
   isDuplicateDeclarationLoading: boolean
@@ -651,6 +652,7 @@ class RegisterFormView extends React.Component<FullProps, State> {
       showConfirmationModal: false,
       confirmDeleteDeclarationModal: false,
       isFileUploading: false,
+      shouldWaitTriggeredEventCompletion: false,
       startTime: 0,
       selectedDuplicateComId: props.declaration.id,
       isDuplicateDeclarationLoading: false,
@@ -763,6 +765,13 @@ class RegisterFormView extends React.Component<FullProps, State> {
     this.setState({
       ...this.state,
       isFileUploading: isUploading
+    })
+  }
+
+  onWaitingRequiredStateChanged = (shouldWaitTriggeredEventCompletion: boolean) => {
+    this.setState({
+      ...this.state,
+      shouldWaitTriggeredEventCompletion
     })
   }
 
@@ -1131,7 +1140,7 @@ class RegisterFormView extends React.Component<FullProps, State> {
                                     declaration.event.toLowerCase()
                                   )
                                 }}
-                                disabled={this.state.isFileUploading}
+                                disabled={this.state.isFileUploading || this.state.shouldWaitTriggeredEventCompletion}
                               >
                                 {intl.formatMessage(
                                   buttonMessages.continueButton
@@ -1229,6 +1238,9 @@ class RegisterFormView extends React.Component<FullProps, State> {
                                 }}
                                 onUploadingStateChanged={
                                   this.onUploadingStateChanged
+                                }
+                                onWaitingRequiredStateChanged={
+                                  this.onWaitingRequiredStateChanged
                                 }
                               />
                             </form>


### PR DESCRIPTION
Bug:
- Having a form with HTTP field for fetching on ID Generator API, for example, and a button to trigger it
- When triggered it and go to the next section before the end of the request, the response is no more considered and the state of the field stays true which will block it indefinitely
- after what, all the user can do is to remove the declaration and restart from beginning

![fetching-button-blocked](https://github.com/user-attachments/assets/607d2ecf-d7a6-4c98-bb0e-d08c6ce1e4b8)

Resolution:
- by adding a waiting state to disable the continue (to next section) button until the end of the request
- the waiting state is linked to the fetching status
- by default disabled, it can be enabled optionally in country config side like:
![config-waiting-activation](https://github.com/user-attachments/assets/db4327fe-de87-4985-a78d-dba7231274da)
