### PR TITLE
fix: improve linting in client/events

### DIFF
--- a/packages/client/src/v2-events/.eslintrc.js
+++ b/packages/client/src/v2-events/.eslintrc.js
@@ -28,7 +28,22 @@ module.exports = {
     '@typescript-eslint/require-await': 2,
     '@typescript-eslint/return-await': 2,
     '@typescript-eslint/switch-exhaustiveness-check': 2,
-    'func-style': ['error', 'declaration'],
+    'func-style': [
+      'error',
+      'declaration',
+      {
+        allowArrowFunctions: true
+      }
+    ],
+    'no-restricted-syntax': [
+      'error',
+      {
+        selector:
+          ':matches(Program > VariableDeclaration) > VariableDeclarator > ArrowFunctionExpression',
+        message: 'Top-level arrow functions are not allowed.'
+      }
+    ],
+    'react/jsx-no-literals': 1,
     'no-shadow': 1,
     'no-undef-init': 2,
     'no-return-assign': 2,

--- a/packages/client/src/v2-events/features/debug/debug.tsx
+++ b/packages/client/src/v2-events/features/debug/debug.tsx
@@ -17,6 +17,10 @@ import { v4 as uuid } from 'uuid'
 import { Text } from '@opencrvs/components'
 import { useOnlineStatus } from '@client/utils'
 import { useEvents } from '@client/v2-events/features/events/useEvents/useEvents'
+
+/* Debug file should be the only transient component which will not be present in near future. */
+/* eslint-disable react/jsx-no-literals */
+
 const Container = styled.div`
   background: #fff;
   position: fixed;
@@ -36,7 +40,7 @@ export function Debug() {
   const queryClient = useQueryClient()
   const createMutation = events.createEvent()
 
-  function createEvents() {
+  const createEvents = () => {
     createMutation.mutate(
       {
         type: 'TENNIS_CLUB_MEMBERSHIP',


### PR DESCRIPTION
- Allow arrow functions inside functions.
- Prevent using string literals within components