### PR TITLE
OCRVS-8278 null extensions cause reindex-search to fail

### DIFF
--- a/packages/commons/src/fhir/extension.ts
+++ b/packages/commons/src/fhir/extension.ts
@@ -258,6 +258,6 @@ export function findExtension<URL extends AllExtensions['url']>(
 ): Extract<AllExtensions, { url: URL }> | undefined {
   return listOfExtensions.find(
     (extension): extension is Extract<AllExtensions, { url: URL }> =>
-      extension.url === url
+      extension && extension.url === url
   )
 }

--- a/packages/search/src/features/fhir/fhir-utils.ts
+++ b/packages/search/src/features/fhir/fhir-utils.ts
@@ -37,7 +37,7 @@ export function findTaskExtension<
   Task extends TaskHistory | SavedTask
 >(task: Task, extensionUrl: T) {
   return task.extension.find(
-    (ext): ext is KnownExtensionType[T] => ext.url === extensionUrl
+    (ext): ext is KnownExtensionType[T] => ext && ext.url === extensionUrl
   )
 }
 


### PR DESCRIPTION
Handle null extensions to resolve the bug raised here: https://github.com/opencrvs/opencrvs-core/issues/8278

Still getting a TypeScript error ```"Array.find(<anonymous>)"``` logging in migration microservice from findExtension function in commons but this fix ensures that the reindex passes and we didnt notice any errors in the data.