### PR TITLE
fix: a failing test on client's DeclarationForm

### DIFF
--- a/packages/client/src/views/RegisterForm/DeclarationForm.test.tsx
+++ b/packages/client/src/views/RegisterForm/DeclarationForm.test.tsx
@@ -228,6 +228,7 @@ describe('when user starts a new declaration', () => {
 
           it('renders list of document upload field', async () => {
             await flushPromises()
+            await waitForElement(app, '#form_section_id_documents-view-group')
             const fileInputs = app
               .find('#form_section_id_documents-view-group')
               .find('section')


### PR DESCRIPTION
A single flaky test `packages/client/src/views/RegisterForm/DeclarationForm.test.tsx` passed locally but not on CI. I added a `waitForElement` to make sure the element gets rendered before counting the children.