### PR TITLE
fix: log error instead of throwing for v2 events

### DIFF
--- a/packages/data-seeder/src/locations.ts
+++ b/packages/data-seeder/src/locations.ts
@@ -286,6 +286,8 @@ export async function seedLocationsForV2Events(token: string) {
   })
 
   if (!res.ok) {
-    raise(await res.json())
+    console.error(
+      'Unable to seed locations for v2 events. Ensure events service is running.'
+    )
   }
 }


### PR DESCRIPTION
events service is not setup in all environment combinations. Only log the error instead of throwing since the service is not required yet.