### PR TITLE
Fix/events client errors

### DIFF
--- a/packages/client/src/v2-events/.eslintrc.js
+++ b/packages/client/src/v2-events/.eslintrc.js
@@ -11,6 +11,7 @@
 module.exports = {
   extends: '../../../../.eslintrc.events.js',
   rules: {
+    'react/jsx-key': 1,
     'react/jsx-no-literals': 1,
     'react/destructuring-assignment': 1,
     'react/jsx-sort-props': [

--- a/packages/client/src/v2-events/features/events/actions/register/Pages.tsx
+++ b/packages/client/src/v2-events/features/events/actions/register/Pages.tsx
@@ -22,15 +22,18 @@ import { Pages as PagesComponent } from '@client/v2-events/features/events/compo
 import { useEventConfiguration } from '@client/v2-events/features/events/useEventConfiguration'
 import { useEventFormNavigation } from '@client/v2-events/features/events/useEventFormNavigation'
 import { ROUTES } from '@client/v2-events/routes'
-import { useEventFormData } from '@client/v2-events/features/events/useEventFormData'
+import {
+  useEventFormData,
+  useSubscribeEventFormData
+} from '@client/v2-events/features/events/useEventFormData'
 import { FormLayout } from '@client/v2-events/layouts/form'
 
 export function Pages() {
   const { eventId, pageId } = useTypedParams(ROUTES.V2.EVENTS.REGISTER.PAGES)
   const [searchParams] = useTypedSearchParams(ROUTES.V2.EVENTS.REGISTER.PAGES)
   const setFormValues = useEventFormData((state) => state.setFormValues)
-  const formEventId = useEventFormData((state) => state.eventId)
-  const form = useEventFormData((state) => state.formValues)
+  const { eventId: formEventId, formValues: form } = useSubscribeEventFormData()
+
   const navigate = useNavigate()
   const events = useEvents()
   const { modal, goToHome } = useEventFormNavigation()
@@ -90,6 +93,7 @@ export function Pages() {
       {modal}
       <PagesComponent
         eventId={eventId}
+        form={form}
         formPages={formPages}
         pageId={currentPageId}
         showReviewButton={searchParams.from === 'review'}

--- a/packages/client/src/v2-events/features/events/components/Pages.tsx
+++ b/packages/client/src/v2-events/features/events/components/Pages.tsx
@@ -13,10 +13,10 @@ import React, { useEffect } from 'react'
 import { useIntl } from 'react-intl'
 import { FormWizard } from '@opencrvs/components'
 import { FormPage } from '@opencrvs/commons'
+import { ActionFormData } from '@opencrvs/commons/client'
 import { FormFieldGenerator } from '@client/v2-events/components/forms/FormFieldGenerator'
 import { usePagination } from '@client/v2-events/hooks/usePagination'
 import { useEventFormData } from '@client/v2-events/features/events/useEventFormData'
-import { getInitialValues } from '@client/v2-events/components/forms/utils'
 
 /**
  *
@@ -27,11 +27,13 @@ export function Pages({
   pageId,
   showReviewButton,
   formPages,
+  form,
   onFormPageChange,
   onSubmit
 }: {
   eventId: string
   pageId: string
+  form: ActionFormData
   showReviewButton?: boolean
   formPages: FormPage[]
   onFormPageChange: (nextPageId: string) => void
@@ -39,9 +41,7 @@ export function Pages({
 }) {
   const intl = useIntl()
 
-  const getFormValues = useEventFormData((state) => state.getFormValues)
   const setFormValues = useEventFormData((state) => state.setFormValues)
-
   const pageIdx = formPages.findIndex((p) => p.id === pageId)
 
   const {
@@ -51,7 +51,6 @@ export function Pages({
     total
   } = usePagination(formPages.length, Math.max(pageIdx, 0))
   const page = formPages[currentPage]
-  const formValues = getFormValues(eventId, getInitialValues(page.fields))
 
   useEffect(() => {
     const pageChanged = formPages[currentPage].id !== pageId
@@ -73,9 +72,9 @@ export function Pages({
     >
       <FormFieldGenerator
         fields={page.fields}
-        formData={formValues}
+        formData={form}
         id="locationForm"
-        initialValues={formValues}
+        initialValues={form}
         setAllFieldsDirty={false}
         onChange={(values) => {
           setFormValues(eventId, values)

--- a/packages/client/src/v2-events/features/events/useEventFormData.ts
+++ b/packages/client/src/v2-events/features/events/useEventFormData.ts
@@ -52,9 +52,6 @@ export const useEventFormData = create<EventFormData>()(
     }),
     {
       name: 'event-form-data',
-      onRehydrateStorage: () => (state) => {
-        console.log('Hydration complete:', state)
-      },
       storage: createJSONStorage(() => ({
         getItem: async (key) => {
           return storage.getItem(key)
@@ -75,7 +72,6 @@ export const useEventFormData = create<EventFormData>()(
  * Access state through subscription-pattern to avoid re-renders on every state change
  */
 export const useSubscribeEventFormData = () => {
-  // Fetch initial state
   const stateEventIdRef = useRef(useEventFormData.getState().eventId)
   const stateFormRef = useRef(useEventFormData.getState().formValues)
 

--- a/packages/client/src/v2-events/layouts/form/FormHeader.tsx
+++ b/packages/client/src/v2-events/layouts/form/FormHeader.tsx
@@ -91,7 +91,7 @@ export function FormHeader({
             {intl.formatMessage(messages.exitButton)}
           </Button>
           <ToggleMenu
-            id={`event-menu`}
+            id={'event-menu'}
             menuItems={
               isUndeclaredDraft(event)
                 ? [
@@ -130,7 +130,7 @@ export function FormHeader({
             <Icon name="X" />
           </Button>
           <ToggleMenu
-            id={`event-menu`}
+            id={'event-menu'}
             menuItems={[
               {
                 label: 'Delete declaration',

--- a/packages/components/src/ToggleMenu/ToggleMenu.tsx
+++ b/packages/components/src/ToggleMenu/ToggleMenu.tsx
@@ -46,7 +46,7 @@ export const ToggleMenu = ({
       <DropdownMenu.Content>
         {menuHeader && <DropdownMenu.Label>{menuHeader}</DropdownMenu.Label>}
         {menuItems.map((item) => (
-          <DropdownMenu.Item onClick={item.handler}>
+          <DropdownMenu.Item onClick={item.handler} key={item.label}>
             {item.icon} {item.label}
           </DropdownMenu.Item>
         ))}

--- a/packages/events/src/service/indexing/indexing.ts
+++ b/packages/events/src/service/indexing/indexing.ts
@@ -23,7 +23,7 @@ import {
   getEventIndexName,
   getOrCreateClient
 } from '@events/storage/elasticsearch'
-import { getAllFields } from '@opencrvs/commons'
+import { getAllFields, logger } from '@opencrvs/commons'
 import { Transform } from 'stream'
 import { z } from 'zod'
 
@@ -42,6 +42,7 @@ export async function ensureIndexExists(eventConfiguration: EventConfig) {
   const hasEventsIndex = await esClient.indices.exists({
     index: indexName
   })
+
   if (!hasEventsIndex) {
     await createIndex(indexName, getAllFields(eventConfiguration))
   }
@@ -75,6 +76,7 @@ export async function createIndex(
       }
     }
   })
+
   return client.indices.putAlias({
     index: indexName,
     name: getEventAliasName()
@@ -194,6 +196,9 @@ export async function getIndexedEvents() {
   })
 
   if (!hasEventsIndex) {
+    logger.error(
+      'Event index not created. Sending empty array. Ensure indexing is running.'
+    )
     return []
   }
 


### PR DESCRIPTION
Client had some open warnings and errors. Some changes caused form to crash. There is a possibility that mismatch between toolkit versions made it possible.

1. Prevent form from crashing due managing state at two levels. Create method for reading state with less re-renders
2. Clean up missing key warning, add rule to avoid it in the future.