### PR TITLE
Events v2: add placeholder views and backend handlers for request/approve/reject corrections

### DIFF
--- a/packages/client/src/v2-events/features/events/EventSelection.tsx
+++ b/packages/client/src/v2-events/features/events/EventSelection.tsx
@@ -12,7 +12,6 @@
 import React, { useState } from 'react'
 import { defineMessages, useIntl } from 'react-intl'
 import { useNavigate } from 'react-router-dom'
-import { v4 as uuid } from 'uuid'
 import { Spinner } from '@opencrvs/components'
 import { AppBar } from '@opencrvs/components/lib/AppBar'
 import { Button } from '@opencrvs/components/lib/Button'
@@ -26,6 +25,7 @@ import { ROUTES } from '@client/v2-events/routes'
 import { useEventConfigurations } from './useEventConfiguration'
 import { useEventFormData } from './useEventFormData'
 import { useEventFormNavigation } from './useEventFormNavigation'
+import { createTemporaryId } from './useEvents/procedures/create'
 import { useEvents } from './useEvents/useEvents'
 
 const messages = defineMessages({
@@ -79,7 +79,7 @@ function EventSelector() {
     if (eventType === '') {
       return setNoEventSelectedError(true)
     }
-    const transactionId = `tmp-${uuid()}`
+    const transactionId = createTemporaryId()
 
     createEvent.mutate({
       type: eventType,

--- a/packages/client/src/v2-events/features/events/actions/correct/request/Pages.tsx
+++ b/packages/client/src/v2-events/features/events/actions/correct/request/Pages.tsx
@@ -9,15 +9,8 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 
-import { z } from 'zod'
-import { ActionDocument } from './ActionDocument'
+import React from 'react'
 
-export const EventDocument = z.object({
-  id: z.string(),
-  type: z.string(),
-  createdAt: z.string().datetime(),
-  updatedAt: z.string().datetime(),
-  actions: z.array(ActionDocument)
-})
-
-export type EventDocument = z.infer<typeof EventDocument>
+export function Pages() {
+  return <div>{'Placeholder'}</div>
+}

--- a/packages/client/src/v2-events/features/events/actions/correct/request/Review.tsx
+++ b/packages/client/src/v2-events/features/events/actions/correct/request/Review.tsx
@@ -9,15 +9,8 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 
-import { z } from 'zod'
-import { ActionDocument } from './ActionDocument'
+import React from 'react'
 
-export const EventDocument = z.object({
-  id: z.string(),
-  type: z.string(),
-  createdAt: z.string().datetime(),
-  updatedAt: z.string().datetime(),
-  actions: z.array(ActionDocument)
-})
-
-export type EventDocument = z.infer<typeof EventDocument>
+export function Review() {
+  return <div />
+}

--- a/packages/client/src/v2-events/features/events/actions/correct/request/index.tsx
+++ b/packages/client/src/v2-events/features/events/actions/correct/request/index.tsx
@@ -9,15 +9,7 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 
-import { z } from 'zod'
-import { ActionDocument } from './ActionDocument'
+import { Pages } from './Pages'
+import { Review } from './Review'
 
-export const EventDocument = z.object({
-  id: z.string(),
-  type: z.string(),
-  createdAt: z.string().datetime(),
-  updatedAt: z.string().datetime(),
-  actions: z.array(ActionDocument)
-})
-
-export type EventDocument = z.infer<typeof EventDocument>
+export { Pages, Review }

--- a/packages/client/src/v2-events/features/events/actions/declare/Pages.tsx
+++ b/packages/client/src/v2-events/features/events/actions/declare/Pages.tsx
@@ -20,10 +20,11 @@ import { ActionType, getCurrentEventState } from '@opencrvs/commons/client'
 import { useEvents } from '@client/v2-events//features/events/useEvents/useEvents'
 import { Pages as PagesComponent } from '@client/v2-events/features/events/components/Pages'
 import { useEventConfiguration } from '@client/v2-events/features/events/useEventConfiguration'
-import { useEventFormNavigation } from '@client/v2-events/features/events/useEventFormNavigation'
-import { ROUTES } from '@client/v2-events/routes'
 import { useEventFormData } from '@client/v2-events/features/events/useEventFormData'
+import { useEventFormNavigation } from '@client/v2-events/features/events/useEventFormNavigation'
 import { FormLayout } from '@client/v2-events/layouts/form'
+import { ROUTES } from '@client/v2-events/routes'
+import { isTemporaryId } from '@client/v2-events/features/events/useEvents/procedures/create'
 
 export function Pages() {
   const { eventId, pageId } = useTypedParams(ROUTES.V2.EVENTS.DECLARE.PAGES)
@@ -80,7 +81,7 @@ export function Pages() {
    * ID.
    */
   useEffect(() => {
-    const hasTemporaryId = event.id === event.transactionId
+    const hasTemporaryId = isTemporaryId(event.id)
 
     if (eventId !== event.id && !hasTemporaryId) {
       navigate(
@@ -89,7 +90,7 @@ export function Pages() {
         })
       )
     }
-  }, [event.id, event.transactionId, eventId, navigate])
+  }, [event.id, eventId, navigate])
 
   return (
     <FormLayout

--- a/packages/client/src/v2-events/features/events/useEvents/procedures/action.ts
+++ b/packages/client/src/v2-events/features/events/useEvents/procedures/action.ts
@@ -18,6 +18,7 @@ import {
   getCurrentEventState
 } from '@opencrvs/commons/client'
 import { api, queryClient, utils } from '@client/v2-events/trpc'
+import { createTemporaryId, isTemporaryId } from './create'
 
 async function updateLocalEvent(updatedEvent: EventDocument) {
   utils.event.get.setData(updatedEvent.id, updatedEvent)
@@ -32,7 +33,7 @@ function waitUntilEventIsCreated<T extends { eventId: string }, R>(
 
     const localVersion = utils.event.get.getData(eventId)
 
-    if (!localVersion || localVersion.id === localVersion.transactionId) {
+    if (!localVersion || isTemporaryId(localVersion.id)) {
       // eslint-disable-next-line no-console
       console.error(
         'Event that has not been stored yet cannot be actioned upon'
@@ -117,6 +118,7 @@ function updateEventOptimistically<T extends ActionInput>(
       actions: [
         ...localEvent.actions,
         {
+          id: createTemporaryId(),
           type: actionType,
           data: variables.data,
           draft: false,

--- a/packages/client/src/v2-events/features/events/useEvents/procedures/create.ts
+++ b/packages/client/src/v2-events/features/events/useEvents/procedures/create.ts
@@ -9,8 +9,17 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 
+import { v4 as uuid } from 'uuid'
 import { CreatedAction, getCurrentEventState } from '@opencrvs/commons/client'
 import { api, utils } from '@client/v2-events/trpc'
+
+export function createTemporaryId() {
+  return `tmp-${uuid()}`
+}
+
+export function isTemporaryId(id: string) {
+  return id.startsWith('tmp-')
+}
 
 utils.event.create.setMutationDefaults(({ canonicalMutationFn }) => ({
   mutationFn: canonicalMutationFn,
@@ -25,6 +34,7 @@ utils.event.create.setMutationDefaults(({ canonicalMutationFn }) => ({
       actions: [
         {
           type: 'CREATE',
+          id: createTemporaryId(),
           createdAt: new Date().toISOString(),
           createdBy: 'offline',
           createdAtLocation: 'TODO',
@@ -40,9 +50,9 @@ utils.event.create.setMutationDefaults(({ canonicalMutationFn }) => ({
     )
     return optimisticEvent
   },
-  onSuccess: async (response) => {
+  onSuccess: async (response, _variables, context) => {
     utils.event.get.setData(response.id, response)
-    utils.event.get.setData(response.transactionId, response)
+    utils.event.get.setData(context.transactionId, response)
     await utils.event.list.invalidate()
   }
 }))

--- a/packages/client/src/v2-events/features/events/useEvents/procedures/delete.ts
+++ b/packages/client/src/v2-events/features/events/useEvents/procedures/delete.ts
@@ -26,7 +26,7 @@ function waitUntilEventIsCreated<R>(
     }
 
     const localVersion = utils.event.get.getData(eventId)
-    if (!localVersion || localVersion.id === localVersion.transactionId) {
+    if (!localVersion || isTemporaryId(localVersion.id)) {
       throw new Error('Event that has not been stored yet cannot be deleted')
     }
 

--- a/packages/client/src/v2-events/features/events/useEvents/useEvents.test.tsx
+++ b/packages/client/src/v2-events/features/events/useEvents/useEvents.test.tsx
@@ -45,11 +45,9 @@ function trpcHandler(
 
 const createHandler = trpcHandler(async ({ request }) => {
   serverSpy({ url: request.url, method: request.method })
-  const body = await request.json()
   await new Promise((resolve) => setTimeout(resolve, 1000))
 
   return HttpResponse.json({
-    transactionId: body.transactionId,
     type: 'TENNIS_CLUB_MEMBERSHIP',
     id: '_REAL_UUID_',
     createdAt: new Date('2024-12-05T18:37:31.295Z').toISOString(),
@@ -57,6 +55,7 @@ const createHandler = trpcHandler(async ({ request }) => {
     actions: [
       {
         type: 'CREATE',
+        id: '_REAL_ACTION_UUID_',
         createdAt: new Date('2024-12-05T18:37:31.295Z').toISOString(),
         createdBy: '6733309827b97e6483877188',
         createdAtLocation: 'ae5be1bb-6c50-4389-a72d-4c78d19ec176',

--- a/packages/client/src/v2-events/features/workqueues/EventOverview/components/ActionMenu.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/components/ActionMenu.tsx
@@ -65,6 +65,8 @@ export function ActionMenu({ eventId }: { eventId: string }) {
                 onClick={() => {
                   if (
                     action.type === ActionType.CREATE ||
+                    action.type === ActionType.APPROVE_CORRECTION ||
+                    action.type === ActionType.REJECT_CORRECTION ||
                     action.type === ActionType.CUSTOM
                   ) {
                     alert(`Action ${action.type} is not implemented yet.`)

--- a/packages/client/src/v2-events/routes/config.tsx
+++ b/packages/client/src/v2-events/routes/config.tsx
@@ -13,6 +13,7 @@ import React from 'react'
 import { Outlet } from 'react-router-dom'
 import { Debug } from '@client/v2-events/features/debug/debug'
 import * as Declare from '@client/v2-events/features/events/actions/declare'
+import * as RequestCorrection from '@client/v2-events/features/events/actions/correct/request'
 import { DeleteEvent } from '@client/v2-events/features/events/actions/delete'
 import * as Register from '@client/v2-events/features/events/actions/register'
 import { ValidateEvent } from '@client/v2-events/features/events/actions/validate'
@@ -88,6 +89,24 @@ export const routesConfig = {
         {
           path: ROUTES.V2.EVENTS.DECLARE.REVIEW.path,
           element: <Declare.Review />
+        }
+      ]
+    },
+    {
+      path: ROUTES.V2.EVENTS.REQUEST_CORRECTION.path,
+      element: <Outlet />,
+      children: [
+        {
+          index: true,
+          element: <RequestCorrection.Pages />
+        },
+        {
+          path: ROUTES.V2.EVENTS.REQUEST_CORRECTION.PAGES.path,
+          element: <RequestCorrection.Pages />
+        },
+        {
+          path: ROUTES.V2.EVENTS.REQUEST_CORRECTION.REVIEW.path,
+          element: <RequestCorrection.Review />
         }
       ]
     },

--- a/packages/client/src/v2-events/routes/routes.ts
+++ b/packages/client/src/v2-events/routes/routes.ts
@@ -61,7 +61,23 @@ export const ROUTES = {
           ),
           VALIDATE: route('validate/:eventId', {
             params: { eventId: string().defined() }
-          })
+          }),
+          REQUEST_CORRECTION: route(
+            'request-correction/:eventId',
+            {
+              params: { eventId: string().defined() }
+            },
+            {
+              REVIEW: route('review'),
+              PAGES: route('pages/:pageId', {
+                params: { pageId: string() },
+                searchParams: {
+                  from: string()
+                },
+                hash: hashValues()
+              })
+            }
+          )
         }
       ),
       WORKQUEUE: route('workqueue', {

--- a/packages/commons/src/events/ActionConfig.ts
+++ b/packages/commons/src/events/ActionConfig.ts
@@ -29,7 +29,9 @@ export const ActionType = {
   UNASSIGN: 'UNASSIGN',
   REGISTER: 'REGISTER',
   VALIDATE: 'VALIDATE',
-  CORRECT: 'CORRECT',
+  REQUEST_CORRECTION: 'REQUEST_CORRECTION',
+  REJECT_CORRECTION: 'REJECT_CORRECTION',
+  APPROVE_CORRECTION: 'APPROVE_CORRECTION',
   DETECT_DUPLICATE: 'DETECT_DUPLICATE',
   NOTIFY: 'NOTIFY',
   DECLARE: 'DECLARE',
@@ -67,6 +69,24 @@ const DeleteConfig = ActionConfigBase.merge(
   })
 )
 
+const RequestCorrectionConfig = ActionConfigBase.merge(
+  z.object({
+    type: z.literal(ActionType.REQUEST_CORRECTION)
+  })
+)
+
+const RejectCorrectionConfig = ActionConfigBase.merge(
+  z.object({
+    type: z.literal(ActionType.REJECT_CORRECTION)
+  })
+)
+
+const ApproveCorrectionConfig = ActionConfigBase.merge(
+  z.object({
+    type: z.literal(ActionType.APPROVE_CORRECTION)
+  })
+)
+
 const CustomConfig = ActionConfigBase.merge(
   z.object({
     type: z.literal(ActionType.CUSTOM)
@@ -79,6 +99,9 @@ export const ActionConfig = z.discriminatedUnion('type', [
   ValidateConfig,
   RegisterConfig,
   DeleteConfig,
+  RequestCorrectionConfig,
+  RejectCorrectionConfig,
+  ApproveCorrectionConfig,
   CustomConfig
 ])
 

--- a/packages/commons/src/events/ActionDocument.ts
+++ b/packages/commons/src/events/ActionDocument.ts
@@ -13,6 +13,7 @@ import { z } from 'zod'
 import { FieldValue } from './FieldValue'
 
 const ActionBase = z.object({
+  id: z.string(),
   createdAt: z.string().datetime(),
   createdBy: z.string(),
   data: z.record(z.string(), FieldValue),
@@ -67,6 +68,26 @@ const NotifiedAction = ActionBase.merge(
   })
 )
 
+const RequestedCorrectionAction = ActionBase.merge(
+  z.object({
+    type: z.literal(ActionType.REQUEST_CORRECTION)
+  })
+)
+
+const ApprovedCorrectionAction = ActionBase.merge(
+  z.object({
+    type: z.literal(ActionType.APPROVE_CORRECTION),
+    requestId: z.string()
+  })
+)
+
+const RejectedCorrectionAction = ActionBase.merge(
+  z.object({
+    type: z.literal(ActionType.REJECT_CORRECTION),
+    requestId: z.string()
+  })
+)
+
 const CustomAction = ActionBase.merge(
   z.object({
     type: z.literal(ActionType.CUSTOM)
@@ -80,6 +101,9 @@ export const ActionDocument = z.discriminatedUnion('type', [
   RegisterAction,
   DeclareAction,
   AssignedAction,
+  RequestedCorrectionAction,
+  ApprovedCorrectionAction,
+  RejectedCorrectionAction,
   UnassignedAction,
   CustomAction
 ])

--- a/packages/commons/src/events/ActionInput.ts
+++ b/packages/commons/src/events/ActionInput.ts
@@ -37,6 +37,8 @@ export const RegisterActionInput = BaseActionInput.merge(
   })
 )
 
+export type RegisterActionInput = z.infer<typeof RegisterActionInput>
+
 export const ValidateActionInput = BaseActionInput.merge(
   z.object({
     type: z.literal(ActionType.VALIDATE).default(ActionType.VALIDATE),
@@ -75,6 +77,44 @@ const UnassignActionInput = BaseActionInput.merge(
   })
 )
 
+export const RequestCorrectionActionInput = BaseActionInput.merge(
+  z.object({
+    type: z
+      .literal(ActionType.REQUEST_CORRECTION)
+      .default(ActionType.REQUEST_CORRECTION)
+  })
+)
+
+export type RequestCorrectionActionInput = z.infer<
+  typeof RequestCorrectionActionInput
+>
+
+export const RejectCorrectionActionInput = BaseActionInput.merge(
+  z.object({
+    requestId: z.string(),
+    type: z
+      .literal(ActionType.REJECT_CORRECTION)
+      .default(ActionType.REJECT_CORRECTION)
+  })
+)
+
+export type RejectCorrectionActionInput = z.infer<
+  typeof RejectCorrectionActionInput
+>
+
+export const ApproveCorrectionActionInput = BaseActionInput.merge(
+  z.object({
+    requestId: z.string(),
+    type: z
+      .literal(ActionType.APPROVE_CORRECTION)
+      .default(ActionType.APPROVE_CORRECTION)
+  })
+)
+
+export type ApproveCorrectionActionInput = z.infer<
+  typeof ApproveCorrectionActionInput
+>
+
 /**
  * ActionInput types are used to validate the input data for the action.
  * In our use case, we use it directly with TRPC to validate the input data for the action.
@@ -90,7 +130,10 @@ export const ActionInput = z.discriminatedUnion('type', [
   NotifyActionInput,
   DeclareActionInput,
   AssignActionInput,
-  UnassignActionInput
+  UnassignActionInput,
+  RequestCorrectionActionInput,
+  RejectCorrectionActionInput,
+  ApproveCorrectionActionInput
 ])
 
 export type ActionInput = z.input<typeof ActionInput>

--- a/packages/commons/src/events/state/index.test.ts
+++ b/packages/commons/src/events/state/index.test.ts
@@ -1,0 +1,129 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+
+import { getCurrentEventState } from '.'
+
+describe('correction requests', () => {
+  test('proposed correction data is not applied before the correction request is approved', () => {
+    const state = getCurrentEventState({
+      type: 'TENNIS_CLUB_MEMBERSHIP',
+      id: 'f743a5d5-19d4-44eb-9b0f-301a2d823bcf',
+      createdAt: '2025-01-23T02:21:38.343Z',
+      updatedAt: '2025-01-23T02:21:42.230Z',
+      actions: [
+        {
+          type: 'CREATE',
+          createdAt: '2025-01-23T02:21:38.343Z',
+          createdBy: '6791a7b2d7f8663e9f9dcbf0',
+          createdAtLocation: '492a62a5-d55f-4421-84f5-defcfb9fe6ba',
+          draft: false,
+          id: '63d19916-dcc8-4cf2-8161-eab9989765e8',
+          data: {}
+        },
+        {
+          draft: false,
+          data: { name: 'John Doe' },
+          type: 'DECLARE',
+          createdBy: '6791a7b2d7f8663e9f9dcbf0',
+          createdAt: '2025-01-23T02:21:39.161Z',
+          createdAtLocation: '492a62a5-d55f-4421-84f5-defcfb9fe6ba',
+          id: 'eb4c18e5-93bc-42f6-b110-909815f6a7c8'
+        },
+        {
+          draft: false,
+          data: {},
+          type: 'REGISTER',
+          identifiers: {
+            trackingId: 'b96cb6f2-ff62-4ed3-97ff-c0b8f1f98ce8',
+            registrationNumber: '47fb252f-9d23-429c-a33e-2db3481bc9fb'
+          },
+          createdBy: '6791a7b2d7f8663e9f9dcbf0',
+          createdAt: '2025-01-23T02:21:40.182Z',
+          createdAtLocation: '492a62a5-d55f-4421-84f5-defcfb9fe6ba',
+          id: 'bec6b33a-7a5f-4acd-9638-9e77db1800e2'
+        },
+        {
+          draft: false,
+          data: { name: 'Doe John' },
+          type: 'REQUEST_CORRECTION',
+          createdBy: '6791a7b2d7f8663e9f9dcbf0',
+          createdAt: '2025-01-23T02:21:41.206Z',
+          createdAtLocation: '492a62a5-d55f-4421-84f5-defcfb9fe6ba',
+          id: '8f4d3b15-dfe9-44fb-b2b4-4b6e294c1c8d'
+        }
+      ]
+    })
+
+    expect(state.data.name).toBe('John Doe')
+  })
+  test('proposed correction data is applied after the correction request is approved', () => {
+    const state = getCurrentEventState({
+      type: 'TENNIS_CLUB_MEMBERSHIP',
+      id: 'f743a5d5-19d4-44eb-9b0f-301a2d823bcf',
+      createdAt: '2025-01-23T02:21:38.343Z',
+      updatedAt: '2025-01-23T02:21:42.230Z',
+      actions: [
+        {
+          type: 'CREATE',
+          createdAt: '2025-01-23T02:21:38.343Z',
+          createdBy: '6791a7b2d7f8663e9f9dcbf0',
+          createdAtLocation: '492a62a5-d55f-4421-84f5-defcfb9fe6ba',
+          draft: false,
+          id: '63d19916-dcc8-4cf2-8161-eab9989765e8',
+          data: {}
+        },
+        {
+          draft: false,
+          data: { name: 'John Doe' },
+          type: 'DECLARE',
+          createdBy: '6791a7b2d7f8663e9f9dcbf0',
+          createdAt: '2025-01-23T02:21:39.161Z',
+          createdAtLocation: '492a62a5-d55f-4421-84f5-defcfb9fe6ba',
+          id: 'eb4c18e5-93bc-42f6-b110-909815f6a7c8'
+        },
+        {
+          draft: false,
+          data: {},
+          type: 'REGISTER',
+          identifiers: {
+            trackingId: 'b96cb6f2-ff62-4ed3-97ff-c0b8f1f98ce8',
+            registrationNumber: '47fb252f-9d23-429c-a33e-2db3481bc9fb'
+          },
+          createdBy: '6791a7b2d7f8663e9f9dcbf0',
+          createdAt: '2025-01-23T02:21:40.182Z',
+          createdAtLocation: '492a62a5-d55f-4421-84f5-defcfb9fe6ba',
+          id: 'bec6b33a-7a5f-4acd-9638-9e77db1800e2'
+        },
+        {
+          draft: false,
+          data: { name: 'Doe John' },
+          type: 'REQUEST_CORRECTION',
+          createdBy: '6791a7b2d7f8663e9f9dcbf0',
+          createdAt: '2025-01-23T02:21:41.206Z',
+          createdAtLocation: '492a62a5-d55f-4421-84f5-defcfb9fe6ba',
+          id: '8f4d3b15-dfe9-44fb-b2b4-4b6e294c1c8d'
+        },
+        {
+          draft: false,
+          data: {},
+          requestId: '8f4d3b15-dfe9-44fb-b2b4-4b6e294c1c8d',
+          type: 'APPROVE_CORRECTION',
+          createdBy: '6791a7b2d7f8663e9f9dcbf0',
+          createdAt: '2025-01-23T02:21:42.230Z',
+          createdAtLocation: '492a62a5-d55f-4421-84f5-defcfb9fe6ba',
+          id: '94d5a963-0125-4d31-85f0-6d77080758f4'
+        }
+      ]
+    })
+
+    expect(state.data.name).toBe('Doe John')
+  })
+})

--- a/packages/commons/src/events/state/index.ts
+++ b/packages/commons/src/events/state/index.ts
@@ -52,6 +52,21 @@ function getAssignedUserFromActions(actions: Array<ActionDocument>) {
 
 function getData(actions: Array<ActionDocument>) {
   return actions.reduce((status, action) => {
+    if (action.type === ActionType.REQUEST_CORRECTION) {
+      return status
+    }
+
+    if (action.type === ActionType.APPROVE_CORRECTION) {
+      const requestAction = actions.find(({ id }) => id === action.requestId)
+      if (!requestAction) {
+        return status
+      }
+      return {
+        ...status,
+        ...requestAction.data
+      }
+    }
+
     return {
       ...status,
       ...action.data

--- a/packages/events/src/router/event/event.actions.correction.test.ts
+++ b/packages/events/src/router/event/event.actions.correction.test.ts
@@ -1,0 +1,118 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+
+import {
+  ActionDocument,
+  ActionType,
+  EventDocument,
+  getUUID
+} from '@opencrvs/commons'
+import { createTestClient, setupTestCase } from '@events/tests/utils'
+
+test('a correction request can be added to a created event', async () => {
+  const { user, generator } = await setupTestCase()
+  const client = createTestClient(user)
+
+  const originalEvent = await client.event.create(generator.event.create())
+
+  await client.event.actions.declare(
+    generator.event.actions.declare(originalEvent.id, {
+      data: {
+        name: 'John Doe'
+      }
+    })
+  )
+  const registeredEvent = await client.event.actions.register(
+    generator.event.actions.register(originalEvent.id)
+  )
+
+  const withCorrectionRequest = await client.event.actions.correct.request(
+    generator.event.actions.correct.request(registeredEvent.id, {
+      data: {
+        name: 'Doe John'
+      }
+    })
+  )
+
+  expect(
+    withCorrectionRequest.actions[withCorrectionRequest.actions.length - 1].type
+  ).toBe(ActionType.REQUEST_CORRECTION)
+})
+
+describe('when a correction request exists', () => {
+  let withCorrectionRequest: EventDocument
+  let client: ReturnType<typeof createTestClient>
+
+  beforeEach(async () => {
+    const { user, generator } = await setupTestCase()
+    client = createTestClient(user)
+
+    const originalEvent = await client.event.create(generator.event.create())
+
+    await client.event.actions.declare(
+      generator.event.actions.declare(originalEvent.id, {
+        data: {
+          name: 'John Doe'
+        }
+      })
+    )
+    const registeredEvent = await client.event.actions.register(
+      generator.event.actions.register(originalEvent.id)
+    )
+
+    withCorrectionRequest = await client.event.actions.correct.request(
+      generator.event.actions.correct.request(registeredEvent.id, {
+        data: {
+          name: 'Doe John'
+        }
+      })
+    )
+  })
+
+  test('a correction request can be approved with correct request id', async () => {
+    const { generator } = await setupTestCase()
+
+    const requestId =
+      withCorrectionRequest.actions[withCorrectionRequest.actions.length - 1].id
+
+    const withApprovedCorrectionRequest =
+      await client.event.actions.correct.approve(
+        generator.event.actions.correct.approve(
+          withCorrectionRequest.id,
+          requestId,
+          {}
+        )
+      )
+
+    const lastAction = withApprovedCorrectionRequest.actions[
+      withApprovedCorrectionRequest.actions.length - 1
+    ] as Extract<ActionDocument, { type: 'APPROVE_CORRECTION' }>
+
+    expect(lastAction.type).toBe(ActionType.APPROVE_CORRECTION)
+
+    expect(lastAction.requestId).toBe(requestId)
+  })
+
+  test('approving a request fails if request id is incorrect', async () => {
+    const { generator } = await setupTestCase()
+
+    const incorrectRequestId = getUUID()
+
+    const request = client.event.actions.correct.approve(
+      generator.event.actions.correct.approve(
+        withCorrectionRequest.id,
+        incorrectRequestId,
+        {}
+      )
+    )
+    await expect(request).rejects.toThrow()
+  })
+})

--- a/packages/events/src/router/event/index.ts
+++ b/packages/events/src/router/event/index.ts
@@ -23,7 +23,13 @@ import {
 } from '@events/service/events/events'
 import { presignFilesInEvent } from '@events/service/files'
 import { getIndexedEvents } from '@events/service/indexing/indexing'
-import { EventConfig, getUUID } from '@opencrvs/commons'
+import {
+  EventConfig,
+  getUUID,
+  ApproveCorrectionActionInput,
+  RejectCorrectionActionInput,
+  RequestCorrectionActionInput
+} from '@opencrvs/commons'
 import {
   DeclareActionInput,
   EventIndex,
@@ -33,6 +39,8 @@ import {
   ValidateActionInput
 } from '@opencrvs/commons/events'
 import { router, publicProcedure } from '@events/router/trpc'
+import { approveCorrection } from '@events/service/events/actions/approve-correction'
+import { rejectCorrection } from '@events/service/events/actions/reject-correction'
 
 function validateEventType({
   eventTypes,
@@ -149,7 +157,39 @@ export const eventRouter = router({
             token: options.ctx.token
           }
         )
-      })
+      }),
+    correct: router({
+      request: publicProcedure
+        .input(RequestCorrectionActionInput)
+        .mutation(async (options) => {
+          return addAction(options.input, {
+            eventId: options.input.eventId,
+            createdBy: options.ctx.user.id,
+            createdAtLocation: options.ctx.user.primaryOfficeId,
+            token: options.ctx.token
+          })
+        }),
+      approve: publicProcedure
+        .input(ApproveCorrectionActionInput)
+        .mutation(async (options) => {
+          return approveCorrection(options.input, {
+            eventId: options.input.eventId,
+            createdBy: options.ctx.user.id,
+            createdAtLocation: options.ctx.user.primaryOfficeId,
+            token: options.ctx.token
+          })
+        }),
+      reject: publicProcedure
+        .input(RejectCorrectionActionInput)
+        .mutation(async (options) => {
+          return rejectCorrection(options.input, {
+            eventId: options.input.eventId,
+            createdBy: options.ctx.user.id,
+            createdAtLocation: options.ctx.user.primaryOfficeId,
+            token: options.ctx.token
+          })
+        })
+    })
   }),
   list: publicProcedure.output(z.array(EventIndex)).query(getIndexedEvents)
 })

--- a/packages/events/src/service/events/actions/approve-correction.ts
+++ b/packages/events/src/service/events/actions/approve-correction.ts
@@ -1,0 +1,56 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+
+import { addAction, getEventById } from '@events/service/events/events'
+import { ApproveCorrectionActionInput } from '@opencrvs/commons'
+import { TRPCError } from '@trpc/server'
+
+class RequestNotFoundError extends TRPCError {
+  constructor(id: string) {
+    super({
+      code: 'NOT_FOUND',
+      message: `Correction request not found with ID: ${id}`
+    })
+  }
+}
+
+export async function approveCorrection(
+  input: ApproveCorrectionActionInput,
+  {
+    eventId,
+    createdBy,
+    token,
+    createdAtLocation
+  }: {
+    eventId: string
+    createdBy: string
+    createdAtLocation: string
+    token: string
+  }
+) {
+  const storedEvent = await getEventById(eventId)
+
+  const requestAction = storedEvent.actions.find(
+    (a) => a.id === input.requestId
+  )
+
+  if (!requestAction) {
+    throw new RequestNotFoundError(input.requestId)
+  }
+
+  const event = await addAction(input, {
+    eventId,
+    createdBy,
+    token,
+    createdAtLocation
+  })
+  return event
+}

--- a/packages/events/src/service/events/actions/reject-correction.ts
+++ b/packages/events/src/service/events/actions/reject-correction.ts
@@ -1,0 +1,56 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+
+import { addAction, getEventById } from '@events/service/events/events'
+import { RejectCorrectionActionInput } from '@opencrvs/commons'
+import { TRPCError } from '@trpc/server'
+
+class RequestNotFoundError extends TRPCError {
+  constructor(id: string) {
+    super({
+      code: 'NOT_FOUND',
+      message: `Correction request not found with ID: ${id}`
+    })
+  }
+}
+
+export async function rejectCorrection(
+  input: RejectCorrectionActionInput,
+  {
+    eventId,
+    createdBy,
+    token,
+    createdAtLocation
+  }: {
+    eventId: string
+    createdBy: string
+    createdAtLocation: string
+    token: string
+  }
+) {
+  const storedEvent = await getEventById(eventId)
+
+  const requestAction = storedEvent.actions.find(
+    (a) => a.id === input.requestId
+  )
+
+  if (!requestAction) {
+    throw new RequestNotFoundError(input.requestId)
+  }
+
+  const event = await addAction(input, {
+    eventId,
+    createdBy,
+    token,
+    createdAtLocation
+  })
+  return event
+}

--- a/packages/events/src/service/events/actions/validate.ts
+++ b/packages/events/src/service/events/actions/validate.ts
@@ -1,0 +1,87 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+
+import {
+  ActionInputWithType,
+  EventIndex,
+  getCurrentEventState
+} from '@opencrvs/commons/events'
+
+import { getEventConfigurations } from '@events/service/config/config'
+import { searchForDuplicates } from '@events/service/deduplication/deduplication'
+import { getUUID } from '@opencrvs/commons'
+import { addAction, getEventById } from '@events/service/events/events'
+
+export async function validate(
+  input: Omit<Extract<ActionInputWithType, { type: 'VALIDATE' }>, 'duplicates'>,
+  {
+    eventId,
+    createdBy,
+    token,
+    createdAtLocation
+  }: {
+    eventId: string
+    createdBy: string
+    createdAtLocation: string
+    token: string
+  }
+) {
+  const config = await getEventConfigurations(token)
+  const storedEvent = await getEventById(eventId)
+  const form = config.find((c) => c.id === storedEvent.type)
+
+  if (!form) {
+    throw new Error(`Form not found with event type: ${storedEvent.type}`)
+  }
+
+  let duplicates: EventIndex[] = []
+
+  const futureEventState = getCurrentEventState({
+    ...storedEvent,
+    actions: [
+      ...storedEvent.actions,
+      {
+        ...input,
+        createdAt: new Date().toISOString(),
+        createdBy,
+        id: getUUID(),
+        createdAtLocation
+      }
+    ]
+  })
+
+  const resultsFromAllRules = await Promise.all(
+    form.deduplication.map(async (deduplication) => {
+      const matches = await searchForDuplicates(futureEventState, deduplication)
+      return matches
+    })
+  )
+
+  duplicates = resultsFromAllRules
+    .flat()
+    .sort((a, b) => b.score - a.score)
+    .filter((hit): hit is { score: number; event: EventIndex } => !!hit.event)
+    .map((hit) => hit.event)
+    .filter((event, index, self) => {
+      return self.findIndex((t) => t.id === event.id) === index
+    })
+
+  const event = await addAction(
+    { ...input, duplicates: duplicates.map((d) => d.id) },
+    {
+      eventId,
+      createdBy,
+      token,
+      createdAtLocation
+    }
+  )
+  return event
+}

--- a/packages/events/src/service/events/events.ts
+++ b/packages/events/src/service/events/events.ts
@@ -12,22 +12,18 @@
 import {
   ActionInputWithType,
   EventDocument,
-  EventIndex,
   EventInput,
   FileFieldValue,
-  getCurrentEventState,
   isUndeclaredDraft
 } from '@opencrvs/commons/events'
 
-import * as events from '@events/storage/mongodb/events'
-import { ActionType, getUUID } from '@opencrvs/commons'
-import { z } from 'zod'
-import { deleteEventIndex, indexEvent } from '@events/service/indexing/indexing'
-import * as _ from 'lodash'
-import { TRPCError } from '@trpc/server'
 import { getEventConfigurations } from '@events/service/config/config'
 import { deleteFile, fileExists } from '@events/service/files'
-import { searchForDuplicates } from '@events/service/deduplication/deduplication'
+import { deleteEventIndex, indexEvent } from '@events/service/indexing/indexing'
+import * as events from '@events/storage/mongodb/events'
+import { ActionType, getUUID } from '@opencrvs/commons'
+import { TRPCError } from '@trpc/server'
+import { z } from 'zod'
 
 export const EventInputWithId = EventInput.extend({
   id: z.string()
@@ -121,6 +117,7 @@ async function deleteEventAttachments(token: string, event: EventDocument) {
   }
 }
 
+type EventDocumentWithTransActionId = EventDocument & { transactionId: string }
 export async function createEvent({
   eventInput,
   createdAtLocation,
@@ -139,7 +136,7 @@ export async function createEvent({
   }
 
   const db = await events.getClient()
-  const collection = db.collection<EventDocument>('events')
+  const collection = db.collection<EventDocumentWithTransActionId>('events')
 
   const now = new Date().toISOString()
   const id = getUUID()
@@ -157,10 +154,11 @@ export async function createEvent({
         createdBy,
         createdAtLocation,
         draft: false,
+        id: getUUID(),
         data: {}
       }
     ]
-  } satisfies EventDocument)
+  })
 
   const event = await getEventById(id)
   await indexEvent(event)
@@ -221,7 +219,8 @@ export async function addAction(
           createdBy,
           createdAt: now,
           createdAtLocation,
-          draft: input.draft || false
+          draft: input.draft || false,
+          id: getUUID()
         }
       },
       $set: {
@@ -233,71 +232,6 @@ export async function addAction(
   const updatedEvent = await getEventById(eventId)
   await indexEvent(updatedEvent)
   return updatedEvent
-}
-
-export async function validate(
-  input: Omit<Extract<ActionInputWithType, { type: 'VALIDATE' }>, 'duplicates'>,
-  {
-    eventId,
-    createdBy,
-    token,
-    createdAtLocation
-  }: {
-    eventId: string
-    createdBy: string
-    createdAtLocation: string
-    token: string
-  }
-) {
-  const config = await getEventConfigurations(token)
-  const storedEvent = await getEventById(eventId)
-  const form = config.find((c) => c.id === storedEvent.type)
-
-  if (!form) {
-    throw new Error(`Form not found with event type: ${storedEvent.type}`)
-  }
-
-  let duplicates: EventIndex[] = []
-
-  const futureEventState = getCurrentEventState({
-    ...storedEvent,
-    actions: [
-      ...storedEvent.actions,
-      {
-        ...input,
-        createdAt: new Date().toISOString(),
-        createdBy,
-        createdAtLocation
-      }
-    ]
-  })
-
-  const resultsFromAllRules = await Promise.all(
-    form.deduplication.map(async (deduplication) => {
-      const matches = await searchForDuplicates(futureEventState, deduplication)
-      return matches
-    })
-  )
-
-  duplicates = resultsFromAllRules
-    .flat()
-    .sort((a, b) => b.score - a.score)
-    .filter((hit): hit is { score: number; event: EventIndex } => !!hit.event)
-    .map((hit) => hit.event)
-    .filter((event, index, self) => {
-      return self.findIndex((t) => t.id === event.id) === index
-    })
-
-  const event = await addAction(
-    { ...input, duplicates: duplicates.map((d) => d.id) },
-    {
-      eventId,
-      createdBy,
-      token,
-      createdAtLocation
-    }
-  )
-  return event
 }
 
 export async function patchEvent(eventInput: EventInputWithId) {

--- a/packages/events/src/tests/generators.ts
+++ b/packages/events/src/tests/generators.ts
@@ -14,7 +14,9 @@ import {
   EventInput,
   getUUID,
   ActionType,
-  ValidateActionInput
+  ValidateActionInput,
+  RegisterActionInput,
+  RequestCorrectionActionInput
 } from '@opencrvs/commons'
 import { Location } from '@events/service/locations/locations'
 import { Db } from 'mongodb'
@@ -70,7 +72,55 @@ export function payloadGenerator() {
         data: input.data ?? {},
         duplicates: [],
         eventId
-      })
+      }),
+      register: (
+        eventId: string,
+        input: Partial<Pick<RegisterActionInput, 'transactionId' | 'data'>> = {}
+      ) => ({
+        type: ActionType.REGISTER,
+        transactionId: input.transactionId ?? getUUID(),
+        data: input.data ?? {},
+        eventId
+      }),
+      correct: {
+        request: (
+          eventId: string,
+          input: Partial<
+            Pick<RequestCorrectionActionInput, 'transactionId' | 'data'>
+          > = {}
+        ) => ({
+          type: ActionType.REQUEST_CORRECTION,
+          transactionId: input.transactionId ?? getUUID(),
+          data: input.data ?? {},
+          eventId
+        }),
+        approve: (
+          eventId: string,
+          requestId: string,
+          input: Partial<
+            Pick<RequestCorrectionActionInput, 'transactionId' | 'data'>
+          > = {}
+        ) => ({
+          type: ActionType.APPROVE_CORRECTION,
+          transactionId: input.transactionId ?? getUUID(),
+          data: input.data ?? {},
+          eventId,
+          requestId
+        }),
+        reject: (
+          eventId: string,
+          requestId: string,
+          input: Partial<
+            Pick<RequestCorrectionActionInput, 'transactionId' | 'data'>
+          > = {}
+        ) => ({
+          type: ActionType.REJECT_CORRECTION,
+          transactionId: input.transactionId ?? getUUID(),
+          data: input.data ?? {},
+          eventId,
+          requestId
+        })
+      }
     }
   }
 


### PR DESCRIPTION
Introduces three new backend operations:
- `event.actions.correct.request`
- `event.actions.correct.approve`
- `event.actions.correct.reject`

and first version of logic that uses these actions to update the record state

Country config: https://github.com/opencrvs/opencrvs-countryconfig/pull/376