### PR TITLE
Events v2: restart events service automatically

### DIFF
--- a/packages/events/src/index.ts
+++ b/packages/events/src/index.ts
@@ -65,10 +65,24 @@ const server = createHTTPServer({
 })
 
 export async function main() {
-  const configurations = await getEventConfigurations(await getAnonymousToken())
-  for (const configuration of configurations) {
-    logger.info(`Loaded event configuration: ${configuration.id}`)
-    await ensureIndexExists(configuration)
+  try {
+    const configurations = await getEventConfigurations(
+      await getAnonymousToken()
+    )
+    for (const configuration of configurations) {
+      logger.info(`Loaded event configuration: ${configuration.id}`)
+      await ensureIndexExists(configuration)
+    }
+  } catch (error) {
+    logger.error(error)
+    if (env.isProd) {
+      process.exit(1)
+    }
+    /*
+     * SIGUSR2 tells nodemon to restart the process with waiting for new file changes
+     */
+    setTimeout(() => process.kill(process.pid, 'SIGUSR2'), 3000)
+    return
   }
 
   server.listen(5555)


### PR DESCRIPTION
If events configuration cannot be fetched from events service, crash the service. In development mode, instruct nodemon to restart after a 3 second delay