### PR TITLE
fix(ocrvs-8437): explicitly check for code

### DIFF
--- a/packages/gateway/src/features/user/usersAPI.ts
+++ b/packages/gateway/src/features/user/usersAPI.ts
@@ -12,8 +12,8 @@
 import { USER_MANAGEMENT_URL } from '@gateway/constants'
 import { Context } from '@gateway/graphql/context'
 import { OpenCRVSRESTDataSource } from '@gateway/graphql/data-source'
+import { AuthenticationError } from '@gateway/utils/graphql-errors'
 import { IUserModelData } from './type-resolvers'
-import { GraphQLError } from 'graphql'
 
 export class UsersAPI extends OpenCRVSRESTDataSource {
   override baseURL = USER_MANAGEMENT_URL
@@ -41,8 +41,7 @@ export class UsersAPI extends OpenCRVSRESTDataSource {
       return await response
     } catch (e) {
       // Don't need to throw errors if unauthorized error is found for no user with this email
-      if (e instanceof GraphQLError && e.extensions.code === 'UNAUTHENTICATED')
-        return null
+      if (e instanceof AuthenticationError) return null
       else throw e
     }
   }
@@ -64,8 +63,7 @@ export class UsersAPI extends OpenCRVSRESTDataSource {
       return await response
     } catch (e) {
       // Don't need to throw errors if unauthorized error is found for no user with this mobile
-      if (e instanceof GraphQLError && e.extensions.code === 'UNAUTHENTICATED')
-        return null
+      if (e instanceof AuthenticationError) return null
       else throw e
     }
   }

--- a/packages/gateway/src/features/user/usersAPI.ts
+++ b/packages/gateway/src/features/user/usersAPI.ts
@@ -12,8 +12,8 @@
 import { USER_MANAGEMENT_URL } from '@gateway/constants'
 import { Context } from '@gateway/graphql/context'
 import { OpenCRVSRESTDataSource } from '@gateway/graphql/data-source'
-import { AuthenticationError } from '@gateway/utils/graphql-errors'
 import { IUserModelData } from './type-resolvers'
+import { GraphQLError } from 'graphql'
 
 export class UsersAPI extends OpenCRVSRESTDataSource {
   override baseURL = USER_MANAGEMENT_URL
@@ -41,7 +41,8 @@ export class UsersAPI extends OpenCRVSRESTDataSource {
       return await response
     } catch (e) {
       // Don't need to throw errors if unauthorized error is found for no user with this email
-      if (e instanceof AuthenticationError) return null
+      if (e instanceof GraphQLError && e.extensions.code === 'UNAUTHENTICATED')
+        return null
       else throw e
     }
   }
@@ -63,7 +64,8 @@ export class UsersAPI extends OpenCRVSRESTDataSource {
       return await response
     } catch (e) {
       // Don't need to throw errors if unauthorized error is found for no user with this mobile
-      if (e instanceof AuthenticationError) return null
+      if (e instanceof GraphQLError && e.extensions.code === 'UNAUTHENTICATED')
+        return null
       else throw e
     }
   }


### PR DESCRIPTION
RESTDataSource throws errors of type GraphQLError so checking for custom error instances won't work, that's why we need to match against GraphQLError & check for 'UNAUTHENTICATED' code explicitly.

![8437](https://github.com/user-attachments/assets/e6f2182d-b9f1-487b-9cf2-3218186f0b8b)
