### PR TITLE
fix: slow render of location options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 # Changelog
 
-## 1.6.2
+## [1.6.2](https://github.com/opencrvs/opencrvs-core/compare/v1.6.1...v1.6.2)
 
 ### Bug fixes
 
 - Fix task history getting corrupted if a user views a record while it's in external validation [#8278](https://github.com/opencrvs/opencrvs-core/issues/8278)
 - Fix health facilities missing from dropdown after correcting a record address [#7528](https://github.com/opencrvs/opencrvs-core/issues/7528)
 - Fix stale validations showing for document uploader with options form field
+
+### Improvements
+
+- Support for 6th administrative level
 
 ## [1.6.1](https://github.com/opencrvs/opencrvs-core/compare/v1.6.0...v1.6.1)
 

--- a/packages/client/src/components/form/FormFieldGenerator.tsx
+++ b/packages/client/src/components/form/FormFieldGenerator.tsx
@@ -1040,6 +1040,7 @@ class FormSectionComponent extends React.Component<Props> {
                   ...field,
                   type: SELECT_WITH_OPTIONS,
                   options: getFieldOptions(
+                    sectionName,
                     field,
                     values,
                     offlineCountryConfig,
@@ -1050,6 +1051,7 @@ class FormSectionComponent extends React.Component<Props> {
               ? ({
                   ...field,
                   options: getFieldOptions(
+                    sectionName,
                     field,
                     values,
                     offlineCountryConfig,

--- a/packages/client/src/forms/utils.ts
+++ b/packages/client/src/forms/utils.ts
@@ -83,6 +83,7 @@ import { PhoneNumberUtil, PhoneNumberFormat } from 'google-libphonenumber'
 import { Conditional } from './conditionals'
 import { UserDetails } from '@client/utils/userUtils'
 import * as SupportedIcons from '@opencrvs/components/lib/Icon/all-icons'
+import { memoize } from 'lodash'
 
 export const VIEW_TYPE = {
   FORM: 'form',
@@ -365,7 +366,8 @@ export function getNextSectionIds(
 export const getVisibleGroupFields = (group: IFormSectionGroup) => {
   return group.fields.filter((field) => !field.hidden)
 }
-export const getFieldOptions = (
+export const getFieldOptionsSlow = (
+  _sectionName: string,
   field:
     | ISelectFormFieldWithOptions
     | ISelectFormFieldWithDynamicOptions
@@ -442,6 +444,22 @@ export const getFieldOptions = (
     return options
   }
 }
+
+/** Due to the large location trees with dependencies, generating options for them can be slow. We fix this by memoizing the options */
+export const getFieldOptions = memoize(
+  getFieldOptionsSlow,
+  (sectionName, field, values) => {
+    if (
+      field.type === SELECT_WITH_OPTIONS ||
+      field.type === DOCUMENT_UPLOADER_WITH_OPTION
+    ) {
+      return `field:${sectionName}.${field.name}`
+    }
+
+    const dependencyVal = values[field.dynamicOptions.dependency!] as string
+    return `field:${sectionName}.${field.name},dependency:${field.dynamicOptions.dependency},dependencyValue:${dependencyVal}`
+  }
+)
 
 interface INested {
   [key: string]: any


### PR DESCRIPTION
### Description

When we added the ability to create a 6th location level, we noticed that the address select performance in the Uganda configuration made using the form sluggish.

This issue was previously encountered in an old Cameroon project where selects had many thousands of values.  Pyry fixed it partially in the Cameroon project but a minor tweak is required to complete the job.  This PR solves the performance problem and should be cherry-picked into the 1.6.3 release branch.  Uganda will go live with a githash (unofficial tagged hotifix) from that branch and if any issues are found in UAT, then we will upgrade from the same branch so as not to impact on core timelines for general UAT on the hotfix release.

### Technical background

Basically the FormSectionComponent renders very slowly but it's not due to the sub-components rendering slowly. A JavaScript flamegraph looks like this, which tells us the option generating is slow. There are multiple different ways to solve this, best would probably be to not generate the options on every render, but this memoization is a hack hot fix that requires further looking into.

![image](https://github.com/user-attachments/assets/d074e8d1-d9dc-437c-aeeb-5a402f5c3036)
