### PR TITLE
fix: read error from the new property

### DIFF
--- a/packages/client/src/user/userReducer.ts
+++ b/packages/client/src/user/userReducer.ts
@@ -365,14 +365,16 @@ export const userFormReducer: LoopReducer<IUserFormState, UserFormAction> = (
       return loop({ ...state, submitting: false, submissionError: false }, list)
 
     case SUBMIT_USER_FORM_DATA_FAIL:
-      const { errorData } = (action as ISubmitFailedAction).payload
+      const { errorData } = action.payload
       const duplicateErrorFromGQL = errorData?.graphQLErrors?.find(
-        (gqlErr) => gqlErr.extensions.duplicateNotificationMethodError
+        (gqlErr) =>
+          gqlErr.extensions.invalidArgs.duplicateNotificationMethodError
       )
 
       if (duplicateErrorFromGQL) {
         const duplicateError =
-          duplicateErrorFromGQL.extensions.duplicateNotificationMethodError
+          duplicateErrorFromGQL.extensions.invalidArgs
+            .duplicateNotificationMethodError
 
         if (duplicateError.field && duplicateError.field === 'email') {
           return loop(


### PR DESCRIPTION
The error structure got changed during the apollo v4 update while the client was still referring to the previous one.

![8438](https://github.com/user-attachments/assets/0fb5b4bd-d003-42b5-b5df-6a3535faaf0d)
