### PR TITLE
fix: allow defining action without active form

### DIFF
--- a/packages/commons/src/fixtures/tennis-club-membership-event.ts
+++ b/packages/commons/src/fixtures/tennis-club-membership-event.ts
@@ -326,7 +326,7 @@ export const tennisClubMembershipEvent = defineConfig({
           'This is shown as the action name anywhere the user can trigger the action from',
         id: 'event.tennis-club-membership.action.validate.label'
       },
-      forms: [TENNIS_CLUB_FORM]
+      forms: []
     },
     {
       type: 'REQUEST_CORRECTION',

--- a/packages/events/src/router/event/__snapshots__/event.actions.validate.test.ts.snap
+++ b/packages/events/src/router/event/__snapshots__/event.actions.validate.test.ts.snap
@@ -1,7 +1,3 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Prevents adding birth date in future 1`] = `[TRPCError: [{"message":"Please enter a valid date","id":"applicant.dob","value":"2040-02-01"}]]`;
-
 exports[`Validation error message contains all the offending fields 1`] = `[TRPCError: [{"message":"Required for registration","id":"applicant.firstname"},{"message":"Required for registration","id":"applicant.surname"},{"message":"Please enter a valid date","id":"applicant.dob","value":"02-02"},{"message":"Invalid date. Please use the format YYYY-MM-DD","id":"applicant.dob","value":"02-02"}]]`;
-
-exports[`when mandatory field is invalid, conditional hidden fields are still skipped 1`] = `[TRPCError: [{"message":"Please enter a valid date","id":"applicant.dob","value":"02-1-2024"},{"message":"Invalid date. Please use the format YYYY-MM-DD","id":"applicant.dob","value":"02-1-2024"}]]`;

--- a/packages/events/src/router/event/event.actions.validate.test.ts
+++ b/packages/events/src/router/event/event.actions.validate.test.ts
@@ -27,64 +27,19 @@ test('Validation error message contains all the offending fields', async () => {
   await expect(client.event.actions.register(data)).rejects.matchSnapshot()
 })
 
-test('when mandatory field is invalid, conditional hidden fields are still skipped', async () => {
+test('Action without form definition should accept empty payload', async () => {
   const { user, generator } = await setupTestCase()
   const client = createTestClient(user)
 
   const event = await client.event.create(generator.event.create())
 
   const data = generator.event.actions.validate(event.id, {
-    data: {
-      'applicant.dob': '02-1-2024',
-      'applicant.firstname': 'John',
-      'applicant.surname': 'Doe',
-      'recommender.none': false
-    }
+    data: {}
   })
 
-  await expect(client.event.actions.validate(data)).rejects.matchSnapshot()
-})
+  const result = await client.event.actions.validate(data)
+  const lastAction = result.actions[result.actions.length - 1]
 
-test('Skips required field validation when they are conditionally hidden', async () => {
-  const { user, generator } = await setupTestCase()
-  const client = createTestClient(user)
-
-  const event = await client.event.create(generator.event.create())
-
-  const form = {
-    'applicant.dob': '2024-02-01',
-    'applicant.firstname': 'John',
-    'applicant.surname': 'Doe',
-    'recommender.none': false
-  }
-
-  const data = generator.event.actions.validate(event.id, {
-    data: form
-  })
-
-  const response = await client.event.actions.validate(data)
-  const savedAction = response.actions.find(
-    (action) => action.type === ActionType.VALIDATE
-  )
-  expect(savedAction?.data).toEqual(form)
-})
-
-test('Prevents adding birth date in future', async () => {
-  const { user, generator } = await setupTestCase()
-  const client = createTestClient(user)
-
-  const event = await client.event.create(generator.event.create())
-
-  const form = {
-    'applicant.dob': '2040-02-01',
-    'applicant.firstname': 'John',
-    'applicant.surname': 'Doe',
-    'recommender.none': false
-  }
-
-  const payload = generator.event.actions.validate(event.id, {
-    data: form
-  })
-
-  await expect(client.event.actions.validate(payload)).rejects.matchSnapshot()
+  expect(lastAction.type).toBe(ActionType.VALIDATE)
+  expect(lastAction.data).toEqual({})
 })

--- a/packages/events/src/service/config/config.ts
+++ b/packages/events/src/service/config/config.ts
@@ -67,10 +67,9 @@ export async function getActionFormFields({
     `No configuration found for event type: ${eventType}`
   )
 
-  return getOrThrow(
-    findActiveActionFields(configuration, action),
-    `No fields found for action: ${action}`
-  )
+  // Action was defined in the configuration but form was not found.
+  // For now, we treat it as possible scenario (e.g. VALIDATE action).
+  return findActiveActionFields(configuration, action) ?? []
 }
 
 export async function notifyOnAction(


### PR DESCRIPTION
Change business rules to allow action definition without (active) form