### PR TITLE
fix(ocrvs-8566): only store certificateTemplateId

### DIFF
--- a/packages/client/src/forms/register/mappings/event-specific-fields/birth/query/registration-mappings.ts
+++ b/packages/client/src/forms/register/mappings/event-specific-fields/birth/query/registration-mappings.ts
@@ -43,7 +43,9 @@ export function getBirthRegistrationSectionTransformer(
         queryData[sectionId].certificates.length - 1
       ]
     if (currentCertificate?.collector?.relationship === 'PRINT_IN_ADVANCE') {
-      transformedData[sectionId].certificates = [currentCertificate]
+      transformedData[sectionId].certificates = [
+        { certificateTemplateId: currentCertificate.certificateTemplateId }
+      ]
     }
   }
 }

--- a/packages/client/src/views/IssueCertificate/IssueCollectorForm/IssueFormForOthers.tsx
+++ b/packages/client/src/views/IssueCertificate/IssueCollectorForm/IssueFormForOthers.tsx
@@ -63,7 +63,7 @@ export const IssueCollectorFormForOthers = ({
   const navigate = useNavigate()
   const config = useSelector(getOfflineData)
   const user = useSelector(getUserDetails)
-  const { relationship, ...collectorForm }: { [key: string]: any } =
+  const form =
     (declaration &&
       declaration.data.registration.certificates &&
       declaration.data.registration.certificates[0].collector) ||
@@ -153,7 +153,7 @@ export const IssueCollectorFormForOthers = ({
         setAllFieldsDirty={false}
         fields={replaceInitialValues(
           fields,
-          collectorForm,
+          form,
           declaration && declaration.data,
           config,
           user


### PR DESCRIPTION
When transforming the gql payload to draft, only pick the certificateTemplateId and not the collector details from the print flow.

![8566](https://github.com/user-attachments/assets/f86727fc-a427-4bfe-a6e9-b4e0757fa4a8)
