### PR TITLE
fix: add missing translation 'form.field.label.empty'

### DIFF
--- a/packages/client/src/i18n/messages/form.ts
+++ b/packages/client/src/i18n/messages/form.ts
@@ -434,6 +434,11 @@ export const formMessageDescriptors = {
     defaultMessage: 'Create new user',
     description: 'The title of user form',
     id: 'form.section.user.title'
+  },
+  empty: {
+    defaultMessage: '',
+    description: 'Empty string',
+    id: 'form.field.label.empty'
   }
 }
 


### PR DESCRIPTION
The translation for `form.field.label.empty` was missing from core although included in country-config.