### PR TITLE
feat: deprecate hide conditional

### DIFF
--- a/packages/client/src/v2-events/components/forms/FormFieldGenerator.tsx
+++ b/packages/client/src/v2-events/components/forms/FormFieldGenerator.tsx
@@ -31,13 +31,14 @@ import {
   FieldType,
   FieldValue,
   FileFieldValue,
-  getConditionalActionsForField,
   isAddressFieldType,
   isBulletListFieldType,
   isCheckboxFieldType,
   isCountryFieldType,
   isDateFieldType,
   isDividerFieldType,
+  isFieldDisabled,
+  isFieldHidden,
   isFileFieldType,
   isLocationFieldType,
   isPageHeaderFieldType,
@@ -312,7 +313,7 @@ const GeneratedInputField = React.memo(
       )
     }
     if (isLocationFieldType(field)) {
-      if (field.config.options.type === 'HEALTH_FACILITY')
+      if (field.config.configuration.type === 'HEALTH_FACILITY')
         return (
           <InputField {...inputFieldProps}>
             <LocationSearch.Input
@@ -330,9 +331,9 @@ const GeneratedInputField = React.memo(
             value={field.value}
             setFieldValue={setFieldValue}
             partOf={
-              (field.config.options?.partOf?.$data &&
+              (field.config.configuration?.partOf?.$data &&
                 (makeFormikFieldIdsOpenCRVSCompatible(formData)[
-                  field.config.options?.partOf.$data
+                  field.config.configuration?.partOf.$data
                 ] as string | undefined | null)) ??
               null
             }
@@ -519,21 +520,25 @@ class FormSectionComponent extends React.Component<AllProps> {
             error = intl.formatMessage(firstError.message, firstError.props)
           }
 
-          const conditionalActions: string[] = getConditionalActionsForField(
-            field,
-            {
-              $form: makeFormikFieldIdsOpenCRVSCompatible(
-                valuesWithFormattedDate
-              ),
-              $now: formatISO(new Date(), { representation: 'date' })
-            }
-          )
+          const formParams = {
+            $form: makeFormikFieldIdsOpenCRVSCompatible(
+              valuesWithFormattedDate
+            ),
+            $now: formatISO(new Date(), { representation: 'date' })
+          }
 
-          if (conditionalActions.includes('HIDE')) {
+          if (isFieldHidden(field, formParams)) {
             return null
           }
 
-          const isFieldDisabled = conditionalActions.includes('disable')
+          console.log(
+            'isFieldHidden',
+            isFieldHidden(field, formParams),
+            field.id,
+            field.conditionals
+          )
+
+          const isDisabled = isFieldDisabled(field, formParams)
 
           return (
             <FormItem
@@ -551,8 +556,8 @@ class FormSectionComponent extends React.Component<AllProps> {
                       setFieldTouched={setFieldTouched}
                       setFieldValue={this.setFieldValuesWithDependency}
                       {...formikFieldProps.field}
-                      disabled={isFieldDisabled}
-                      error={isFieldDisabled ? '' : error}
+                      disabled={isDisabled}
+                      error={isDisabled ? '' : error}
                       fields={fields}
                       formData={formData}
                       touched={touched[field.id] || false}

--- a/packages/client/src/v2-events/components/forms/utils.ts
+++ b/packages/client/src/v2-events/components/forms/utils.ts
@@ -13,8 +13,8 @@ import {
   ActionFormData,
   FieldConfig,
   Inferred,
-  getConditionalActionsForField,
-  FieldValue
+  FieldValue,
+  isFieldHidden
 } from '@opencrvs/commons/client'
 import { DependencyInfo } from '@client/forms'
 import { FIELD_SEPARATOR } from './FormFieldGenerator'
@@ -35,12 +35,12 @@ export function handleInitialValue(
 }
 
 export function isFormFieldVisible(field: FieldConfig, form: ActionFormData) {
-  return getConditionalActionsForField(field, {
+  return !isFieldHidden(field, {
     $form: form,
     $now: formatISO(new Date(), {
       representation: 'date'
     })
-  }).every((fieldAction) => fieldAction !== 'HIDE')
+  })
 }
 
 export function evalExpressionInFieldDefinition(

--- a/packages/client/src/v2-events/features/events/registered-fields/Address.tsx
+++ b/packages/client/src/v2-events/features/events/registered-fields/Address.tsx
@@ -14,10 +14,12 @@ import {
   AddressField,
   AddressFieldValue,
   alwaysTrue,
+  ConditionalType,
   field as createFieldCondition,
   defineConditional,
   FieldConfig,
-  FieldProps
+  FieldProps,
+  not
 } from '@opencrvs/commons/client'
 import { FormFieldGenerator } from '@client/v2-events/components/forms/FormFieldGenerator'
 import { Output } from '@client/v2-events/features/events/components/Output'
@@ -34,8 +36,8 @@ function hide<T extends FieldConfig>(fieldConfig: T): T {
   return {
     ...fieldConfig,
     conditionals: (fieldConfig.conditionals || []).concat({
-      type: 'HIDE',
-      conditional: defineConditional(alwaysTrue())
+      type: ConditionalType.SHOW,
+      conditional: not(defineConditional(alwaysTrue()))
     })
   }
 }
@@ -187,8 +189,8 @@ const ADMIN_STRUCTURE = [
     id: 'province',
     conditionals: [
       {
-        type: 'HIDE',
-        conditional: createFieldCondition('country').isUndefined()
+        type: ConditionalType.SHOW,
+        conditional: not(createFieldCondition('country').isUndefined())
       }
     ],
     required: true,
@@ -198,7 +200,7 @@ const ADMIN_STRUCTURE = [
       description: 'This is the label for the field'
     },
     type: 'LOCATION',
-    options: {
+    configuration: {
       type: 'ADMIN_STRUCTURE'
     }
   },
@@ -206,8 +208,8 @@ const ADMIN_STRUCTURE = [
     id: 'district',
     conditionals: [
       {
-        type: 'HIDE',
-        conditional: createFieldCondition('province').isUndefined()
+        type: ConditionalType.SHOW,
+        conditional: not(createFieldCondition('province').isUndefined())
       }
     ],
     required: true,
@@ -217,7 +219,7 @@ const ADMIN_STRUCTURE = [
       description: 'This is the label for the field'
     },
     type: 'LOCATION',
-    options: {
+    configuration: {
       partOf: {
         $data: 'province'
       },
@@ -228,8 +230,8 @@ const ADMIN_STRUCTURE = [
     id: 'urbanOrRural',
     conditionals: [
       {
-        type: 'HIDE',
-        conditional: createFieldCondition('district').isUndefined()
+        type: ConditionalType.SHOW,
+        conditional: not(createFieldCondition('district').isUndefined())
       }
     ],
     required: false,

--- a/packages/client/src/v2-events/features/workqueues/EventOverview/components/ActionMenu.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/components/ActionMenu.tsx
@@ -49,9 +49,7 @@ export function ActionMenu({ eventId }: { eventId: string }) {
       if (conditional.type === 'SHOW') {
         return acc && validate(conditional.conditional, params)
       }
-      if (conditional.type === 'HIDE') {
-        return acc && !validate(conditional.conditional, params)
-      }
+
       return acc
     }, true)
   }

--- a/packages/commons/src/conditionals/conditionals.test.ts
+++ b/packages/commons/src/conditionals/conditionals.test.ts
@@ -19,7 +19,8 @@ import {
   ConditionalParameters,
   UserConditionalParameters,
   EventConditionalParameters,
-  event
+  event,
+  FormConditionalParameters
 } from './conditionals'
 import { formatISO } from 'date-fns'
 import { SCOPES } from '../scopes'
@@ -33,213 +34,229 @@ const fieldParams = {
   $now: formatISO(new Date(), { representation: 'date' })
 } satisfies ConditionalParameters
 
-describe('Validate conditionals', () => {
-  describe('"universal" conditionals', () => {
-    it('validates "and" conditional', () => {
-      expect(
-        validate(
-          and(
-            field('applicant.name').isEqualTo('John Doe'),
-            field('applicant.dob').isAfter().date('1989-01-01')
-          ),
-          fieldParams
-        )
-      ).toBe(true)
-
-      expect(
-        validate(
-          and(
-            field('applicant.name').isEqualTo('John Doe'),
-            field('applicant.dob').isAfter().date('1991-01-01')
-          ),
-          fieldParams
-        )
-      ).toBe(false)
-    })
-
-    it('validates "or" conditional', () => {
-      expect(
-        validate(
-          or(
-            field('applicant.name').isEqualTo('John Doe'),
-            field('applicant.dob').isAfter().date('1989-01-01')
-          ),
-          fieldParams
-        )
-      ).toBe(true)
-
-      expect(
-        validate(
-          or(
-            field('applicant.name').isEqualTo('John Doe'),
-            field('applicant.dob').isAfter().date('1991-01-01')
-          ),
-          fieldParams
-        )
-      ).toBe(true)
-
-      expect(
-        validate(
-          or(
-            field('applicant.name').isEqualTo('Jack Doe'),
-            field('applicant.dob').isAfter().date('1991-01-01')
-          ),
-          fieldParams
-        )
-      ).toBe(false)
-    })
-
-    it('validates "not" conditional', () => {
-      expect(
-        validate(
-          not(field('applicant.name').isEqualTo('John Doe')),
-          fieldParams
-        )
-      ).toBe(false)
-
-      expect(
-        validate(
-          not(field('applicant.name').isEqualTo('Jack Doe')),
-          fieldParams
-        )
-      ).toBe(true)
-    })
-  })
-
-  describe('"field" conditionals', () => {
-    it('validates "field.isAfter" conditional', () => {
-      expect(
-        validate(
-          field('applicant.dob').isAfter().date('1990-01-03'),
-          fieldParams
-        )
-      ).toBe(false)
-
-      // seems to be inclusive
-      expect(
-        validate(
-          field('applicant.dob').isAfter().date('1990-01-02'),
-          fieldParams
-        )
-      ).toBe(true)
-
-      expect(
-        validate(
-          field('applicant.dob').isAfter().date('1990-01-01'),
-          fieldParams
-        )
-      ).toBe(true)
-    })
-
-    it('validates "field.isBefore" conditional', () => {
-      expect(
-        validate(
-          field('applicant.dob').isBefore().date('1990-01-03'),
-          fieldParams
-        )
-      ).toBe(true)
-
-      // seems to be exclusive
-      expect(
-        validate(
-          field('applicant.dob').isBefore().date('1990-01-02'),
-          fieldParams
-        )
-      ).toBe(true)
-
-      expect(
-        validate(
-          field('applicant.dob').isBefore().date('1990-01-01'),
-          fieldParams
-        )
-      ).toBe(false)
-    })
-
-    it('validates "field.isEqualTo" conditional', () => {
-      expect(
-        validate(field('applicant.name').isEqualTo('John Doe'), fieldParams)
-      ).toBe(true)
-      expect(
-        validate(field('applicant.name').isEqualTo('Jane Doe'), fieldParams)
-      ).toBe(false)
-    })
-
-    it('validates "field.isUndefined" conditional', () => {
-      expect(validate(field('applicant.name').isUndefined(), fieldParams)).toBe(
-        false
+describe('"universal" conditionals', () => {
+  it('validates "and" conditional', () => {
+    expect(
+      validate(
+        and(
+          field('applicant.name').isEqualTo('John Doe'),
+          field('applicant.dob').isAfter().date('1989-01-01')
+        ),
+        fieldParams
       )
-      expect(
-        validate(field('applicant.name.foo').isUndefined(), fieldParams)
-      ).toBe(true)
-    })
+    ).toBe(true)
 
-    it('validates "field.inArray" conditional', () => {
-      expect(
-        validate(
-          field('applicant.name').inArray(['Jack Doe', 'Jane Doe']),
-          fieldParams
-        )
-      ).toBe(false)
-      expect(
-        validate(
-          field('applicant.name').inArray(['John Doe', 'Jane Doe']),
-          fieldParams
-        )
-      ).toBe(true)
-    })
+    expect(
+      validate(
+        and(
+          field('applicant.name').isEqualTo('John Doe'),
+          field('applicant.dob').isAfter().date('1991-01-01')
+        ),
+        fieldParams
+      )
+    ).toBe(false)
   })
 
-  describe('"user" conditionals', () => {
-    const userParams = {
-      $user: {
-        scope: ['record.register', 'record.registration-correct'],
-        exp: '1739881718',
-        algorithm: 'RS256',
-        sub: '677b33fea7efb08730f3abfa33'
+  it('validates "or" conditional', () => {
+    expect(
+      validate(
+        or(
+          field('applicant.name').isEqualTo('John Doe'),
+          field('applicant.dob').isAfter().date('1989-01-01')
+        ),
+        fieldParams
+      )
+    ).toBe(true)
+
+    expect(
+      validate(
+        or(
+          field('applicant.name').isEqualTo('John Doe'),
+          field('applicant.dob').isAfter().date('1991-01-01')
+        ),
+        fieldParams
+      )
+    ).toBe(true)
+
+    expect(
+      validate(
+        or(
+          field('applicant.name').isEqualTo('Jack Doe'),
+          field('applicant.dob').isAfter().date('1991-01-01')
+        ),
+        fieldParams
+      )
+    ).toBe(false)
+  })
+
+  it('validates "not" conditional', () => {
+    expect(
+      validate(not(field('applicant.name').isEqualTo('John Doe')), fieldParams)
+    ).toBe(false)
+
+    expect(
+      validate(not(field('applicant.name').isEqualTo('Jack Doe')), fieldParams)
+    ).toBe(true)
+  })
+})
+
+describe('"field" conditionals', () => {
+  it('validates "field.isAfter" conditional', () => {
+    expect(
+      validate(field('applicant.dob').isAfter().date('1990-01-03'), fieldParams)
+    ).toBe(false)
+
+    // seems to be inclusive
+    expect(
+      validate(field('applicant.dob').isAfter().date('1990-01-02'), fieldParams)
+    ).toBe(true)
+
+    expect(
+      validate(field('applicant.dob').isAfter().date('1990-01-01'), fieldParams)
+    ).toBe(true)
+  })
+
+  it('validates "field.isBefore" conditional', () => {
+    expect(
+      validate(
+        field('applicant.dob').isBefore().date('1990-01-03'),
+        fieldParams
+      )
+    ).toBe(true)
+
+    // seems to be exclusive
+    expect(
+      validate(
+        field('applicant.dob').isBefore().date('1990-01-02'),
+        fieldParams
+      )
+    ).toBe(true)
+
+    expect(
+      validate(
+        field('applicant.dob').isBefore().date('1990-01-01'),
+        fieldParams
+      )
+    ).toBe(false)
+  })
+
+  it('validates "field.isEqualTo" conditional', () => {
+    expect(
+      validate(field('applicant.name').isEqualTo('John Doe'), fieldParams)
+    ).toBe(true)
+
+    expect(
+      validate(field('applicant.name').isEqualTo('Jane Doe'), fieldParams)
+    ).toBe(false)
+
+    expect(
+      validate(
+        field('applicant.field.not.exist').isEqualTo('Jane Doe'),
+        fieldParams
+      )
+    ).toBe(false)
+  })
+
+  it('validates "field.isUndefined" conditional', () => {
+    expect(validate(field('applicant.name').isUndefined(), fieldParams)).toBe(
+      false
+    )
+    expect(
+      validate(field('applicant.field.not.exist').isUndefined(), fieldParams)
+    ).toBe(true)
+  })
+
+  it('validates "field.inArray" conditional', () => {
+    expect(
+      validate(
+        field('applicant.name').inArray(['Jack Doe', 'Jane Doe']),
+        fieldParams
+      )
+    ).toBe(false)
+
+    expect(
+      validate(
+        field('applicant.name').inArray(['John Doe', 'Jane Doe']),
+        fieldParams
+      )
+    ).toBe(true)
+  })
+
+  it('validates "field.isFalsy" conditional', () => {
+    const falsyFormParams = {
+      $form: {
+        'empty.string': '',
+        'null.value': null,
+        'undefined.value': undefined,
+        'false.value': false
       },
       $now: formatISO(new Date(), { representation: 'date' })
-    } satisfies UserConditionalParameters
+    } satisfies FormConditionalParameters
 
-    it('validates "user.hasScope" conditional', () => {
-      expect(validate(user.hasScope(SCOPES.VALIDATE), userParams)).toBe(false)
-
-      expect(validate(user.hasScope(SCOPES.RECORD_REGISTER), userParams)).toBe(
-        true
-      )
-    })
+    expect(
+      validate(field('some.id.not.defined.in.form').isFalsy(), falsyFormParams)
+    ).toBe(true)
+    expect(validate(field('empty.string').isFalsy(), falsyFormParams)).toBe(
+      true
+    )
+    expect(validate(field('null.value').isFalsy(), falsyFormParams)).toBe(true)
+    expect(validate(field('undefined.value').isFalsy(), falsyFormParams)).toBe(
+      true
+    )
+    expect(validate(field('false.value').isFalsy(), falsyFormParams)).toBe(true)
   })
+})
 
-  describe('"event" conditionals', () => {
-    it('validates "event.hasAction" conditional', () => {
-      const now = formatISO(new Date(), { representation: 'date' })
-      const eventParams = {
-        $now: now,
-        $event: {
-          id: '123',
-          type: 'birth',
-          createdAt: now,
-          updatedAt: now,
-          actions: [
-            {
-              id: '1234',
-              type: ActionType.DECLARE,
-              createdAt: now,
-              createdBy: '12345',
-              data: {},
-              createdAtLocation: '123456',
-              draft: false
-            }
-          ]
-        }
-      } satisfies EventConditionalParameters
+describe('"user" conditionals', () => {
+  const userParams = {
+    $user: {
+      scope: ['record.register', 'record.registration-correct'],
+      exp: '1739881718',
+      algorithm: 'RS256',
+      sub: '677b33fea7efb08730f3abfa33'
+    },
+    $now: formatISO(new Date(), { representation: 'date' })
+  } satisfies UserConditionalParameters
 
-      expect(validate(event.hasAction(ActionType.DECLARE), eventParams)).toBe(
-        true
-      )
+  it('validates "user.hasScope" conditional', () => {
+    expect(validate(user.hasScope(SCOPES.VALIDATE), userParams)).toBe(false)
 
-      expect(validate(event.hasAction(ActionType.REGISTER), eventParams)).toBe(
-        false
-      )
-    })
+    expect(validate(user.hasScope(SCOPES.RECORD_REGISTER), userParams)).toBe(
+      true
+    )
+  })
+})
+
+describe('"event" conditionals', () => {
+  it('validates "event.hasAction" conditional', () => {
+    const now = formatISO(new Date(), { representation: 'date' })
+    const eventParams = {
+      $now: now,
+      $event: {
+        id: '123',
+        type: 'birth',
+        createdAt: now,
+        updatedAt: now,
+        actions: [
+          {
+            id: '1234',
+            type: ActionType.DECLARE,
+            createdAt: now,
+            createdBy: '12345',
+            data: {},
+            createdAtLocation: '123456',
+            draft: false
+          }
+        ]
+      }
+    } satisfies EventConditionalParameters
+
+    expect(validate(event.hasAction(ActionType.DECLARE), eventParams)).toBe(
+      true
+    )
+
+    expect(validate(event.hasAction(ActionType.REGISTER), eventParams)).toBe(
+      false
+    )
   })
 })

--- a/packages/commons/src/conditionals/conditionals.ts
+++ b/packages/commons/src/conditionals/conditionals.ts
@@ -26,7 +26,11 @@ export function defineConditional(schema: any) {
 
 export type UserConditionalParameters = { $now: string; $user: TokenPayload }
 export type EventConditionalParameters = { $now: string; $event: EventDocument }
-export type FormConditionalParameters = { $now: string; $form: ActionFormData }
+// @TODO: Reconcile which types should be used. The same values are used within form and config. In form values can be undefined, for example.
+export type FormConditionalParameters = {
+  $now: string
+  $form: ActionFormData | Record<string, any>
+}
 
 export type ConditionalParameters =
   | UserConditionalParameters
@@ -244,6 +248,44 @@ export function field(fieldId: string) {
               }
             },
             required: [fieldId]
+          }
+        },
+        required: ['$form']
+      }),
+    /**
+     * Use case: Some fields are rendered when selection is not made, or boolean false is explicitly selected.
+     * @example field('recommender.none').isFalsy() vs not(field('recommender.none').isEqualTo(true))
+     * @returns whether the field is falsy (undefined, false, null, empty string)
+     *
+     * NOTE: For now, this only works with string, boolean, and null types. 0 is still allowed.
+     *
+     */
+    isFalsy: () =>
+      defineConditional({
+        type: 'object',
+        properties: {
+          $form: {
+            type: 'object',
+            properties: {
+              [fieldId]: {
+                anyOf: [
+                  { const: 'undefined' },
+                  { const: false },
+                  { const: null },
+                  { const: '' }
+                ]
+              }
+            },
+            anyOf: [
+              {
+                required: [fieldId]
+              },
+              {
+                not: {
+                  required: [fieldId]
+                }
+              }
+            ]
           }
         },
         required: ['$form']

--- a/packages/commons/src/conditionals/validate.ts
+++ b/packages/commons/src/conditionals/validate.ts
@@ -31,7 +31,7 @@ export function validate(schema: JSONSchema, data: ConditionalParameters) {
   return ajv.validate(schema, data)
 }
 
-export function getConditionalActionsForField(
+function getConditionalActionsForField(
   field: FieldConfig,
   values: ConditionalParameters
 ) {
@@ -43,7 +43,10 @@ export function getConditionalActionsForField(
     .map((conditional) => conditional.type)
 }
 
-function isFieldHidden(field: FieldConfig, params: ConditionalParameters) {
+export function isFieldHidden(
+  field: FieldConfig,
+  params: ConditionalParameters
+) {
   const hasShowRule = (field.conditionals ?? []).some(
     (conditional) => conditional.type === 'SHOW'
   )
@@ -54,7 +57,10 @@ function isFieldHidden(field: FieldConfig, params: ConditionalParameters) {
   return !isVisible
 }
 
-function isFieldDisabled(field: FieldConfig, params: ConditionalParameters) {
+export function isFieldDisabled(
+  field: FieldConfig,
+  params: ConditionalParameters
+) {
   const hasEnableRule = (field.conditionals ?? []).some(
     (conditional) => conditional.type === 'ENABLE'
   )

--- a/packages/commons/src/events/ActionConfig.ts
+++ b/packages/commons/src/events/ActionConfig.ts
@@ -9,20 +9,18 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 import { z } from 'zod'
-import {
-  EnableConditional,
-  HideConditional,
-  ShowConditional
-} from './Conditional'
+import { EnableConditional, ShowConditional } from './Conditional'
 import { FormConfig, FormPage } from './FormConfig'
 import { TranslationConfig } from './TranslationConfig'
 import { ActionType } from './ActionType'
 
+/**
+ * By default, when conditionals are not defined, action is visible and enabled to the user.
+ */
 const ActionConditional = z.discriminatedUnion('type', [
-  // Action can be shown / hidden
+  /** If conditional is defined, the action is shown to the user only if the condition is met */
   ShowConditional,
-  HideConditional,
-  // Action can be shown to the user in the list but as disabled
+  /** If conditional is defined, the action is enabled only if the condition is met */
   EnableConditional
 ])
 

--- a/packages/commons/src/events/Conditional.ts
+++ b/packages/commons/src/events/Conditional.ts
@@ -21,23 +21,22 @@ export function Conditional() {
   return z.custom<JSONSchema>((val) => typeof val === 'object' && val !== null)
 }
 
-const ConditionalTypes = {
+/**
+ * By default, when conditionals are undefined, action is visible and enabled to everyone.
+ */
+export const ConditionalType = {
+  /** When 'SHOW' conditional is defined, the action is shown to the user only if the condition is met */
   SHOW: 'SHOW',
-  HIDE: 'HIDE',
+  /** If 'ENABLE' conditional is defined, the action is enabled only if the condition is met */
   ENABLE: 'ENABLE'
 } as const
 
 export const ShowConditional = z.object({
-  type: z.literal(ConditionalTypes.SHOW),
-  conditional: Conditional()
-})
-
-export const HideConditional = z.object({
-  type: z.literal(ConditionalTypes.HIDE),
+  type: z.literal(ConditionalType.SHOW),
   conditional: Conditional()
 })
 
 export const EnableConditional = z.object({
-  type: z.literal(ConditionalTypes.ENABLE),
+  type: z.literal(ConditionalType.ENABLE),
   conditional: Conditional()
 })

--- a/packages/commons/src/events/FieldConfig.ts
+++ b/packages/commons/src/events/FieldConfig.ts
@@ -9,12 +9,7 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 import { z } from 'zod'
-import {
-  Conditional,
-  EnableConditional,
-  HideConditional,
-  ShowConditional
-} from './Conditional'
+import { Conditional, EnableConditional, ShowConditional } from './Conditional'
 import { TranslationConfig } from './TranslationConfig'
 
 import { FieldType } from './FieldType'
@@ -23,7 +18,6 @@ const FieldId = z.string()
 
 const FieldConditional = z.discriminatedUnion('type', [
   ShowConditional,
-  HideConditional,
   EnableConditional
 ])
 
@@ -182,7 +176,7 @@ const Country = BaseField.extend({
 
 export type Country = z.infer<typeof Country>
 
-const LocationOptions = z.object({
+const LocationConfiguration = z.object({
   partOf: z
     .object({
       $data: z.string()
@@ -194,7 +188,7 @@ const LocationOptions = z.object({
 
 const Location = BaseField.extend({
   type: z.literal(FieldType.LOCATION),
-  options: LocationOptions
+  configuration: LocationConfiguration
 }).describe('Location input field')
 
 export type Location = z.infer<typeof Location>
@@ -266,5 +260,5 @@ export type FieldConfig = Inferred
 
 export type FieldProps<T extends FieldType> = Extract<FieldConfig, { type: T }>
 export type SelectOption = z.infer<typeof SelectOption>
-export type LocationOptions = z.infer<typeof LocationOptions>
+export type LocationOptions = z.infer<typeof LocationConfiguration>
 export type FieldConditional = z.infer<typeof FieldConditional>


### PR DESCRIPTION
- Deprecate 'HIDE' in favour of 'SHOW'
- fix config definition issues where option was still used instead of configuration

NOTE: 

As discussed,  people tend to read the following definition as "one needs to be true in order to show it" (`OR`)
``` 
conditionals: [
        {
          type: ConditionalType.SHOW,
          conditional: not(
            field('informant.relation').inArray([
              InformantTypes.MOTHER,
              InformantTypes.FATHER
            ])
          )
        },
        {
          type: ConditionalType.SHOW,
          conditional: field('some.other.field').isUndefined(),
          )
        }
      ]
```
We want to keep it that way.

This has another implication for configuration:
Whereas when the action was `HIDE` one could technically just append to an array of conditions, and having one match, field would be hidden. (e.g. ["Hide if informant is parent", "hide if id type is not selected"])

Since the condition is flipped, to achieve the same thing, the conditions would need to be `AND`
 (e.g. ["Show if informant is parent", "Show if id type is selected"])
 
I decided to flatten all the configurations, and explicitly define all the fields. We still need to figure out the right level of abstraction. How much repetition is acceptable, how much should SI configuring the event build their own convenience functions.

