### PR TITLE
fix: error message quick disappearance in qr scanner dialog

### DIFF
--- a/packages/components/src/IDReader/readers/QRReader/QRReader.tsx
+++ b/packages/components/src/IDReader/readers/QRReader/QRReader.tsx
@@ -48,7 +48,7 @@ export const QRReader = (props: ScannableQRReader) => {
   )
   const handleScanError: ErrorHandler = useCallback(
     (type, error) => {
-      if (type === 'invalid' || type === 'parse') {
+      if (type === 'invalid') {
         setError(error.message)
       }
       if (onError) {


### PR DESCRIPTION
make error message stay until a valid qr is read