### PR TITLE
Events v2: client-side feature flag for showing Events v2 as the default view

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -74,6 +74,7 @@ import { SystemList } from './views/SysAdmin/Config/Systems/Systems'
 import { UserList } from './views/SysAdmin/Team/user/UserList'
 import VSExport from './views/SysAdmin/Vsexports/VSExport'
 import { UserAudit } from './views/UserAudit/UserAudit'
+import { config } from './config'
 
 // Injecting global styles for the body tag - used only once
 // eslint-disable-line
@@ -99,7 +100,7 @@ function createRedirect(from: string, to: string) {
   }
 }
 
-export const routesConfig = window.config.FEATURES.V2_EVENTS
+export const routesConfig = config.FEATURES.V2_EVENTS
   ? [
       {
         path: '/',

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -11,6 +11,20 @@
 
 type Config = typeof window.config
 
+/*
+ * The following logic is temporary logic so that Events v2 can be tested as the "primary"
+ * events. This will be removed once Events v2 is published.
+ *
+ * Country configuration, as part of its config can define a flag FEATURES.V2_EVENTS = true
+ * that enables the same mode. The following logic overrides that config and makes it configurable
+ * in the client.
+ * The overrides are primarily read from local storage. The values in local storage can be controlled by
+ * setting up the URL parameters. For example, to enable V2_EVENTS, the URL can be:
+ *
+ * http://localhost:3000/?V2_EVENTS=true
+ * http://localhost:3000/?V2_EVENTS=false
+ */
+
 const localFeaturesOverrides = JSON.parse(
   localStorage.getItem('config') || '{}'
 ) as Partial<Config['FEATURES']>

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -1,0 +1,36 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+
+type Config = typeof window.config
+
+const localFeaturesOverrides = JSON.parse(
+  localStorage.getItem('config') || '{}'
+) as Partial<Config['FEATURES']>
+
+const urlParams = new URLSearchParams(window.location.search)
+const allowedParams = ['V2_EVENTS'] as const satisfies Array<
+  keyof typeof localFeaturesOverrides
+>
+
+allowedParams.forEach((param) => {
+  if (urlParams.has(param)) {
+    localFeaturesOverrides[param] = urlParams.get(param) === 'true'
+    localStorage.setItem('config', JSON.stringify(localFeaturesOverrides))
+  }
+})
+
+export const config = {
+  ...window.config,
+  FEATURES: {
+    ...window.config.FEATURES,
+    ...localFeaturesOverrides
+  }
+}

--- a/packages/client/src/v2-events/.eslintrc.js
+++ b/packages/client/src/v2-events/.eslintrc.js
@@ -53,7 +53,8 @@ module.exports = {
           '!@client/forms',
           '!@client/i18n',
           '!@client/search',
-          '!@client/offline'
+          '!@client/offline',
+          '!@client/config'
         ]
       }
     ]

--- a/packages/client/src/v2-events/routes/routes.ts
+++ b/packages/client/src/v2-events/routes/routes.ts
@@ -10,12 +10,13 @@
  */
 
 import { hashValues, route, string } from 'react-router-typesafe-routes/dom'
+import { config } from '@client/config'
 import { routes as correctionRoutes } from '@client/v2-events/features/events/actions/correct/request/routes'
 import { routes as workqueueRoutes } from '@client/v2-events/features/workqueues/routes'
 
 export const ROUTES = {
   V2: route(
-    window.config.FEATURES.V2_EVENTS ? '' : 'v2',
+    config.FEATURES.V2_EVENTS ? '' : 'v2',
     {},
     {
       EVENTS: route(


### PR DESCRIPTION
Adds a mechanism for the client to decide if they want Events v2 to be default or not regardless of environment variables in country config.

`http://localhost:3000/?V2_EVENTS=true`

Will set up a flag in local storage
<img width="443" alt="image" src="https://github.com/user-attachments/assets/5ebaf965-15a7-4e8e-905a-74ce9d82a612" />

that from that point forwards will dictate which view is render as default