### PR TITLE
fix: Replace bash script with github action (#6910)

### DIFF
--- a/.github/workflows/mirror-trivy-db.yml
+++ b/.github/workflows/mirror-trivy-db.yml
@@ -24,16 +24,15 @@ jobs:
       RETRIES: 100
 
     steps:
-      - name: Install Skopeo
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y skopeo
-
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Log in to GHCR
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | skopeo login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create mirror-image.sh script
         run: |


### PR DESCRIPTION
Goal of this particular pull request is to optimize login to GHCR and remove usage of third-party tool.

See test results at: https://github.com/opencrvs/opencrvs-core/actions/runs/13498016010
