### PR TITLE
fix event history modal title

### DIFF
--- a/packages/client/src/v2-events/features/workqueues/EventOverview/components/EventHistory/EventHistory.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/components/EventHistory/EventHistory.tsx
@@ -39,17 +39,19 @@ const TableDiv = styled.div`
 
 const DEFAULT_HISTORY_RECORD_PAGE_SIZE = 10
 
+export const eventHistoryStatusMessage = {
+  id: `v2.events.history.status`,
+  defaultMessage:
+    '{status, select, CREATE {Draft} VALIDATE {Validated} DRAFT {Draft} DECLARE {Declared} REGISTER {Registered} PRINT_CERTIFICATE {Print certificate} other {Unknown}}'
+}
+
 const messages = defineMessages({
   'event.history.timeFormat': {
     defaultMessage: 'MMMM dd, yyyy · hh.mm a',
     id: 'v2.event.history.timeFormat',
     description: 'Time format for timestamps in event history'
   },
-  'events.history.status': {
-    id: `v2.events.history.status`,
-    defaultMessage:
-      '{status, select, CREATE {Draft} VALIDATE {Validated} DRAFT {Draft} DECLARE {Declared} REGISTER {Registered} PRINT_CERTIFICATE {Print certificate} other {Unknown}}'
-  },
+
   'event.history.role': {
     id: 'v2.event.history.role',
     defaultMessage:
@@ -90,7 +92,7 @@ export function EventHistory({ history }: { history: ActionDocument[] }) {
             onHistoryRowClick(item, user)
           }}
         >
-          {intl.formatMessage(messages['events.history.status'], {
+          {intl.formatMessage(eventHistoryStatusMessage, {
             status: item.type
           })}
         </Link>

--- a/packages/client/src/v2-events/features/workqueues/EventOverview/components/EventHistory/EventHistory.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/components/EventHistory/EventHistory.tsx
@@ -26,7 +26,10 @@ import { constantsMessages } from '@client/v2-events/messages'
 import * as routes from '@client/navigation/routes'
 import { formatUrl } from '@client/navigation'
 import { useEventOverviewContext } from '@client/v2-events/features/workqueues/EventOverview/EventOverviewContext'
-import { EventHistoryModal } from './EventHistoryModal'
+import {
+  EventHistoryModal,
+  eventHistoryStatusMessage
+} from './EventHistoryModal'
 import { UserAvatar } from './UserAvatar'
 
 /**
@@ -38,12 +41,6 @@ const TableDiv = styled.div`
 `
 
 const DEFAULT_HISTORY_RECORD_PAGE_SIZE = 10
-
-export const eventHistoryStatusMessage = {
-  id: `v2.events.history.status`,
-  defaultMessage:
-    '{status, select, CREATE {Draft} VALIDATE {Validated} DRAFT {Draft} DECLARE {Declared} REGISTER {Registered} PRINT_CERTIFICATE {Print certificate} other {Unknown}}'
-}
 
 const messages = defineMessages({
   'event.history.timeFormat': {

--- a/packages/client/src/v2-events/features/workqueues/EventOverview/components/EventHistory/EventHistoryModal.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/components/EventHistory/EventHistoryModal.tsx
@@ -16,6 +16,7 @@ import { Text } from '@opencrvs/components/lib/Text'
 import { ActionDocument } from '@opencrvs/commons/client'
 import { ResolvedUser } from '@opencrvs/commons'
 import { getUsersFullName, joinValues } from '@client/v2-events/utils'
+import { eventHistoryStatusMessage } from './EventHistory'
 
 const messages = defineMessages({
   'event.history.modal.timeFormat': {
@@ -41,7 +42,11 @@ export function EventHistoryModal({
 }) {
   const intl = useIntl()
 
-  const name = getUsersFullName(user.name, intl.locale)
+  const userName = getUsersFullName(user.name, intl.locale)
+  const title = intl.formatMessage(eventHistoryStatusMessage, {
+    status: history.type
+  })
+
   return (
     <ResponsiveModal
       autoHeight
@@ -49,14 +54,14 @@ export function EventHistoryModal({
       handleClose={close}
       responsive={true}
       show={true}
-      title={history.type}
+      title={title}
       width={1024}
     >
       <Stack>
         <Text color="grey500" element="p" variant="reg19">
           {joinValues(
             [
-              name,
+              userName,
               format(
                 new Date(history.createdAt),
                 intl.formatMessage(messages['event.history.modal.timeFormat'])

--- a/packages/client/src/v2-events/features/workqueues/EventOverview/components/EventHistory/EventHistoryModal.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/components/EventHistory/EventHistoryModal.tsx
@@ -16,7 +16,12 @@ import { Text } from '@opencrvs/components/lib/Text'
 import { ActionDocument } from '@opencrvs/commons/client'
 import { ResolvedUser } from '@opencrvs/commons'
 import { getUsersFullName, joinValues } from '@client/v2-events/utils'
-import { eventHistoryStatusMessage } from './EventHistory'
+
+export const eventHistoryStatusMessage = {
+  id: `v2.events.history.status`,
+  defaultMessage:
+    '{status, select, CREATE {Draft} VALIDATE {Validated} DRAFT {Draft} DECLARE {Declared} REGISTER {Registered} PRINT_CERTIFICATE {Print certificate} other {Unknown}}'
+}
 
 const messages = defineMessages({
   'event.history.modal.timeFormat': {


### PR DESCRIPTION
Fix event history modal title to display proper action name, instead of 'technical' action name

Before:
<img width="972" alt="Screenshot 2025-02-24 at 16 37 49" src="https://github.com/user-attachments/assets/726bd482-88db-4550-a737-d0ab23692e71" />

After: 
<img width="969" alt="Screenshot 2025-02-24 at 16 37 29" src="https://github.com/user-attachments/assets/8226a3d8-a216-4acf-94de-243f60c2e251" />

