### PR TITLE
Hide event action header menu if it doesnt have any actions (e.g. on register form)

### DIFF
--- a/packages/client/src/v2-events/features/events/actions/declare/Declare.stories.tsx
+++ b/packages/client/src/v2-events/features/events/actions/declare/Declare.stories.tsx
@@ -38,12 +38,20 @@ const tRPCMsw = createTRPCMsw<AppRouter>({
   transformer: { input: superjson, output: superjson }
 })
 
+// Use an undeclared draft event for tests
+const undeclaredDraftEvent = {
+  ...tennisClueMembershipEventDocument,
+  actions: tennisClueMembershipEventDocument.actions.filter(
+    ({ type }) => type === 'CREATE'
+  )
+}
+
 export const Page: Story = {
   parameters: {
     reactRouter: {
       router: routesConfig,
       initialPath: ROUTES.V2.EVENTS.DECLARE.PAGES.buildPath({
-        eventId: tennisClueMembershipEventDocument.id,
+        eventId: undeclaredDraftEvent.id,
         pageId: 'applicant'
       })
     },
@@ -51,7 +59,7 @@ export const Page: Story = {
       handlers: {
         event: [
           tRPCMsw.event.get.query(() => {
-            return tennisClueMembershipEventDocument
+            return undeclaredDraftEvent
           })
         ]
       }
@@ -64,14 +72,14 @@ export const Review: Story = {
     reactRouter: {
       router: routesConfig,
       initialPath: ROUTES.V2.EVENTS.DECLARE.REVIEW.buildPath({
-        eventId: tennisClueMembershipEventDocument.id
+        eventId: undeclaredDraftEvent.id
       })
     },
     msw: {
       handlers: {
         event: [
           tRPCMsw.event.get.query(() => {
-            return tennisClueMembershipEventDocument
+            return undeclaredDraftEvent
           })
         ]
       }
@@ -84,6 +92,10 @@ export const FilledPagesVisibleInReview: Story = {
     const canvas = within(canvasElement)
 
     await canvas.findByText(/Who is applying for the membership?/)
+
+    await expect(
+      await canvas.findByTestId('event-menu-toggle-button-image')
+    ).toBeInTheDocument()
 
     await step('Fill the applicant details', async () => {
       await userEvent.type(
@@ -118,7 +130,7 @@ export const FilledPagesVisibleInReview: Story = {
     reactRouter: {
       router: routesConfig,
       initialPath: ROUTES.V2.EVENTS.DECLARE.PAGES.buildPath({
-        eventId: tennisClueMembershipEventDocument.id,
+        eventId: undeclaredDraftEvent.id,
         pageId: 'applicant'
       })
     },
@@ -126,7 +138,7 @@ export const FilledPagesVisibleInReview: Story = {
       handlers: {
         event: [
           tRPCMsw.event.get.query(() => {
-            return tennisClueMembershipEventDocument
+            return undeclaredDraftEvent
           })
         ]
       }

--- a/packages/client/src/v2-events/layouts/form/FormHeader.tsx
+++ b/packages/client/src/v2-events/layouts/form/FormHeader.tsx
@@ -62,6 +62,16 @@ export function FormHeader({
     await deleteDeclaration(eventId)
   }, [eventId, deleteDeclaration])
 
+  const menuItems = isUndeclaredDraft(event)
+    ? [
+        {
+          label: 'Delete declaration',
+          icon: <Icon name="Trash" />,
+          handler: onDelete
+        }
+      ]
+    : []
+
   return (
     <AppBar
       desktopLeft={appbarIcon}
@@ -84,23 +94,19 @@ export function FormHeader({
                 <Icon name="X" />
                 {intl.formatMessage(messages.exitButton)}
               </Button>
-              <ToggleMenu
-                id={'event-menu'}
-                menuItems={
-                  isUndeclaredDraft(event)
-                    ? [
-                        {
-                          label: 'Delete declaration',
-                          icon: <Icon name="Trash" />,
-                          handler: onDelete
-                        }
-                      ]
-                    : []
-                }
-                toggleButton={
-                  <Icon color="primary" name="DotsThreeVertical" size="large" />
-                }
-              />
+              {menuItems.length > 0 && (
+                <ToggleMenu
+                  id={'event-menu'}
+                  menuItems={menuItems}
+                  toggleButton={
+                    <Icon
+                      color="primary"
+                      name="DotsThreeVertical"
+                      size="large"
+                    />
+                  }
+                />
+              )}
             </>
           ) : (
             <Button size="small" type="icon" onClick={goToHome}>

--- a/packages/client/src/v2-events/layouts/form/FormHeader.tsx
+++ b/packages/client/src/v2-events/layouts/form/FormHeader.tsx
@@ -100,6 +100,7 @@ export function FormHeader({
                   menuItems={menuItems}
                   toggleButton={
                     <Icon
+                      data-testid="event-menu-toggle-button-image"
                       color="primary"
                       name="DotsThreeVertical"
                       size="large"


### PR DESCRIPTION
- Form header menu is only shown if it has items
- Declare story test checks that event menu is shown for undeclared form

Before:

<img width="1000" alt="Screenshot 2025-02-25 at 13 13 39" src="https://github.com/user-attachments/assets/d976a6d1-637e-41c8-9c30-a0614098fdd6" />

After:

<img width="1000" alt="Screenshot 2025-02-25 at 13 13 15" src="https://github.com/user-attachments/assets/c24818b3-2ff3-4d7c-a115-10f779e54da3" />
