### PR TITLE
fix: set default value for QA_ENV

### DIFF
--- a/packages/webhooks/src/environment.ts
+++ b/packages/webhooks/src/environment.ts
@@ -18,7 +18,7 @@ export const env = cleanEnv(process.env, {
   CERT_PUBLIC_KEY_PATH: str({ devDefault: '../../.secrets/public-key.pem' }),
   SENTRY_DSN: str({ default: undefined }),
   NODE_ENV: str({ devDefault: 'development' }),
-  QA_ENV: bool({ devDefault: false }),
+  QA_ENV: bool({ default: false }),
   AUTH_URL: url({ devDefault: 'http://localhost:4040' }),
   FHIR_URL: url({ devDefault: 'http://localhost:3447/fhir' }),
   CHECK_INVALID_TOKEN: bool({


### PR DESCRIPTION
Fixes webhook failing to start because of missing `QA_ENV` variable