### PR TITLE
Disable react-router v7_startTransition, to fix problems with routing

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -98,7 +98,7 @@
     "react-intl": "5.25.1",
     "react-page-visibility": "^3.2.1",
     "react-redux": "^7.1.1",
-    "react-router-dom": "^6.28.0",
+    "react-router-dom": "^6.28.1",
     "react-router-typesafe-routes": "1.2.2",
     "react-stickynode": "^2.0.1",
     "react-tooltip": "^4.2.21",

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -519,7 +519,11 @@ export function App({ client, store, router }: IAppProps) {
           <I18nContainer>
             <ThemeProvider theme={getTheme()}>
               <StyledErrorBoundary>
-                <RouterProvider router={router} />
+                <RouterProvider
+                  router={router}
+                  // v7_startTransition used to be true for a moment, but it changed the routing and broke some farajaland e2e tests (and possibly changed actual functionality as well).
+                  future={{ v7_startTransition: false }}
+                />
               </StyledErrorBoundary>
             </ThemeProvider>
           </I18nContainer>

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -519,10 +519,7 @@ export function App({ client, store, router }: IAppProps) {
           <I18nContainer>
             <ThemeProvider theme={getTheme()}>
               <StyledErrorBoundary>
-                <RouterProvider
-                  router={router}
-                  future={{ v7_startTransition: true }}
-                />
+                <RouterProvider router={router} />
               </StyledErrorBoundary>
             </ThemeProvider>
           </I18nContainer>

--- a/yarn.lock
+++ b/yarn.lock
@@ -23138,6 +23138,14 @@ react-router-dom@^6.28.0:
     "@remix-run/router" "1.21.0"
     react-router "6.28.0"
 
+react-router-dom@^6.28.1:
+  version "6.28.1"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.28.1.tgz#b78fe452d2cd31919b80e57047a896bfa1509f8c"
+  integrity sha512-YraE27C/RdjcZwl5UCqF/ffXnZDxpJdk9Q6jw38SZHjXs7NNdpViq2l2c7fO7+4uWaEfcwfGCv3RSg4e1By/fQ==
+  dependencies:
+    "@remix-run/router" "1.21.0"
+    react-router "6.28.1"
+
 react-router-typesafe-routes@1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/react-router-typesafe-routes/-/react-router-typesafe-routes-1.2.2.tgz#548a8a46f3f71bfcd0da5cef789bcb5a422fbe71"
@@ -23147,6 +23155,13 @@ react-router@6.28.0:
   version "6.28.0"
   resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.28.0.tgz#29247c86d7ba901d7e5a13aa79a96723c3e59d0d"
   integrity sha512-HrYdIFqdrnhDw0PqG/AKjAqEqM7AvxCz0DQ4h2W8k6nqmc5uRBYDag0SBxx9iYz5G8gnuNVLzUe13wl9eAsXXg==
+  dependencies:
+    "@remix-run/router" "1.21.0"
+
+react-router@6.28.1:
+  version "6.28.1"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.28.1.tgz#f82317ab24eee67d7beb7b304c0378b2b48fa178"
+  integrity sha512-2omQTA3rkMljmrvvo6WtewGdVh45SpL9hGiCI9uUrwGGfNFDIvGK4gYJsKlJoNVi6AQZcopSCballL+QGOm7fA==
   dependencies:
     "@remix-run/router" "1.21.0"
 


### PR DESCRIPTION
react-router v7_startTransition was introduced in this PR: https://github.com/opencrvs/opencrvs-core/pull/8703

However it changed the routing on some actions, and caused farajaland e2e tests to fail and possibly to some functionality to change.

In this PR we firstly update the react-router-dom package to 6.28.1, which supports warning suppression by setting the value to false, and we set the `v7_startTransition ` value to false.