### PR TITLE
fix: add delete public key step after installing ssh key step

### DIFF
--- a/.github/workflows/cd-manual-e2e.yml
+++ b/.github/workflows/cd-manual-e2e.yml
@@ -70,6 +70,8 @@ jobs:
         with:
           key: ${{ secrets.SSH_KEY }}
           known_hosts: ${{ secrets.KNOWN_HOSTS }}
+      - name: Delete public key
+        run: rm -f ~/.ssh/id_rsa.pub
       - name: Deploy to staging
         env:
           SMTP_PORT: ${{ secrets.SMTP_PORT }}

--- a/.github/workflows/create-backup-data-action.yml
+++ b/.github/workflows/create-backup-data-action.yml
@@ -47,6 +47,8 @@ jobs:
         with:
           key: ${{ secrets.SSH_KEY }}
           known_hosts: ${{ secrets.KNOWN_HOSTS }}
+      - name: Delete public key
+        run: rm -f ~/.ssh/id_rsa.pub
       - name: Create backup data in given environment and copy it over to the backup environment
         run: ssh root@$SRC_HOST "MONGODB_ADMIN_USER=$MONGODB_ADMIN_USER MONGODB_ADMIN_PASSWORD=$MONGODB_ADMIN_PASSWORD ELASTICSEARCH_ADMIN_USER=$ELASTICSEARCH_ADMIN_USER ELASTICSEARCH_ADMIN_PASSWORD=$ELASTICSEARCH_ADMIN_PASSWORD /opt/opencrvs/infrastructure/emergency-backup-metadata.sh root $BACKUP_HOST 22 $SRC_HOST $REMOTE_DIR $REPLICAS $VERSION_LABEL"
         env:

--- a/.github/workflows/reset-env-action.yml
+++ b/.github/workflows/reset-env-action.yml
@@ -40,6 +40,8 @@ jobs:
         with:
           key: ${{ secrets.SSH_KEY }}
           known_hosts: ${{ secrets.KNOWN_HOSTS }}
+      - name: Delete public key
+        run: rm -f ~/.ssh/id_rsa.pub
       - name: Clear data from given environment
         run: ssh root@$SSH_HOST "MONGODB_ADMIN_USER=$MONGODB_ADMIN_USER MONGODB_ADMIN_PASSWORD=$MONGODB_ADMIN_PASSWORD ELASTICSEARCH_ADMIN_USER=$ELASTICSEARCH_ADMIN_USER ELASTICSEARCH_ADMIN_PASSWORD=$ELASTICSEARCH_ADMIN_PASSWORD /opt/opencrvs/infrastructure/clear-all-data.sh $REPLICAS $ENV"
       - name: Restore backup data in given environment


### PR DESCRIPTION
Description
This pull request addresses issue [#8808](https://github.com/opencrvs/opencrvs-core/issues/8808), which involves a conflict between the `id_rsa` and `id_rsa.pub` keys in GitHub Actions, causing `SSH_KEY` permission denied errors.

Changes
 - Added a step to delete the id_rsa.pub file in the .ssh folder after the "Install SSH Key" step in the GitHub Actions workflow to resolve the key conflict.
 
Steps to Verify
- Ensure that the `SSH_KEY` permission denied error no longer occurs during the provision and deploy actions.
- Verify that the workflow proceeds successfully after the deletion of the `id_rsa.pub` file.

Related Issue
[Issue #8808](https://github.com/opencrvs/opencrvs-core/issues/8808)