### PR TITLE
fix(ocrvs-8505): create a new id field for corrections

### DIFF
--- a/packages/config/src/handlers/dashboardQueries/defaultQueries.ts
+++ b/packages/config/src/handlers/dashboardQueries/defaultQueries.ts
@@ -616,7 +616,8 @@ const declarations = ({ lastUpdatedAt }: { lastUpdatedAt: string }) => ({
     { $unwind: '$state' },
     {
       $project: {
-        _id: 1,
+        _id: 0,
+        id: '$meta.versionId',
         gender: '$child.gender',
         reason: '$reason.text',
         extensions: '$extensions',
@@ -632,7 +633,7 @@ const declarations = ({ lastUpdatedAt }: { lastUpdatedAt: string }) => ({
     {
       $merge: {
         into: { db: 'performance', coll: 'corrections' },
-        on: '_id',
+        on: 'id',
         whenMatched: 'replace',
         whenNotMatched: 'insert'
       }

--- a/packages/migration/src/migrations/hearth/20250303113723-create-id-field-for-corrections.ts
+++ b/packages/migration/src/migrations/hearth/20250303113723-create-id-field-for-corrections.ts
@@ -1,0 +1,353 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+
+import { Db, MongoClient } from 'mongodb'
+
+const DASHBOARD_MONGO_URL =
+  process.env.DASHBOARD_MONGO_URL || 'mongodb://localhost/performance'
+
+export const up = async (db: Db, client: MongoClient) => {
+  const dashboardDb = (
+    await new MongoClient(DASHBOARD_MONGO_URL).connect()
+  ).db()
+  await db
+    .collection('Task')
+    .aggregate([
+      {
+        $unionWith: 'Task_history'
+      },
+      {
+        $match: {
+          'extension.url': 'http://opencrvs.org/specs/extension/makeCorrection'
+        }
+      },
+      {
+        $addFields: {
+          compositionId: {
+            $arrayElemAt: [{ $split: ['$focus.reference', '/'] }, 1]
+          },
+          extensionsObject: {
+            $arrayToObject: {
+              $map: {
+                input: '$extension',
+                as: 'el',
+                in: [
+                  {
+                    $replaceOne: {
+                      input: '$$el.url',
+                      find: 'http://opencrvs.org/specs/extension/',
+                      replacement: ''
+                    }
+                  },
+                  {
+                    $arrayElemAt: [
+                      { $split: ['$$el.valueReference.reference', '/'] },
+                      1
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      {
+        $lookup: {
+          from: 'Composition',
+          localField: 'compositionId',
+          foreignField: 'id',
+          as: 'composition'
+        }
+      },
+      { $unwind: '$composition' },
+      {
+        $addFields: {
+          extensions: {
+            $arrayToObject: {
+              $map: {
+                input: '$composition.section',
+                as: 'el',
+                in: [
+                  {
+                    $let: {
+                      vars: {
+                        firstElement: {
+                          $arrayElemAt: ['$$el.code.coding', 0]
+                        }
+                      },
+                      in: '$$firstElement.code'
+                    }
+                  },
+                  {
+                    $let: {
+                      vars: {
+                        firstElement: { $arrayElemAt: ['$$el.entry', 0] }
+                      },
+                      in: {
+                        $arrayElemAt: [
+                          { $split: ['$$firstElement.reference', '/'] },
+                          1
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      {
+        $lookup: {
+          from: 'Patient',
+          localField: 'extensions.child-details',
+          foreignField: 'id',
+          as: 'child'
+        }
+      },
+      { $unwind: '$child' },
+      {
+        $lookup: {
+          from: 'Location',
+          localField: 'extensionsObject.regLastOffice',
+          foreignField: 'id',
+          as: 'office'
+        }
+      },
+      { $unwind: '$office' },
+      {
+        $addFields: {
+          'office.district': {
+            $arrayElemAt: [{ $split: ['$office.partOf.reference', '/'] }, 1]
+          }
+        }
+      },
+      {
+        $lookup: {
+          from: 'Location',
+          localField: 'office.district',
+          foreignField: 'id',
+          as: 'district'
+        }
+      },
+      { $unwind: '$district' },
+      {
+        $addFields: {
+          'district.state': {
+            $arrayElemAt: [{ $split: ['$district.partOf.reference', '/'] }, 1]
+          }
+        }
+      },
+      {
+        $lookup: {
+          from: 'Location',
+          localField: 'district.state',
+          foreignField: 'id',
+          as: 'state'
+        }
+      },
+      { $unwind: '$state' },
+      {
+        $project: {
+          _id: 0,
+          id: '$meta.versionId',
+          gender: '$child.gender',
+          reason: '$reason.text',
+          extensions: '$extensions',
+          officeName: '$office.name',
+          districtName: '$district.name',
+          stateName: '$state.name',
+          event: 'Birth',
+          createdAt: {
+            $dateFromString: { dateString: '$lastModified' }
+          }
+        }
+      },
+      {
+        $out: {
+          db: 'performance',
+          coll: 'corrections'
+        }
+      }
+    ])
+    .toArray()
+
+  await dashboardDb
+    .collection('corrections')
+    .createIndex({ id: 1 }, { unique: true })
+}
+
+export const down = async (db: Db, client: MongoClient) => {
+  const dashboardDb = (
+    await new MongoClient(DASHBOARD_MONGO_URL).connect()
+  ).db()
+
+  dashboardDb.collection('corrections').dropIndex('id_1')
+  await db
+    .collection('Task')
+    .aggregate([
+      {
+        $unionWith: 'Task_history'
+      },
+      {
+        $match: {
+          'extension.url': 'http://opencrvs.org/specs/extension/makeCorrection'
+        }
+      },
+      {
+        $addFields: {
+          compositionId: {
+            $arrayElemAt: [{ $split: ['$focus.reference', '/'] }, 1]
+          },
+          extensionsObject: {
+            $arrayToObject: {
+              $map: {
+                input: '$extension',
+                as: 'el',
+                in: [
+                  {
+                    $replaceOne: {
+                      input: '$$el.url',
+                      find: 'http://opencrvs.org/specs/extension/',
+                      replacement: ''
+                    }
+                  },
+                  {
+                    $arrayElemAt: [
+                      { $split: ['$$el.valueReference.reference', '/'] },
+                      1
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      {
+        $lookup: {
+          from: 'Composition',
+          localField: 'compositionId',
+          foreignField: 'id',
+          as: 'composition'
+        }
+      },
+      { $unwind: '$composition' },
+      {
+        $addFields: {
+          extensions: {
+            $arrayToObject: {
+              $map: {
+                input: '$composition.section',
+                as: 'el',
+                in: [
+                  {
+                    $let: {
+                      vars: {
+                        firstElement: {
+                          $arrayElemAt: ['$$el.code.coding', 0]
+                        }
+                      },
+                      in: '$$firstElement.code'
+                    }
+                  },
+                  {
+                    $let: {
+                      vars: {
+                        firstElement: { $arrayElemAt: ['$$el.entry', 0] }
+                      },
+                      in: {
+                        $arrayElemAt: [
+                          { $split: ['$$firstElement.reference', '/'] },
+                          1
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      {
+        $lookup: {
+          from: 'Patient',
+          localField: 'extensions.child-details',
+          foreignField: 'id',
+          as: 'child'
+        }
+      },
+      { $unwind: '$child' },
+      {
+        $lookup: {
+          from: 'Location',
+          localField: 'extensionsObject.regLastOffice',
+          foreignField: 'id',
+          as: 'office'
+        }
+      },
+      { $unwind: '$office' },
+      {
+        $addFields: {
+          'office.district': {
+            $arrayElemAt: [{ $split: ['$office.partOf.reference', '/'] }, 1]
+          }
+        }
+      },
+      {
+        $lookup: {
+          from: 'Location',
+          localField: 'office.district',
+          foreignField: 'id',
+          as: 'district'
+        }
+      },
+      { $unwind: '$district' },
+      {
+        $addFields: {
+          'district.state': {
+            $arrayElemAt: [{ $split: ['$district.partOf.reference', '/'] }, 1]
+          }
+        }
+      },
+      {
+        $lookup: {
+          from: 'Location',
+          localField: 'district.state',
+          foreignField: 'id',
+          as: 'state'
+        }
+      },
+      { $unwind: '$state' },
+      {
+        $project: {
+          gender: '$child.gender',
+          reason: '$reason.text',
+          extensions: '$extensions',
+          officeName: '$office.name',
+          districtName: '$district.name',
+          stateName: '$state.name',
+          event: 'Birth',
+          createdAt: {
+            $dateFromString: { dateString: '$lastModified' }
+          }
+        }
+      },
+      {
+        $out: {
+          db: 'performance',
+          coll: 'corrections'
+        }
+      }
+    ])
+    .toArray()
+}

--- a/packages/migration/src/migrations/hearth/20250303113723-create-id-field-for-corrections.ts
+++ b/packages/migration/src/migrations/hearth/20250303113723-create-id-field-for-corrections.ts
@@ -190,7 +190,7 @@ export const down = async (db: Db, client: MongoClient) => {
     await new MongoClient(DASHBOARD_MONGO_URL).connect()
   ).db()
 
-  dashboardDb.collection('corrections').dropIndex('id_1')
+  await dashboardDb.collection('corrections').dropIndex('id_1')
   await db
     .collection('Task')
     .aggregate([


### PR DESCRIPTION
The `_id` field was being used for deduping the corrections which was behaving inconsistently. So it had to be switched to another field, in this case the newly created `id`, which we are sure would be unique across both the `Task` & `Task_histories` collections.

countryconfig PR: https://github.com/opencrvs/opencrvs-countryconfig/pull/461