### PR TITLE
Update time field with AM/PM

### DIFF
--- a/packages/client/src/components/form/FormFieldGenerator.tsx
+++ b/packages/client/src/components/form/FormFieldGenerator.tsx
@@ -473,6 +473,7 @@ const GeneratedInputField = React.memo<GeneratedInputFieldProps>(
         <InputField {...inputFieldProps}>
           <TimeField
             {...inputProps}
+            use12HourFormat={fieldDefinition.use12HourFormat}
             ignorePlaceHolder={fieldDefinition.ignorePlaceHolder}
             onChange={onChangeGroupInput}
             value={value as string}

--- a/packages/client/src/forms/index.ts
+++ b/packages/client/src/forms/index.ts
@@ -700,6 +700,7 @@ export interface ILoaderButton extends IFormFieldBase {
 interface ITimeFormFIeld extends IFormFieldBase {
   type: typeof TIME
   ignorePlaceHolder?: boolean
+  use12HourFormat?: boolean
 }
 
 export interface ISignatureFormField extends IFormFieldBase {
@@ -1249,6 +1250,7 @@ interface I18nHeading3Field extends Ii18nFormFieldBase {
 interface Ii18nTimeFormField extends Ii18nFormFieldBase {
   type: typeof TIME
   ignorePlaceHolder?: boolean
+  use12HourFormat?: boolean
 }
 
 interface Ii18nSignatureField extends Ii18nFormFieldBase {


### PR DESCRIPTION
**Changes Introduced**

- Added a boolean `use12HourFormat` prop to the time field component (default: false).
- `padStart()`: If the hour field is `empty or set to '0'`, it automatically defaults to '01' in the 12-hour format.
- Prevented users from entering `'00'` as a valid hour in 12-hour format.
- Added a select field for AM/PM selection
- Updated the time value format to `hh:mm AM/PM` when use12HourFormat is enabled

**Ticket/Issue Number**: https://github.com/opencrvs/opencrvs-core/issues/8336
