### PR TITLE
fix(v1.6.3) Fix mongo client connection errors and other performance enhancements

### DIFF
--- a/packages/config/src/config/hearthClient.ts
+++ b/packages/config/src/config/hearthClient.ts
@@ -1,0 +1,35 @@
+import { env } from '@config/environment'
+import { logger } from '@opencrvs/commons'
+import { MongoClient } from 'mongodb'
+
+const client = new MongoClient(env.HEARTH_MONGO_URL)
+
+client.on('close', () => {
+  logger.error('MongoDB connection closed.')
+})
+
+client.on('error', (err) => {
+  logger.error('MongoDB connection error:', err)
+})
+
+async function wait(delay: number) {
+  await new Promise((resolve) => setTimeout(resolve, delay))
+}
+
+export const start = async (): Promise<MongoClient> => {
+  try {
+    await client.connect()
+    logger.info('Connected to MongoDB')
+    return client
+  } catch (err) {
+    logger.error('Failed to connect to MongoDB. Retrying...')
+    await wait(1000)
+    return await start()
+  }
+}
+
+export const stop = async (): Promise<void> => {
+  await client.close()
+}
+
+export default client

--- a/packages/config/src/config/hearthClient.ts
+++ b/packages/config/src/config/hearthClient.ts
@@ -1,3 +1,14 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+
 import { env } from '@config/environment'
 import { logger } from '@opencrvs/commons'
 import { MongoClient } from 'mongodb'

--- a/packages/config/src/handlers/locations/locationTreeSolver.test.ts
+++ b/packages/config/src/handlers/locations/locationTreeSolver.test.ts
@@ -53,6 +53,11 @@ describe('resolveChildren', () => {
 
     const db = connectedClient.db()
     collection = db.collection<Location>('Location_view_with_plain_ids')
+
+    jest.doMock('@config/config/hearthClient', () => ({
+      __esModule: true,
+      default: client
+    }))
   }, 60000 /* Timeout to allow mongo binary download*/)
 
   afterAll(async () => {
@@ -95,8 +100,21 @@ describe('resolveChildren', () => {
         'uuid1' as UUID
       )) as SavedLocation[]
 
+      const projectedChild = {
+        id: child.id,
+        name: child.name,
+        type: child.type
+      }
+      const projectedGrandchild = {
+        id: grandchild.id,
+        name: grandchild.name,
+        type: grandchild.type
+      }
+
       expect(children).toHaveLength(2)
-      expect(children).toEqual(expect.arrayContaining([child, grandchild]))
+      expect(children).toEqual(
+        expect.arrayContaining([projectedChild, projectedGrandchild])
+      )
     })
   })
 })

--- a/packages/config/src/handlers/locations/locationTreeSolver.ts
+++ b/packages/config/src/handlers/locations/locationTreeSolver.ts
@@ -16,48 +16,41 @@ import {
 } from '@opencrvs/commons/types'
 import { UUID } from '@opencrvs/commons'
 import { fetchFromHearth } from '@config/services/hearth'
-import { MongoClient } from 'mongodb'
-import { env } from '@config/environment'
+import client from '@config/config/hearthClient'
 
 export const resolveLocationChildren = async (id: UUID) => {
-  const client = new MongoClient(HEARTH_MONGO_URL)
-  try {
-    const connectedClient = await client.connect()
-    const db = connectedClient.db()
+  const db = client.db()
 
-    const childQuery = [
-      {
-        $match: { id: id }
-      },
-      {
-        $graphLookup: {
-          from: 'Location_view_with_plain_ids',
-          startWith: '$id',
-          connectFromField: 'id',
-          connectToField: 'partOf.reference',
-          as: 'children'
-        }
-      },
-      {
-        $project: {
-          children: {
-            id: 1,
-            name: 1,
-            type: 1
-          }
+  const childQuery = [
+    {
+      $match: { id: id }
+    },
+    {
+      $graphLookup: {
+        from: 'Location_view_with_plain_ids',
+        startWith: '$id',
+        connectFromField: 'id',
+        connectToField: 'partOf.reference',
+        as: 'children'
+      }
+    },
+    {
+      $project: {
+        children: {
+          id: 1,
+          name: 1,
+          type: 1
         }
       }
-    ]
+    }
+  ]
 
-    const result = await db
-      .collection<Location>('Location_view_with_plain_ids')
-      .aggregate(childQuery)
-      .toArray()
+  const result = await db
+    .collection<Location>('Location_view_with_plain_ids')
+    .aggregate(childQuery)
+    .toArray()
 
-    return result.length ? result[0].children : []
-  } finally {
-    await client.close()
-  }
+  return result.length ? result[0].children : []
 }
 
 /** Resolves any given location's parents multi-level up to the root node */

--- a/packages/config/src/handlers/locations/locationTreeSolver.ts
+++ b/packages/config/src/handlers/locations/locationTreeSolver.ts
@@ -19,9 +19,8 @@ import { fetchFromHearth } from '@config/services/hearth'
 import { MongoClient } from 'mongodb'
 import { env } from '@config/environment'
 
-const client = new MongoClient(env.HEARTH_MONGO_URL)
-
 export const resolveLocationChildren = async (id: UUID) => {
+  const client = new MongoClient(HEARTH_MONGO_URL)
   try {
     const connectedClient = await client.connect()
     const db = connectedClient.db()
@@ -37,6 +36,15 @@ export const resolveLocationChildren = async (id: UUID) => {
           connectFromField: 'id',
           connectToField: 'partOf.reference',
           as: 'children'
+        }
+      },
+      {
+        $project: {
+          children: {
+            id: 1,
+            name: 1,
+            type: 1
+          }
         }
       }
     ]

--- a/packages/config/src/server.ts
+++ b/packages/config/src/server.ts
@@ -14,6 +14,7 @@ import { DEFAULT_TIMEOUT } from '@config/config/constants'
 import getRoutes from '@config/config/routes'
 import getPlugins from '@config/config/plugins'
 import * as database from '@config/config/database'
+import * as mongoDirect from '@config/config/hearthClient'
 import { validateFunc, logger } from '@opencrvs/commons'
 import { readFileSync } from 'fs'
 import { badRequest } from '@hapi/boom'
@@ -78,12 +79,14 @@ export async function createServer() {
   async function stop() {
     await server.stop()
     await database.stop()
+    await mongoDirect.stop()
     server.log('info', 'Config server stopped')
   }
 
   async function start() {
     await server.start()
     await database.start()
+    await mongoDirect.start()
     server.log('info', `Config server started on ${env.HOST}:${env.PORT}`)
   }
 

--- a/packages/metrics/src/config/hearthClient.ts
+++ b/packages/metrics/src/config/hearthClient.ts
@@ -1,3 +1,14 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+
 import { HEARTH_MONGO_URL } from '@metrics/constants'
 import { logger } from '@opencrvs/commons'
 import { MongoClient } from 'mongodb'

--- a/packages/metrics/src/config/hearthClient.ts
+++ b/packages/metrics/src/config/hearthClient.ts
@@ -1,0 +1,35 @@
+import { HEARTH_MONGO_URL } from '@metrics/constants'
+import { logger } from '@opencrvs/commons'
+import { MongoClient } from 'mongodb'
+
+const client = new MongoClient(HEARTH_MONGO_URL)
+
+client.on('close', () => {
+  logger.error('MongoDB connection closed.')
+})
+
+client.on('error', (err) => {
+  logger.error('MongoDB connection error:', err)
+})
+
+async function wait(delay: number) {
+  await new Promise((resolve) => setTimeout(resolve, delay))
+}
+
+export const start = async (): Promise<MongoClient> => {
+  try {
+    await client.connect()
+    logger.info('Connected to MongoDB')
+    return client
+  } catch (err) {
+    logger.error('Failed to connect to MongoDB. Retrying...')
+    await wait(1000)
+    return await start()
+  }
+}
+
+export const stop = async (): Promise<void> => {
+  await client.close()
+}
+
+export default client

--- a/packages/metrics/src/features/certifications/service.ts
+++ b/packages/metrics/src/features/certifications/service.ts
@@ -11,7 +11,9 @@
 
 import { fetchLocationChildrenIds } from '@metrics/configApi'
 import { query } from '@metrics/influxdb/client'
+import { createChunks } from '@metrics/utils/batchHelpers'
 import { helpers } from '@metrics/utils/queryHelper'
+import { logger } from '@opencrvs/commons'
 import { ResourceIdentifier, Location } from '@opencrvs/commons/types'
 
 export async function getTotalCertificationsByLocation(
@@ -20,28 +22,40 @@ export async function getTotalCertificationsByLocation(
   locationId: ResourceIdentifier<Location>
 ) {
   const locationIds = await fetchLocationChildrenIds(locationId)
-  const [officeLocationInChildren, locationPlaceholders] = helpers.in(
-    locationIds,
-    'officeLocation'
-  )
 
-  const totalMetrics = await query<Array<{ total: number; eventType: string }>>(
-    `SELECT COUNT(DISTINCT(compositionId)) AS total
-      FROM certification
-    WHERE time > $timeFrom
-      AND time <= $timeTo
-      AND (${officeLocationInChildren})
-    GROUP BY eventType`,
-    {
-      placeholders: {
-        timeFrom,
-        timeTo,
-        ...locationPlaceholders
-      }
+  const batchQuery = async (locationIds: string[]) => {
+    const [officeLocationInChildren, locationPlaceholders] = helpers.in(
+      locationIds,
+      'officeLocation'
+    )
+    try {
+      return await query<Array<{ total: number; eventType: string }>>(
+        `SELECT COUNT(DISTINCT(compositionId)) AS total
+          FROM certification
+        WHERE time > $timeFrom
+          AND time <= $timeTo
+          AND (${officeLocationInChildren})
+        GROUP BY eventType`,
+        {
+          placeholders: {
+            timeFrom,
+            timeTo,
+            ...locationPlaceholders
+          }
+        }
+      )
+    } catch (error) {
+      logger.error(
+        `Error fetching total certifications by location: ${error.message}`
+      )
+      throw error
     }
-  )
+  }
 
-  return totalMetrics
+  const locationBatches = createChunks(locationIds, 1000)
+  return await Promise.all(locationBatches.map(batchQuery)).then((res) =>
+    res.flat()
+  )
 }
 
 export async function getTotalCertifications(timeFrom: string, timeTo: string) {

--- a/packages/metrics/src/features/corrections/service.ts
+++ b/packages/metrics/src/features/corrections/service.ts
@@ -13,6 +13,8 @@ import { ResourceIdentifier, Location } from '@opencrvs/commons/types'
 import { query } from '@metrics/influxdb/client'
 import { fetchLocationChildrenIds } from '@metrics/configApi'
 import { helpers } from '@metrics/utils/queryHelper'
+import { logger } from '@opencrvs/commons'
+import { createChunks } from '@metrics/utils/batchHelpers'
 
 interface ICorrectionTotalGroup {
   total: number
@@ -49,27 +51,41 @@ export async function getTotalCorrectionsByLocation(
   event: EVENT_TYPE
 ) {
   const locationIds = await fetchLocationChildrenIds(locationId)
-  const [officeLocationInChildren, locationPlaceholders] = helpers.in(
-    locationIds,
-    'officeLocation'
-  )
 
-  const q = `SELECT COUNT(compositionId) AS total
-      FROM correction
-    WHERE time > $timeFrom
-      AND time <= $timeTo
-      AND eventType = $event
-      AND (${officeLocationInChildren})
-    GROUP BY reason`
+  const batchQuery = async (locationIds: string[]) => {
+    const [officeLocationInChildren, locationPlaceholders] = helpers.in(
+      locationIds,
+      'officeLocation'
+    )
 
-  const totalCorrections: ICorrectionTotalGroup[] = await query(q, {
-    placeholders: {
-      timeFrom,
-      timeTo,
-      event,
-      ...locationPlaceholders
+    const q = `SELECT COUNT(compositionId) AS total
+                FROM correction
+              WHERE time > $timeFrom
+                AND time <= $timeTo
+                AND eventType = $event
+                AND (${officeLocationInChildren})
+              GROUP BY reason`
+
+    try {
+      const totalCorrections: ICorrectionTotalGroup[] = await query(q, {
+        placeholders: {
+          timeFrom,
+          timeTo,
+          event,
+          ...locationPlaceholders
+        }
+      })
+      return totalCorrections
+    } catch (error) {
+      logger.error(
+        `Error fetching total corrections by location: ${error.message}`
+      )
+      throw error
     }
-  })
+  }
 
-  return totalCorrections
+  const locationBatches = createChunks(locationIds, 1000)
+  return await Promise.all(locationBatches.map(batchQuery)).then((res) =>
+    res.flat()
+  )
 }

--- a/packages/metrics/src/features/locationStatistics/service.ts
+++ b/packages/metrics/src/features/locationStatistics/service.ts
@@ -66,13 +66,11 @@ async function cacheOfficeCount(authHeader: IAuthHeader) {
     fetchLocationsByType('CRVS_OFFICE', authHeader)
   ])
   locations.forEach(({ id }) => (OFFICE_COUNT_CACHE[id] = -1))
-  const locationsMap = locations.reduce<LocationsMap>(
-    (locationsMap, location) => {
-      locationsMap[location.id] = location
-      return locationsMap
-    },
-    {}
+
+  const locationsMap = Object.fromEntries(
+    locations.map((location) => [location.id, location])
   )
+
   const adjacency: Record<string, string[] | undefined> = {}
   ;[...offices, ...locations].forEach((location) => {
     const partOf = location.partOf?.reference?.split('/')[1]

--- a/packages/metrics/src/features/locationStatistics/service.ts
+++ b/packages/metrics/src/features/locationStatistics/service.ts
@@ -67,10 +67,10 @@ async function cacheOfficeCount(authHeader: IAuthHeader) {
   ])
   locations.forEach(({ id }) => (OFFICE_COUNT_CACHE[id] = -1))
   const locationsMap = locations.reduce<LocationsMap>(
-    (locationsMap, location) => ({
-      ...locationsMap,
-      [location.id]: location
-    }),
+    (locationsMap, location) => {
+      locationsMap[location.id] = location
+      return locationsMap
+    },
     {}
   )
   const adjacency: Record<string, string[] | undefined> = {}

--- a/packages/metrics/src/features/metrics/metricsGenerator.ts
+++ b/packages/metrics/src/features/metrics/metricsGenerator.ts
@@ -8,6 +8,7 @@
  *
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
+
 import { INFLUXDB_URL, INFLUX_DB } from '@metrics/influxdb/constants'
 import {
   FEMALE,
@@ -37,9 +38,8 @@ import {
   ResourceIdentifier,
   Location as FhirLocation
 } from '@opencrvs/commons/types'
-import { UUID } from '@opencrvs/commons'
+import { UUID, logger } from '@opencrvs/commons'
 import { createChunks } from '@metrics/utils/batchHelpers'
-import { logger } from '@opencrvs/commons'
 
 interface IGroupedByGender {
   total: number

--- a/packages/metrics/src/features/performance/viewRefresher.ts
+++ b/packages/metrics/src/features/performance/viewRefresher.ts
@@ -8,7 +8,6 @@
  *
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
-import { HEARTH_MONGO_URL } from '@metrics/constants'
 import { logger } from '@opencrvs/commons'
 import { MongoClient } from 'mongodb'
 
@@ -26,6 +25,7 @@ import { MongoClient } from 'mongodb'
  */
 import * as Hapi from '@hapi/hapi'
 import { getDashboardQueries } from '@metrics/configApi'
+import client from '@metrics/config/hearthClient'
 
 let updateInProgress = false
 let nextUpdateRequested = false
@@ -50,17 +50,13 @@ export async function refresh() {
     return
   }
   logger.info('Refreshing performance materialised views')
-  const client = new MongoClient(HEARTH_MONGO_URL)
   try {
     updateInProgress = true
-    const connectedClient = await client.connect()
-    await refreshPerformanceMaterialisedViews(connectedClient)
+    await refreshPerformanceMaterialisedViews(client)
     logger.info('Performance materialised views refreshed')
   } catch (error) {
     logger.error(`Error refreshing performances materialised views ${error}`)
   } finally {
-    await client.close()
-
     updateInProgress = false
     if (nextUpdateRequested) {
       nextUpdateRequested = false

--- a/packages/metrics/src/features/registration/handler.test.ts
+++ b/packages/metrics/src/features/registration/handler.test.ts
@@ -17,6 +17,17 @@ import * as fetchAny from 'jest-fetch-mock'
 import { testDeclaration } from '@metrics/features/registration/testUtils'
 import { cloneDeep } from 'lodash'
 
+jest.mock('@metrics/features/performance/viewRefresher', () => {
+  const actualModule = jest.requireActual(
+    '@metrics/features/performance/viewRefresher'
+  )
+
+  return {
+    ...actualModule,
+    refresh: jest.fn()
+  }
+})
+
 const fetch = fetchAny as any
 const fetchTaskHistory = api.fetchTaskHistory as jest.Mock
 

--- a/packages/metrics/src/server.ts
+++ b/packages/metrics/src/server.ts
@@ -26,6 +26,7 @@ import {
   INFLUX_PORT
 } from '@metrics/influxdb/constants'
 import * as database from '@metrics/config/database'
+import * as mongoDirect from '@metrics/config/hearthClient'
 
 const publicCert = readFileSync(CERT_PUBLIC_KEY_PATH)
 
@@ -80,6 +81,7 @@ export async function createServer() {
         server.log('info', `InfluxDB started on ${INFLUX_HOST}:${INFLUX_PORT}`)
         await server.start()
         await database.start()
+        await mongoDirect.start()
         server.log('info', `Metrics server started on ${HOST}:${PORT}`)
       })
       .catch((err: Error) => {
@@ -91,6 +93,7 @@ export async function createServer() {
   async function stop() {
     await server.stop()
     await database.stop()
+    await mongoDirect.stop()
     server.log('info', 'Metrics server stopped')
   }
 

--- a/packages/metrics/src/utils/batchHelpers.ts
+++ b/packages/metrics/src/utils/batchHelpers.ts
@@ -1,0 +1,7 @@
+export function createChunks<T>(array: T[], limit: number): T[][] {
+  const result = []
+  for (let i = 0; i < array.length; i += limit) {
+    result.push(array.slice(i, i + limit))
+  }
+  return result
+}

--- a/packages/metrics/src/utils/batchHelpers.ts
+++ b/packages/metrics/src/utils/batchHelpers.ts
@@ -1,3 +1,13 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
 export function createChunks<T>(array: T[], limit: number): T[][] {
   const result = []
   for (let i = 0; i < array.length; i += limit) {

--- a/packages/search/src/config/hearthClient.ts
+++ b/packages/search/src/config/hearthClient.ts
@@ -1,3 +1,14 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+
 import { logger } from '@opencrvs/commons'
 import { HEARTH_MONGO_URL } from '@search/constants'
 import { MongoClient } from 'mongodb'

--- a/packages/search/src/config/hearthClient.ts
+++ b/packages/search/src/config/hearthClient.ts
@@ -1,0 +1,35 @@
+import { logger } from '@opencrvs/commons'
+import { HEARTH_MONGO_URL } from '@search/constants'
+import { MongoClient } from 'mongodb'
+
+const client = new MongoClient(HEARTH_MONGO_URL)
+
+client.on('close', () => {
+  logger.error('MongoDB connection closed.')
+})
+
+client.on('error', (err) => {
+  logger.error('MongoDB connection error:', err)
+})
+
+async function wait(delay: number) {
+  await new Promise((resolve) => setTimeout(resolve, delay))
+}
+
+export const start = async (): Promise<MongoClient> => {
+  try {
+    await client.connect()
+    logger.info('Connected to MongoDB')
+    return client
+  } catch (err) {
+    logger.error('Failed to connect to MongoDB. Retrying...')
+    await wait(1000)
+    return await start()
+  }
+}
+
+export const stop = async (): Promise<void> => {
+  await client.close()
+}
+
+export default client

--- a/packages/search/src/features/records/service.ts
+++ b/packages/search/src/features/records/service.ts
@@ -15,15 +15,12 @@ import {
   getFromBundleById,
   isComposition
 } from '@opencrvs/commons/types'
-import { HEARTH_MONGO_URL } from '@search/constants'
-import { MongoClient } from 'mongodb'
 import { writeFileSync } from 'fs'
 import * as os from 'os'
 import { join } from 'path'
 import { sortBy, uniqBy } from 'lodash'
 import { UUID } from '@opencrvs/commons'
-
-const client = new MongoClient(HEARTH_MONGO_URL)
+import client from '@search/config/hearthClient'
 
 function developmentTimeError(...params: Parameters<typeof console.error>) {
   /* eslint-disable no-console */
@@ -1061,8 +1058,7 @@ export async function getRecordById<T extends Array<keyof StateIdenfitiers>>(
   _allowedStates: T,
   includeHistoryResources: boolean
 ): Promise<StateIdenfitiers[T[number]]> {
-  const connectedClient = await client.connect()
-  const db = connectedClient.db()
+  const db = client.db()
   const query = aggregateRecords({ recordId, includeHistoryResources })
   const result = await db
     .collection('Composition')

--- a/packages/search/src/server.ts
+++ b/packages/search/src/server.ts
@@ -19,6 +19,7 @@ import {
 import getPlugins from '@search/config/plugins'
 import { getRoutes } from '@search/config/routes'
 import { readFileSync } from 'fs'
+import * as mongoDirect from '@search/config/hearthClient'
 
 const publicCert = readFileSync(CERT_PUBLIC_KEY_PATH)
 
@@ -61,11 +62,13 @@ export async function createServer() {
 
   async function start() {
     await server.start()
+    await mongoDirect.start()
     server.log('info', `Search server started on ${HOST}:${PORT}`)
   }
 
   async function stop() {
     await server.stop()
+    await mongoDirect.stop()
     server.log('info', 'Search server stopped')
   }
 


### PR DESCRIPTION
### Issues

- Mongo client was declared outside the scope of the calling function so after the called closed the connection, it could not be reopened. 
  -  Solved by moving instantiation inside the function.
- Mongo has a BSON limit of 16mb so requests were failing. 
  - Projected only `id`, `type` and `name` to cut down on bundle size.
- Influx DB has a hard limit on header size, so with 20k location ids joined in the query, this was exceeded. 
  - Solved by querying in batches of 1000
-  A reduce in the locationStatistics was causing a timeout because the spread operator was creating a new object every iteration, with 100k iterations.
    -  Changed to array index assignment. 


