### PR TITLE
fix: hide verification pill in review section when details dont exist

### DIFF
--- a/packages/client/src/views/RegisterForm/review/ReviewSection.tsx
+++ b/packages/client/src/views/RegisterForm/review/ReviewSection.tsx
@@ -1632,6 +1632,7 @@ class ReviewSectionComp extends React.Component<FullProps, State> {
         items: items.filter((item) => item),
         action:
           this.includesVerificationStatus(section) &&
+          declaration.data[section.id]?.detailsExist !== false &&
           Boolean(declaration.data[section.id]?.verified) ? (
             <VerificationPill
               type={declaration.data[section.id].verified as string}


### PR DESCRIPTION
potential fix for: https://github.com/opencrvs/opencrvs-core/issues/8776

![image](https://github.com/user-attachments/assets/94ceaebf-5b31-4a07-ae7d-5a6f1224fa98)
