### PR TITLE
scroll to top of page change using element ref in context

### DIFF
--- a/packages/client/src/v2-events/features/events/components/Pages.tsx
+++ b/packages/client/src/v2-events/features/events/components/Pages.tsx
@@ -13,6 +13,7 @@ import React, { useEffect } from 'react'
 import { useIntl } from 'react-intl'
 import { EventState, FormPage } from '@opencrvs/commons/client'
 import { FormWizard } from '@opencrvs/components'
+import { useFrameMainContentRef } from '@opencrvs/components/lib/Frame/Frame'
 import { FormFieldGenerator } from '@client/v2-events/components/forms/FormFieldGenerator'
 import { usePagination } from '@client/v2-events/hooks/usePagination'
 
@@ -42,7 +43,7 @@ export function Pages({
   children?: (page: FormPage) => React.ReactNode
 }) {
   const intl = useIntl()
-
+  const mainContentRef = useFrameMainContentRef()
   const pageIdx = formPages.findIndex((p) => p.id === pageId)
 
   const {
@@ -58,8 +59,10 @@ export function Pages({
 
     if (pageChanged) {
       onFormPageChange(formPages[currentPage].id)
+
+      mainContentRef?.current?.scrollTo({ top: 0 })
     }
-  }, [pageId, currentPage, formPages, onFormPageChange])
+  }, [pageId, currentPage, formPages, onFormPageChange, mainContentRef])
 
   return (
     <FormWizard

--- a/packages/components/src/Frame/Frame.tsx
+++ b/packages/components/src/Frame/Frame.tsx
@@ -8,7 +8,7 @@
  *
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
-import * as React from 'react'
+import React, { createContext, useContext } from 'react'
 import styled from 'styled-components'
 import { Layout, LayoutCentered, LayoutForm } from './components/Layout'
 import { Section, SectionFormBackAction } from './components/Section'
@@ -52,21 +52,32 @@ const FrameMainContent = styled.main`
   background: ${({ theme }) => theme.colors.background};
 `
 
+const FrameMainContentRefContext =
+  createContext<React.RefObject<HTMLDivElement> | null>(null)
+
+export function useFrameMainContentRef() {
+  return useContext(FrameMainContentRefContext)
+}
+
 export function Frame({
   header,
   navigation,
   skipToContentText,
   children
 }: FrameProps) {
+  const mainContentRef = React.useRef<HTMLDivElement | null>(null)
+
   return (
-    <FrameGrid>
-      <SkipToContent>{skipToContentText}</SkipToContent>
-      <FrameNavigation>{navigation}</FrameNavigation>
-      <FrameHeader id="page-title">{header}</FrameHeader>
-      <FrameMainContent id={MAIN_CONTENT_ANCHOR_ID}>
-        {children}
-      </FrameMainContent>
-    </FrameGrid>
+    <FrameMainContentRefContext.Provider value={mainContentRef}>
+      <FrameGrid>
+        <SkipToContent>{skipToContentText}</SkipToContent>
+        <FrameNavigation>{navigation}</FrameNavigation>
+        <FrameHeader id="page-title">{header}</FrameHeader>
+        <FrameMainContent id={MAIN_CONTENT_ANCHOR_ID} ref={mainContentRef}>
+          {children}
+        </FrameMainContent>
+      </FrameGrid>
+    </FrameMainContentRefContext.Provider>
   )
 }
 


### PR DESCRIPTION
**Option B** for scrolling to top on form page change. 

Use ref to element in context to find scrollable element.