### PR TITLE
fix: Filter metrics locations by office as other types cant have stats

### DIFF
--- a/packages/config/src/handlers/locations/children.ts
+++ b/packages/config/src/handlers/locations/children.ts
@@ -17,6 +17,7 @@ import { resolveLocationChildren } from './locationTreeSolver'
 
 export const resolveChildren: ServerRoute['handler'] = async (req) => {
   const { locationId } = req.params as { locationId: UUID }
+  const { type } = req.query || { type: undefined }
 
   const location = await fetchFromHearth<SavedLocation>(
     `Location/${locationId}`
@@ -25,7 +26,7 @@ export const resolveChildren: ServerRoute['handler'] = async (req) => {
     return [location]
   }
 
-  const children = await resolveLocationChildren(locationId)
+  const children = await resolveLocationChildren(locationId, type)
 
   return [location, ...children]
 }

--- a/packages/config/src/handlers/locations/locationTreeSolver.ts
+++ b/packages/config/src/handlers/locations/locationTreeSolver.ts
@@ -14,7 +14,7 @@ import {
   resourceIdentifierToUUID,
   SavedLocation
 } from '@opencrvs/commons/types'
-import { UUID } from '@opencrvs/commons'
+import { logger, UUID } from '@opencrvs/commons'
 import { fetchFromHearth } from '@config/services/hearth'
 import client from '@config/config/hearthClient'
 
@@ -44,13 +44,17 @@ export const resolveLocationChildren = async (id: UUID) => {
       }
     }
   ]
+  try {
+    const result = await db
+      .collection<Location>('Location_view_with_plain_ids')
+      .aggregate(childQuery)
+      .toArray()
 
-  const result = await db
-    .collection<Location>('Location_view_with_plain_ids')
-    .aggregate(childQuery)
-    .toArray()
-
-  return result.length ? result[0].children : []
+    return result.length ? result[0].children : []
+  } catch (error) {
+    logger.error(error)
+    throw error
+  }
 }
 
 /** Resolves any given location's parents multi-level up to the root node */

--- a/packages/metrics/src/configApi.ts
+++ b/packages/metrics/src/configApi.ts
@@ -13,6 +13,7 @@ import { CONFIG_API_URL } from '@metrics/constants'
 import { Document } from 'mongoose'
 import { UUID } from '@opencrvs/commons'
 import {
+  getLocationType,
   Location,
   ResourceIdentifier,
   SavedLocation
@@ -120,11 +121,14 @@ export const fetchLocationChildren = async (id: UUID) => {
 }
 
 export const fetchLocationChildrenIds = async (
-  id: ResourceIdentifier<Location>
+  id: ResourceIdentifier<Location>,
+  typeFilter?: 'CRVS_OFFICE' | 'HEALTH_FACILITY' | 'ADMIN_STRUCTURE'
 ) => {
   // TODO: Migrate InfluxDB to use UUID's instead of the "Location/" prefix
   const locations = await fetchLocationChildren(
     id.replace('Location/', '') as UUID
   )
-  return locations.map(({ id }) => `Location/${id}`)
+  return locations
+    .filter((x) => (typeFilter ? getLocationType(x) === typeFilter : true))
+    .map(({ id }) => `Location/${id}`)
 }

--- a/packages/metrics/src/configApi.ts
+++ b/packages/metrics/src/configApi.ts
@@ -13,7 +13,6 @@ import { CONFIG_API_URL } from '@metrics/constants'
 import { Document } from 'mongoose'
 import { UUID } from '@opencrvs/commons'
 import {
-  getLocationType,
   Location,
   ResourceIdentifier,
   SavedLocation
@@ -62,6 +61,8 @@ export interface IApplicationConfig {
   LOGIN_BACKGROUND: ILoginBackground
 }
 
+type LocationType = 'CRVS_OFFICE' | 'HEALTH_FACILITY' | 'ADMIN_STRUCTURE'
+
 export async function getApplicationConfig(
   authorization: string
 ): Promise<IApplicationConfig> {
@@ -105,11 +106,13 @@ export async function getDashboardQueries(): Promise<
     })
 }
 
-const FETCH_ALL_LOCATION_CHILDREN = (id: UUID) =>
-  new URL(`/locations/${id}/children`, CONFIG_API_URL)
+const FETCH_ALL_LOCATION_CHILDREN = (id: UUID, type?: LocationType) => {
+  const typeQuery = type ? `?type=${type}` : ''
+  return new URL(`/locations/${id}/children${typeQuery}`, CONFIG_API_URL)
+}
 
-export const fetchLocationChildren = async (id: UUID) => {
-  const response = await fetch(FETCH_ALL_LOCATION_CHILDREN(id))
+export const fetchLocationChildren = async (id: UUID, type?: LocationType) => {
+  const response = await fetch(FETCH_ALL_LOCATION_CHILDREN(id, type))
 
   if (!response.ok) {
     throw new Error(
@@ -122,13 +125,12 @@ export const fetchLocationChildren = async (id: UUID) => {
 
 export const fetchLocationChildrenIds = async (
   id: ResourceIdentifier<Location>,
-  typeFilter?: 'CRVS_OFFICE' | 'HEALTH_FACILITY' | 'ADMIN_STRUCTURE'
+  typeFilter?: LocationType
 ) => {
   // TODO: Migrate InfluxDB to use UUID's instead of the "Location/" prefix
   const locations = await fetchLocationChildren(
-    id.replace('Location/', '') as UUID
+    id.replace('Location/', '') as UUID,
+    typeFilter
   )
-  return locations
-    .filter((x) => (typeFilter ? getLocationType(x) === typeFilter : true))
-    .map(({ id }) => `Location/${id}`)
+  return locations.map(({ id }) => `Location/${id}`)
 }

--- a/packages/metrics/src/features/certifications/service.ts
+++ b/packages/metrics/src/features/certifications/service.ts
@@ -21,7 +21,7 @@ export async function getTotalCertificationsByLocation(
   timeTo: string,
   locationId: ResourceIdentifier<Location>
 ) {
-  const locationIds = await fetchLocationChildrenIds(locationId)
+  const locationIds = await fetchLocationChildrenIds(locationId, 'CRVS_OFFICE')
 
   const batchQuery = async (locationIds: string[]) => {
     const [officeLocationInChildren, locationPlaceholders] = helpers.in(

--- a/packages/metrics/src/features/corrections/service.ts
+++ b/packages/metrics/src/features/corrections/service.ts
@@ -50,7 +50,7 @@ export async function getTotalCorrectionsByLocation(
   locationId: ResourceIdentifier<Location>,
   event: EVENT_TYPE
 ) {
-  const locationIds = await fetchLocationChildrenIds(locationId)
+  const locationIds = await fetchLocationChildrenIds(locationId, 'CRVS_OFFICE')
 
   const batchQuery = async (locationIds: string[]) => {
     const [officeLocationInChildren, locationPlaceholders] = helpers.in(

--- a/packages/metrics/src/features/declarationsStarted/service.ts
+++ b/packages/metrics/src/features/declarationsStarted/service.ts
@@ -24,7 +24,7 @@ export async function fetchLocationWiseDeclarationsStarted(
   timeTo: string,
   locationId: ResourceIdentifier<Location>
 ) {
-  const locationIds = await fetchLocationChildrenIds(locationId)
+  const locationIds = await fetchLocationChildrenIds(locationId, 'CRVS_OFFICE')
   const [officeLocationInChildren, locationPlaceholders] = helpers.in(
     locationIds,
     'officeLocation'
@@ -98,7 +98,7 @@ export async function getNumberOfAppStartedByPractitioners(
     totalStarted: number
   }[]
 > {
-  const locationIds = await fetchLocationChildrenIds(locationId)
+  const locationIds = await fetchLocationChildrenIds(locationId, 'CRVS_OFFICE')
   const [officeLocationInChildren, locationPlaceholders] = helpers.in(
     locationIds,
     'officeLocation'
@@ -142,7 +142,7 @@ export async function getNumberOfRejectedAppStartedByPractitioners(
     totalStarted: number
   }[]
 > {
-  const locationIds = await fetchLocationChildrenIds(locationId)
+  const locationIds = await fetchLocationChildrenIds(locationId, 'CRVS_OFFICE')
   const [officeLocationInChildren, locationPlaceholders] = helpers.in(
     locationIds,
     'officeLocation'
@@ -185,7 +185,7 @@ export async function getAvgTimeSpentOnAppByPractitioners(
     totalTimeSpent: number
   }[]
 > {
-  const locationIds = await fetchLocationChildrenIds(locationId)
+  const locationIds = await fetchLocationChildrenIds(locationId, 'CRVS_OFFICE')
   const [officeLocationInChildren, locationPlaceholders] = helpers.in(
     locationIds,
     'officeLocation'

--- a/packages/metrics/src/features/getTimeLogged/utils.ts
+++ b/packages/metrics/src/features/getTimeLogged/utils.ts
@@ -66,7 +66,7 @@ export async function getTimeLoggedForPractitioner(
   locationId: ResourceIdentifier<Location>,
   count?: number
 ): Promise<ITimeLoggedData[]> {
-  const locationIds = await fetchLocationChildrenIds(locationId)
+  const locationIds = await fetchLocationChildrenIds(locationId, 'CRVS_OFFICE')
   const [officeLocationInChildren, locationPlaceholders] = helpers.in(
     locationIds,
     'officeLocation'

--- a/packages/metrics/src/features/metrics/metricsGenerator.ts
+++ b/packages/metrics/src/features/metrics/metricsGenerator.ts
@@ -339,7 +339,7 @@ export async function getCurrentAndLowerLocationLevels(
   locationId: ResourceIdentifier<FhirLocation>,
   event: EVENT_TYPE
 ): Promise<ICurrentAndLowerLocationLevels> {
-  const locationIds = await fetchLocationChildrenIds(locationId)
+  const locationIds = await fetchLocationChildrenIds(locationId, 'CRVS_OFFICE')
   const [officeLocationInChildren, locationPlaceholders] = helpers.in(
     locationIds,
     'officeLocation'
@@ -443,7 +443,10 @@ export async function fetchKeyFigures(
   const keyFigures: IBirthKeyFigures[] = []
   const queryLocationId =
     `Location/${estimatedFigureForTargetDays.locationId}` as `Location/${UUID}`
-  const locationIds = await fetchLocationChildrenIds(queryLocationId)
+  const locationIds = await fetchLocationChildrenIds(
+    queryLocationId,
+    'CRVS_OFFICE'
+  )
   const [officeLocationInChildren, locationPlaceholders] = helpers.in(
     locationIds,
     'officeLocation'
@@ -805,7 +808,7 @@ export async function getTotalNumberOfRegistrations(
   locationId: ResourceIdentifier<FhirLocation>,
   event: EVENT_TYPE
 ) {
-  const locationIds = await fetchLocationChildrenIds(locationId)
+  const locationIds = await fetchLocationChildrenIds(locationId, 'CRVS_OFFICE')
   const [officeLocationInChildren, locationPlaceholders] = helpers.in(
     locationIds,
     'officeLocation'
@@ -836,7 +839,7 @@ export async function fetchLocationWiseEventEstimations(
   event: EVENT_TYPE,
   authHeader: IAuthHeader
 ) {
-  const locationIds = await fetchLocationChildrenIds(locationId)
+  const locationIds = await fetchLocationChildrenIds(locationId, 'CRVS_OFFICE')
   const [officeLocationInChildren, locationPlaceholders] = helpers.in(
     locationIds,
     'officeLocation'
@@ -974,29 +977,43 @@ export async function fetchEventsGroupByMonthDatesByLocation(
   const measurement =
     event === EVENT_TYPE.BIRTH ? 'birth_registration' : 'death_registration'
   const column = event === EVENT_TYPE.BIRTH ? 'ageInDays' : 'deathDays'
-  const locationIds = await fetchLocationChildrenIds(locationId)
-  const [officeLocationInChildren, locationPlaceholders] = helpers.in(
-    locationIds,
-    'officeLocation'
-  )
+  const locationIds = await fetchLocationChildrenIds(locationId, 'CRVS_OFFICE')
 
-  const registrationsInTargetDaysPoints: IGroupByEventDate[] = await query(
-    `SELECT COUNT(${column}) AS total
-      FROM ${measurement}
-    WHERE time > $timeFrom
-      AND time <= $timeTo
-      AND (${officeLocationInChildren})
-    GROUP BY dateLabel, timeLabel`,
-    {
-      placeholders: {
-        timeFrom,
-        timeTo,
-        ...locationPlaceholders
-      }
+  const batchquery = async (locationIds: string[]) => {
+    const [officeLocationInChildren, locationPlaceholders] = helpers.in(
+      locationIds,
+      'officeLocation'
+    )
+    try {
+      const registrationsInTargetDaysPoints: IGroupByEventDate[] = await query(
+        `SELECT COUNT(${column}) AS total
+          FROM ${measurement}
+        WHERE time > $timeFrom
+          AND time <= $timeTo
+          AND (${officeLocationInChildren})
+        GROUP BY dateLabel, timeLabel`,
+        {
+          placeholders: {
+            timeFrom,
+            timeTo,
+            ...locationPlaceholders
+          }
+        }
+      )
+
+      return registrationsInTargetDaysPoints
+    } catch (error) {
+      logger.error(
+        `Error fetching events group by month dates by location: ${error.message}`
+      )
+      throw error
     }
-  )
+  }
 
-  return registrationsInTargetDaysPoints
+  const locationBatches = createChunks(locationIds, 1000)
+  return await Promise.all(locationBatches.map(batchquery)).then((res) =>
+    res.flat()
+  )
 }
 
 export async function fetchEventsGroupByMonthDates(
@@ -1037,8 +1054,7 @@ export async function getTotalMetricsByLocation(
   const measurement =
     event === EVENT_TYPE.BIRTH ? 'birth_registration' : 'death_registration'
   const column = event === EVENT_TYPE.BIRTH ? 'ageInDays' : 'deathDays'
-  const locationIds = await fetchLocationChildrenIds(locationId)
-
+  const locationIds = await fetchLocationChildrenIds(locationId, 'CRVS_OFFICE')
   const batchquery = async (locationIds: string[]) => {
     const [officeLocationInChildren, locationPlaceholders] = helpers.in(
       locationIds,
@@ -1135,23 +1151,34 @@ export async function fetchRegistrationsGroupByOfficeLocationByLocation(
   const measurement =
     event === EVENT_TYPE.BIRTH ? 'birth_registration' : 'death_registration'
   const column = event === EVENT_TYPE.BIRTH ? 'ageInDays' : 'deathDays'
-  const locationIds = await fetchLocationChildrenIds(locationId)
-  const [officeLocationInChildren, locationPlaceholders] = helpers.in(
-    locationIds,
-    'officeLocation'
-  )
+  const locationIds = await fetchLocationChildrenIds(locationId, 'CRVS_OFFICE')
 
-  const result: IMetricsTotalGroupByLocation[] = await query(
-    `SELECT COUNT(${column}) AS total
-    FROM ${measurement}
-  WHERE time > '${timeFrom}'
-    AND time <= '${timeTo}'
-    AND (${officeLocationInChildren})
-  GROUP BY officeLocation, eventLocationType, timeLabel`,
-    { placeholders: { ...locationPlaceholders } }
-  )
+  const batchquery = async (locationIds: string[]) => {
+    const [officeLocationInChildren, locationPlaceholders] = helpers.in(
+      locationIds,
+      'officeLocation'
+    )
 
-  return result
+    try {
+      return await query(
+        `SELECT COUNT(${column}) AS total
+      FROM ${measurement}
+    WHERE time > '${timeFrom}'
+      AND time <= '${timeTo}'
+      AND (${officeLocationInChildren})
+    GROUP BY officeLocation, eventLocationType, timeLabel`,
+        { placeholders: { ...locationPlaceholders } }
+      )
+    } catch (error) {
+      logger.error(`Error fetching total metrics by location: ${error.message}`)
+      throw error
+    }
+  }
+
+  const locationBatches = createChunks(locationIds, 1000)
+  return await Promise.all(locationBatches.map(batchquery)).then((res) =>
+    res.flat()
+  )
 }
 
 export async function fetchRegistrationsGroupByOfficeLocation(
@@ -1183,36 +1210,46 @@ export async function fetchRegistrationsGroupByTime(
   const measurement =
     event === EVENT_TYPE.BIRTH ? 'birth_registration' : 'death_registration'
   const column = event === EVENT_TYPE.BIRTH ? 'ageInDays' : 'deathDays'
-  const locationIds = locationId && (await fetchLocationChildrenIds(locationId))
+  const locationIds =
+    locationId && (await fetchLocationChildrenIds(locationId, 'CRVS_OFFICE'))
 
-  const fluxQuery = `
-   from(bucket: "${INFLUX_DB}")
-   |> range(start: ${timeFrom}, stop: ${timeTo})
-   |> filter(fn: (r) => r._measurement == "${measurement}")
-   ${
-     locationIds
-       ? `|> filter(fn: (r) => (${locationIds
-           .map((locationId) => `r.officeLocation == "${locationId}"`)
-           .join(' or ')}))`
-       : ``
-   }
-   |> filter(fn: (r) => r._field == "${column}")
-   |> group(columns: ["timeLabel", "eventLocationType"])
-   |> aggregateWindow(every: 1mo, fn: count, timeSrc: "_start")
-   |> sort(columns: ["_time"], desc: true)
-   |> rename(columns: {_value: "total"})
-   `
+  const batchquery = async (locationIds: string[]) => {
+    const fluxQuery = `
+      from(bucket: "${INFLUX_DB}")
+      |> range(start: ${timeFrom}, stop: ${timeTo})
+      |> filter(fn: (r) => r._measurement == "${measurement}")
+      ${
+        locationIds
+          ? `|> filter(fn: (r) => (${locationIds
+              .map((locationId) => `r.officeLocation == "${locationId}"`)
+              .join(' or ')}))`
+          : ``
+      }
+      |> filter(fn: (r) => r._field == "${column}")
+      |> group(columns: ["timeLabel", "eventLocationType"])
+      |> aggregateWindow(every: 1mo, fn: count, timeSrc: "_start")
+      |> sort(columns: ["_time"], desc: true)
+      |> rename(columns: {_value: "total"})
+      `
 
-  const res = await fetch(`${INFLUXDB_URL}/api/v2/query`, {
-    method: 'POST',
-    headers: {
-      Accept: 'application/csv',
-      'Content-type': 'application/vnd.flux'
-    },
-    body: fluxQuery
-  })
-  // slice(4) to ignoring unwanted rows in csv
-  const fluxJson = (await csvToJSON(await res.text())).slice(4)
+    const res = await fetch(`${INFLUXDB_URL}/api/v2/query`, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/csv',
+        'Content-type': 'application/vnd.flux'
+      },
+      body: fluxQuery
+    })
+
+    // slice(4) to ignoring unwanted rows in csv
+    return (await csvToJSON(await res.text())).slice(4)
+  }
+  const locationBatches = createChunks(locationIds || [], 1000)
+
+  const fluxJson = await Promise.all(locationBatches.map(batchquery)).then(
+    (res) => res.flat()
+  )
+
   const keys = ['eventLocationType', 'timeLabel', 'total', 'time']
   const fluxRes: IMetricsTotalGroupByTime[] = fluxJson
     .slice(0, -1)

--- a/packages/metrics/src/features/payments/service.ts
+++ b/packages/metrics/src/features/payments/service.ts
@@ -49,7 +49,7 @@ export async function getTotalPaymentsByLocation(
   locationId: ResourceIdentifier<Location>,
   eventType: EVENT_TYPE
 ) {
-  const locationIds = await fetchLocationChildrenIds(locationId)
+  const locationIds = await fetchLocationChildrenIds(locationId, 'CRVS_OFFICE')
 
   const batchQuery = async (locationIds: string[]) => {
     const [officeLocationInChildren, locationPlaceholders] = helpers.in(


### PR DESCRIPTION
Currently the performance view checks all child locations for registration stats.
But only offices can have registrations attached to them.
So filter locations for metric by type `CRVS_OFFICE` to improve query performance. 

Fixes: https://github.com/opencrvs/opencrvs-core/issues/8575