### PR TITLE
fix: filter out inactive locations in the Organisations menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.7.1 Release candidate
 
+### Bug fixes
+
+- Filter out inactive locations in the Organisations menu [#8782](https://github.com/opencrvs/opencrvs-core/issues/8782)
+
 ## 1.7.0 Release candidate
 
 ### Breaking changes

--- a/packages/client/src/views/Organisation/AdministrativeLevels.tsx
+++ b/packages/client/src/views/Organisation/AdministrativeLevels.tsx
@@ -77,10 +77,12 @@ export function AdministrativeLevels() {
       }
 
       const childLocations = Object.values(locations)
-        .filter((s) => s.partOf === `Location/${location}`)
+        .filter(
+          (s) => s.status === 'active' && s.partOf === `Location/${location}`
+        )
         .concat(
           Object.values(offices).filter(
-            (s) => s.partOf === `Location/${location}`
+            (s) => s.status === 'active' && s.partOf === `Location/${location}`
           )
         )
 


### PR DESCRIPTION
Linked to this Issue: #8782

The Locations hierarchy in the Organization menu is limited to: 
Country -> ADMIN_STRUCTURE -> CRVS_OFFICE

This limits our scope of making locations inactive using the FHIR Location API, to the following types ADMIN_STRUCTURE and CRVS_OFFICE. HEALTH_FACILITY was ignored in this investigation, as it does not appear in the Organization menu.

Initial thought was to add a query parameter `status=active ` to the `loadLocations` and `loadFacilities` calls in [referenceApi.ts](https://github.com/opencrvs/opencrvs-core/blob/develop/packages/client/src/utils/referenceApi.ts#L279)

But the locations and facilities data from the above mentioned calls are used elsewhere than the Organization menu as well, which breaks rendering of location data while viewing records where locations have been marked as inactive after the record was created.

Further talks with Euan revealed that this ticket is meant to be a quick fix, since there is a bigger refactor going to take place regarding the FHIR Location API. Potential updates to test cases and marking some locations as inactive in test [data](https://github.com/opencrvs/opencrvs-core/blob/develop/packages/client/src/tests/mock-offline-data.ts) was also discussed, but deemed unnecessary at this stage due to the upcoming refactor.

- [x] Update CHANGELOG