### PR TITLE
fix: explicitly handle plain dates in certificate date handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,10 @@
 
 - For countries where local phone numbers start with 0, we now ensure the prefix remains unchanged when converting to and from the international format.
 
+### Bug fixes
+
+- Fix rendering of Custom Date fields [#8885](https://github.com/opencrvs/opencrvs-core/issues/8885)
+
 ## 1.6.2 Release candidate
 
 ### Deprecated

--- a/packages/client/src/views/PrintCertificate/PDFUtils.ts
+++ b/packages/client/src/views/PrintCertificate/PDFUtils.ts
@@ -29,6 +29,10 @@ import {
 } from '@client/utils/referenceApi'
 import htmlToPdfmake from 'html-to-pdfmake'
 import { Content } from 'pdfmake/interfaces'
+import {
+  formatPlainDate,
+  isValidPlainDate
+} from '@client/utils/date-formatting'
 
 type TemplateDataType = string | MessageDescriptor | Array<string>
 function isMessageDescriptor(
@@ -163,6 +167,9 @@ export function compileSvg(
   Handlebars.registerHelper(
     'formatDate',
     function (this: any, dateString: string, formatString: string) {
+      if (isValidPlainDate(dateString)) {
+        return formatPlainDate(dateString, formatString)
+      }
       const date = new Date(dateString)
       return isValid(date) ? format(date, formatString) : ''
     }


### PR DESCRIPTION
Linked to this Issue: #8885

Fix rendering of Custom Date fields, by explicitly handling plain dates in certificate date handler

 