### PR TITLE
Fix typo in getLocationsByIdentifier() hearth url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,10 @@
 
 ## 1.6.3 Release candidate
 
+### Bug fixes
+
+- Fix a bug in the POST `{{gateway}}/locations` endpoint used to create new locations , the check to verify if a `statisticalId` was already used was broken so we've fixed that. This was picked when we were trying to seed a location for a country via the endpoint [#8606](https://github.com/opencrvs/opencrvs-core/issues/8606)
+
 ### Improvements
 
 - For countries where local phone numbers start with 0, we now ensure the prefix remains unchanged when converting to and from the international format.

--- a/packages/config/src/handlers/locations/utils.ts
+++ b/packages/config/src/handlers/locations/utils.ts
@@ -244,7 +244,7 @@ export function updateStatisticalExtensions(
 
 export async function getLocationsByIdentifier(identifier: string) {
   const locationSearchResult = await fetchFromHearth<Bundle<Location>>(
-    `/Location/?identifier=${identifier}&_count=0`
+    `Location/?identifier=${identifier}&_count=0`
   )
 
   return (


### PR DESCRIPTION
We were providing an absolute path instead of a relative one that we needed to pass

https://github.com/opencrvs/opencrvs-core/issues/8606