### PR TITLE
translation check workflow: matching countryconfig branch is now synced with develop

### DIFF
--- a/.github/workflows/check-missing-translation.yml
+++ b/.github/workflows/check-missing-translation.yml
@@ -19,53 +19,61 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Create directory for core and countryconfig
+        run: |
+          mkdir -m 777 -p $HOME/core
+          mkdir -m 777 -p $HOME/countryconfig
 
-    - name: Create directory for core and countryconfig
-      run: |
-        mkdir -m 777 -p $HOME/core
-        mkdir -m 777 -p $HOME/countryconfig
-  
-    - name: Clone countryconfig and check if there any branch exists with the same name like current branch
-      id: set_branch
-      run: |
-        cd $HOME/countryconfig
-        git clone https://github.com/opencrvs/opencrvs-countryconfig.git
-        cd opencrvs-countryconfig
-        working_branch='develop'
-        if [ -z "$(git branch -a | grep ${{ github.head_ref }})" ]; then
-          echo "Branch ${{ github.head_ref }} does not exist in countryconfig, we will use the develop branch"
-          echo "working_branch='develop'" >> $GITHUB_OUTPUT
-        else
-          echo "Branch ${{ github.head_ref }} exists in countryconfig"
-          working_branch='${{ github.head_ref }}'
-          echo "working_branch='${{ github.head_ref }}'" >> $GITHUB_OUTPUT
-        fi
-        echo "countryconfig_path=$HOME/countryconfig/opencrvs-countryconfig" >> $GITHUB_OUTPUT
-        git checkout $working_branch
+      - name: Clone countryconfig and check if there any branch exists with the same name like current branch
+        id: set_branch
+        run: |
+          cd $HOME/countryconfig
+          git clone https://github.com/opencrvs/opencrvs-countryconfig.git
+          cd opencrvs-countryconfig
+          working_branch='develop'
+          if [ -z "$(git branch -a | grep ${{ github.head_ref }})" ]; then
+            echo "Branch ${{ github.head_ref }} does not exist in countryconfig, we will use the develop branch"
+            echo "working_branch='develop'" >> $GITHUB_OUTPUT
+          else
+            echo "Branch ${{ github.head_ref }} exists in countryconfig"
+            working_branch='${{ github.head_ref }}'
+            echo "working_branch='${{ github.head_ref }}'" >> $GITHUB_OUTPUT
+          fi
+          echo "countryconfig_path=$HOME/countryconfig/opencrvs-countryconfig" >> $GITHUB_OUTPUT
+          git checkout $working_branch
 
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with: 
-        node-version: 18
-    
-    - name: Clone the Core repository and Check for missing translation
-      run: |
-        cd $HOME/core
-        acting_branch=${{steps.set_branch.outputs.working_branch}}
-        export COUNTRY_CONFIG_PATH=${{steps.set_branch.outputs.countryconfig_path}}
-        git clone  https://github.com/opencrvs/opencrvs-core.git
-        cd ./opencrvs-core
-        git checkout $acting_branch
-        yarn install
-        cd ./packages/client
-        CI=true yarn extract:translations 2>&1 | tee output.txt
-        if grep -q "Missing translations" output.txt; then
-           awk '/You are missing the following content keys from your country configuration package:/ {flag=1; next} /Add them to this file and run again:/ {flag=0} flag' output.txt > missing_translations.txt
-           sed -i '/^$/d' missing_translations.txt
-           echo "### Summary Of Missing Translation" >> $GITHUB_STEP_SUMMARY
-           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-           cat missing_translations.txt >> $GITHUB_STEP_SUMMARY
-           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-           echo "Create a pull request to the \`opencrvs/countryconfig\` repository with a branch name $acting_branch and add the translations to \`src/translations/client.csv\`. After pushing the changes, you can run this pipeline again." >> $GITHUB_STEP_SUMMARY
-           exit 1
-        fi
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Clone the Core repository and Check for missing translation
+        run: |
+          cd $HOME/core
+          acting_branch=${{steps.set_branch.outputs.working_branch}}
+          export COUNTRY_CONFIG_PATH=${{steps.set_branch.outputs.countryconfig_path}}
+          git clone  https://github.com/opencrvs/opencrvs-core.git
+          cd ./opencrvs-core
+          git checkout $acting_branch
+
+          # Sync acting branch with develop, so we get both the newest changes from develop and the changes from acting branch
+          if git merge origin/develop --no-commit --no-ff; then
+            git merge --continue
+          else
+            git merge --abort
+            echo "Could not merge origin/develop due to conflicts"
+          fi
+
+          yarn install
+          cd ./packages/client
+          CI=true yarn extract:translations 2>&1 | tee output.txt
+          if grep -q "Missing translations" output.txt; then
+             awk '/You are missing the following content keys from your country configuration package:/ {flag=1; next} /Add them to this file and run again:/ {flag=0} flag' output.txt > missing_translations.txt
+             sed -i '/^$/d' missing_translations.txt
+             echo "### Summary Of Missing Translation" >> $GITHUB_STEP_SUMMARY
+             echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+             cat missing_translations.txt >> $GITHUB_STEP_SUMMARY
+             echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+             echo "Create a pull request to the \`opencrvs/countryconfig\` repository with a branch name $acting_branch and add the translations to \`src/translations/client.csv\`. After pushing the changes, you can run this pipeline again." >> $GITHUB_STEP_SUMMARY
+             exit 1
+          fi

--- a/.github/workflows/check-missing-translation.yml
+++ b/.github/workflows/check-missing-translation.yml
@@ -51,6 +51,7 @@ jobs:
               if git merge origin/develop --no-commit --no-ff; then
                 echo "Successfully synced countryconfig branch '$working_branch' with 'develop'"
               else
+                # If there are merge conflicts in the translation file, abort the merge
                 if git diff --name-only --diff-filter=U | grep -q "src/translations/client.csv"; then
                   echo "Found merge conflicts in src/translations/client.csv, aborting merge"
                   git merge --abort

--- a/.github/workflows/check-missing-translation.yml
+++ b/.github/workflows/check-missing-translation.yml
@@ -42,6 +42,7 @@ jobs:
             # Sync countryconfig with develop, so we get both the newest changes from develop and the changes from working branch
             if [ "$working_branch" != "develop" ]; then
               echo "Syncing countryconfig branch '$working_branch' with 'develop'"
+              git fetch origin
               if git merge origin/develop --no-commit --no-ff; then
                 echo "Successfully synced countryconfig branch '$working_branch' with 'develop'"
               else

--- a/.github/workflows/check-missing-translation.yml
+++ b/.github/workflows/check-missing-translation.yml
@@ -43,7 +43,8 @@ jobs:
             # Sync countryconfig with develop, so we get both the newest changes from develop and the changes from working branch
             if [ "$working_branch" != "develop" ]; then
               echo "Syncing countryconfig branch '$working_branch' with 'develop'"
-              if git merge origin/develop --no-commit --no-ff; then
+
+              if git merge origin/develop --no-commit --no-ff --no-edit; then
                 echo "Successfully synced countryconfig branch '$working_branch' with 'develop'"
               else
                 echo "Could not merge origin/develop due to conflicts"

--- a/.github/workflows/check-missing-translation.yml
+++ b/.github/workflows/check-missing-translation.yml
@@ -43,7 +43,6 @@ jobs:
             # Sync countryconfig with develop, so we get both the newest changes from develop and the changes from working branch
             if [ "$working_branch" != "develop" ]; then
               echo "Syncing countryconfig branch '$working_branch' with 'develop'"
-              git fetch origin
               if git merge origin/develop --no-commit --no-ff; then
                 echo "Successfully synced countryconfig branch '$working_branch' with 'develop'"
               else

--- a/.github/workflows/check-missing-translation.yml
+++ b/.github/workflows/check-missing-translation.yml
@@ -38,6 +38,18 @@ jobs:
             echo "Branch ${{ github.head_ref }} exists in countryconfig"
             working_branch='${{ github.head_ref }}'
             echo "working_branch='${{ github.head_ref }}'" >> $GITHUB_OUTPUT
+
+            # Sync countryconfig with develop, so we get both the newest changes from develop and the changes from working branch
+            if [ "$working_branch" != "develop" ]; then
+              echo "Syncing countryconfig branch '$working_branch' with 'develop'"
+              if git merge origin/develop --no-commit --no-ff; then
+                echo "Successfully synced countryconfig branch '$working_branch' with 'develop'"
+              else
+                echo "Could not merge origin/develop due to conflicts"
+                git merge --abort
+              fi
+            fi
+
           fi
           echo "countryconfig_path=$HOME/countryconfig/opencrvs-countryconfig" >> $GITHUB_OUTPUT
           git checkout $working_branch
@@ -55,18 +67,6 @@ jobs:
           git clone  https://github.com/opencrvs/opencrvs-core.git
           cd ./opencrvs-core
           git checkout $acting_branch
-
-          # Sync acting branch with develop, so we get both the newest changes from develop and the changes from acting branch
-          if [ "$acting_branch" != "develop" ]; then
-            echo "Syncing $acting_branch with develop"
-            if git merge origin/develop --no-commit --no-ff; then
-              echo "Successfully synced $acting_branch with develop"
-            else
-              git merge --abort
-              echo "Could not merge origin/develop due to conflicts"
-            fi
-          fi
-
           yarn install
           cd ./packages/client
           CI=true yarn extract:translations 2>&1 | tee output.txt

--- a/.github/workflows/check-missing-translation.yml
+++ b/.github/workflows/check-missing-translation.yml
@@ -51,8 +51,12 @@ jobs:
               if git merge origin/develop --no-commit --no-ff; then
                 echo "Successfully synced countryconfig branch '$working_branch' with 'develop'"
               else
-                echo "Could not merge origin/develop due to conflicts"
-                git merge --abort
+                if git diff --name-only --diff-filter=U | grep -q "src/translations/client.csv"; then
+                  echo "Found merge conflicts in src/translations/client.csv, aborting merge"
+                  git merge --abort
+                else
+                  echo "No conflicts in translations file, continuing"
+                fi
               fi
             fi
 

--- a/.github/workflows/check-missing-translation.yml
+++ b/.github/workflows/check-missing-translation.yml
@@ -64,7 +64,7 @@ jobs:
           cd $HOME/core
           acting_branch=${{steps.set_branch.outputs.working_branch}}
           export COUNTRY_CONFIG_PATH=${{steps.set_branch.outputs.countryconfig_path}}
-          git clone  https://github.com/opencrvs/opencrvs-core.git
+          git clone https://github.com/opencrvs/opencrvs-core.git
           cd ./opencrvs-core
           git checkout $acting_branch
           yarn install

--- a/.github/workflows/check-missing-translation.yml
+++ b/.github/workflows/check-missing-translation.yml
@@ -58,8 +58,9 @@ jobs:
 
           # Sync acting branch with develop, so we get both the newest changes from develop and the changes from acting branch
           if [ "$acting_branch" != "develop" ]; then
+            echo "Syncing $acting_branch with develop"
             if git merge origin/develop --no-commit --no-ff; then
-              git merge --continue
+              echo "Successfully synced $acting_branch with develop"
             else
               git merge --abort
               echo "Could not merge origin/develop due to conflicts"

--- a/.github/workflows/check-missing-translation.yml
+++ b/.github/workflows/check-missing-translation.yml
@@ -44,7 +44,11 @@ jobs:
             if [ "$working_branch" != "develop" ]; then
               echo "Syncing countryconfig branch '$working_branch' with 'develop'"
 
-              if git merge origin/develop --no-commit --no-ff --no-edit; then
+              # Unfortunately the merge requires user.name and email to be set here
+              git config --local user.name "OpenCRVS Bot"
+              git config --local user.email "bot@opencrvs.org"
+
+              if git merge origin/develop --no-commit --no-ff; then
                 echo "Successfully synced countryconfig branch '$working_branch' with 'develop'"
               else
                 echo "Could not merge origin/develop due to conflicts"

--- a/.github/workflows/check-missing-translation.yml
+++ b/.github/workflows/check-missing-translation.yml
@@ -57,11 +57,13 @@ jobs:
           git checkout $acting_branch
 
           # Sync acting branch with develop, so we get both the newest changes from develop and the changes from acting branch
-          if git merge origin/develop --no-commit --no-ff; then
-            git merge --continue
-          else
-            git merge --abort
-            echo "Could not merge origin/develop due to conflicts"
+          if [ "$acting_branch" != "develop" ]; then
+            if git merge origin/develop --no-commit --no-ff; then
+              git merge --continue
+            else
+              git merge --abort
+              echo "Could not merge origin/develop due to conflicts"
+            fi
           fi
 
           yarn install

--- a/.github/workflows/check-missing-translation.yml
+++ b/.github/workflows/check-missing-translation.yml
@@ -38,6 +38,7 @@ jobs:
             echo "Branch ${{ github.head_ref }} exists in countryconfig"
             working_branch='${{ github.head_ref }}'
             echo "working_branch='${{ github.head_ref }}'" >> $GITHUB_OUTPUT
+            git checkout $working_branch
 
             # Sync countryconfig with develop, so we get both the newest changes from develop and the changes from working branch
             if [ "$working_branch" != "develop" ]; then
@@ -53,7 +54,6 @@ jobs:
 
           fi
           echo "countryconfig_path=$HOME/countryconfig/opencrvs-countryconfig" >> $GITHUB_OUTPUT
-          git checkout $working_branch
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
- If a matching countryconfig PR is found while checking for missing translations, we sync the countryconfig PR with latest `develop` so that we get changes from both the newest develop and the branch.
- If merge conflicts appear in `opencrvs-countryconfig/src/translations/client.csv`, we abort the merge.
- Run workflow file through prettier.

This was tested with countryconfig branch:
https://github.com/opencrvs/opencrvs-countryconfig/tree/check-missing-translation-use-branch-synced-with-develop

Discussion on slack: https://opencrvsworkspace.slack.com/archives/C07NQAULENB/p1742893406570809?
thread_ts=1742892993.373889&cid=C07NQAULENB