### PR TITLE
fix: ./run-migrations.sh: 19: Bad substitution

### DIFF
--- a/packages/migration/revert-migrations.sh
+++ b/packages/migration/revert-migrations.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/packages/migration/run-migrations.sh
+++ b/packages/migration/run-migrations.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.


### PR DESCRIPTION
Error is happening while running migrations script:
```
yarn run v1.22.22
$ NODE_ENV=production ./run-migrations.sh
./run-migrations.sh: 19: Bad substitution
```

Root cause of the error is incorrect interpreter used for running following command:
```bash
SCRIPT_PATH=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
```

<img width="715" alt="image" src="https://github.com/user-attachments/assets/2566b374-e43f-4f59-9d5b-30485837bbb9" />

Steps to reproduce:
1. Create script:
   ```bash
   SCRIPT_PATH=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
   echo SCRIPT_PATH: $SCRIPT_PATH
   ```
2. Run script with `bash` and `sh` interpreter and compare output:

```
node@a0c5d7167385:/app/opencrvs-core/packages/migration$ 
bash ./test.sh 
SCRIPT_PATH: /app/opencrvs-core/packages/migration
node@a0c5d7167385:/app/opencrvs-core/packages/migration$ 
sh ./test.sh 
./test.sh: 1: Bad substitution
SCRIPT_PATH: /app/opencrvs-core/packages/migration
node@a0c5d7167385:/app/opencrvs-core/packages/migration$ 
```


In bash scripting, the BASH_SOURCE variable is an array variable that contains the source filenames of the currently executing script or sourced files. It helps to determine the location or path from which the currently executing script or sourced file originated. This can be particularly useful for determining the directory of the currently running script, for debugging purposes, or for making scripts more portable by using relative paths.
