### PR TITLE
fix: Make possible to run prod script on dev environment

### DIFF
--- a/packages/client/src/v2-events/README.md
+++ b/packages/client/src/v2-events/README.md
@@ -31,7 +31,33 @@ We will be iterating over the structure during the project. Treat it as a starti
 
 ## Route structure
 
-By default, Events V2 is accessible via the /v2 route, allowing the application’s normal operations to continue alongside its development. When Events V2 needs to be deployed to a live environment as the primary event type, the environment variable V2_EVENTS=true can be set in the country config package. This hides the old event views completely and replaces them with Events V2. Once Events V2 is officially released, it will become the default event view.
+By default, Events V2 is accessible via the /v2 route, allowing the application’s normal operations to continue alongside its development. When Events V2 needs to be deployed to a live environment as the primary event type, the environment variable `V2_EVENTS=true` can be set in the country config package. This hides the old event views completely and replaces them with Events V2. Once Events V2 is officially released, it will become the default event view.
+
+### Creating route components
+1. Each action route should be wrapped with `Action.tsx` component.
+  ```tsx
+  // packages/client/src/v2-events/routes/config.tsx
+  {
+    path: ROUTES.V2.EVENTS.DECLARE.path,
+    element: (
+      <Action type={ActionType.DECLARE}>
+        <Outlet />
+      </Action>
+    )
+  }
+  ```
+  - Action-component manages the action form state for the child components (pages, review).
+
+2. Each route component should be wrapped with `withSuspense.tsx` component.
+```tsx
+// packages/client/src/v2-events/features/events/actions/declare/index.tsx
+const PagesIndex = withSuspense(Pages)
+const ReviewIndex = withSuspense(Review)
+export { PagesIndex as Pages, ReviewIndex as Review }
+```
+  - `withSuspense` allows the route to use suspense queries. Usage without the hook will result to intermittent crashing of the route components.
+
+  
 
 ## Development practices
 

--- a/packages/client/src/v2-events/components/forms/FormFieldGenerator.tsx
+++ b/packages/client/src/v2-events/components/forms/FormFieldGenerator.tsx
@@ -143,6 +143,7 @@ interface GeneratedInputFieldProps<T extends FieldConfig> {
   requiredErrorMessage?: MessageDescriptor
   eventConfig?: EventConfig
   event?: EventIndex
+  readonlyMode?: boolean
 }
 
 const GeneratedInputField = React.memo(
@@ -156,7 +157,8 @@ const GeneratedInputField = React.memo(
     value,
     formData,
     disabled,
-    eventConfig
+    eventConfig,
+    readonlyMode
   }: GeneratedInputFieldProps<T>) => {
     const intl = useIntl()
 
@@ -168,7 +170,7 @@ const GeneratedInputField = React.memo(
           ? undefined
           : intl.formatMessage(fieldDefinition.label),
       required: fieldDefinition.required,
-      disabled: fieldDefinition.disabled,
+      disabled: fieldDefinition.disabled || readonlyMode,
       error,
       touched
     }
@@ -179,7 +181,7 @@ const GeneratedInputField = React.memo(
       onChange,
       onBlur,
       value,
-      disabled: fieldDefinition.disabled ?? disabled,
+      disabled: disabled || fieldDefinition.disabled || readonlyMode,
       error: Boolean(error),
       touched: Boolean(touched),
       placeholder:
@@ -299,7 +301,6 @@ const GeneratedInputField = React.memo(
         >
           <Number.Input
             {...inputProps}
-            disabled={disabled}
             value={field.value}
             onChange={(val) => setFieldValue(fieldDefinition.id, val)}
             min={field.config.configuration?.min}
@@ -324,7 +325,6 @@ const GeneratedInputField = React.memo(
         >
           <TextArea
             {...inputProps}
-            disabled={disabled}
             maxLength={field.config.configuration?.maxLength}
             value={field.value}
           />
@@ -411,7 +411,9 @@ const GeneratedInputField = React.memo(
     }
 
     if (isSignatureFieldType(field)) {
-      return (
+      return readonlyMode ? (
+        <></>
+      ) : (
         <InputField {...inputFieldProps}>
           <SignatureUploader
             name={fieldDefinition.id}
@@ -547,6 +549,7 @@ interface ExposedProps {
   initialValues?: EventState
   eventConfig?: EventConfig
   eventDeclarationData?: EventState
+  readonlyMode?: boolean
 }
 
 type AllProps = ExposedProps &
@@ -669,7 +672,8 @@ class FormSectionComponent extends React.Component<AllProps> {
       touched,
       intl,
       className,
-      eventDeclarationData
+      eventDeclarationData,
+      readonlyMode
     } = this.props
 
     const language = this.props.intl.locale
@@ -732,6 +736,7 @@ class FormSectionComponent extends React.Component<AllProps> {
                         this.props.onUploadingStateChanged
                       }
                       eventConfig={this.props.eventConfig}
+                      readonlyMode={readonlyMode}
                     />
                   )
                 }}

--- a/packages/client/src/v2-events/features/events/AdvancedSearch/AdvancedSearch.stories.tsx
+++ b/packages/client/src/v2-events/features/events/AdvancedSearch/AdvancedSearch.stories.tsx
@@ -15,7 +15,7 @@ import superjson from 'superjson'
 import { tennisClubMembershipEvent } from '@opencrvs/commons/client'
 import { TRPCProvider, AppRouter } from '@client/v2-events/trpc'
 import { ROUTES } from '@client/v2-events/routes'
-import AdvancedSearch from './AdvancedSearch'
+import { AdvancedSearch } from './index'
 
 const meta: Meta<typeof AdvancedSearch> = {
   title: 'AdvancedSearch',

--- a/packages/client/src/v2-events/features/events/AdvancedSearch/AdvancedSearch.tsx
+++ b/packages/client/src/v2-events/features/events/AdvancedSearch/AdvancedSearch.tsx
@@ -18,7 +18,6 @@ import {
   IFormTabProps
 } from '@opencrvs/components'
 import { useEventConfigurations } from '@client/v2-events/features/events/useEventConfiguration'
-import { withSuspense } from '@client/v2-events/components/withSuspense'
 import { TabSearch } from './TabSearch'
 
 const messagesToDefine = {
@@ -37,7 +36,7 @@ const messagesToDefine = {
 
 const messages = defineMessages(messagesToDefine)
 
-function AdvancedSearch() {
+export function AdvancedSearch() {
   const intl = useIntl()
   const allEvents = useEventConfigurations()
   const location = useLocation()
@@ -87,4 +86,3 @@ function AdvancedSearch() {
   )
 }
 
-export default withSuspense(AdvancedSearch)

--- a/packages/client/src/v2-events/features/events/AdvancedSearch/index.tsx
+++ b/packages/client/src/v2-events/features/events/AdvancedSearch/index.tsx
@@ -10,9 +10,10 @@
  */
 
 import { withSuspense } from '@client/v2-events/components/withSuspense'
-import { Review } from './Review'
-import { Pages } from './Pages'
+import { AdvancedSearch } from './AdvancedSearch'
+import { SearchResultIndex as SearchResult } from './SearchResultIndex'
 
-const PagesIndex = withSuspense(Pages)
-const ReviewIndex = withSuspense(Review)
-export { ReviewIndex as Review, PagesIndex as Pages }
+
+const AdvancedSearchIndex = withSuspense(AdvancedSearch)
+const SearchResultIndex = withSuspense(SearchResult)
+export { AdvancedSearchIndex as AdvancedSearch, SearchResultIndex as SearchResult }

--- a/packages/client/src/v2-events/features/events/ReadOnlyView.stories.tsx
+++ b/packages/client/src/v2-events/features/events/ReadOnlyView.stories.tsx
@@ -1,0 +1,97 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+import type { Meta, StoryObj } from '@storybook/react'
+import { createTRPCMsw, httpLink } from '@vafanassieff/msw-trpc'
+import { graphql, HttpResponse } from 'msw'
+import superjson from 'superjson'
+import {
+  ActionType,
+  generateEventDocument,
+  generateEventDraftDocument,
+  tennisClubMembershipEvent
+} from '@opencrvs/commons/client'
+import { AppRouter } from '@client/v2-events/trpc'
+import { ROUTES, routesConfig } from '@client/v2-events/routes'
+// eslint-disable-next-line
+import { testDataGenerator } from '@client/tests/test-data-generators'
+import { tennisClubMembershipEventIndex } from '@client/v2-events/features/events/fixtures'
+import { ReadOnlyView } from './ReadOnlyView'
+
+const generator = testDataGenerator()
+
+const meta: Meta<typeof ReadOnlyView> = {
+  title: 'ReadOnlyView'
+}
+
+export default meta
+
+type Story = StoryObj<typeof ReadOnlyView>
+const tRPCMsw = createTRPCMsw<AppRouter>({
+  links: [
+    httpLink({
+      url: '/api/events'
+    })
+  ],
+  transformer: { input: superjson, output: superjson }
+})
+
+const eventDocument = generateEventDocument({
+  configuration: tennisClubMembershipEvent,
+  actions: [
+    ActionType.CREATE,
+    ActionType.DECLARE,
+    ActionType.VALIDATE,
+    ActionType.REGISTER
+  ]
+})
+
+const eventId = eventDocument.id
+const draft = generateEventDraftDocument(eventId)
+
+export const ReadOnlyViewForUserWithReadPermission: Story = {
+  parameters: {
+    reactRouter: {
+      router: routesConfig,
+      initialPath: ROUTES.V2.EVENTS.VIEW.buildPath({
+        eventId
+      })
+    },
+    msw: {
+      handlers: {
+        drafts: [
+          tRPCMsw.event.draft.list.query(() => {
+            return [draft]
+          })
+        ],
+        events: [
+          tRPCMsw.event.config.get.query(() => {
+            return [tennisClubMembershipEvent]
+          }),
+          tRPCMsw.event.get.query(() => {
+            return eventDocument
+          }),
+          tRPCMsw.event.list.query(() => {
+            return [tennisClubMembershipEventIndex]
+          })
+        ],
+        user: [
+          graphql.query('fetchUser', () => {
+            return HttpResponse.json({
+              data: {
+                getUser: generator.user.localRegistrar()
+              }
+            })
+          })
+        ]
+      }
+    }
+  }
+}

--- a/packages/client/src/v2-events/features/events/ReadOnlyView.tsx
+++ b/packages/client/src/v2-events/features/events/ReadOnlyView.tsx
@@ -1,0 +1,102 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+
+import React from 'react'
+import { useTypedParams } from 'react-router-typesafe-routes/dom'
+import { noop } from 'lodash'
+import {
+  ActionType,
+  EventConfig,
+  EventDocument,
+  findActiveActionForm,
+  getMetadataForAction
+} from '@opencrvs/commons/client'
+import { useEventConfiguration } from '@client/v2-events/features/events/useEventConfiguration'
+import { useEventFormData } from '@client/v2-events/features/events/useEventFormData'
+import { useEventMetadata } from '@client/v2-events/features/events/useEventMeta'
+import { useEvents } from '@client/v2-events/features/events/useEvents/useEvents'
+import { ROUTES } from '@client/v2-events/routes'
+import { Review as ReviewComponent } from '@client/v2-events/features/events/components/Review'
+import { FormLayout } from '@client/v2-events/layouts'
+import { useIntlFormatMessageWithFlattenedParams } from '@client/v2-events/messages/utils'
+
+// These are the allowed actions based on which we can read a declarations data
+const READ_ONLY_MODE_ALLOWED_ACTIONS = [
+  ActionType.APPROVE_CORRECTION,
+  ActionType.REGISTER,
+  ActionType.VALIDATE,
+  ActionType.DECLARE
+]
+
+function findLastActionFormConfigForReadOnlyMode(
+  config: EventConfig,
+  event: EventDocument
+) {
+  for (const actionType of READ_ONLY_MODE_ALLOWED_ACTIONS) {
+    const availableAllowedAction = event.actions.find(
+      (a) => a.type === actionType
+    )
+    if (availableAllowedAction) {
+      return findActiveActionForm(config, actionType)
+    }
+  }
+}
+
+function findLastActionMetadata(event: EventDocument) {
+  for (const actionType of READ_ONLY_MODE_ALLOWED_ACTIONS) {
+    const availableAllowedAction = event.actions.find(
+      (a) => a.type === actionType
+    )
+    if (availableAllowedAction) {
+      return getMetadataForAction({ event, actionType, drafts: [] })
+    }
+  }
+}
+
+export function ReadOnlyView() {
+  const { eventId } = useTypedParams(ROUTES.V2.EVENTS.VIEW)
+  const { getEventState, getEvent } = useEvents()
+  const { formatMessage } = useIntlFormatMessageWithFlattenedParams()
+  const currentEventState = getEventState.useSuspenseQuery(eventId)
+  const { eventConfiguration: config } = useEventConfiguration(
+    currentEventState.type
+  )
+  const [fullEvent] = getEvent.useSuspenseQuery(eventId)
+  const formConfig = findLastActionFormConfigForReadOnlyMode(config, fullEvent)
+
+  if (!formConfig) {
+    throw new Error('No active form configuration found for any action')
+  }
+
+  const form = useEventFormData((state) =>
+    state.getFormValues(currentEventState.data)
+  )
+
+  const { setMetadata, getMetadata } = useEventMetadata()
+  const metadata = getMetadata(findLastActionMetadata(fullEvent))
+
+  return (
+    <FormLayout route={ROUTES.V2.EVENTS.DECLARE}>
+      <ReviewComponent.Body
+        readonlyMode
+        eventConfig={config}
+        form={form}
+        formConfig={formConfig}
+        metadata={metadata}
+        title={formatMessage(formConfig.review.title, form)}
+        onEdit={noop}
+        onMetadataChange={(values) => setMetadata(values)}
+      >
+        <></>
+      </ReviewComponent.Body>
+    </FormLayout>
+  )
+}

--- a/packages/client/src/v2-events/features/events/actions/delete/index.tsx
+++ b/packages/client/src/v2-events/features/events/actions/delete/index.tsx
@@ -14,8 +14,9 @@ import { useTypedParams } from 'react-router-typesafe-routes/dom'
 import { useNavigate } from 'react-router-dom'
 import { ROUTES } from '@client/v2-events/routes'
 import { useEvents } from '@client/v2-events/features/events/useEvents/useEvents'
+import { withSuspense } from '@client/v2-events/components/withSuspense'
 
-export function DeleteEvent() {
+function DeleteEvent() {
   const { eventId } = useTypedParams(ROUTES.V2.EVENTS.DELETE)
   const navigate = useNavigate()
   const events = useEvents()
@@ -32,3 +33,5 @@ export function DeleteEvent() {
 
   return <div />
 }
+
+export const DeleteEventIndex = withSuspense(DeleteEvent)

--- a/packages/client/src/v2-events/features/events/components/DocumentViewer.tsx
+++ b/packages/client/src/v2-events/features/events/components/DocumentViewer.tsx
@@ -179,12 +179,14 @@ export function DocumentViewer({
   form,
   formConfig,
   onEdit,
-  showInMobile
+  showInMobile,
+  disabled
 }: {
   formConfig: FormConfig
   form: EventState
   onEdit: () => void
   showInMobile?: boolean
+  disabled?: boolean
 }) {
   const intl = useIntl()
   const fileOptions = getFileOptions(form, formConfig, intl)
@@ -195,15 +197,17 @@ export function DocumentViewer({
         {fileOptions.documentOptions.length === 0 && (
           <ZeroDocument id={`zero_document`}>
             {intl.formatMessage(reviewMessages.zeroDocumentsTextForAnySection)}
-            <Link
-              id="edit-document"
-              onClick={(e) => {
-                e.stopPropagation()
-                onEdit()
-              }}
-            >
-              {intl.formatMessage(reviewMessages.editDocuments)}
-            </Link>
+            {!disabled && (
+              <Link
+                id="edit-document"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onEdit()
+                }}
+              >
+                {intl.formatMessage(reviewMessages.editDocuments)}
+              </Link>
+            )}
           </ZeroDocument>
         )}
       </DocumentViewerComponent>

--- a/packages/client/src/v2-events/features/events/components/Review.tsx
+++ b/packages/client/src/v2-events/features/events/components/Review.tsx
@@ -277,13 +277,15 @@ function FormReview({
   form,
   previousForm,
   onEdit,
-  showPreviouslyMissingValuesAsChanged
+  showPreviouslyMissingValuesAsChanged,
+  readonlyMode
 }: {
   formConfig: FormConfig
   form: EventState
   previousForm: EventState
   onEdit: ({ pageId, fieldId }: { pageId: string; fieldId?: string }) => void
   showPreviouslyMissingValuesAsChanged: boolean
+  readonlyMode?: boolean
 }) {
   const intl = useIntl()
   const visiblePages = formConfig.pages.filter((page) =>
@@ -346,14 +348,16 @@ function FormReview({
             >
               <Accordion
                 action={
-                  <Link
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      onEdit({ pageId: page.id })
-                    }}
-                  >
-                    {intl.formatMessage(reviewMessages.changeAllButton)}
-                  </Link>
+                  !readonlyMode && (
+                    <Link
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        onEdit({ pageId: page.id })
+                      }}
+                    >
+                      {intl.formatMessage(reviewMessages.changeAllButton)}
+                    </Link>
+                  )
                 }
                 expand={true}
                 label={intl.formatMessage(page.title)}
@@ -371,19 +375,21 @@ function FormReview({
                       <ListReview.Row
                         key={id}
                         actions={
-                          <Link
-                            data-testid={`change-button-${id}`}
-                            onClick={(e) => {
-                              e.stopPropagation()
+                          !readonlyMode && (
+                            <Link
+                              data-testid={`change-button-${id}`}
+                              onClick={(e) => {
+                                e.stopPropagation()
 
-                              onEdit({
-                                pageId: page.id,
-                                fieldId: id
-                              })
-                            }}
-                          >
-                            {intl.formatMessage(reviewMessages.changeButton)}
-                          </Link>
+                                onEdit({
+                                  pageId: page.id,
+                                  fieldId: id
+                                })
+                              }}
+                            >
+                              {intl.formatMessage(reviewMessages.changeButton)}
+                            </Link>
+                          )
                         }
                         id={id}
                         label={intl.formatMessage(label)}
@@ -412,7 +418,8 @@ function ReviewComponent({
   onEdit,
   children,
   title,
-  onMetadataChange
+  onMetadataChange,
+  readonlyMode
 }: {
   children: React.ReactNode
   eventConfig: EventConfig
@@ -431,6 +438,7 @@ function ReviewComponent({
   }) => void
   title: string
   onMetadataChange?: (values: EventState) => void
+  readonlyMode?: boolean
 }) {
   const scopes = useSelector(getScope)
   const showPreviouslyMissingValuesAsChanged = previousFormValues !== undefined
@@ -457,6 +465,7 @@ function ReviewComponent({
             form={form}
             formConfig={formConfig}
             previousForm={previousForm}
+            readonlyMode={readonlyMode}
             showPreviouslyMissingValuesAsChanged={
               showPreviouslyMissingValuesAsChanged
             }
@@ -471,6 +480,7 @@ function ReviewComponent({
                   formData={metadata}
                   id={'review'}
                   initialValues={metadata}
+                  readonlyMode={readonlyMode}
                   setAllFieldsDirty={false}
                   onChange={onMetadataChange}
                 />
@@ -483,6 +493,7 @@ function ReviewComponent({
       {pageIdsWithFile.length > 0 && (
         <RightColumn>
           <DocumentViewer
+            disabled={readonlyMode}
             form={form}
             formConfig={formConfig}
             // @todo: ask about this rule

--- a/packages/client/src/v2-events/features/events/registered-fields/SelectCountry.tsx
+++ b/packages/client/src/v2-events/features/events/registered-fields/SelectCountry.tsx
@@ -42,7 +42,17 @@ function SelectCountryOutput({ value }: { value: string | undefined }) {
   return selectedCountry ? intl.formatMessage(selectedCountry.label) : ''
 }
 
+function useStringifier() {
+  const intl = useIntl()
+
+  return (value: string) => {
+    const selectedCountry = countries.find((country) => country.value === value)
+    return selectedCountry ? intl.formatMessage(selectedCountry.label) : ''
+  }
+}
+
 export const SelectCountry = {
   Input: SelectCountryInput,
-  Output: SelectCountryOutput
+  Output: SelectCountryOutput,
+  useStringifier: useStringifier
 }

--- a/packages/client/src/v2-events/features/workqueues/EventOverview/EventOverview.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/EventOverview.tsx
@@ -110,8 +110,7 @@ function EventOverview({
     string,
     FieldValue | null | RecursiveStringRecord
   > = {
-    ...eventWithDefaults,
-    ...flattenEventIndex({ ...eventIndex, data: eventWithDrafts.data }),
+    ...flattenEventIndex({ ...eventIndex, data: eventWithDefaults }),
     ...getDefaultFieldValues(trackingId, status)
   }
 

--- a/packages/client/src/v2-events/hooks/useFormDataStringifier.ts
+++ b/packages/client/src/v2-events/hooks/useFormDataStringifier.ts
@@ -15,6 +15,7 @@ import {
   FieldValue,
   isAddressFieldType,
   isAdministrativeAreaFieldType,
+  isCountryFieldType,
   isFacilityFieldType,
   isLocationFieldType,
   isRadioGroupFieldType
@@ -22,13 +23,15 @@ import {
 import {
   Address,
   AdministrativeArea,
-  RadioGroup
+  RadioGroup,
+  SelectCountry as Country
 } from '@client/v2-events/features/events/registered-fields'
 
 function useFieldStringifier() {
   const stringifyLocation = AdministrativeArea.useStringifier()
   const stringifyAddress = Address.useStringifier()
   const stringifyRadioGroup = RadioGroup.useStringifier()
+  const stringifyCountry = Country.useStringifier()
 
   return (fieldConfig: FieldConfig, value: FieldValue) => {
     const field = { config: fieldConfig, value }
@@ -47,6 +50,10 @@ function useFieldStringifier() {
 
     if (isRadioGroupFieldType(field)) {
       return stringifyRadioGroup(field.value, field.config)
+    }
+
+    if (isCountryFieldType(field)) {
+      return stringifyCountry(field.value)
     }
 
     return !value ? '' : value.toString()

--- a/packages/client/src/v2-events/routes/config.tsx
+++ b/packages/client/src/v2-events/routes/config.tsx
@@ -30,6 +30,7 @@ import { TRPCProvider } from '@client/v2-events/trpc'
 import { SearchResultIndex } from '@client/v2-events/features/events/AdvancedSearch/SearchResultIndex'
 import { Action } from '@client/v2-events/features/events/components/Action'
 import { NavigationHistoryProvider } from '@client/v2-events/components/NavigationStack'
+import { ReadOnlyView } from '@client/v2-events/features/events/ReadOnlyView'
 import { ROUTES } from './routes'
 
 /**
@@ -52,6 +53,10 @@ export const routesConfig = {
   ),
   children: [
     workqueueRouter,
+    {
+      path: ROUTES.V2.EVENTS.VIEW.path,
+      element: <ReadOnlyView />
+    },
     {
       path: ROUTES.V2.EVENTS.OVERVIEW.path,
       element: (

--- a/packages/client/src/v2-events/routes/config.tsx
+++ b/packages/client/src/v2-events/routes/config.tsx
@@ -16,18 +16,17 @@ import { ActionType } from '@opencrvs/commons/client'
 import { Debug } from '@client/v2-events/features/debug/debug'
 import { router as correctionRouter } from '@client/v2-events/features/events/actions/correct/request/router'
 import * as Declare from '@client/v2-events/features/events/actions/declare'
-import { DeleteEvent } from '@client/v2-events/features/events/actions/delete'
+import { DeleteEventIndex } from '@client/v2-events/features/events/actions/delete'
 import * as PrintCertificate from '@client/v2-events/features/events/actions/print-certificate'
 import * as Register from '@client/v2-events/features/events/actions/register'
 import * as Validate from '@client/v2-events/features/events/actions/validate'
-import AdvancedSearch from '@client/v2-events/features/events/AdvancedSearch/AdvancedSearch'
+import { AdvancedSearch, SearchResult } from '@client/v2-events/features/events/AdvancedSearch'
 import { EventSelectionIndex } from '@client/v2-events/features/events/EventSelection'
 import { EventOverviewIndex } from '@client/v2-events/features/workqueues/EventOverview/EventOverview'
 import { router as workqueueRouter } from '@client/v2-events/features/workqueues/router'
 import { EventOverviewLayout, WorkqueueLayout } from '@client/v2-events/layouts'
 import { TRPCErrorBoundary } from '@client/v2-events/routes/TRPCErrorBoundary'
 import { TRPCProvider } from '@client/v2-events/trpc'
-import { SearchResultIndex } from '@client/v2-events/features/events/AdvancedSearch/SearchResultIndex'
 import { Action } from '@client/v2-events/features/events/components/Action'
 import { NavigationHistoryProvider } from '@client/v2-events/components/NavigationStack'
 import { ReadOnlyView } from '@client/v2-events/features/events/ReadOnlyView'
@@ -71,7 +70,7 @@ export const routesConfig = {
     },
     {
       path: ROUTES.V2.EVENTS.DELETE.path,
-      element: <DeleteEvent />
+      element: <DeleteEventIndex />
     },
     {
       path: ROUTES.V2.EVENTS.DECLARE.path,
@@ -170,7 +169,7 @@ export const routesConfig = {
       path: ROUTES.V2.SEARCH_RESULT.path,
       element: (
         <WorkqueueLayout>
-          <SearchResultIndex />
+          <SearchResult />
         </WorkqueueLayout>
       )
     }

--- a/packages/client/src/v2-events/routes/routes.ts
+++ b/packages/client/src/v2-events/routes/routes.ts
@@ -23,6 +23,9 @@ export const ROUTES = {
         'events',
         {},
         {
+          VIEW: route('view/:eventId', {
+            params: { eventId: string().defined() }
+          }),
           OVERVIEW: route('overview/:eventId', {
             params: { eventId: string().defined() }
           }),

--- a/packages/commons/src/conditionals/conditionals.test.ts
+++ b/packages/commons/src/conditionals/conditionals.test.ts
@@ -584,3 +584,126 @@ describe('"range number" conditional', () => {
     })
   })
 })
+
+describe('Matches conditional validation', () => {
+  const PHONE_NUMBER_REGEX = '^0(7|9)[0-9]{8}$'
+  it('should pass validation for existing phone number starting with 07', () => {
+    const params = {
+      $form: { 'applicant.phoneNo': '0733445566' },
+      $now: formatISO(new Date(), { representation: 'date' })
+    }
+    expect(
+      validate(field('applicant.phoneNo').matches(PHONE_NUMBER_REGEX), params)
+    ).toBe(true)
+  })
+
+  it('should pass validation for different phone number starting with 09', () => {
+    const params = {
+      $form: { 'applicant.phoneNo': '0933445566' },
+      $now: formatISO(new Date(), { representation: 'date' })
+    }
+    expect(
+      validate(field('applicant.phoneNo').matches(PHONE_NUMBER_REGEX), params)
+    ).toBe(true)
+  })
+
+  it('should fail validation for phone number starting with 05', () => {
+    const params = {
+      $form: { 'applicant.phoneNo': '0533445566' },
+      $now: formatISO(new Date(), { representation: 'date' })
+    }
+    expect(
+      validate(field('applicant.phoneNo').matches(PHONE_NUMBER_REGEX), params)
+    ).toBe(false)
+  })
+
+  it('should fail validation for phone number shorter than 10 digits', () => {
+    const params = {
+      $form: { 'applicant.phoneNo': '07334455' }, // Only 8 digits
+      $now: formatISO(new Date(), { representation: 'date' })
+    }
+    expect(
+      validate(field('applicant.phoneNo').matches(PHONE_NUMBER_REGEX), params)
+    ).toBe(false)
+  })
+
+  it('should fail validation for phone number longer than 10 digits', () => {
+    const params = {
+      $form: { 'applicant.phoneNo': '073344556677' }, // 12 digits
+      $now: formatISO(new Date(), { representation: 'date' })
+    }
+    expect(
+      validate(field('applicant.phoneNo').matches(PHONE_NUMBER_REGEX), params)
+    ).toBe(false)
+  })
+
+  it('should fail validation for phone number without leading 0', () => {
+    const params = {
+      $form: { 'applicant.phoneNo': '733445566' }, // Missing leading 0
+      $now: formatISO(new Date(), { representation: 'date' })
+    }
+    expect(
+      validate(field('applicant.phoneNo').matches(PHONE_NUMBER_REGEX), params)
+    ).toBe(false)
+  })
+
+  it('should fail validation for non-numeric input', () => {
+    const params = {
+      $form: { 'applicant.phoneNo': '07A3445566' }, // Contains a letter
+      $now: formatISO(new Date(), { representation: 'date' })
+    }
+    expect(
+      validate(field('applicant.phoneNo').matches(PHONE_NUMBER_REGEX), params)
+    ).toBe(false)
+  })
+
+  it('should fail validation for phone number not starting with 07 or 09', () => {
+    const params = {
+      $form: { 'applicant.phoneNo': '08334455667' }, // Invalid prefix
+      $now: formatISO(new Date(), { representation: 'date' })
+    }
+    expect(
+      validate(field('applicant.phoneNo').matches(PHONE_NUMBER_REGEX), params)
+    ).toBe(false)
+  })
+
+  it('should fail validation for phone number with incorrect length (too short)', () => {
+    const params = {
+      $form: { 'applicant.phoneNo': '073344556' }, // 9 digits only
+      $now: formatISO(new Date(), { representation: 'date' })
+    }
+    expect(
+      validate(field('applicant.phoneNo').matches(PHONE_NUMBER_REGEX), params)
+    ).toBe(false)
+  })
+
+  it('should fail validation for phone number with incorrect length (too long)', () => {
+    const params = {
+      $form: { 'applicant.phoneNo': '073344556677' }, // 12 digits
+      $now: formatISO(new Date(), { representation: 'date' })
+    }
+    expect(
+      validate(field('applicant.phoneNo').matches(PHONE_NUMBER_REGEX), params)
+    ).toBe(false)
+  })
+
+  it('should fail validation for phone number with spaces when strict regex is used', () => {
+    const params = {
+      $form: { 'applicant.phoneNo': '07 334455667' }, // Spaces not allowed
+      $now: formatISO(new Date(), { representation: 'date' })
+    }
+    expect(
+      validate(field('applicant.phoneNo').matches(PHONE_NUMBER_REGEX), params)
+    ).toBe(false)
+  })
+
+  it('should fail validation for phone number containing non-numeric characters', () => {
+    const params = {
+      $form: { 'applicant.phoneNo': '07A34455667' }, // Contains letter
+      $now: formatISO(new Date(), { representation: 'date' })
+    }
+    expect(
+      validate(field('applicant.phoneNo').matches(PHONE_NUMBER_REGEX), params)
+    ).toBe(false)
+  })
+})

--- a/packages/commons/src/conditionals/conditionals.ts
+++ b/packages/commons/src/conditionals/conditionals.ts
@@ -336,6 +336,28 @@ export function field(fieldId: string) {
         },
         required: ['$form']
       }),
+    /**
+     * Checks if the field value matches a given regular expression pattern.
+     * @param pattern - The regular expression pattern to match the field value against.
+     * @returns A JSONSchema conditional that validates the field value against the pattern.
+     */
+    matches: (pattern: string) =>
+      defineConditional({
+        type: 'object',
+        properties: {
+          $form: {
+            type: 'object',
+            properties: {
+              [fieldId]: {
+                type: 'string',
+                pattern
+              }
+            },
+            required: [fieldId]
+          }
+        },
+        required: ['$form']
+      }),
     isBetween: (min: number, max: number) =>
       defineConditional({
         type: 'object',

--- a/packages/commons/src/events/utils.ts
+++ b/packages/commons/src/events/utils.ts
@@ -290,6 +290,7 @@ export function stripHiddenFields(fields: FieldConfig[], data: EventState) {
 export function findActiveDrafts(event: EventDocument, drafts: Draft[]) {
   const actions = event.actions
     .slice()
+    .filter(({ type }) => type !== ActionType.READ)
     .sort((a, b) => a.createdAt.localeCompare(b.createdAt))
 
   const lastAction = actions[actions.length - 1]

--- a/packages/dashboards/run.sh
+++ b/packages/dashboards/run.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -7,7 +8,6 @@
 #
 # Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
 
-#!/bin/bash
 
 if [ -z "${OPENCRVS_METABASE_SITE_NAME}" ]; then
   echo "Error: OPENCRVS_METABASE_SITE_NAME environment variable is not defined"
@@ -38,13 +38,13 @@ if [ -z "${OPENCRVS_METABASE_DB_HOST}" ]; then
   echo "Error: OPENCRVS_METABASE_DB_HOST environment variable is not defined"
   exit 1
 fi
-
-if [ -z "${OPENCRVS_METABASE_DB_USER}" ]; then
+if [ -z "${OPENCRVS_METABASE_DB_USER}" ] && [ -z "${OPENCRVS_METABASE_DB_PASS}" ]; then
+  echo "Warning: OPENCRVS_METABASE_DB_USER and OPENCRVS_METABASE_DB_PASS environment variables are not defined"
+  echo "Using H2 (Metabase) connection without authentication"
+elif [ -z "${OPENCRVS_METABASE_DB_USER}" ]; then
   echo "Error: OPENCRVS_METABASE_DB_USER environment variable is not defined"
   exit 1
-fi
-
-if [ -z "${OPENCRVS_METABASE_DB_PASS}" ]; then
+elif [ -z "${OPENCRVS_METABASE_DB_PASS}" ]; then
   echo "Error: OPENCRVS_METABASE_DB_PASS environment variable is not defined"
   exit 1
 fi

--- a/packages/events/src/router/event/event.actions.test.ts
+++ b/packages/events/src/router/event/event.actions.test.ts
@@ -168,14 +168,16 @@ test('READ action does not delete draft', async () => {
 
   const draftEvents = await client.event.draft.list()
 
-  await client.event.get(originalEvent.id) // this triggers READ action
+  const event = await client.event.get(originalEvent.id)
+  // this triggers READ action
+  expect(event.actions.at(-1)?.type).toBe(ActionType.READ)
 
   const draftEventsAfterRead = await client.event.draft.list()
 
   expect(draftEvents).toEqual(draftEventsAfterRead)
 })
 
-test('Other than READ action deletes draft', async () => {
+test('Action other than READ deletes draft', async () => {
   const { user, generator } = await setupTestCase()
   const client = createTestClient(user)
 

--- a/packages/events/src/router/event/event.actions.test.ts
+++ b/packages/events/src/router/event/event.actions.test.ts
@@ -136,5 +136,10 @@ test('Action data accepts partial changes', async () => {
 
   const events = await client.event.list()
 
-  expect(events).toEqual([stateAfterVillageRemoval])
+  expect(events).toEqual([
+    expect.objectContaining({
+      ...stateAfterVillageRemoval,
+      modifiedAt: expect.any(String)
+    })
+  ])
 })

--- a/packages/events/src/service/events/events.ts
+++ b/packages/events/src/service/events/events.ts
@@ -335,9 +335,11 @@ export async function addAction(
   )
 
   const updatedEvent = await getEventById(eventId)
-  await indexEvent(updatedEvent)
-  await notifyOnAction(input, updatedEvent, token)
-  await deleteDraftsByEventId(eventId)
+  if (action.type !== ActionType.READ) {
+    await indexEvent(updatedEvent)
+    await notifyOnAction(input, updatedEvent, token)
+    await deleteDraftsByEventId(eventId)
+  }
 
   return updatedEvent
 }

--- a/packages/migration/revert-migrations.sh
+++ b/packages/migration/revert-migrations.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/packages/migration/run-migrations.sh
+++ b/packages/migration/run-migrations.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.


### PR DESCRIPTION
This PR is followup to original work done by @n1koo and aims to address issue https://github.com/opencrvs/opencrvs-core/blob/k8s/kubernetes/dashboards-deployment.yaml.bak#L50

On development environment Metabase doesn't require authentication while on server environment it is required.

Since that difference long list of variables is hardcoded on development version of the script: https://github.com/opencrvs/opencrvs-core/blob/develop/packages/dashboards/run-dev.sh#L40-L61

As the starting point we give production script a way to start without authorization. On kubernetes environments that change will allow connections without login and password.