### PR TITLE
fix: pass GH_TOKEN to authorize gh cli

### DIFF
--- a/.github/workflows/deploy-to-feature-environment.yml
+++ b/.github/workflows/deploy-to-feature-environment.yml
@@ -42,6 +42,8 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Get input data (when manually triggered)
+        env:
+          GH_TOKEN: ${{ github.token }}
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           PR_NUMBER=${{ github.event.inputs.pr_number }}
@@ -55,7 +57,7 @@ jobs:
         uses: 8BitJonny/gh-get-current-pr@3.0.0
         if: github.event_name == 'push'
         id: PR_push
-  
+
       # TODO: Replace curl usage to gh cli
       - name: Get PR labels on pull_request event
         id: PR_pull
@@ -65,9 +67,9 @@ jobs:
             response=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/issues/${pr_number}")
             labels=$(echo "$response" | jq '.labels | map(.name) | join(",")' | sed 's/"//g')
             echo pr_labels=$labels >> $GITHUB_OUTPUT
-  
+
       - name: Get input data (when triggered by event)
-        if: github.event_name != 'workflow_dispatch' 
+        if: github.event_name != 'workflow_dispatch'
         id: label_check
         run: |
           if [[ ${{github.event_name}} == 'pull_request' ]]
@@ -236,11 +238,11 @@ jobs:
           # E2E Environment summary
           Action workflow (pipeline): $E2E_RUN_LINK
           All Deployments: https://github.com/opencrvs/e2e/deployments/${{ steps.generate_stack.outputs.stack }}
-          
+
           Web link: $DEPLOYMENT_LINK
 
-          **NOTE**: Web link is available only while deployment, if you would like to 
-          keep environment accessible for debug purposes, please add '🔒 Keep e2e' to PR 
+          **NOTE**: Web link is available only while deployment, if you would like to
+          keep environment accessible for debug purposes, please add '🔒 Keep e2e' to PR
           https://github.com/${{ github.repository }}/pull/${{ needs.generate_stack_name_and_branch.outputs.pr_number }}
           """ >> $GITHUB_STEP_SUMMARY
 


### PR DESCRIPTION
Manually triggering the e2e pipeline was failing because the gh cli needs the `GH_TOKEN` environment variable

