### PR TITLE
fix: set different colors for incomplete declaration

### DIFF
--- a/packages/client/src/v2-events/features/events/actions/declare/Review.stories.tsx
+++ b/packages/client/src/v2-events/features/events/actions/declare/Review.stories.tsx
@@ -234,12 +234,7 @@ export const ReviewForFieldAgentComplete: Story = {
             return [tennisClubMembershipEvent]
           }),
           tRPCMsw.event.get.query(() => {
-            return {
-              ...generateEventDocument({
-                configuration: tennisClubMembershipEvent,
-                actions: [ActionType.CREATE]
-              })
-            }
+            return eventDocument
           }),
           tRPCMsw.event.list.query(() => {
             return [tennisClubMembershipEventIndex]

--- a/packages/client/src/v2-events/features/events/actions/declare/Review.tsx
+++ b/packages/client/src/v2-events/features/events/actions/declare/Review.tsx
@@ -144,7 +144,7 @@ export function Review() {
       >
         <ReviewComponent.Actions
           canSendIncomplete={scopes?.includes(SCOPES.RECORD_SUBMIT_INCOMPLETE)}
-          isPrimaryActionDisabled={reviewActionConfiguration.isDisabled}
+          incomplete={reviewActionConfiguration.incomplete}
           messages={reviewActionConfiguration.messages}
           primaryButtonType={reviewActionConfiguration.buttonType}
           onConfirm={handleDeclaration}

--- a/packages/client/src/v2-events/features/events/actions/declare/useReviewActionConfig.tsx
+++ b/packages/client/src/v2-events/features/events/actions/declare/useReviewActionConfig.tsx
@@ -269,18 +269,14 @@ export function useReviewActionConfig({
     reviewFields
   })
 
-  const isDisabled =
-    incomplete && !scopes?.includes(SCOPES.RECORD_SUBMIT_INCOMPLETE)
-
   if (
     incomplete &&
     scopes?.includes(SCOPES.RECORD_SUBMIT_INCOMPLETE) &&
     scopes.includes(SCOPES.RECORD_DECLARE)
   ) {
     return {
-      buttonType: 'positive' as const,
+      buttonType: 'primary' as const,
       incomplete,
-      isDisabled,
       onConfirm: (eventId: string) => {
         events.actions.notify.mutate({
           eventId,
@@ -297,7 +293,6 @@ export function useReviewActionConfig({
     return {
       buttonType: 'positive' as const,
       incomplete,
-      isDisabled,
       onConfirm: (eventId: string) =>
         events.customActions.registerOnDeclare.mutate({
           eventId,
@@ -314,7 +309,6 @@ export function useReviewActionConfig({
     return {
       buttonType: 'positive' as const,
       incomplete,
-      isDisabled,
       onConfirm: (eventId: string) =>
         events.customActions.validateOnDeclare.mutate({
           eventId,
@@ -329,9 +323,8 @@ export function useReviewActionConfig({
 
   if (scopes?.includes(SCOPES.RECORD_DECLARE)) {
     return {
-      buttonType: 'primary' as const,
+      buttonType: 'positive' as const,
       incomplete,
-      isDisabled,
       onConfirm: (eventId: string) =>
         events.actions.declare.mutate({
           eventId,

--- a/packages/client/src/v2-events/features/events/actions/register/Review.tsx
+++ b/packages/client/src/v2-events/features/events/actions/register/Review.tsx
@@ -208,7 +208,7 @@ export function Review() {
         onEdit={handleEdit}
       >
         <ReviewComponent.Actions
-          isPrimaryActionDisabled={hasValidationErrors}
+          incomplete={hasValidationErrors}
           messages={{
             title: messages.registerActionTitle,
             description: hasValidationErrors

--- a/packages/client/src/v2-events/features/events/actions/validate/Review.tsx
+++ b/packages/client/src/v2-events/features/events/actions/validate/Review.tsx
@@ -211,7 +211,7 @@ export function Review() {
         onEdit={handleEdit}
       >
         <ReviewComponent.Actions
-          isPrimaryActionDisabled={hasValidationErrors}
+          incomplete={hasValidationErrors}
           messages={{
             title: messages.validateActionTitle,
             description: hasValidationErrors

--- a/packages/client/src/v2-events/features/events/components/Review.tsx
+++ b/packages/client/src/v2-events/features/events/components/Review.tsx
@@ -566,14 +566,14 @@ const ActionContainer = styled.div`
 `
 
 function ReviewActionComponent({
+  incomplete,
   onConfirm,
   onReject,
   messages,
   primaryButtonType,
-  canSendIncomplete,
-  isPrimaryActionDisabled
+  canSendIncomplete
 }: {
-  isPrimaryActionDisabled: boolean
+  incomplete: boolean
   onConfirm: () => void
   onReject?: () => void
   messages: {
@@ -587,7 +587,7 @@ function ReviewActionComponent({
 }) {
   const intl = useIntl()
 
-  const background = isPrimaryActionDisabled ? 'error' : 'success'
+  const background = incomplete ? 'error' : 'success'
 
   return (
     <Container>
@@ -597,7 +597,7 @@ function ReviewActionComponent({
           <Description>{intl.formatMessage(messages.description)}</Description>
           <ActionContainer>
             <Button
-              disabled={isPrimaryActionDisabled && !canSendIncomplete}
+              disabled={!!incomplete && !canSendIncomplete}
               id="validateDeclarationBtn"
               size="large"
               type={primaryButtonType ?? 'positive'}


### PR DESCRIPTION
Set different colors for declaration submission when it is incomplete:
<img width="857" alt="Screenshot 2025-04-07 at 9 51 50" src="https://github.com/user-attachments/assets/465706da-be7c-4553-bf47-8eaef0e13511" />
<img width="898" alt="Screenshot 2025-04-07 at 9 51 53" src="https://github.com/user-attachments/assets/b3b97e4a-a236-4139-8ef5-3dd69cf9ba9b" />

