### PR TITLE
fix bug with deepDropNulls(), where it turned arrays into objects

### DIFF
--- a/packages/commons/src/events/state/index.test.ts
+++ b/packages/commons/src/events/state/index.test.ts
@@ -248,34 +248,6 @@ describe('deepDropNulls()', () => {
     })
   })
 
-  it('should handle arrays with null values', () => {
-    const before = {
-      items: [null, 'item1', null, 'item2']
-    }
-
-    const after = deepDropNulls(before)
-
-    expect(after).toEqual({
-      items: ['item1', 'item2']
-    })
-  })
-
-  it('should handle deeply nested nulls in arrays', () => {
-    const before = {
-      records: [
-        { id: 1, value: null },
-        { id: 2, value: 'valid' },
-        { id: null, value: 'missing-id' }
-      ]
-    }
-
-    const after = deepDropNulls(before)
-
-    expect(after).toEqual({
-      records: [{ id: 1 }, { id: 2, value: 'valid' }, { value: 'missing-id' }]
-    })
-  })
-
   it('should preserve primitive values', () => {
     expect(deepDropNulls('string')).toBe('string')
     expect(deepDropNulls(123)).toBe(123)

--- a/packages/commons/src/events/state/index.test.ts
+++ b/packages/commons/src/events/state/index.test.ts
@@ -9,7 +9,7 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 
-import { getCurrentEventState } from '.'
+import { deepDropNulls, getCurrentEventState } from '.'
 import { tennisClubMembershipEvent } from '../../fixtures'
 import { getUUID } from '../../uuid'
 import { ActionStatus } from '../ActionDocument'
@@ -222,5 +222,65 @@ describe('address state transitions', () => {
       ...initialForm,
       'applicant.address': addressWithoutVillage
     })
+  })
+})
+
+describe('deepDropNulls()', () => {
+  it('should clean nulls correctly with nested objects', () => {
+    const before = {
+      a: null,
+      b: {
+        c: null,
+        d: 'foo',
+        e: [{ foo: 'bar' }]
+      },
+      f: [{ asd: 'asd' }]
+    }
+
+    const after = deepDropNulls(before)
+
+    expect(after).toEqual({
+      b: {
+        d: 'foo',
+        e: [{ foo: 'bar' }]
+      },
+      f: [{ asd: 'asd' }]
+    })
+  })
+
+  it('should handle arrays with null values', () => {
+    const before = {
+      items: [null, 'item1', null, 'item2']
+    }
+
+    const after = deepDropNulls(before)
+
+    expect(after).toEqual({
+      items: ['item1', 'item2']
+    })
+  })
+
+  it('should handle deeply nested nulls in arrays', () => {
+    const before = {
+      records: [
+        { id: 1, value: null },
+        { id: 2, value: 'valid' },
+        { id: null, value: 'missing-id' }
+      ]
+    }
+
+    const after = deepDropNulls(before)
+
+    expect(after).toEqual({
+      records: [{ id: 1 }, { id: 2, value: 'valid' }, { value: 'missing-id' }]
+    })
+  })
+
+  it('should preserve primitive values', () => {
+    expect(deepDropNulls('string')).toBe('string')
+    expect(deepDropNulls(123)).toBe(123)
+    expect(deepDropNulls(false)).toBe(false)
+    expect(deepDropNulls(null)).toBe(null)
+    expect(deepDropNulls(undefined)).toBe(undefined)
   })
 })

--- a/packages/commons/src/events/state/index.ts
+++ b/packages/commons/src/events/state/index.ts
@@ -120,26 +120,26 @@ function aggregateActionDeclarations(actions: Array<ActionDocument>) {
  * deepDropNulls({ a: null, b: { c: null, d: 'foo' } }) // { b: { d: 'foo' } }
  *
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function deepDropNulls<T extends Record<string, any>>(obj: T): T {
-  if (!_.isObject(obj)) {
+
+export function deepDropNulls<T>(obj: T): T {
+  if (Array.isArray(obj)) {
     return obj
+      .map((item) => deepDropNulls(item))
+      .filter((item) => item !== null) as T
   }
 
-  return Object.entries(obj).reduce((acc: T, [key, value]) => {
-    if (_.isObject(value)) {
-      value = deepDropNulls(value)
-    }
-
-    if (value !== null) {
-      return {
-        ...acc,
-        [key]: value
+  if (obj !== null && typeof obj === 'object') {
+    return Object.entries(obj).reduce((acc, [key, value]) => {
+      const cleanedValue = deepDropNulls(value)
+      if (cleanedValue !== null) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ;(acc as any)[key] = cleanedValue
       }
-    }
+      return acc
+    }, {} as T)
+  }
 
-    return acc
-  }, {} as T)
+  return obj
 }
 
 export function isUndeclaredDraft(status: EventStatus): boolean {

--- a/packages/commons/src/events/state/index.ts
+++ b/packages/commons/src/events/state/index.ts
@@ -120,12 +120,9 @@ function aggregateActionDeclarations(actions: Array<ActionDocument>) {
  * deepDropNulls({ a: null, b: { c: null, d: 'foo' } }) // { b: { d: 'foo' } }
  *
  */
-
 export function deepDropNulls<T>(obj: T): T {
   if (Array.isArray(obj)) {
-    return obj
-      .map((item) => deepDropNulls(item))
-      .filter((item) => item !== null) as T
+    return obj as T
   }
 
   if (obj !== null && typeof obj === 'object') {

--- a/packages/components/src/ImageUploader/ImageUploader.tsx
+++ b/packages/components/src/ImageUploader/ImageUploader.tsx
@@ -57,6 +57,7 @@ export const ImageUploader: React.FC<ImageUploaderProps> = ({
       {children}
       <HiddenInput
         name={props.name}
+        data-testid={props.name}
         ref={fileUploader}
         type="file"
         accept="image/*"


### PR DESCRIPTION
## Description

This fixes bug: https://github.com/opencrvs/opencrvs-core/issues/9065

There was an issue `deepDropNulls()` where it turned arrays into objects

## Checklist

- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly

