### PR TITLE
fix: metabase startup on kubernetes localhost env

### DIFF
--- a/packages/dashboards/run.sh
+++ b/packages/dashboards/run.sh
@@ -40,8 +40,8 @@ if [ -z "${OPENCRVS_METABASE_DB_HOST}" ]; then
   exit 1
 fi
 
-if [ -z "${OPENCRVS_METABASE_DB_USER}" ] && [ -z "${OPENCRVS_METABASE_DB_PASS}" ]; then
-  echo "Warning: OPENCRVS_METABASE_DB_USER and OPENCRVS_METABASE_DB_PASS environment variables are not defined"
+if [ -z "${OPENCRVS_METABASE_DB_USER}" ] && [ -z "${OPENCRVS_METABASE_DB_PASS}" ] && [ -z "${OPENCRVS_METABASE_DB_AUTH_DB}" ]; then
+  echo "Warning: OPENCRVS_METABASE_DB_USER, OPENCRVS_METABASE_DB_PASS and OPENCRVS_METABASE_DB_AUTH_DB environment variables are not defined"
   echo "Using H2 (Metabase) connection without authentication"
 elif [ -z "${OPENCRVS_METABASE_DB_USER}" ]; then
   echo "Error: OPENCRVS_METABASE_DB_USER environment variable is not defined"
@@ -49,9 +49,7 @@ elif [ -z "${OPENCRVS_METABASE_DB_USER}" ]; then
 elif [ -z "${OPENCRVS_METABASE_DB_PASS}" ]; then
   echo "Error: OPENCRVS_METABASE_DB_PASS environment variable is not defined"
   exit 1
-fi
-
-if [ -z "${OPENCRVS_METABASE_DB_AUTH_DB}" ]; then
+elif [ -z "${OPENCRVS_METABASE_DB_AUTH_DB}" ]; then
   echo "Error: OPENCRVS_METABASE_DB_AUTH_DB environment variable is not defined"
   exit 1
 fi

--- a/packages/dashboards/run.sh
+++ b/packages/dashboards/run.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -39,12 +40,13 @@ if [ -z "${OPENCRVS_METABASE_DB_HOST}" ]; then
   exit 1
 fi
 
-if [ -z "${OPENCRVS_METABASE_DB_USER}" ]; then
+if [ -z "${OPENCRVS_METABASE_DB_USER}" ] && [ -z "${OPENCRVS_METABASE_DB_PASS}" ]; then
+  echo "Warning: OPENCRVS_METABASE_DB_USER and OPENCRVS_METABASE_DB_PASS environment variables are not defined"
+  echo "Using H2 (Metabase) connection without authentication"
+elif [ -z "${OPENCRVS_METABASE_DB_USER}" ]; then
   echo "Error: OPENCRVS_METABASE_DB_USER environment variable is not defined"
   exit 1
-fi
-
-if [ -z "${OPENCRVS_METABASE_DB_PASS}" ]; then
+elif [ -z "${OPENCRVS_METABASE_DB_PASS}" ]; then
   echo "Error: OPENCRVS_METABASE_DB_PASS environment variable is not defined"
   exit 1
 fi


### PR DESCRIPTION
## Description

This PR is followup to  https://github.com/opencrvs/opencrvs-core/pull/9120

## Checklist

- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths): tested locally, see logs
   ```
    Warning: OPENCRVS_METABASE_DB_USER, OPENCRVS_METABASE_DB_PASS and 
    OPENCRVS_METABASE_DB_AUTH_DB environment variables are not defined
    Using H2 (Metabase) connection without authentication
    Initializing Metabase database
    ...
    ```
- [ ] I have updated the changelog with this change (if applicable): N/A
- [ ] I have updated the GitHub issue status accordingly: There is no related issue (bug)
