### PR TITLE
in number inputs, dont allow minus sign if min is 0 or larger

### DIFF
--- a/packages/client/src/v2-events/features/events/registered-fields/Number.tsx
+++ b/packages/client/src/v2-events/features/events/registered-fields/Number.tsx
@@ -19,12 +19,15 @@ interface NumberInputProps
   extends Omit<TextInputProps, 'type' | 'maxLength' | 'onChange'> {
   onChange(val: number | undefined): void
   value: number | undefined
+  min?: number
 }
 
 function NumberInput({ value, disabled, ...props }: NumberInputProps) {
   const [inputValue, setInputValue] = React.useState(
     value && isNaN(value) ? undefined : value
   )
+
+  const allowOnlyPositive = props.min !== undefined && props.min >= 0
 
   return (
     <TextInputComponent
@@ -45,6 +48,11 @@ function NumberInput({ value, disabled, ...props }: NumberInputProps) {
         isNaN(updatedValue)
           ? setInputValue(undefined)
           : setInputValue(updatedValue)
+      }}
+      onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (allowOnlyPositive && e.key === '-') {
+          e.preventDefault()
+        }
       }}
     />
   )


### PR DESCRIPTION
## Description

https://github.com/opencrvs/opencrvs-core/issues/8893

If number input has a `min` value of 0 or larger, dont allow entering minus sign to input. This is similar to how it works in V1 currently.

## Checklist

- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly

