### PR TITLE
fix: checkout branch before building images

### DIFF
--- a/.github/workflows/build-images-from-branch.yml
+++ b/.github/workflows/build-images-from-branch.yml
@@ -35,12 +35,7 @@ jobs:
           ref: '${{ github.event.inputs.branch_name }}'
 
       - uses: actions/checkout@v4
-        if: github.event_name == 'push'
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - uses: actions/checkout@v4
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'push' || github.event_name == 'pull_request'
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -113,6 +108,8 @@ jobs:
 
       - uses: actions/checkout@v4
         if: github.event_name == 'push' || github.event_name == 'pull_request'
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Login to DockerHub
         uses: docker/login-action@v3


### PR DESCRIPTION
## Description

In the CI when building the images, the base image build job was checking out the branch but the job for building the other images was not.
This PR fixes that by checking out the branch properly

Link to failing workflow: https://github.com/opencrvs/opencrvs-core/actions/runs/14311635572/job/40108023123?pr=9162

Base build checkout ref: https://github.com/opencrvs/opencrvs-core/actions/runs/14311635572/job/40107858054?pr=9162#step:4:84

Client build checkout ref: https://github.com/opencrvs/opencrvs-core/actions/runs/14311635572/job/40108023123?pr=9162#step:3:83
