### PR TITLE
fix: Allow to define http protocol for minio

### DIFF
--- a/packages/documents/src/minio/constants.ts
+++ b/packages/documents/src/minio/constants.ts
@@ -21,4 +21,4 @@ export const MINIO_ACCESS_KEY = process.env.MINIO_ACCESS_KEY || 'minioadmin'
 export const MINIO_SECRET_KEY = process.env.MINIO_SECRET_KEY || 'minioadmin'
 
 export const MINIO_PRESIGNED_URL_EXPIRY_IN_SECOND = PRODUCTION ? 3600 : 259200
-export const MINIO_PROTOCOL = PRODUCTION ? 'https:' : 'http:'
+export const MINIO_PROTOCOL = process.env.MINIO_PROTOCOL ?? (PRODUCTION ? 'https:' : 'http:');


### PR DESCRIPTION
## Description

While testing on local kubernetes setup PWA was trying to communicate with minio on https URL:
![image](https://github.com/user-attachments/assets/7fccb042-bcea-4980-a764-afec775faaff)


## Checklist

- [x] I have tested the changes locally, and written appropriate tests
   <img width="1471" alt="image" src="https://github.com/user-attachments/assets/31af3d59-1c89-4bf7-85d1-99a63fc76362" />

- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable): N/A
- [ ] I have updated the GitHub issue status accordingly: N/A
