### PR TITLE
perf: use useMemo to cache expensive function call

### DIFF
--- a/packages/client/src/utils/locationUtils.ts
+++ b/packages/client/src/utils/locationUtils.ts
@@ -23,7 +23,7 @@ import { locationMessages, countryMessages } from '@client/i18n/messages'
 import { countries } from '@client/utils/countries'
 import { lookup } from 'country-data'
 import { getDefaultLanguage } from '@client/i18n/utils'
-import { camelCase, memoize } from 'lodash'
+import { camelCase } from 'lodash'
 
 export const countryAlpha3toAlpha2 = (isoCode: string): string | undefined => {
   const alpha2 =
@@ -148,22 +148,7 @@ export function generateSearchableLocations(
   return generated
 }
 
-export const generateLocations = memoize(
-  generateLocationsSlow,
-  (
-    locations: { [key: string]: ILocation },
-    intl: IntlShape,
-    filterByJurisdictionTypes?: string[],
-    filterByLocationTypes?: LocationType[]
-  ) => {
-    const locKeys = Object.keys(locations)
-    const firstKey = locKeys[0] || ''
-    const lastKey = locKeys[locKeys.length - 1] || ''
-    return `${firstKey}|${lastKey}|${locKeys.length}|${intl.locale}|${filterByJurisdictionTypes}|${filterByLocationTypes}`
-  }
-)
-
-export function generateLocationsSlow(
+export function generateLocations(
   locations: { [key: string]: ILocation },
   intl: IntlShape,
   filterByJurisdictionTypes?: string[],


### PR DESCRIPTION
## Description

Fixes advanced search sluggishness mentioned in #8575
We had tried using lodash memoize to cache one layer of the expensive operation but another expensive object creation was missed. I tried lodash memoize &  `React.useMemo` side by side and profiling showed that we are getting far better performance with the later. 


![advanced-search-perf](https://github.com/user-attachments/assets/b03838f3-5f88-46e6-a6fa-c4cc950d5cd3)
