### PR TITLE
add conditional for hiding fields on review page

### DIFF
--- a/packages/client/src/v2-events/features/events/components/Review.tsx
+++ b/packages/client/src/v2-events/features/events/components/Review.tsx
@@ -33,6 +33,7 @@ import {
   FieldType,
   FormConfig,
   getFieldValidationErrors,
+  isFieldDisplayedOnReview,
   isFieldVisible,
   isPageVisible,
   SCOPES
@@ -296,7 +297,7 @@ function FormReview({
       <ReviewContainter>
         {visiblePages.map((page) => {
           const fields = page.fields
-            .filter((field) => isFieldVisible(field, form))
+            .filter((field) => isFieldDisplayedOnReview(field, form))
             .map((field) => {
               const value = form[field.id]
               const previousValue = previousForm[field.id]

--- a/packages/commons/src/conditionals/conditionals.test.ts
+++ b/packages/commons/src/conditionals/conditionals.test.ts
@@ -197,7 +197,7 @@ describe('"field" conditionals', () => {
           'mother.dob': '1990-01-02'
         })
       )
-    ).toBe(false)
+    ).toBe(true)
 
     // Reference to another field, when the comparable field is wrong format
     expect(
@@ -285,7 +285,7 @@ describe('"field" conditionals', () => {
           'child.dob': '1990-01-02'
         })
       )
-    ).toBe(false)
+    ).toBe(true)
 
     // Reference to another field, when the comparable field is wrong format
     expect(

--- a/packages/commons/src/conditionals/conditionals.ts
+++ b/packages/commons/src/conditionals/conditionals.ts
@@ -189,29 +189,27 @@ function getDateFromNow(days: number) {
     .toISOString()
     .split('T')[0]
 }
-
-/* This function will output JSONSchema which looks for example like this:
-{
-  "type": "object",
-  "properties": {
-    "mother.dob": {
-      "type": "string",
-      "format": "date",
-      "formatMaximum": {
-        "$data": "1/child.dob"
-      }
-    },
-    "child.dob": {
-      "type": "string",
-      "format": "date"
-    }
-  },
-  "required": [
-    "mother.dob",
-    "child.dob"
-  ]
-}
-*/
+/**
+ * This function will output JSONSchema which looks for example like this:
+ * @example
+ * {
+ *   "type": "object",
+ *   "properties": {
+ *     "mother.dob": {
+ *       "type": "string",
+ *       "format": "date",
+ *       "formatMinimum": {
+ *         "$data": "1/child.dob"
+ *       }
+ *     },
+ *     "child.dob": {
+ *       "type": "string",
+ *       "format": "date"
+ *     }
+ *   },
+ *   "required": ["mother.dob"]
+ * }
+ */
 function getDateRangeToFieldReference(
   fieldId: string,
   comparedFieldId: string,
@@ -227,7 +225,7 @@ function getDateRangeToFieldReference(
       },
       [comparedFieldId]: { type: 'string', format: 'date' }
     },
-    required: [fieldId, comparedFieldId]
+    required: [fieldId]
   }
 }
 

--- a/packages/commons/src/conditionals/conditionals.ts
+++ b/packages/commons/src/conditionals/conditionals.ts
@@ -117,6 +117,15 @@ export function not(condition: AjvJSONSchema): JSONSchema {
 }
 
 /**
+ * Returns an JSON Schema object, which is treated as always invalid.
+ *
+ * @returns {JSONSchema} An schema object that always evaluates to false.
+ */
+export function never(): JSONSchema {
+  return not(alwaysTrue())
+}
+
+/**
  *
  * Generate conditional rules for user.
  */

--- a/packages/commons/src/conditionals/validate.ts
+++ b/packages/commons/src/conditionals/validate.ts
@@ -48,7 +48,7 @@ function getConditionalActionsForField(
 function isFieldConditionMet(
   field: FieldConfig,
   form: ActionUpdate | EventState,
-  conditionalType: typeof ConditionalType.SHOW | typeof ConditionalType.ENABLE
+  conditionalType: ConditionalType
 ) {
   const hasRule = (field.conditionals ?? []).some(
     (conditional) => conditional.type === conditionalType
@@ -80,6 +80,17 @@ export function isFieldEnabled(
   form: ActionUpdate | EventState
 ) {
   return isFieldConditionMet(field, form, ConditionalType.ENABLE)
+}
+
+// Fields are displayed on review if both the 'ConditionalType.SHOW' and 'ConditionalType.DISPLAY_ON_REVIEW' are met
+export function isFieldDisplayedOnReview(
+  field: FieldConfig,
+  form: ActionUpdate | EventState
+) {
+  return (
+    isFieldVisible(field, form) &&
+    isFieldConditionMet(field, form, ConditionalType.DISPLAY_ON_REVIEW)
+  )
 }
 
 export const errorMessages = {

--- a/packages/commons/src/events/Conditional.ts
+++ b/packages/commons/src/events/Conditional.ts
@@ -28,8 +28,13 @@ export const ConditionalType = {
   /** When 'SHOW' conditional is defined, the action is shown to the user only if the condition is met */
   SHOW: 'SHOW',
   /** If 'ENABLE' conditional is defined, the action is enabled only if the condition is met */
-  ENABLE: 'ENABLE'
+  ENABLE: 'ENABLE',
+  /** If 'DISPLAY_ON_REVIEW' conditional is defined, the action is displayed on the review page only if the condition is met */
+  DISPLAY_ON_REVIEW: 'DISPLAY_ON_REVIEW'
 } as const
+
+export type ConditionalType =
+  (typeof ConditionalType)[keyof typeof ConditionalType]
 
 export const ShowConditional = z.object({
   type: z.literal(ConditionalType.SHOW),
@@ -65,3 +70,37 @@ export const ActionConditional = z.discriminatedUnion('type', [
 ]) as unknown as z.ZodDiscriminatedUnion<'type', AllActionConditionalFields[]>
 
 export type ActionConditional = InferredActionConditional
+
+export const DisplayOnReviewConditional = z.object({
+  type: z.literal(ConditionalType.DISPLAY_ON_REVIEW),
+  conditional: Conditional()
+})
+
+/*
+ * This needs to be exported so that Typescript can refer to the type in
+ * the declaration output type. If it can't do that, you might start encountering
+ * "The inferred type of this node exceeds the maximum length the compiler will serialize. An explicit type annotation is needed"
+ * errors when compiling
+ */
+/** @knipignore */
+export type AllFieldConditionalFields =
+  | typeof ShowConditional
+  | typeof EnableConditional
+  | typeof DisplayOnReviewConditional
+
+/** @knipignore */
+export type InferredFieldConditional =
+  | z.infer<typeof ShowConditional>
+  | z.infer<typeof EnableConditional>
+  | z.infer<typeof DisplayOnReviewConditional>
+
+export const FieldConditional = z.discriminatedUnion('type', [
+  // Field can be shown / hidden
+  ShowConditional,
+  // Field can be shown to the user but as disabled
+  EnableConditional,
+  // Field result can be shown / hidden on the review page
+  DisplayOnReviewConditional
+]) as unknown as z.ZodDiscriminatedUnion<'type', AllFieldConditionalFields[]>
+
+export type FieldConditional = z.infer<typeof FieldConditional>

--- a/packages/commons/src/events/FieldConfig.ts
+++ b/packages/commons/src/events/FieldConfig.ts
@@ -9,7 +9,7 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 import { z } from 'zod'
-import { Conditional, ActionConditional } from './Conditional'
+import { Conditional, FieldConditional } from './Conditional'
 import { TranslationConfig } from './TranslationConfig'
 
 import { FieldType } from './FieldType'
@@ -44,7 +44,7 @@ const BaseField = z.object({
       DependencyExpression
     ])
     .optional(),
-  conditionals: z.array(ActionConditional).default([]).optional(),
+  conditionals: z.array(FieldConditional).default([]).optional(),
   required: z.boolean().default(false).optional(),
   disabled: z.boolean().default(false).optional(),
   hidden: z.boolean().default(false).optional(),


### PR DESCRIPTION
Fix bug with isBefore and isAfter validations when referring to other fields.

Previously the validation failed if the reference field was undefined. We want it to pass.

E.g.:

Validator: `field('mother.dob').isBefore().date(field('child.dob'))` should pass even if child.dob is undefined.