### PR TITLE
field reference validation should pass if reference field is undefined

### DIFF
--- a/packages/commons/src/conditionals/conditionals.test.ts
+++ b/packages/commons/src/conditionals/conditionals.test.ts
@@ -197,7 +197,7 @@ describe('"field" conditionals', () => {
           'mother.dob': '1990-01-02'
         })
       )
-    ).toBe(false)
+    ).toBe(true)
 
     // Reference to another field, when the comparable field is wrong format
     expect(
@@ -285,7 +285,7 @@ describe('"field" conditionals', () => {
           'child.dob': '1990-01-02'
         })
       )
-    ).toBe(false)
+    ).toBe(true)
 
     // Reference to another field, when the comparable field is wrong format
     expect(

--- a/packages/commons/src/conditionals/conditionals.ts
+++ b/packages/commons/src/conditionals/conditionals.ts
@@ -180,29 +180,27 @@ function getDateFromNow(days: number) {
     .toISOString()
     .split('T')[0]
 }
-
-/* This function will output JSONSchema which looks for example like this:
-{
-  "type": "object",
-  "properties": {
-    "mother.dob": {
-      "type": "string",
-      "format": "date",
-      "formatMaximum": {
-        "$data": "1/child.dob"
-      }
-    },
-    "child.dob": {
-      "type": "string",
-      "format": "date"
-    }
-  },
-  "required": [
-    "mother.dob",
-    "child.dob"
-  ]
-}
-*/
+/**
+ * This function will output JSONSchema which looks for example like this:
+ * @example
+ * {
+ *   "type": "object",
+ *   "properties": {
+ *     "mother.dob": {
+ *       "type": "string",
+ *       "format": "date",
+ *       "formatMinimum": {
+ *         "$data": "1/child.dob"
+ *       }
+ *     },
+ *     "child.dob": {
+ *       "type": "string",
+ *       "format": "date"
+ *     }
+ *   },
+ *   "required": ["mother.dob"]
+ * }
+ */
 function getDateRangeToFieldReference(
   fieldId: string,
   comparedFieldId: string,
@@ -218,7 +216,7 @@ function getDateRangeToFieldReference(
       },
       [comparedFieldId]: { type: 'string', format: 'date' }
     },
-    required: [fieldId, comparedFieldId]
+    required: [fieldId]
   }
 }
 


### PR DESCRIPTION
Fix bug with isBefore and isAfter validations when referring to other fields.

Previously the validation failed if the reference field was undefined. We want it to pass.

E.g.:

Validator: `field('mother.dob').isBefore().date(field('child.dob'))` should pass even if child.dob is undefined.