### PR TITLE
Don't hide outputs from review page unless they are undefined.

### DIFF
--- a/packages/client/src/v2-events/features/events/components/Review.tsx
+++ b/packages/client/src/v2-events/features/events/components/Review.tsx
@@ -341,8 +341,10 @@ function FormReview({
             return <></>
           }
 
+          // Only display fields that have a non-undefined/null value or have an validation error
           const displayedFields = fields.filter(
             ({ valueDisplay, errorDisplay }) => {
+              // Explicitly check for undefined and null, so that e.g. number 0 and empty string outputs are shown
               const hasValue =
                 valueDisplay !== undefined && valueDisplay !== null
               return hasValue || Boolean(errorDisplay)

--- a/packages/client/src/v2-events/features/events/components/Review.tsx
+++ b/packages/client/src/v2-events/features/events/components/Review.tsx
@@ -368,8 +368,9 @@ function FormReview({
                   {fields
                     .filter(
                       ({ valueDisplay, errorDisplay }) =>
-                        // Explicitly check for undefined, so that e.g. number 0 and empty string is considered a value
-                        valueDisplay !== undefined || errorDisplay
+                        // Explicitly check for undefined and null, so that e.g. number 0 and empty string is considered a value
+                        (valueDisplay !== undefined && valueDisplay !== null) ||
+                        errorDisplay
                     )
                     .map(({ id, label, errorDisplay, valueDisplay }) => (
                       <ListReview.Row

--- a/packages/client/src/v2-events/features/events/components/Review.tsx
+++ b/packages/client/src/v2-events/features/events/components/Review.tsx
@@ -341,6 +341,14 @@ function FormReview({
             return <></>
           }
 
+          const displayedFields = fields.filter(
+            ({ valueDisplay, errorDisplay }) => {
+              const hasValue =
+                valueDisplay !== undefined && valueDisplay !== null
+              return hasValue || Boolean(errorDisplay)
+            }
+          )
+
           return (
             <DeclarationDataContainer
               key={'Section_' + page.title.defaultMessage}
@@ -365,13 +373,8 @@ function FormReview({
                 name={'Accordion_' + page.id}
               >
                 <ListReview id={'Section_' + page.id}>
-                  {fields
-                    .filter(({ valueDisplay, errorDisplay }) => {
-                      const hasValue =
-                        valueDisplay !== undefined && valueDisplay !== null
-                      return hasValue || Boolean(errorDisplay)
-                    })
-                    .map(({ id, label, errorDisplay, valueDisplay }) => (
+                  {displayedFields.map(
+                    ({ id, label, errorDisplay, valueDisplay }) => (
                       <ListReview.Row
                         key={id}
                         actions={
@@ -395,7 +398,8 @@ function FormReview({
                         label={intl.formatMessage(label)}
                         value={errorDisplay || valueDisplay}
                       />
-                    ))}
+                    )
+                  )}
                 </ListReview>
               </Accordion>
             </DeclarationDataContainer>

--- a/packages/client/src/v2-events/features/events/components/Review.tsx
+++ b/packages/client/src/v2-events/features/events/components/Review.tsx
@@ -366,12 +366,11 @@ function FormReview({
               >
                 <ListReview id={'Section_' + page.id}>
                   {fields
-                    .filter(
-                      ({ valueDisplay, errorDisplay }) =>
-                        // Explicitly check for undefined and null, so that e.g. number 0 and empty string is considered a value
-                        (valueDisplay !== undefined && valueDisplay !== null) ||
-                        errorDisplay
-                    )
+                    .filter(({ valueDisplay, errorDisplay }) => {
+                      const hasValue =
+                        valueDisplay !== undefined && valueDisplay !== null
+                      return hasValue || Boolean(errorDisplay)
+                    })
                     .map(({ id, label, errorDisplay, valueDisplay }) => (
                       <ListReview.Row
                         key={id}

--- a/packages/client/src/v2-events/features/events/components/Review.tsx
+++ b/packages/client/src/v2-events/features/events/components/Review.tsx
@@ -368,7 +368,8 @@ function FormReview({
                   {fields
                     .filter(
                       ({ valueDisplay, errorDisplay }) =>
-                        valueDisplay || errorDisplay
+                        // Explicitly check for undefined, so that e.g. number 0 and empty string is considered a value
+                        valueDisplay !== undefined || errorDisplay
                     )
                     .map(({ id, label, errorDisplay, valueDisplay }) => (
                       <ListReview.Row


### PR DESCRIPTION
## Description

https://github.com/opencrvs/opencrvs-core/issues/9157

Don't hide `<Output/>` values on the review page unless they are undefined/null. We want to show empty strings.

## Checklist

- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly


Before:
![register events-v2-test-environment opencrvs dev_v2](https://github.com/user-attachments/assets/378d429a-ccad-4d0e-9838-06225b6ad3fd)

After:
![localhost_3000_v2_events_declare_912db736-2cff-4eba-b479-db982b4e11bc_review](https://github.com/user-attachments/assets/c2b42674-5969-475a-a065-c3a539c899d7)
