### PR TITLE
Calculate pageIdx from visiblePages, not all pages

### DIFF
--- a/packages/client/src/v2-events/features/events/components/Pages.tsx
+++ b/packages/client/src/v2-events/features/events/components/Pages.tsx
@@ -53,9 +53,8 @@ export function Pages({
   declaration?: EventState
 }) {
   const intl = useIntl()
-
-  const pageIdx = formPages.findIndex((p) => p.id === pageId)
   const visiblePages = formPages.filter((page) => isPageVisible(page, form))
+  const pageIdx = visiblePages.findIndex((p) => p.id === pageId)
 
   const {
     page: currentPage,


### PR DESCRIPTION
## Description

https://github.com/opencrvs/opencrvs-core/issues/9144

This caused a bug, where:

1. if there are hidden pages on the form
2. user presses browser's 'back' button on review page
3. `pageIdx` would be calculated from all pages, not just visible pages, i.e. it would be too large and would not find a page
4. frontend crashes with confusing error

## Checklist

- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly

