### PR TITLE
remove comment tags from pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,3 @@
-<!--
 ## Description
 
 Link to the GitHub issue (or name the branch `ocrvs-<issue #>`)
@@ -11,4 +10,3 @@ Explain how the issue was fixed (if applicable) and the root cause.
 - [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
 - [ ] I have updated the changelog with this change (if applicable)
 - [ ] I have updated the GitHub issue status accordingly
--->


### PR DESCRIPTION
## Description

No need to have the PR template in comments by default

## Checklist

- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly