### PR TITLE
fix updates to informant type from any to mother, father

### DIFF
--- a/packages/commons/src/fhir/transformers/utils.ts
+++ b/packages/commons/src/fhir/transformers/utils.ts
@@ -61,7 +61,6 @@ import {
   isObservation,
   isURLReference,
   urlReferenceToResourceIdentifier,
-  BundleEntryWithFullUrl,
   findEntryFromBundle
 } from '..'
 
@@ -804,9 +803,9 @@ export function setInformantReference<T extends CompositionSectionCode>(
     throw new Error(`${sectionCode} not found in composition!`)
   }
   const personSectionEntry = section.entry[0]
-  const personEntry = fhirBundle.entry.find(
-    (entry): entry is BundleEntryWithFullUrl<Patient> =>
-      entry.fullUrl === personSectionEntry.reference
+  const personEntry = findEntryFromBundle(
+    fhirBundle,
+    personSectionEntry.reference
   )
   if (!personEntry) {
     return


### PR DESCRIPTION
Add fix for updating informant type in birth declaration from any to mother, father.

Fix already exists in release-v1.7.0 but the fix in there is spread over several commits affecting several files. Since 1.6.3 is not going to be merged into develop, applying the fix without cherry picking