### PR TITLE
fix: ensure user create/update is allowed only in jurisdiction

### DIFF
--- a/packages/client/src/user/userReducer.ts
+++ b/packages/client/src/user/userReducer.ts
@@ -312,9 +312,7 @@ export const userFormReducer: LoopReducer<IUserFormState, UserFormAction> = (
       }
 
     case SUBMIT_USER_FORM_DATA:
-      const { client, mutation, variables, isUpdate } = (
-        action as IUserFormDataSubmitAction
-      ).payload
+      const { client, mutation, variables, isUpdate } = action.payload
       const token = getToken()
       const tokenPayload = getTokenPayload(token)
       const userDetails = variables.user
@@ -368,7 +366,7 @@ export const userFormReducer: LoopReducer<IUserFormState, UserFormAction> = (
       const { errorData } = action.payload
       const duplicateErrorFromGQL = errorData?.graphQLErrors?.find(
         (gqlErr) =>
-          gqlErr.extensions.invalidArgs.duplicateNotificationMethodError
+          gqlErr.extensions.invalidArgs?.duplicateNotificationMethodError
       )
 
       if (duplicateErrorFromGQL) {

--- a/packages/client/src/views/SysAdmin/Team/user/userCreation/CreateNewUser.tsx
+++ b/packages/client/src/views/SysAdmin/Team/user/userCreation/CreateNewUser.tsx
@@ -36,12 +36,12 @@ import { gqlToDraftTransformer } from '@client/transformer'
 import { messages as userFormMessages } from '@client/i18n/messages/views/userForm'
 import { CREATE_USER_ON_LOCATION } from '@client/navigation/routes'
 import { getOfflineData } from '@client/offline/selectors'
-import { getUserDetails } from '@client/profile/profileSelectors'
+import { getScope, getUserDetails } from '@client/profile/profileSelectors'
 import {
   RouteComponentProps,
   withRouter
 } from '@client/components/WithRouterProps'
-import { UUID } from '@opencrvs/commons/client'
+import { Scope, SCOPES, UUID } from '@opencrvs/commons/client'
 
 type IUserProps = {
   userId?: string
@@ -221,6 +221,7 @@ function addJurisdictionFilterToLocationSearchInput(
 const mapStateToProps = (state: IStoreState, props: RouteComponentProps) => {
   const config = getOfflineData(state)
   const user = getUserDetails(state)
+  const scopes = getScope(state) ?? []
   const sectionId =
     props.router.params.sectionId || state.userForm.userForm!.sections[0].id
 
@@ -236,10 +237,19 @@ const mapStateToProps = (state: IStoreState, props: RouteComponentProps) => {
     throw new Error(`No primary office found for user`)
   }
 
-  section = addJurisdictionFilterToLocationSearchInput(
-    section,
-    user.primaryOffice.id as UUID
+  section = scopes.some((scope) =>
+    (
+      [
+        SCOPES.USER_CREATE_MY_JURISDICTION,
+        SCOPES.USER_UPDATE_MY_JURISDICTION
+      ] as Scope[]
+    ).includes(scope)
   )
+    ? addJurisdictionFilterToLocationSearchInput(
+        section,
+        user.primaryOffice.id as UUID
+      )
+    : section
 
   let formData = { ...state.userForm.userFormData }
   if (props.router.params.locationId) {

--- a/packages/gateway/src/features/user/root-resolvers.ts
+++ b/packages/gateway/src/features/user/root-resolvers.ts
@@ -320,16 +320,17 @@ export const resolvers: GQLResolver = {
       )
       const userId = tokenPayload.sub
       const requestingUser = await getUser({ userId }, authHeader)
+      const isUnderJurisdiction = await isOfficeUnderJurisdiction(
+        requestingUser.primaryOfficeId as UUID,
+        user.primaryOffice as UUID
+      )
       if (
         inScope(authHeader, [
           SCOPES.USER_CREATE_MY_JURISDICTION,
           SCOPES.USER_UPDATE_MY_JURISDICTION
         ]) &&
         user.primaryOffice &&
-        !isOfficeUnderJurisdiction(
-          requestingUser.primaryOfficeId as UUID,
-          user.primaryOffice as UUID
-        )
+        !isUnderJurisdiction
       ) {
         throw new Error(
           'Cannot create or update user in offices not under jurisdiction'

--- a/packages/gateway/src/features/user/root-resolvers.ts
+++ b/packages/gateway/src/features/user/root-resolvers.ts
@@ -27,9 +27,8 @@ import {
   inScope,
   isTokenOwner,
   getUserId,
-  getTokenPayload,
-  getUser,
-  isOfficeUnderJurisdiction
+  isOfficeUnderJurisdiction,
+  getUserFromHeader
 } from '@gateway/features/user/utils'
 import {
   GQLHumanNameInput,
@@ -322,11 +321,7 @@ export const resolvers: GQLResolver = {
         ]) &&
         user.primaryOffice
       ) {
-        const tokenPayload = getTokenPayload(
-          authHeader.Authorization.split(' ')[1]
-        )
-        const userId = tokenPayload.sub
-        const requestingUser = await getUser({ userId }, authHeader)
+        const requestingUser = await getUserFromHeader(authHeader)
         const isUnderJurisdiction = await isOfficeUnderJurisdiction(
           requestingUser.primaryOfficeId as UUID,
           user.primaryOffice as UUID

--- a/packages/gateway/src/features/user/utils/index.ts
+++ b/packages/gateway/src/features/user/utils/index.ts
@@ -136,6 +136,11 @@ export const getUserId = (authHeader: IAuthHeader): string => {
   return tokenPayload.sub
 }
 
+export function getUserFromHeader(header: IAuthHeader) {
+  const userId = getUserId(header)
+  return getUser({ userId }, header)
+}
+
 export function getFullName(user: IUserModelData, language: string) {
   const localName = user.name.find((name) => name.use === language)
   return `${localName?.given.join(' ') || ''} ${localName?.family || ''}`.trim()

--- a/packages/gateway/src/location.ts
+++ b/packages/gateway/src/location.ts
@@ -60,3 +60,18 @@ export const fetchLocationChildren = async (id: UUID) => {
 
   return response.json() as Promise<SavedLocation[]>
 }
+
+const FETCH_ALL_LOCATION_HIERARCHY = (id: UUID) =>
+  new URL(`/locations/${id}/hierarchy`, APPLICATION_CONFIG_URL)
+
+export const fetchLocationHierarchy = async (id: UUID) => {
+  const response = await fetch(FETCH_ALL_LOCATION_HIERARCHY(id))
+
+  if (!response.ok) {
+    throw new Error(
+      `Couldn't fetch the hierarchy of a location from config: ${await response.text()}`
+    )
+  }
+
+  return response.json() as Promise<SavedLocation[]>
+}

--- a/packages/workflow/src/utils/location.ts
+++ b/packages/workflow/src/utils/location.ts
@@ -22,7 +22,7 @@ export const fetchLocationHierarchy = async (id: UUID) => {
 
   if (!response.ok) {
     throw new Error(
-      `Couldn't fetch the hierarch of a location from config: ${await response.text()}`
+      `Couldn't fetch the hierarchy of a location from config: ${await response.text()}`
     )
   }
 


### PR DESCRIPTION
## Description

#9188 
Allow users to create/update users only in their own jurisdiction.

## Checklist

- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
