### PR TITLE
Fix logic for disallowing event deletion

### DIFF
--- a/packages/events/src/router/event/__snapshots__/event.delete.test.ts.snap
+++ b/packages/events/src/router/event/__snapshots__/event.delete.test.ts.snap
@@ -1,3 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`declared event can not be deleted 1`] = `[TRPCError: A declared or notified event can not be deleted]`;
+
 exports[`should return 404 if event does not exist 1`] = `[TRPCError: Event not found with ID: some event]`;

--- a/packages/events/src/router/event/event.delete.test.ts
+++ b/packages/events/src/router/event/event.delete.test.ts
@@ -62,6 +62,21 @@ test('stored events can be deleted', async () => {
   )
 })
 
+test('declared event can not be deleted', async () => {
+  const { user, generator } = await setupTestCase()
+  const client = createTestClient(user)
+
+  const event = await client.event.create(generator.event.create())
+
+  await client.event.actions.declare.request(
+    generator.event.actions.declare(event.id)
+  )
+
+  await expect(
+    client.event.delete({ eventId: event.id })
+  ).rejects.toThrowErrorMatchingSnapshot()
+})
+
 describe('check unreferenced draft attachments are deleted while final action submission', () => {
   const deleteUnreferencedDraftAttachmentsMock = vi.fn()
   const fileExistMock = vi.fn()

--- a/packages/events/src/service/events/events.ts
+++ b/packages/events/src/service/events/events.ts
@@ -26,7 +26,9 @@ import {
   getDeclarationFields,
   getAcceptedActions,
   AsyncRejectActionDocument,
-  ActionType
+  ActionType,
+  getCurrentEventState,
+  EventStatus
 } from '@opencrvs/commons/events'
 import { getUUID } from '@opencrvs/commons'
 import { getEventConfigurationById } from '@events/service/config/config'
@@ -117,17 +119,13 @@ export async function deleteEvent(
     throw new EventNotFoundError(eventId)
   }
 
-  /**
-   * Once an event is declared, it cannot be removed anymore.
-   */
-  const hasNonDeletableActions = event.actions.some(
-    (action) => action.type !== ActionType.CREATE
-  )
+  const eventState = getCurrentEventState(event)
 
-  if (hasNonDeletableActions) {
+  // Once an event is declared or notified, it can not be deleted anymore
+  if (eventState.status !== EventStatus.CREATED) {
     throw new TRPCError({
       code: 'BAD_REQUEST',
-      message: 'Event has actions that cannot be deleted'
+      message: 'A declared or notified event can not be deleted'
     })
   }
 


### PR DESCRIPTION
## Description

This fixes both:
https://github.com/opencrvs/opencrvs-core/issues/9213
https://github.com/opencrvs/opencrvs-core/issues/9206

E2e tests: https://github.com/opencrvs/opencrvs-farajaland/pull/1336

Fix logic for disallowing event deletion. Previously e.g. READ actions prevented event deletion, which we dont want.

## Checklist

- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
