### PR TITLE
Automatically unassign user when submitting an action

### DIFF
--- a/packages/client/src/v2-events/custom-api/index.ts
+++ b/packages/client/src/v2-events/custom-api/index.ts
@@ -80,7 +80,8 @@ export async function validateOnDeclare(variables: {
     declaration,
     annotation,
     eventId,
-    transactionId: getUUID()
+    transactionId: getUUID(),
+    keepAssignment: true
   })
 
   const latestResponse = await trpcClient.event.actions.validate.request.mutate(
@@ -90,8 +91,7 @@ export async function validateOnDeclare(variables: {
       annotation,
       eventId,
       transactionId: getUUID(),
-      duplicates: [],
-      keepAssignment: true
+      duplicates: []
     }
   )
 

--- a/packages/client/src/v2-events/custom-api/index.ts
+++ b/packages/client/src/v2-events/custom-api/index.ts
@@ -38,7 +38,8 @@ export async function registerOnDeclare({
     declaration,
     annotation,
     eventId,
-    transactionId: getUUID()
+    transactionId: getUUID(),
+    keepAssignment: true
   })
 
   // update is a patch, no need to send again.
@@ -47,7 +48,8 @@ export async function registerOnDeclare({
     annotation,
     eventId,
     transactionId: getUUID(),
-    duplicates: []
+    duplicates: [],
+    keepAssignment: true
   })
 
   const latestResponse = await trpcClient.event.actions.register.request.mutate(
@@ -88,7 +90,8 @@ export async function validateOnDeclare(variables: {
       annotation,
       eventId,
       transactionId: getUUID(),
-      duplicates: []
+      duplicates: [],
+      keepAssignment: true
     }
   )
 
@@ -112,7 +115,8 @@ export async function registerOnValidate(variables: {
     annotation,
     eventId,
     transactionId: getUUID(),
-    duplicates: []
+    duplicates: [],
+    keepAssignment: true
   })
 
   const latestResponse = await trpcClient.event.actions.register.request.mutate(

--- a/packages/client/src/v2-events/features/workqueues/EventOverview/components/ActionMenu.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/components/ActionMenu.tsx
@@ -22,7 +22,7 @@ import {
   type ActionConfig,
   getCurrentEventStateWithDrafts,
   getUUID,
-  EventIndex
+  isWriteAction
 } from '@opencrvs/commons/client'
 import { CaretDown } from '@opencrvs/components/lib/Icon/all-icons'
 import { PrimaryButton } from '@opencrvs/components/lib/buttons'
@@ -34,11 +34,7 @@ import { ROUTES } from '@client/v2-events/routes'
 import { messages } from '@client/i18n/messages/views/action'
 import ProtectedComponent from '@client/components/ProtectedComponent'
 import { useDrafts } from '@client/v2-events/features/drafts/useDrafts'
-import {
-  AssignmentStatus,
-  getAssignmentStatus,
-  isWriteAction
-} from '@client/v2-events/utils'
+import { AssignmentStatus, getAssignmentStatus } from '@client/v2-events/utils'
 
 const viewRecordMessage = {
   id: 'v2.view.record',

--- a/packages/client/src/v2-events/utils.ts
+++ b/packages/client/src/v2-events/utils.ts
@@ -25,8 +25,6 @@ import {
   isFieldValueWithoutTemplates,
   compositeFieldTypes,
   getDeclarationFields,
-  ActionType,
-  writeActions,
   SystemVariables
 } from '@opencrvs/commons/client'
 import { getLocations } from '@client/offline/selectors'
@@ -221,10 +219,6 @@ export function useResolveLocationFullName(
     partOf,
     joinValues([name, location.name], ', ')
   )
-}
-
-export function isWriteAction(actionType: ActionType): boolean {
-  return writeActions.safeParse(actionType).success
 }
 
 export const AssignmentStatus = {

--- a/packages/commons/src/events/ActionDocument.ts
+++ b/packages/commons/src/events/ActionDocument.ts
@@ -57,7 +57,8 @@ const AssignedAction = ActionBase.merge(
 
 const UnassignedAction = ActionBase.merge(
   z.object({
-    type: z.literal(ActionType.UNASSIGN)
+    type: z.literal(ActionType.UNASSIGN),
+    assignedTo: z.literal(null).default(null)
   })
 )
 

--- a/packages/commons/src/events/ActionInput.ts
+++ b/packages/commons/src/events/ActionInput.ts
@@ -18,7 +18,8 @@ export const BaseActionInput = z.object({
   transactionId: z.string(),
   declaration: ActionUpdate.default({}),
   annotation: ActionUpdate.optional(),
-  originalActionId: z.string().optional()
+  originalActionId: z.string().optional(),
+  keepAssignment: z.boolean().optional()
 })
 
 const CreateActionInput = BaseActionInput.merge(

--- a/packages/commons/src/events/ActionType.ts
+++ b/packages/commons/src/events/ActionType.ts
@@ -100,5 +100,7 @@ export type AnnotationActionType = z.infer<typeof annotationActions>
 /** Actions which requires the user to be assigned */
 export const writeActions = ActionTypes.exclude([
   ActionType.CREATE,
-  ActionType.READ
+  ActionType.READ,
+  ActionType.ASSIGN,
+  ActionType.UNASSIGN
 ])

--- a/packages/commons/src/events/test.utils.ts
+++ b/packages/commons/src/events/test.utils.ts
@@ -436,7 +436,7 @@ export function generateActionDocument({
     case ActionType.DECLARE:
       return { ...actionBase, type: action }
     case ActionType.UNASSIGN:
-      return { ...actionBase, type: action }
+      return { ...actionBase, type: action, assignedTo: null }
     case ActionType.ASSIGN:
       return { ...actionBase, assignedTo: getUUID(), type: action }
     case ActionType.VALIDATE:

--- a/packages/commons/src/events/utils.test.ts
+++ b/packages/commons/src/events/utils.test.ts
@@ -73,13 +73,15 @@ const testCases: { actions: Action[]; expected: Action | undefined }[] = [
       {
         ...commonAction,
         type: ActionType.UNASSIGN,
-        createdAt: '2023-01-01T02:00:00Z'
+        createdAt: '2023-01-01T02:00:00Z',
+        assignedTo: null
       }
     ],
     expected: {
       ...commonAction,
       type: ActionType.UNASSIGN,
-      createdAt: '2023-01-01T02:00:00Z'
+      createdAt: '2023-01-01T02:00:00Z',
+      assignedTo: null
     }
   },
   {
@@ -98,7 +100,8 @@ const testCases: { actions: Action[]; expected: Action | undefined }[] = [
       {
         ...commonAction,
         type: ActionType.UNASSIGN,
-        createdAt: '2023-01-01T02:00:00Z'
+        createdAt: '2023-01-01T02:00:00Z',
+        assignedTo: null
       },
       {
         ...commonAction,

--- a/packages/commons/src/events/utils.ts
+++ b/packages/commons/src/events/utils.ts
@@ -14,7 +14,8 @@ import { workqueues } from '../workqueues'
 import {
   ActionType,
   DeclarationActionType,
-  DeclarationActions
+  DeclarationActions,
+  writeActions
 } from './ActionType'
 import { EventConfig } from './EventConfig'
 import { FieldConfig } from './FieldConfig'
@@ -252,4 +253,8 @@ export function findLastAssignmentAction(actions: Action[]) {
  */
 export type IndexMap<T> = {
   [id: string]: T | undefined
+}
+
+export function isWriteAction(actionType: ActionType): boolean {
+  return writeActions.safeParse(actionType).success
 }

--- a/packages/events/src/router/event/event.actions.archive.test.ts
+++ b/packages/events/src/router/event/event.actions.archive.test.ts
@@ -51,8 +51,11 @@ test(`contains both ${ActionType.MARKED_AS_DUPLICATE} and ${ActionType.ARCHIVE} 
     )
   ).actions.map(({ type }) => type)
 
-  expect(actions.at(-1)).toStrictEqual(ActionType.ARCHIVE)
-  expect(actions.at(-2)).toStrictEqual(ActionType.MARKED_AS_DUPLICATE)
+  expect(actions.slice(-3)).toEqual([
+    ActionType.MARKED_AS_DUPLICATE,
+    ActionType.ARCHIVE,
+    ActionType.UNASSIGN
+  ])
 })
 
 test(`should only contain ${ActionType.ARCHIVE} action if not marked as duplicate`, async () => {
@@ -71,6 +74,6 @@ test(`should only contain ${ActionType.ARCHIVE} action if not marked as duplicat
     )
   ).actions.map(({ type }) => type)
 
-  expect(actions.at(-1)).toStrictEqual(ActionType.ARCHIVE)
-  expect(actions.at(-2)).not.toStrictEqual(ActionType.MARKED_AS_DUPLICATE)
+  expect(actions.at(-2)).toStrictEqual(ActionType.ARCHIVE)
+  expect(actions.at(-3)).not.toStrictEqual(ActionType.MARKED_AS_DUPLICATE)
 })

--- a/packages/events/src/router/event/event.actions.correction.test.ts
+++ b/packages/events/src/router/event/event.actions.correction.test.ts
@@ -11,7 +11,6 @@
 
 import { TRPCError } from '@trpc/server'
 import {
-  ActionDocument,
   ActionType,
   AddressType,
   EventDocument,

--- a/packages/events/src/router/event/event.actions.correction.test.ts
+++ b/packages/events/src/router/event/event.actions.correction.test.ts
@@ -124,9 +124,12 @@ test('a correction request can be added to a created event', async () => {
     generator.event.actions.correction.request(registeredEvent.id)
   )
 
-  expect(
-    withCorrectionRequest.actions[withCorrectionRequest.actions.length - 1].type
-  ).toBe(ActionType.REQUEST_CORRECTION)
+  expect(withCorrectionRequest.actions.slice(-2)).toEqual([
+    expect.objectContaining({
+      type: ActionType.REQUEST_CORRECTION
+    }),
+    expect.objectContaining({ type: ActionType.UNASSIGN })
+  ])
 })
 
 test(`${ActionType.REQUEST_CORRECTION} validation error message contains all the offending fields`, async () => {
@@ -260,9 +263,12 @@ test('a correction request can be added to a created event', async () => {
     generator.event.actions.correction.request(registeredEvent.id)
   )
 
-  expect(
-    withCorrectionRequest.actions[withCorrectionRequest.actions.length - 1].type
-  ).toBe(ActionType.REQUEST_CORRECTION)
+  expect(withCorrectionRequest.actions.slice(-2)).toEqual([
+    expect.objectContaining({
+      type: ActionType.REQUEST_CORRECTION
+    }),
+    expect.objectContaining({ type: ActionType.UNASSIGN })
+  ])
 })
 
 describe('when a correction request exists', () => {
@@ -309,14 +315,13 @@ describe('when a correction request exists', () => {
           requestId
         )
       )
-
-    const lastAction = withApprovedCorrectionRequest.actions[
-      withApprovedCorrectionRequest.actions.length - 1
-    ] as Extract<ActionDocument, { type: 'APPROVE_CORRECTION' }>
-
-    expect(lastAction.type).toBe(ActionType.APPROVE_CORRECTION)
-
-    expect(lastAction.requestId).toBe(requestId)
+    expect(withApprovedCorrectionRequest.actions.slice(-2)).toEqual([
+      expect.objectContaining({
+        type: ActionType.APPROVE_CORRECTION,
+        requestId
+      }),
+      expect.objectContaining({ type: ActionType.UNASSIGN })
+    ])
   })
 
   test('approving a request fails if request id is incorrect', async () => {

--- a/packages/events/src/router/event/event.actions.declare.test.ts
+++ b/packages/events/src/router/event/event.actions.declare.test.ts
@@ -261,6 +261,7 @@ test('valid action is appended to event actions', async () => {
     expect.objectContaining({
       type: ActionType.DECLARE
     }),
+    expect.objectContaining({ type: ActionType.UNASSIGN }),
     expect.objectContaining({
       type: ActionType.READ
     })

--- a/packages/events/src/router/event/event.actions.printCertificate.test.ts
+++ b/packages/events/src/router/event/event.actions.printCertificate.test.ts
@@ -96,9 +96,10 @@ test(`${ActionType.PRINT_CERTIFICATE} action can be added to registered event`, 
     generator.event.actions.printCertificate(registeredEvent.id)
   )
 
-  expect(
-    printCertificate.actions[printCertificate.actions.length - 1].type
-  ).toBe(ActionType.PRINT_CERTIFICATE)
+  expect(printCertificate.actions.slice(-2)).toEqual([
+    expect.objectContaining({ type: ActionType.PRINT_CERTIFICATE }),
+    expect.objectContaining({ type: ActionType.UNASSIGN })
+  ])
 })
 
 test('when mandatory field is invalid, conditional hidden fields are still skipped', async () => {

--- a/packages/events/src/router/event/event.actions.reject.test.ts
+++ b/packages/events/src/router/event/event.actions.reject.test.ts
@@ -51,5 +51,8 @@ test(`should contain REJECT action for a valid request`, async () => {
     )
   ).actions.map(({ type }) => type)
 
-  expect(actions.at(-1)).toStrictEqual(ActionType.REJECT)
+  expect(actions.slice(-2)).toStrictEqual([
+    ActionType.REJECT,
+    ActionType.UNASSIGN
+  ])
 })

--- a/packages/events/src/router/event/event.actions.test.ts
+++ b/packages/events/src/router/event/event.actions.test.ts
@@ -29,7 +29,8 @@ test('actions can be added to created events', async () => {
   expect(event.actions).toEqual([
     expect.objectContaining({ type: ActionType.CREATE }),
     expect.objectContaining({ type: ActionType.ASSIGN }),
-    expect.objectContaining({ type: ActionType.DECLARE })
+    expect.objectContaining({ type: ActionType.DECLARE }),
+    expect.objectContaining({ type: ActionType.UNASSIGN })
   ])
 })
 
@@ -56,8 +57,11 @@ test('Action data can be retrieved', async () => {
     expect.objectContaining({ type: ActionType.CREATE }),
     expect.objectContaining({ type: ActionType.ASSIGN }),
     expect.objectContaining({ type: ActionType.DECLARE }),
+    expect.objectContaining({ type: ActionType.UNASSIGN }),
     expect.objectContaining({ type: ActionType.VALIDATE }),
+    expect.objectContaining({ type: ActionType.UNASSIGN }),
     expect.objectContaining({ type: ActionType.REGISTER }),
+    expect.objectContaining({ type: ActionType.UNASSIGN }),
     expect.objectContaining({ type: ActionType.READ })
   ])
 })

--- a/packages/events/src/router/event/event.actions.validate.test.ts
+++ b/packages/events/src/router/event/event.actions.validate.test.ts
@@ -215,9 +215,11 @@ test('valid action is appended to event actions', async () => {
     expect.objectContaining({
       type: ActionType.DECLARE
     }),
+    expect.objectContaining({ type: ActionType.UNASSIGN }),
     expect.objectContaining({
       type: ActionType.VALIDATE
     }),
+    expect.objectContaining({ type: ActionType.UNASSIGN }),
     expect.objectContaining({
       type: ActionType.READ
     })

--- a/packages/events/src/router/event/event.delete.test.ts
+++ b/packages/events/src/router/event/event.delete.test.ts
@@ -161,6 +161,7 @@ describe('check unreferenced draft attachments are deleted while final action su
       expect.objectContaining({ type: ActionType.CREATE }),
       expect.objectContaining({ type: ActionType.ASSIGN }),
       expect.objectContaining({ type: ActionType.DECLARE }),
+      expect.objectContaining({ type: ActionType.UNASSIGN }),
       expect.objectContaining({ type: ActionType.READ })
     ])
   })

--- a/packages/events/src/service/events/events.ts
+++ b/packages/events/src/service/events/events.ts
@@ -303,11 +303,13 @@ export async function addAction(
   }
 
   if (input.type === ActionType.ARCHIVE && input.annotation?.isDuplicate) {
-    input.transactionId = getUUID()
+    input.transactionId = `${transactionId}-${ActionType.MARKED_AS_DUPLICATE.toLocaleLowerCase()}`
     await db.collection<EventDocument>('events').updateOne(
       {
         id: eventId,
-        'actions.transactionId': { $nin: [transactionId, input.transactionId] }
+        'actions.transactionId': {
+          $ne: input.transactionId
+        }
       },
       {
         $push: {
@@ -326,8 +328,9 @@ export async function addAction(
         }
       }
     )
-    input.transactionId = transactionId
   }
+
+  input.transactionId = `${transactionId}-${input.type.toLocaleLowerCase()}`
 
   const action: ActionDocument = {
     ...input,
@@ -341,18 +344,21 @@ export async function addAction(
   await db
     .collection<EventDocument>('events')
     .updateOne(
-      { id: eventId, 'actions.transactionId': { $ne: transactionId } },
+      { id: eventId, 'actions.transactionId': { $ne: input.transactionId } },
       { $push: { actions: action }, $set: { updatedAt: now } }
     )
 
   if (isWriteAction(input.type) && !input.keepAssignment) {
+    input.transactionId = `${transactionId}-${ActionType.UNASSIGN.toLocaleLowerCase()}`
     await db.collection<EventDocument>('events').updateOne(
-      { id: eventId },
+      { id: eventId, 'actions.transactionId': { $ne: input.transactionId } },
       {
         $push: {
           actions: {
+            ...input,
             type: ActionType.UNASSIGN,
             declaration: {},
+            assignedTo: null,
             createdBy,
             createdAt: now,
             createdAtLocation,


### PR DESCRIPTION
## Description

Link to the GitHub issue https://github.com/opencrvs/opencrvs-core/issues/9102

 - Adds `Unassign` action with every writeActions
 - Exception: Don't add Unassign action when it's an intermediate action. (declare for validateOnDeclare)

## Checklist

- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
