### PR TITLE
fix: use closest role entry when none available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 - Fix the informant column on the Perfomance page showing "Other family member" when `Someone else` is selected for a registration [#6157](https://github.com/opencrvs/opencrvs-core/issues/6157)
 - Fix the event name displayed in email templates for death correction requests [#7703](https://github.com/opencrvs/opencrvs-core/issues/7703)
 - Fix the "email all users" feature by setting the _To_ email to the logged user's email [#8343](https://github.com/opencrvs/opencrvs-core/issues/8343)
+- Use the first role assigned to a user for record history entry if no role found at the point of time when the action was performed [#9300](https://github.com/opencrvs/opencrvs-core/issues/9300)
 
 ## 1.6.3 Release candidate
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## 1.7.0 Release candidate
+## 1.7.1 Release candidate
+
+### Bug fixes
+
+- Use the first role assigned to a user for record history entry if no role found at the point of time when the action was performed [#9300](https://github.com/opencrvs/opencrvs-core/issues/9300)
+
+## [1.7.0](https://github.com/opencrvs/opencrvs-core/compare/v1.6.2...v1.7.0)
 
 ### Breaking changes
 
@@ -52,7 +58,6 @@
 - Fix the informant column on the Perfomance page showing "Other family member" when `Someone else` is selected for a registration [#6157](https://github.com/opencrvs/opencrvs-core/issues/6157)
 - Fix the event name displayed in email templates for death correction requests [#7703](https://github.com/opencrvs/opencrvs-core/issues/7703)
 - Fix the "email all users" feature by setting the _To_ email to the logged user's email [#8343](https://github.com/opencrvs/opencrvs-core/issues/8343)
-- Use the first role assigned to a user for record history entry if no role found at the point of time when the action was performed [#9300](https://github.com/opencrvs/opencrvs-core/issues/9300)
 
 ## 1.6.3 Release candidate
 

--- a/packages/commons/src/fhir/practitioner.ts
+++ b/packages/commons/src/fhir/practitioner.ts
@@ -104,12 +104,17 @@ export const getUserRoleFromHistory = (
     )
   })
 
-  const result = practitionerRoleHistorySorted.find(
-    (it) =>
-      it?.meta?.lastUpdated &&
-      lastModified &&
-      it?.meta?.lastUpdated <= lastModified!
-  )
+  /*
+   * Find the the first history entry that was added before the
+   * lastModified date or take the earliest entry if none found
+   */
+  const result =
+    practitionerRoleHistorySorted.find(
+      (it) =>
+        it?.meta?.lastUpdated &&
+        lastModified &&
+        it?.meta?.lastUpdated <= lastModified!
+    ) ?? practitionerRoleHistorySorted.at(-1)
 
   const targetCode = result?.code?.find((element) => {
     return element.coding?.[0].system === 'http://opencrvs.org/specs/roles'

--- a/packages/commons/src/fhir/practitioner.ts
+++ b/packages/commons/src/fhir/practitioner.ts
@@ -86,7 +86,7 @@ export function getPractitionerContactDetails(practitioner: Practitioner) {
 
 export const getUserRoleFromHistory = (
   practitionerRoleHistory: PractitionerRoleHistory[],
-  lastModified: string
+  timePoint: string
 ) => {
   const practitionerRoleHistorySorted = practitionerRoleHistory.sort((a, b) => {
     if (a.meta?.lastUpdated === b.meta?.lastUpdated) {
@@ -106,14 +106,12 @@ export const getUserRoleFromHistory = (
 
   /*
    * Find the the first history entry that was added before the
-   * lastModified date or take the earliest entry if none found
+   * given point in time or take the earliest entry if none found
    */
   const result =
     practitionerRoleHistorySorted.find(
       (it) =>
-        it?.meta?.lastUpdated &&
-        lastModified &&
-        it?.meta?.lastUpdated <= lastModified!
+        it?.meta?.lastUpdated && timePoint && it?.meta?.lastUpdated <= timePoint
     ) ?? practitionerRoleHistorySorted.at(-1)
 
   const targetCode = result?.code?.find((element) => {

--- a/packages/gateway/src/features/registration/recordHistory.test.ts
+++ b/packages/gateway/src/features/registration/recordHistory.test.ts
@@ -1,0 +1,67 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+import {
+  getUserRoleFromHistory,
+  PractitionerRoleHistory,
+  ResourceIdentifier
+} from '@opencrvs/commons/types'
+
+const history = [
+  {
+    resourceType: 'PractitionerRole',
+    id: '1',
+    meta: { versionId: '1', lastUpdated: '2020-01-01' },
+    location: [{ reference: 'Location/1' as ResourceIdentifier }],
+    code: [
+      {
+        coding: [
+          {
+            system: 'http://opencrvs.org/specs/roles',
+            code: 'REGISTRATION_AGENT'
+          }
+        ]
+      }
+    ]
+  },
+  {
+    resourceType: 'PractitionerRole',
+    id: '2',
+    location: [{ reference: 'Location/2' as ResourceIdentifier }],
+    meta: { versionId: '2', lastUpdated: '2023-01-01' },
+    code: [
+      {
+        coding: [
+          {
+            system: 'http://opencrvs.org/specs/roles',
+            code: 'LOCAL_REGISTRAR'
+          }
+        ]
+      }
+    ]
+  }
+] satisfies PractitionerRoleHistory[]
+
+describe('getUserRoleFromHistory', () => {
+  it('should find the user role from history at the given point in time', () => {
+    expect(getUserRoleFromHistory(history, '2022-01-15')).toEqual(
+      'REGISTRATION_AGENT'
+    )
+    expect(getUserRoleFromHistory(history, '2023-01-15')).toEqual(
+      'LOCAL_REGISTRAR'
+    )
+  })
+
+  it('should find the first user role from history if there is no role entry present in the given point in time', () => {
+    expect(getUserRoleFromHistory(history, '2019-01-15')).toEqual(
+      'REGISTRATION_AGENT'
+    )
+  })
+})

--- a/packages/gateway/src/features/registration/recordHistory.test.ts
+++ b/packages/gateway/src/features/registration/recordHistory.test.ts
@@ -59,7 +59,7 @@ describe('getUserRoleFromHistory', () => {
     )
   })
 
-  it('should find the first user role from history if there is no role entry present in the given point in time', () => {
+  it('should find the first user role from history if there is no role entry present at the given point in time', () => {
     expect(getUserRoleFromHistory(history, '2019-01-15')).toEqual(
       'REGISTRATION_AGENT'
     )


### PR DESCRIPTION
Records generated for demo purposes include history entries dated before even a user was created in the system. Therefore, those history entries are unable to be matched against the role of the user in that particular time period. We are now using the first role entry available for that user in those cases.


![9300](https://github.com/user-attachments/assets/74eb8b44-2b20-47f6-a080-8f72a3d85dd5)

P.S. Ignore the broken profile images please. I only restored mongo & elasticsearch locally so the minio documents weren't available in the system.

## Checklist

- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [x] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
