### PR TITLE
Support referencing fields in event summary fields

### DIFF
--- a/packages/client/src/v2-events/components/forms/FormFieldGenerator/FormSectionComponent.tsx
+++ b/packages/client/src/v2-events/components/forms/FormFieldGenerator/FormSectionComponent.tsx
@@ -23,8 +23,7 @@ import {
   isFieldEnabled,
   isFieldVisible,
   AddressType,
-  TranslationConfig,
-  deepMerge
+  TranslationConfig
 } from '@opencrvs/commons/client'
 import { TEXT } from '@client/forms'
 import {

--- a/packages/client/src/v2-events/features/workqueues/EventOverview/EventOverview.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/EventOverview.tsx
@@ -88,8 +88,6 @@ function EventOverviewContainer() {
   const { getUsers } = useUsers()
 
   const [fullEvent] = getEvent.useSuspenseQuery(params.eventId)
-  const { eventConfiguration: config } = useEventConfiguration(fullEvent.type)
-
   const activeActions = getAcceptedActions(fullEvent)
   const userIds = getUserIdsFromActions(activeActions)
   const [users] = getUsers.useSuspenseQuery(userIds)

--- a/packages/client/src/v2-events/features/workqueues/EventOverview/EventOverview.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/EventOverview.tsx
@@ -12,7 +12,6 @@ import React from 'react'
 import { useTypedParams } from 'react-router-typesafe-routes/dom'
 import { useSelector } from 'react-redux'
 import {
-  SummaryConfig,
   EventDocument,
   getCurrentEventState,
   getAcceptedActions

--- a/packages/client/src/v2-events/features/workqueues/EventOverview/EventOverview.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/EventOverview.tsx
@@ -14,7 +14,8 @@ import { useSelector } from 'react-redux'
 import {
   EventDocument,
   getCurrentEventState,
-  getAcceptedActions
+  getAcceptedActions,
+  getCurrentEventStateWithDrafts
 } from '@opencrvs/commons/client'
 import { Content, ContentSize } from '@opencrvs/components/lib/Content'
 import { IconWithName } from '@client/v2-events/components/IconWithName'
@@ -30,6 +31,7 @@ import {
   flattenEventIndex,
   getUserIdsFromActions
 } from '@client/v2-events/utils'
+import { useDrafts } from '../../drafts/useDrafts'
 import { EventHistory } from './components/EventHistory'
 import { EventSummary } from './components/EventSummary'
 
@@ -48,9 +50,12 @@ function EventOverview({ event }: { event: EventDocument }) {
   const intl = useIntlFormatMessageWithFlattenedParams()
   const eventIndex = getCurrentEventState(event)
   const { trackingId, status, registrationNumber } = eventIndex
+  const { getRemoteDrafts } = useDrafts()
+  const drafts = getRemoteDrafts()
+  const eventWithDrafts = getCurrentEventStateWithDrafts(event, drafts)
 
   const flattenedEventIndex = {
-    ...flattenEventIndex(eventIndex),
+    ...flattenEventIndex(eventWithDrafts),
     // @TODO: Ask why these are defined outside of flatten index?
     'event.trackingId': trackingId,
     'event.status': status,

--- a/packages/client/src/v2-events/features/workqueues/EventOverview/EventOverview.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/EventOverview.tsx
@@ -31,7 +31,6 @@ import {
   flattenEventIndex,
   getUserIdsFromActions
 } from '@client/v2-events/utils'
-import { useDrafts } from '@client/v2-events/features/drafts/useDrafts'
 import { EventHistory } from './components/EventHistory'
 import { EventSummary } from './components/EventSummary'
 
@@ -45,13 +44,7 @@ import { EventOverviewProvider } from './EventOverviewContext'
 /**
  * Renders the event overview page, including the event summary and history.
  */
-function EventOverview({
-  event,
-  summary
-}: {
-  event: EventDocument
-  summary: SummaryConfig
-}) {
+function EventOverview({ event }: { event: EventDocument }) {
   const { eventConfiguration } = useEventConfiguration(event.type)
   const intl = useIntlFormatMessageWithFlattenedParams()
   const eventIndex = getCurrentEventState(event)
@@ -65,6 +58,7 @@ function EventOverview({
     'event.registrationNumber': registrationNumber
   }
 
+  const { summary } = eventConfiguration
   const title = intl.formatMessage(summary.title.label, flattenedEventIndex)
   const fallbackTitle = summary.title.emptyValueMessage
     ? intl.formatMessage(summary.title.emptyValueMessage)
@@ -83,7 +77,6 @@ function EventOverview({
       <EventSummary
         event={flattenedEventIndex}
         eventConfiguration={eventConfiguration}
-        summary={summary}
       />
       <EventHistory history={actions} />
     </Content>
@@ -93,7 +86,6 @@ function EventOverview({
 function EventOverviewContainer() {
   const params = useTypedParams(ROUTES.V2.EVENTS.OVERVIEW)
   const { getEvent } = useEvents()
-  const { getRemoteDrafts } = useDrafts()
   const { getUsers } = useUsers()
 
   const [fullEvent] = getEvent.useSuspenseQuery(params.eventId)
@@ -106,7 +98,7 @@ function EventOverviewContainer() {
 
   return (
     <EventOverviewProvider locations={locations} users={users}>
-      <EventOverview event={fullEvent} summary={config.summary} />
+      <EventOverview event={fullEvent} />
     </EventOverviewProvider>
   )
 }

--- a/packages/client/src/v2-events/features/workqueues/EventOverview/EventOverview.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/EventOverview.tsx
@@ -61,24 +61,12 @@ function EventOverview({
   summary: SummaryConfig
 }) {
   const { eventConfiguration } = useEventConfiguration(event.type)
-  const allFields = getDeclarationFields(eventConfiguration)
   const intl = useIntlFormatMessageWithFlattenedParams()
-
-  const eventWithDrafts = getCurrentEventStateWithDrafts(event, drafts)
   const eventIndex = getCurrentEventState(event)
   const { trackingId, status, registrationNumber } = eventIndex
 
-  const stringifyFormData = useFormDataStringifier()
-  const eventWithDefaults = stringifyFormData(
-    allFields,
-    eventWithDrafts.declaration
-  )
-
-  const flattenedEventIndex: Record<
-    string,
-    FieldValue | null | RecursiveStringRecord
-  > = {
-    ...flattenEventIndex({ ...eventIndex, declaration: eventWithDefaults }),
+  const flattenedEventIndex = {
+    ...flattenEventIndex(eventIndex),
     // @TODO: Ask why these are defined outside of flatten index?
     'event.trackingId': trackingId,
     'event.status': status,
@@ -102,7 +90,7 @@ function EventOverview({
     >
       <EventSummary
         event={flattenedEventIndex}
-        eventLabel={eventConfiguration.label}
+        eventConfiguration={eventConfiguration}
         summary={summary}
       />
       <EventHistory history={actions} />

--- a/packages/client/src/v2-events/features/workqueues/EventOverview/EventOverview.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/EventOverview.tsx
@@ -13,12 +13,8 @@ import { useTypedParams } from 'react-router-typesafe-routes/dom'
 import { useSelector } from 'react-redux'
 import {
   SummaryConfig,
-  FieldValue,
-  getCurrentEventStateWithDrafts,
   EventDocument,
-  Draft,
   getCurrentEventState,
-  getDeclarationFields,
   getAcceptedActions
 } from '@opencrvs/commons/client'
 import { Content, ContentSize } from '@opencrvs/components/lib/Content'
@@ -35,9 +31,7 @@ import {
   flattenEventIndex,
   getUserIdsFromActions
 } from '@client/v2-events/utils'
-import { useFormDataStringifier } from '@client/v2-events/hooks/useFormDataStringifier'
 import { useDrafts } from '@client/v2-events/features/drafts/useDrafts'
-import { RecursiveStringRecord } from '@client/v2-events/hooks/useSimpleFieldStringifier'
 import { EventHistory } from './components/EventHistory'
 import { EventSummary } from './components/EventSummary'
 
@@ -53,10 +47,8 @@ import { EventOverviewProvider } from './EventOverviewContext'
  */
 function EventOverview({
   event,
-  drafts,
   summary
 }: {
-  drafts: Draft[]
   event: EventDocument
   summary: SummaryConfig
 }) {
@@ -105,7 +97,6 @@ function EventOverviewContainer() {
   const { getUsers } = useUsers()
 
   const [fullEvent] = getEvent.useSuspenseQuery(params.eventId)
-  const drafts = getRemoteDrafts()
   const { eventConfiguration: config } = useEventConfiguration(fullEvent.type)
 
   const activeActions = getAcceptedActions(fullEvent)
@@ -115,11 +106,7 @@ function EventOverviewContainer() {
 
   return (
     <EventOverviewProvider locations={locations} users={users}>
-      <EventOverview
-        drafts={drafts}
-        event={fullEvent}
-        summary={config.summary}
-      />
+      <EventOverview event={fullEvent} summary={config.summary} />
     </EventOverviewProvider>
   )
 }

--- a/packages/client/src/v2-events/features/workqueues/EventOverview/components/EventSummary.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/components/EventSummary.tsx
@@ -123,13 +123,11 @@ export function EventSummary({
         placeholder:
           field.emptyValueMessage &&
           intl.formatMessage(field.emptyValueMessage),
-        value: (
-          <Output
-            field={config}
-            showPreviouslyMissingValuesAsChanged={false}
-            value={value}
-          />
-        )
+        value: Output({
+          field: config,
+          showPreviouslyMissingValuesAsChanged: false,
+          value: value
+        })
       }
     }
 

--- a/packages/client/src/v2-events/features/workqueues/EventOverview/components/EventSummary.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/components/EventSummary.tsx
@@ -109,7 +109,7 @@ export function EventSummary({
   const declarationFields = getDeclarationFields(eventConfiguration)
 
   const fields = summaryPageFields.map((field) => {
-    if ('conditional' in field && field.conditional) {
+    if (field.conditional) {
       if (!isConditionMet(field.conditional, event)) {
         return null
       }

--- a/packages/client/src/v2-events/features/workqueues/EventOverview/components/EventSummary.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/components/EventSummary.tsx
@@ -96,15 +96,14 @@ function getDefaultFields(
 
 export function EventSummary({
   event,
-  summary,
   eventConfiguration
 }: {
   event: Record<string, FieldValue | null>
-  summary: SummaryConfig
   eventConfiguration: EventConfig
 }) {
   const intl = useIntlFormatMessageWithFlattenedParams()
-  const defaultFields = getDefaultFields(eventConfiguration.label)
+  const { summary, label } = eventConfiguration
+  const defaultFields = getDefaultFields(label)
   const summaryPageFields = [...defaultFields, ...summary.fields]
   const declarationFields = getDeclarationFields(eventConfiguration)
 

--- a/packages/client/src/v2-events/features/workqueues/EventOverview/components/EventSummary.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/components/EventSummary.tsx
@@ -14,10 +14,10 @@ import { Summary } from '@opencrvs/components/lib/Summary'
 import {
   EventConfig,
   getDeclarationFields,
+  isConditionMet,
   SummaryConfig
 } from '@opencrvs/commons/client'
 import { FieldValue, TranslationConfig } from '@opencrvs/commons/client'
-import { EventIndex } from '@opencrvs/commons'
 import { useIntlFormatMessageWithFlattenedParams } from '@client/v2-events/messages/utils'
 import { Output } from '@client/v2-events/features/events/components/Output'
 
@@ -109,6 +109,12 @@ export function EventSummary({
   const declarationFields = getDeclarationFields(eventConfiguration)
 
   const fields = summaryPageFields.map((field) => {
+    if ('conditional' in field && field.conditional) {
+      if (!isConditionMet(field.conditional, event)) {
+        return null
+      }
+    }
+
     if ('fieldId' in field) {
       const config = declarationFields.find((f) => f.id === field.fieldId)
       const value = event[field.fieldId] ?? undefined

--- a/packages/client/src/v2-events/features/workqueues/EventOverview/components/EventSummary.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/components/EventSummary.tsx
@@ -109,10 +109,8 @@ export function EventSummary({
   const declarationFields = getDeclarationFields(eventConfiguration)
 
   const fields = summaryPageFields.map((field) => {
-    if (field.conditional) {
-      if (!isConditionMet(field.conditional, event)) {
-        return null
-      }
+    if (field.conditional && !isConditionMet(field.conditional, event)) {
+      return null
     }
 
     if ('fieldId' in field) {

--- a/packages/client/src/v2-events/features/workqueues/EventOverview/components/EventSummary.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/components/EventSummary.tsx
@@ -108,51 +108,56 @@ export function EventSummary({
   const summaryPageFields = [...defaultFields, ...summary.fields]
   const declarationFields = getDeclarationFields(eventConfiguration)
 
+  const fields = summaryPageFields.map((field) => {
+    if ('fieldId' in field) {
+      const config = declarationFields.find((f) => f.id === field.fieldId)
+      const value = event[field.fieldId] ?? undefined
+
+      if (!config) {
+        return null
+      }
+
+      return {
+        id: field.fieldId,
+        label: intl.formatMessage(config.label),
+        placeholder:
+          field.emptyValueMessage &&
+          intl.formatMessage(field.emptyValueMessage),
+        value: (
+          <Output
+            field={config}
+            showPreviouslyMissingValuesAsChanged={false}
+            value={value}
+          />
+        )
+      }
+    }
+
+    return {
+      id: field.id,
+      label: intl.formatMessage(field.label),
+      placeholder:
+        field.emptyValueMessage && intl.formatMessage(field.emptyValueMessage),
+      value: intl.formatMessage(field.value, event)
+    }
+  })
+
   return (
     <>
       <Summary id="summary">
-        {summaryPageFields.map((field) => {
-          if ('fieldId' in field) {
-            const config = declarationFields.find((f) => f.id === field.fieldId)
-            const value = event[field.fieldId] ?? undefined
-
-            if (!config) {
-              return null
-            }
-
+        {fields
+          .filter((f): f is NonNullable<typeof f> => f !== null)
+          .map((field) => {
             return (
               <Summary.Row
-                key={field.fieldId}
-                data-testid={field.fieldId}
-                label={intl.formatMessage(config.label)}
-                placeholder={
-                  field.emptyValueMessage &&
-                  intl.formatMessage(field.emptyValueMessage)
-                }
-                value={
-                  <Output
-                    field={config}
-                    showPreviouslyMissingValuesAsChanged={false}
-                    value={value}
-                  />
-                }
+                key={field.id}
+                data-testid={field.id}
+                label={field.label}
+                placeholder={field.placeholder}
+                value={field.value}
               />
             )
-          }
-
-          return (
-            <Summary.Row
-              key={field.id}
-              data-testid={field.id}
-              label={intl.formatMessage(field.label)}
-              placeholder={
-                field.emptyValueMessage &&
-                intl.formatMessage(field.emptyValueMessage)
-              }
-              value={intl.formatMessage(field.value, event)}
-            />
-          )
-        })}
+          })}
       </Summary>
     </>
   )

--- a/packages/client/src/v2-events/features/workqueues/EventOverview/components/EventSummary.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/components/EventSummary.tsx
@@ -14,13 +14,12 @@ import { Summary } from '@opencrvs/components/lib/Summary'
 import {
   EventConfig,
   getDeclarationFields,
-  isConditionMet,
+  areConditionsMet,
   SummaryConfig
 } from '@opencrvs/commons/client'
 import { FieldValue, TranslationConfig } from '@opencrvs/commons/client'
 import { useIntlFormatMessageWithFlattenedParams } from '@client/v2-events/messages/utils'
 import { Output } from '@client/v2-events/features/events/components/Output'
-
 /**
  * Based on packages/client/src/views/RecordAudit/DeclarationInfo.tsx
  */
@@ -108,7 +107,7 @@ export function EventSummary({
   const declarationFields = getDeclarationFields(eventConfiguration)
 
   const fields = summaryPageFields.map((field) => {
-    if (field.conditional && !isConditionMet(field.conditional, event)) {
+    if (field.conditionals && !areConditionsMet(field.conditionals, event)) {
       return null
     }
 

--- a/packages/client/src/v2-events/features/workqueues/EventOverview/components/EventSummary.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/components/EventSummary.tsx
@@ -123,10 +123,8 @@ export function EventSummary({
 
       return {
         id: field.fieldId,
-        label: intl.formatMessage(config.label),
-        placeholder:
-          field.emptyValueMessage &&
-          intl.formatMessage(field.emptyValueMessage),
+        label: config.label,
+        emptyValueMessage: field.emptyValueMessage,
         value: Output({
           field: config,
           showPreviouslyMissingValuesAsChanged: false,
@@ -137,9 +135,8 @@ export function EventSummary({
 
     return {
       id: field.id,
-      label: intl.formatMessage(field.label),
-      placeholder:
-        field.emptyValueMessage && intl.formatMessage(field.emptyValueMessage),
+      label: field.label,
+      emptyValueMessage: field.emptyValueMessage,
       value: intl.formatMessage(field.value, event)
     }
   })
@@ -154,8 +151,11 @@ export function EventSummary({
               <Summary.Row
                 key={field.id}
                 data-testid={field.id}
-                label={field.label}
-                placeholder={field.placeholder}
+                label={intl.formatMessage(field.label)}
+                placeholder={
+                  field.emptyValueMessage &&
+                  intl.formatMessage(field.emptyValueMessage)
+                }
                 value={field.value}
               />
             )

--- a/packages/client/src/v2-events/hooks/useSimpleFieldStringifier.ts
+++ b/packages/client/src/v2-events/hooks/useSimpleFieldStringifier.ts
@@ -24,7 +24,7 @@ import {
   SelectCountry as Country
 } from '@client/v2-events/features/events/registered-fields'
 
-export interface RecursiveStringRecord {
+interface RecursiveStringRecord {
   [key: string]: string | undefined | RecursiveStringRecord
 }
 

--- a/packages/client/src/v2-events/messages/utils.tsx
+++ b/packages/client/src/v2-events/messages/utils.tsx
@@ -159,7 +159,7 @@ export function useIntlFormatMessageWithFlattenedParams() {
     }
     // When multiple variables are provided, we trim to ensure empty content in case both are missing.
     // We might need to adjust this and allow more freedom for configuration (e.g. provide values and join pattern)
-    return formatted.trim().replaceAll(EMPTY_TOKEN, '')
+    return formatted.replaceAll(EMPTY_TOKEN, '').trim()
   }
 
   return {

--- a/packages/commons/src/conditionals/validate.ts
+++ b/packages/commons/src/conditionals/validate.ts
@@ -20,7 +20,7 @@ import { FieldConfig } from '../events/FieldConfig'
 import { mapFieldTypeToZod } from '../events/FieldTypeMapping'
 import { FieldUpdateValue } from '../events/FieldValue'
 import { TranslationConfig } from '../events/TranslationConfig'
-import { ConditionalType } from '../events/Conditional'
+import { ConditionalType, FieldConditional } from '../events/Conditional'
 
 const ajv = new Ajv({
   $data: true,
@@ -53,6 +53,15 @@ function getConditionalActionsForField(
   return field.conditionals
     .filter((conditional) => validate(conditional.conditional, values))
     .map((conditional) => conditional.type)
+}
+
+export function areConditionsMet(
+  conditions: FieldConditional[],
+  values: Record<string, unknown>
+) {
+  return conditions.every((condition) =>
+    isConditionMet(condition.conditional, values)
+  )
 }
 
 function isFieldConditionMet(

--- a/packages/commons/src/conditionals/validate.ts
+++ b/packages/commons/src/conditionals/validate.ts
@@ -33,6 +33,16 @@ export function validate(schema: JSONSchema, data: ConditionalParameters) {
   return ajv.validate(schema, data)
 }
 
+export function isConditionMet(
+  conditional: JSONSchema,
+  values: Record<string, unknown>
+) {
+  return validate(conditional, {
+    $form: values,
+    $now: formatISO(new Date(), { representation: 'date' })
+  })
+}
+
 function getConditionalActionsForField(
   field: FieldConfig,
   values: ConditionalParameters

--- a/packages/commons/src/events/SummaryConfig.ts
+++ b/packages/commons/src/events/SummaryConfig.ts
@@ -10,6 +10,7 @@
  */
 import { z } from 'zod'
 import { TranslationConfig } from './TranslationConfig'
+import { Conditional } from './Conditional'
 
 const Field = z.union([
   z
@@ -19,13 +20,19 @@ const Field = z.union([
         'Summary field value. Can utilise values defined in configuration and EventMetadata'
       ),
       label: TranslationConfig,
-      emptyValueMessage: TranslationConfig.optional()
+      emptyValueMessage: TranslationConfig.optional(),
+      conditional: Conditional.optional().describe(
+        'Field will be shown if condition is met. If conditional is not defined, the field will always be shown.'
+      )
     })
     .describe('Custom configured field'),
   z
     .object({
       fieldId: z.string(),
-      emptyValueMessage: TranslationConfig.optional()
+      emptyValueMessage: TranslationConfig.optional(),
+      conditional: Conditional.optional().describe(
+        'Field will be shown if condition is met. If conditional is not defined, the field will always be shown.'
+      )
     })
     .describe('Field directly referencing event data with field id')
 ])

--- a/packages/commons/src/events/SummaryConfig.ts
+++ b/packages/commons/src/events/SummaryConfig.ts
@@ -11,14 +11,24 @@
 import { z } from 'zod'
 import { TranslationConfig } from './TranslationConfig'
 
-const Field = z.object({
-  id: z.string().describe('Id of summary field'),
-  value: TranslationConfig.describe(
-    'Summary field value. Can utilise values defined in configuration and EventMetadata'
-  ),
-  label: TranslationConfig,
-  emptyValueMessage: TranslationConfig.optional()
-})
+const Field = z.union([
+  z
+    .object({
+      id: z.string().describe('Id of summary field'),
+      value: TranslationConfig.describe(
+        'Summary field value. Can utilise values defined in configuration and EventMetadata'
+      ),
+      label: TranslationConfig,
+      emptyValueMessage: TranslationConfig.optional()
+    })
+    .describe('Custom configured field'),
+  z
+    .object({
+      fieldId: z.string(),
+      emptyValueMessage: TranslationConfig.optional()
+    })
+    .describe('Field directly referencing event data with field id')
+])
 
 const Title = z.object({
   id: z.string(),

--- a/packages/commons/src/events/SummaryConfig.ts
+++ b/packages/commons/src/events/SummaryConfig.ts
@@ -10,32 +10,25 @@
  */
 import { z } from 'zod'
 import { TranslationConfig } from './TranslationConfig'
-import { Conditional } from './Conditional'
+import { ShowConditional } from './Conditional'
 
-const Field = z.union([
-  z
-    .object({
-      id: z.string().describe('Id of summary field'),
-      value: TranslationConfig.describe(
-        'Summary field value. Can utilise values defined in configuration and EventMetadata'
-      ),
-      label: TranslationConfig,
-      emptyValueMessage: TranslationConfig.optional(),
-      conditional: Conditional.optional().describe(
-        'Field will be shown if condition is met. If conditional is not defined, the field will always be shown.'
-      )
-    })
-    .describe('Custom configured field'),
-  z
-    .object({
-      fieldId: z.string(),
-      emptyValueMessage: TranslationConfig.optional(),
-      conditional: Conditional.optional().describe(
-        'Field will be shown if condition is met. If conditional is not defined, the field will always be shown.'
-      )
-    })
-    .describe('Field directly referencing event data with field id')
-])
+const BaseField = z.object({
+  emptyValueMessage: TranslationConfig.optional(),
+  conditionals: z.array(ShowConditional).default([]).optional()
+})
+
+const ReferenceField = BaseField.extend({
+  fieldId: z.string()
+}).describe('Field directly referencing event data with field id')
+
+const Field = BaseField.extend({
+  id: z.string().describe('Id of summary field'),
+  value: TranslationConfig.describe(
+    'Summary field value. Can utilise values defined in configuration and EventMetadata'
+  ),
+  label: TranslationConfig,
+  emptyValueMessage: TranslationConfig.optional()
+}).describe('Custom configured field')
 
 const Title = z.object({
   id: z.string(),
@@ -46,7 +39,9 @@ const Title = z.object({
 export const SummaryConfig = z
   .object({
     title: Title.describe('Title of summary view.'),
-    fields: z.array(Field).describe('Fields rendered in summary view.')
+    fields: z
+      .array(z.union([Field, ReferenceField]))
+      .describe('Fields rendered in summary view.')
   })
   .describe('Configuration for summary in event.')
 

--- a/packages/commons/src/events/utils.ts
+++ b/packages/commons/src/events/utils.ts
@@ -22,15 +22,13 @@ import { FieldConfig } from './FieldConfig'
 import { WorkqueueConfig } from './WorkqueueConfig'
 import { Action, ActionUpdate, EventState } from './ActionDocument'
 import { PageConfig, PageTypes, VerificationPageConfig } from './PageConfig'
-import { isFieldVisible, validate } from '../conditionals/validate'
+import { isConditionMet, isFieldVisible } from '../conditionals/validate'
 import { Draft } from './Draft'
 import { EventDocument } from './EventDocument'
 import { getUUID } from '../uuid'
-import { formatISO } from 'date-fns'
 import { ActionConfig, DeclarationActionConfig } from './ActionConfig'
 import { FormConfig } from './FormConfig'
 import { getOrThrow } from '../utils'
-import { JSONSchema } from 'src/client'
 
 function isDeclarationActionConfig(
   action: ActionConfig
@@ -136,16 +134,6 @@ export function validateWorkqueueConfig(workqueueConfigs: WorkqueueConfig[]) {
         `Invalid workqueue configuration: workqueue not found with id: ${workqueue.id}`
       )
     }
-  })
-}
-
-export function isConditionMet(
-  conditional: JSONSchema,
-  values: Record<string, unknown>
-) {
-  return validate(conditional, {
-    $form: values,
-    $now: formatISO(new Date(), { representation: 'date' })
   })
 }
 

--- a/packages/commons/src/events/utils.ts
+++ b/packages/commons/src/events/utils.ts
@@ -30,6 +30,7 @@ import { formatISO } from 'date-fns'
 import { ActionConfig, DeclarationActionConfig } from './ActionConfig'
 import { FormConfig } from './FormConfig'
 import { getOrThrow } from '../utils'
+import { JSONSchema } from 'src/client'
 
 function isDeclarationActionConfig(
   action: ActionConfig
@@ -138,15 +139,22 @@ export function validateWorkqueueConfig(workqueueConfigs: WorkqueueConfig[]) {
   })
 }
 
+export function isConditionMet(
+  conditional: JSONSchema,
+  values: Record<string, unknown>
+) {
+  return validate(conditional, {
+    $form: values,
+    $now: formatISO(new Date(), { representation: 'date' })
+  })
+}
+
 export function isPageVisible(page: PageConfig, formValues: ActionUpdate) {
   if (!page.conditional) {
     return true
   }
 
-  return validate(page.conditional, {
-    $form: formValues,
-    $now: formatISO(new Date(), { representation: 'date' })
-  })
+  return isConditionMet(page.conditional, formValues)
 }
 
 export function omitHiddenFields(fields: FieldConfig[], values: EventState) {


### PR DESCRIPTION
## Description

Issue: https://github.com/opencrvs/opencrvs-core/issues/9044#issuecomment-2808408860
Countryconfig PR: https://github.com/opencrvs/opencrvs-countryconfig/pull/646

Support field id references on summary page. They will use label and output as configured in the event configuration.

## Checklist

- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
