### PR TITLE
File selector fixes

### DIFF
--- a/packages/client/src/v2-events/components/forms/File.interaction.stories.tsx
+++ b/packages/client/src/v2-events/components/forms/File.interaction.stories.tsx
@@ -193,7 +193,12 @@ export const FileInputButton: StoryObj<typeof StyledFormFieldGenerator> = {
             type: FieldType.FILE,
             configuration: {
               maxFileSize: 1 * 1024 * 1024,
-              acceptedFileTypes: ['image/jpeg']
+              acceptedFileTypes: ['image/jpeg'],
+              fileName: {
+                defaultMessage: 'Uploaded photo',
+                description: 'The title for the file input',
+                id: 'storybook.file.label'
+              }
             },
             label: {
               id: 'storybook.file.label',
@@ -259,7 +264,7 @@ export const FileInputButton: StoryObj<typeof StyledFormFieldGenerator> = {
 
       await userEvent.upload(input, validFile)
 
-      await canvas.findByRole('button', { name: filename })
+      await canvas.findByRole('button', { name: 'Uploaded photo' })
     })
   }
 }

--- a/packages/client/src/v2-events/components/forms/FormFieldGenerator/GeneratedInputField.tsx
+++ b/packages/client/src/v2-events/components/forms/FormFieldGenerator/GeneratedInputField.tsx
@@ -279,12 +279,17 @@ export const GeneratedInputField = React.memo(
     }
 
     if (isFileFieldType(field)) {
+      const fileInputLabel = field.config.configuration.fileName
+        ? intl.formatMessage(field.config.configuration.fileName)
+        : intl.formatMessage(field.config.label)
+
       return (
         <InputField {...inputFieldProps}>
           <File.Input
             {...inputProps}
             acceptedFileTypes={field.config.configuration.acceptedFileTypes}
             error={inputFieldProps.error}
+            label={fileInputLabel}
             maxFileSize={field.config.configuration.maxFileSize}
             value={field.value}
             width={field.config.configuration.style?.width}

--- a/packages/client/src/v2-events/components/forms/FormFieldGenerator/GeneratedInputField.tsx
+++ b/packages/client/src/v2-events/components/forms/FormFieldGenerator/GeneratedInputField.tsx
@@ -279,7 +279,7 @@ export const GeneratedInputField = React.memo(
     }
 
     if (isFileFieldType(field)) {
-      const fileInputLabel = field.config.configuration.fileName
+      const uploadedFileNameLabel = field.config.configuration.fileName
         ? intl.formatMessage(field.config.configuration.fileName)
         : intl.formatMessage(field.config.label)
 
@@ -289,7 +289,7 @@ export const GeneratedInputField = React.memo(
             {...inputProps}
             acceptedFileTypes={field.config.configuration.acceptedFileTypes}
             error={inputFieldProps.error}
-            label={fileInputLabel}
+            label={uploadedFileNameLabel}
             maxFileSize={field.config.configuration.maxFileSize}
             value={field.value}
             width={field.config.configuration.style?.width}

--- a/packages/client/src/v2-events/components/forms/inputs/FileInput/File.stories.tsx
+++ b/packages/client/src/v2-events/components/forms/inputs/FileInput/File.stories.tsx
@@ -134,7 +134,12 @@ export const FileInputWithoutOption: StoryObj<typeof StyledFormFieldGenerator> =
               },
               configuration: {
                 style: { width: args.width },
-                maxFileSize: 5 * 1024 * 1024
+                maxFileSize: 5 * 1024 * 1024,
+                fileName: {
+                  defaultMessage: 'Uploaded photo',
+                  description: 'The title for the file input',
+                  id: 'storybook.file.label'
+                }
               }
             }
           ]}

--- a/packages/client/src/v2-events/components/forms/inputs/FileInput/SimpleDocumentUploader.tsx
+++ b/packages/client/src/v2-events/components/forms/inputs/FileInput/SimpleDocumentUploader.tsx
@@ -119,16 +119,15 @@ export function SimpleDocumentUploader({
           onDelete={onDelete}
         />
       )}
-      {!file && (
-        <DocumentUploader
-          fullWidth={width === 'full'}
-          id={name}
-          name={name}
-          onChange={handleFileChange}
-        >
-          {intl.formatMessage(messages.uploadFile)}
-        </DocumentUploader>
-      )}
+      <DocumentUploader
+        data-testid={name}
+        fullWidth={width === 'full'}
+        id={name}
+        name={name}
+        onChange={handleFileChange}
+      >
+        {intl.formatMessage(messages.uploadFile)}
+      </DocumentUploader>
     </>
   )
 }

--- a/packages/client/src/v2-events/features/events/components/DocumentViewer.tsx
+++ b/packages/client/src/v2-events/features/events/components/DocumentViewer.tsx
@@ -43,11 +43,15 @@ function getOptions(
   const fieldObj = { config: fieldConfig, value }
 
   if (isFileFieldType(fieldObj)) {
+    const label = fieldObj.config.configuration.fileName
+      ? `${intl.formatMessage(fieldObj.config.label)} (${intl.formatMessage(fieldObj.config.configuration.fileName)})`
+      : intl.formatMessage(fieldObj.config.label)
+
     return {
       selectOptions: [
         {
           value: fieldObj.config.id,
-          label: intl.formatMessage(fieldObj.config.label)
+          label
         }
       ],
       documentOptions: [

--- a/packages/commons/src/events/FieldConfig.ts
+++ b/packages/commons/src/events/FieldConfig.ts
@@ -233,7 +233,8 @@ const File = BaseField.extend({
               'Whether the file upload button should take the full width of the container or not'
             )
         })
-        .optional()
+        .optional(),
+      fileName: TranslationConfig.optional()
     })
     .default({
       maxFileSize: DEFAULT_MAX_FILE_SIZE_BYTES


### PR DESCRIPTION
## Description

Github issue: https://github.com/opencrvs/opencrvs-core/issues/9211
Countryconfig PR: https://github.com/opencrvs/opencrvs-countryconfig/pull/651

* File input selector now shows upload button even if file is already selected (as in V1)
* File input selector now shows configured file name or label, instead of actual file name (as in V1)
* File select on review page now shows configured file name along with label (as in V1)

![Screenshot 2025-04-24 at 8 33 18](https://github.com/user-attachments/assets/14614e97-c435-4490-bf6d-994720b7c7f1)

![Screenshot 2025-04-24 at 8 33 27](https://github.com/user-attachments/assets/757782f4-ea0d-4a27-94f4-e22a7554d00d)

## Checklist

- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
