### PR TITLE
fix backend validation for duplicate field ids

### DIFF
--- a/packages/client/src/v2-events/components/forms/validation.ts
+++ b/packages/client/src/v2-events/components/forms/validation.ts
@@ -11,12 +11,12 @@
 import { MessageDescriptor } from 'react-intl'
 import {
   FieldConfig,
-  getFieldValidationErrors,
   EventState,
   omitHiddenPaginatedFields,
   isPageVisible,
   FormConfig,
-  omitHiddenFields
+  omitHiddenFields,
+  runFieldValidations
 } from '@opencrvs/commons/client'
 
 interface FieldErrors {
@@ -44,7 +44,7 @@ export function getValidationErrorsForForm(
 
     return {
       ...errorsForAllFields,
-      [field.id]: getFieldValidationErrors({ field, values })
+      [field.id]: runFieldValidations({ field, values })
     }
   }, {})
 }

--- a/packages/client/src/v2-events/features/events/components/Review.tsx
+++ b/packages/client/src/v2-events/features/events/components/Review.tsx
@@ -32,9 +32,9 @@ import {
   FieldConfig,
   FieldType,
   FormConfig,
-  getFieldValidationErrors,
   isFieldDisplayedOnReview,
   isPageVisible,
+  runFieldValidations,
   SCOPES
 } from '@opencrvs/commons/client'
 import { FormFieldGenerator } from '@client/v2-events/components/forms/FormFieldGenerator'
@@ -308,7 +308,7 @@ function FormReview({
                 value
               })
 
-              const error = getFieldValidationErrors({
+              const error = runFieldValidations({
                 field,
                 values: form
               })

--- a/packages/commons/src/conditionals/validate.ts
+++ b/packages/commons/src/conditionals/validate.ts
@@ -270,6 +270,12 @@ export function runFieldValidations({
   field: FieldConfig
   values: ActionUpdate
 }) {
+  if (!isFieldVisible(field, values)) {
+    return {
+      errors: []
+    }
+  }
+
   const conditionalParameters = {
     $form: values,
     $now: formatISO(new Date(), { representation: 'date' })

--- a/packages/commons/src/conditionals/validate.ts
+++ b/packages/commons/src/conditionals/validate.ts
@@ -263,7 +263,7 @@ export function validateFieldInput({
   }[]
 }
 
-function runFieldValidations({
+export function runFieldValidations({
   field,
   values
 }: {
@@ -289,39 +289,4 @@ function runFieldValidations({
     // Assumes that custom validation errors are based on the field type, and extend the validation.
     errors: [...fieldValidationResult, ...customValidationResults]
   }
-}
-
-/**
- * Gets applicable validation errors based on its type and custom validators.
- *
- * @returns an array of error messages for the field
- */
-export function getFieldValidationErrors({
-  field,
-  values
-}: {
-  // Checkboxes can never have validation errors since they represent a boolean choice that defaults to unchecked
-  field: FieldConfig
-  values: ActionUpdate
-}) {
-  if (!isFieldVisible(field, values) || !isFieldEnabled(field, values)) {
-    if (values[field.id]) {
-      return {
-        errors: [
-          {
-            message: errorMessages.hiddenField
-          }
-        ]
-      }
-    }
-
-    return {
-      errors: []
-    }
-  }
-
-  return runFieldValidations({
-    field,
-    values
-  })
 }

--- a/packages/events/src/router/middleware/validate/index.ts
+++ b/packages/events/src/router/middleware/validate/index.ts
@@ -83,9 +83,15 @@ function validateDeclarationUpdateAction({
   }
 
   // 4. Validate declaration update against conditional rules, taking into account conditional pages.
-  const declarationErrors = declarationConfig.pages
+
+  const allVisiblePageFields = declarationConfig.pages
     .filter((page) => isPageVisible(page, cleanedDeclaration))
-    .flatMap((page) => getFormFieldErrors(page.fields, cleanedDeclaration))
+    .flatMap((page) => page.fields)
+
+  const declarationErrors = getFormFieldErrors(
+    allVisiblePageFields,
+    cleanedDeclaration
+  )
 
   const declarationActionParse = DeclarationActions.safeParse(actionType)
 

--- a/packages/events/src/router/middleware/validate/utils.ts
+++ b/packages/events/src/router/middleware/validate/utils.ts
@@ -16,7 +16,8 @@ import {
   Inferred,
   errorMessages,
   runFieldValidations,
-  isFieldVisible
+  isFieldVisible,
+  EventState
 } from '@opencrvs/commons/events'
 
 type ValidationError = {
@@ -25,12 +26,17 @@ type ValidationError = {
   value: unknown
 }
 
-export function getFormFieldErrors(formFields: Inferred[], data: ActionUpdate) {
+export function getFormFieldErrors(
+  formFields: Inferred[],
+  data: ActionUpdate,
+  declaration: EventState = {}
+) {
   const visibleFields = formFields.filter((field) =>
-    isFieldVisible(field, data)
+    isFieldVisible(field, { ...data, ...declaration })
   )
 
   const visibleFieldIds = visibleFields.map((field) => field.id)
+
   const hiddenFieldIds = formFields
     .filter(
       (field) =>


### PR DESCRIPTION
## Description

Fix backend field validations not working correctly in cases where multiple fields with the same id were configured in the form, with some of them being conditionally visible and some of them hidden.

Now it allows payload to include data for any field id which has at least one visible instance.

Also do some minor refactoring.

## Checklist

- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
