### PR TITLE
move and rename function, add unit tests

### DIFF
--- a/packages/events/src/router/middleware/validate/__snapshots__/validate.test.ts.snap
+++ b/packages/events/src/router/middleware/validate/__snapshots__/validate.test.ts.snap
@@ -1,0 +1,43 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`getFieldErrors() > should not return an error if a required field is provided 1`] = `[]`;
+
+exports[`getFieldErrors() > should not return an error if a value for a conditionally hidden required field is not provided 1`] = `[]`;
+
+exports[`getFieldErrors() > should not return an error if a value for a conditionally visible required field is provided 1`] = `[]`;
+
+exports[`getFieldErrors() > should not return an error if a value for a hidden field is not provided 1`] = `[]`;
+
+exports[`getFieldErrors() > should not return error if multiple fields with same id are configured, and value is provided 1`] = `[]`;
+
+exports[`getFieldErrors() > should return an error if a required field is not provided 1`] = `
+[
+  {
+    "id": "test.checkbox",
+    "message": "Required for registration",
+    "value": undefined,
+  },
+]
+`;
+
+exports[`getFieldErrors() > should return an error if a value for a conditionally hidden required field is provided 1`] = `
+[
+  {
+    "id": "test.checkbox",
+    "message": "Hidden or disabled field should not receive a value",
+    "value": true,
+  },
+]
+`;
+
+exports[`getFieldErrors() > should return an error if a value for a conditionally visible required field is not provided 1`] = `[]`;
+
+exports[`getFieldErrors() > should return an error if a value for a hidden field is provided 1`] = `
+[
+  {
+    "id": "test.checkbox",
+    "message": "Hidden or disabled field should not receive a value",
+    "value": true,
+  },
+]
+`;

--- a/packages/events/src/router/middleware/validate/__snapshots__/validate.test.ts.snap
+++ b/packages/events/src/router/middleware/validate/__snapshots__/validate.test.ts.snap
@@ -6,8 +6,6 @@ exports[`getFieldErrors() > should not return an error if a value for a conditio
 
 exports[`getFieldErrors() > should not return an error if a value for a conditionally visible required field is provided 1`] = `[]`;
 
-exports[`getFieldErrors() > should not return an error if a value for a hidden field is not provided 1`] = `[]`;
-
 exports[`getFieldErrors() > should not return error if multiple fields with same id are configured, and value is provided 1`] = `[]`;
 
 exports[`getFieldErrors() > should return an error if a required field is not provided 1`] = `
@@ -21,18 +19,6 @@ exports[`getFieldErrors() > should return an error if a required field is not pr
 `;
 
 exports[`getFieldErrors() > should return an error if a value for a conditionally hidden required field is provided 1`] = `
-[
-  {
-    "id": "test.checkbox",
-    "message": "Hidden or disabled field should not receive a value",
-    "value": true,
-  },
-]
-`;
-
-exports[`getFieldErrors() > should return an error if a value for a conditionally visible required field is not provided 1`] = `[]`;
-
-exports[`getFieldErrors() > should return an error if a value for a hidden field is provided 1`] = `
 [
   {
     "id": "test.checkbox",

--- a/packages/events/src/router/middleware/validate/__snapshots__/validate.test.ts.snap
+++ b/packages/events/src/router/middleware/validate/__snapshots__/validate.test.ts.snap
@@ -8,6 +8,8 @@ exports[`getFieldErrors() > should not return an error if a value for a conditio
 
 exports[`getFieldErrors() > should not return error if multiple fields with same id are configured, and value is provided 1`] = `[]`;
 
+exports[`getFieldErrors() > should not return errors for field with custom validations if value passes validation 1`] = `[]`;
+
 exports[`getFieldErrors() > should return an error if a required field is not provided 1`] = `
 [
   {
@@ -24,6 +26,16 @@ exports[`getFieldErrors() > should return an error if a value for a conditionall
     "id": "test.checkbox",
     "message": "Hidden or disabled field should not receive a value",
     "value": true,
+  },
+]
+`;
+
+exports[`getFieldErrors() > should return errors for field with custom validation if value does not pass validation 1`] = `
+[
+  {
+    "id": "test.input",
+    "message": "Failed validation!",
+    "value": "not hello!",
   },
 ]
 `;

--- a/packages/events/src/router/middleware/validate/utils.ts
+++ b/packages/events/src/router/middleware/validate/utils.ts
@@ -11,69 +11,12 @@
 
 import { TRPCError } from '@trpc/server'
 import _ from 'lodash'
-import {
-  ActionUpdate,
-  Inferred,
-  errorMessages,
-  runFieldValidations,
-  isFieldVisible,
-  EventState
-} from '@opencrvs/commons/events'
+import { ActionUpdate } from '@opencrvs/commons/events'
 
 type ValidationError = {
   message: string
   id: string
   value: unknown
-}
-
-export function getFormFieldErrors(
-  formFields: Inferred[],
-  data: ActionUpdate,
-  declaration: EventState = {}
-) {
-  const visibleFields = formFields.filter((field) =>
-    isFieldVisible(field, { ...data, ...declaration })
-  )
-
-  const visibleFieldIds = visibleFields.map((field) => field.id)
-
-  const hiddenFieldIds = formFields
-    .filter(
-      (field) =>
-        // If field is not visible and not in the visible fields list, it is a hidden field
-        // We need to check against the visible fields list because there might be fields with same ids, one of which is visible and others are hidden
-        !isFieldVisible(field, data) && !visibleFieldIds.includes(field.id)
-    )
-    .map((field) => field.id)
-
-  // Add errors if there are any hidden fields sent in the payloa
-  const hiddenFieldErrors = hiddenFieldIds.flatMap((fieldId) => {
-    if (data[fieldId as keyof typeof data]) {
-      return {
-        message: errorMessages.hiddenField.defaultMessage,
-        id: fieldId,
-        value: data[fieldId as keyof typeof data]
-      }
-    }
-
-    return []
-  })
-
-  // For visible fields, run the field validations as configured
-  const visibleFieldErrors = visibleFields.flatMap((field) => {
-    const fieldErrors = runFieldValidations({
-      field,
-      values: data
-    })
-
-    return fieldErrors.errors.map((error) => ({
-      message: error.message.defaultMessage,
-      id: field.id,
-      value: data[field.id as keyof typeof data]
-    }))
-  })
-
-  return [...hiddenFieldErrors, ...visibleFieldErrors]
 }
 
 export function getVerificationPageErrors(

--- a/packages/events/src/router/middleware/validate/utils.ts
+++ b/packages/events/src/router/middleware/validate/utils.ts
@@ -11,7 +11,7 @@
 
 import { TRPCError } from '@trpc/server'
 import _ from 'lodash'
-import { ActionUpdate } from '@opencrvs/commons/events'
+import { ActionUpdate, errorMessages } from '@opencrvs/commons/events'
 
 type ValidationError = {
   message: string

--- a/packages/events/src/router/middleware/validate/validate.test.ts
+++ b/packages/events/src/router/middleware/validate/validate.test.ts
@@ -180,4 +180,66 @@ describe('getFieldErrors()', () => {
 
     expect(errors).toMatchSnapshot()
   })
+
+  it('should return errors for field with custom validation if value does not pass validation', () => {
+    const errors = getFieldErrors(
+      [
+        {
+          id: 'test.input',
+          type: FieldType.TEXT,
+          required: true,
+          label: {
+            id: 'test.field.label',
+            defaultMessage: 'Test Field',
+            description: 'Test Field Description'
+          },
+          validation: [
+            {
+              message: {
+                id: 'test.field.validation.message',
+                defaultMessage: 'Failed validation!',
+                description: 'Test Field Validation Message Description'
+              },
+              validator: field('test.input').isEqualTo('helloooo')
+            }
+          ]
+        }
+      ],
+      { 'test.input': 'not hello!' },
+      {}
+    )
+
+    expect(errors).toMatchSnapshot()
+  })
+
+  it('should not return errors for field with custom validations if value passes validation', () => {
+    const errors = getFieldErrors(
+      [
+        {
+          id: 'test.input',
+          type: FieldType.TEXT,
+          required: true,
+          label: {
+            id: 'test.field.label',
+            defaultMessage: 'Test Field',
+            description: 'Test Field Description'
+          },
+          validation: [
+            {
+              message: {
+                id: 'test.field.validation.message',
+                defaultMessage: 'Failed validation!',
+                description: 'Test Field Validation Message Description'
+              },
+              validator: field('test.input').isEqualTo('helloooo')
+            }
+          ]
+        }
+      ],
+      { 'test.input': 'helloooo' },
+      {}
+    )
+
+    expect(errors).toMatchSnapshot()
+  })
 })

--- a/packages/events/src/router/middleware/validate/validate.test.ts
+++ b/packages/events/src/router/middleware/validate/validate.test.ts
@@ -1,3 +1,13 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
 import { ConditionalType, field, FieldType } from '@opencrvs/commons'
 import { getFieldErrors } from './index'
 

--- a/packages/events/src/router/middleware/validate/validate.test.ts
+++ b/packages/events/src/router/middleware/validate/validate.test.ts
@@ -1,0 +1,173 @@
+import { ConditionalType, field, FieldType } from '@opencrvs/commons'
+import { getFieldErrors } from './index'
+
+describe('getFieldErrors()', () => {
+  it('should return an empty array there are no fields to validate', () => {
+    const errors = getFieldErrors([], {}, {})
+    expect(errors).toEqual([])
+  })
+
+  it('should return an error if a required field is not provided', () => {
+    const errors = getFieldErrors(
+      [
+        {
+          id: 'test.checkbox',
+          type: FieldType.CHECKBOX,
+          required: true,
+          label: {
+            id: 'test.checkbox.label',
+            defaultMessage: 'Test Field',
+            description: 'Test Field Description'
+          }
+        }
+      ],
+      {},
+      {}
+    )
+    expect(errors).toMatchSnapshot()
+  })
+
+  it('should not return an error if a required field is provided', () => {
+    const errors = getFieldErrors(
+      [
+        {
+          id: 'test.checkbox',
+          type: FieldType.CHECKBOX,
+          required: true,
+          label: {
+            id: 'test.checkbox.label',
+            defaultMessage: 'Test Field',
+            description: 'Test Field Description'
+          }
+        }
+      ],
+      { 'test.checkbox': true }
+    )
+
+    expect(errors).toMatchSnapshot()
+  })
+
+  it('should return an error if a value for a conditionally hidden required field is provided', () => {
+    const errors = getFieldErrors(
+      [
+        {
+          id: 'test.checkbox',
+          type: FieldType.CHECKBOX,
+          required: true,
+          label: {
+            id: 'test.field.label',
+            defaultMessage: 'Test Field',
+            description: 'Test Field Description'
+          },
+          conditionals: [
+            {
+              type: ConditionalType.SHOW,
+              conditional: field('test.text').isEqualTo('helloooo')
+            }
+          ]
+        }
+      ],
+      { 'test.checkbox': true },
+      {}
+    )
+
+    expect(errors).toMatchSnapshot()
+  })
+
+  it('should not return an error if a value for a conditionally hidden required field is not provided', () => {
+    const errors = getFieldErrors(
+      [
+        {
+          id: 'test.checkbox',
+          type: FieldType.CHECKBOX,
+          required: true,
+          label: {
+            id: 'test.field.label',
+            defaultMessage: 'Test Field',
+            description: 'Test Field Description'
+          },
+          conditionals: [
+            {
+              type: ConditionalType.SHOW,
+              conditional: field('test.text').isEqualTo('helloooo')
+            }
+          ]
+        }
+      ],
+      {},
+      {}
+    )
+
+    expect(errors).toMatchSnapshot()
+  })
+
+  it('should not return an error if a value for a conditionally visible required field is provided', () => {
+    const errors = getFieldErrors(
+      [
+        {
+          id: 'test.checkbox',
+          type: FieldType.CHECKBOX,
+          required: true,
+          label: {
+            id: 'test.field.label',
+            defaultMessage: 'Test Field',
+            description: 'Test Field Description'
+          },
+          conditionals: [
+            {
+              type: ConditionalType.SHOW,
+              conditional: field('test.text').isEqualTo('helloooo')
+            }
+          ]
+        }
+      ],
+      { 'test.checkbox': true },
+      { 'test.text': 'helloooo' }
+    )
+
+    expect(errors).toMatchSnapshot()
+  })
+
+  it('should not return error if multiple fields with same id are configured, and value is provided', () => {
+    const errors = getFieldErrors(
+      [
+        {
+          id: 'test.input',
+          type: FieldType.TEXT,
+          required: true,
+          label: {
+            id: 'test.field.label',
+            defaultMessage: 'Test Field',
+            description: 'Test Field Description'
+          },
+          conditionals: [
+            {
+              type: ConditionalType.SHOW,
+              conditional: field('test.text').isEqualTo('helloooo')
+            }
+          ]
+        },
+        {
+          id: 'test.input',
+          type: FieldType.TEXT,
+          required: true,
+          label: {
+            id: 'test.field.label',
+            defaultMessage: 'Test Field',
+            description: 'Test Field Description'
+          },
+          conditionals: [
+            {
+              type: ConditionalType.SHOW,
+              conditional: field('test.other').isEqualTo('helloooo')
+            }
+          ]
+        }
+      ],
+      { 'test.checkbox': true },
+      { 'test.text': 'helloooo' }
+    )
+
+    expect(errors).toMatchSnapshot()
+  })
+})


### PR DESCRIPTION
## Description

* Move and rename function `getFormFieldErrors()` -> `getFieldErrors()`
* Write simple unit tests for function

## Checklist

- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
