### PR TITLE
Improve relevance of quick searches using name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug fixes
 
 - Filter out inactive locations in the Organisations menu [#8782](https://github.com/opencrvs/opencrvs-core/issues/8782)
+- Improve quick search results when searching by name [#9272](https://github.com/opencrvs/opencrvs-core/issues/9272)
 
 ## 1.7.0 Release candidate
 

--- a/packages/client/src/views/SearchResult/SearchResult.tsx
+++ b/packages/client/src/views/SearchResult/SearchResult.tsx
@@ -41,7 +41,6 @@ import { getScope, getUserDetails } from '@client/profile/profileSelectors'
 import { SEARCH_EVENTS } from '@client/search/queries'
 import { transformData } from '@client/search/transformer'
 import { IStoreState } from '@client/store'
-import { SEARCH_RESULT_SORT } from '@client/utils/constants'
 import { Scope, SCOPES } from '@opencrvs/commons/client'
 import { SearchEventsQuery } from '@client/utils/gateway'
 import { getUserLocation, UserDetails } from '@client/utils/userUtils'
@@ -349,8 +348,7 @@ function SearchResultView(props: ISearchResultProps) {
                           !canSearchAnywhere() && userDetails
                             ? getUserLocation(userDetails).id
                             : ''
-                      },
-                      sort: SEARCH_RESULT_SORT
+                      }
                     }
                   }
                 ],
@@ -480,8 +478,7 @@ function SearchResultView(props: ISearchResultProps) {
               contactEmail:
                 searchType === SearchCriteria.EMAIL ? searchText : '',
               name: searchType === SearchCriteria.NAME ? searchText : ''
-            },
-            sort: SEARCH_RESULT_SORT
+            }
           }}
           fetchPolicy="cache-and-network"
         >

--- a/packages/client/src/views/SearchResult/SearchResult.tsx
+++ b/packages/client/src/views/SearchResult/SearchResult.tsx
@@ -41,6 +41,7 @@ import { getScope, getUserDetails } from '@client/profile/profileSelectors'
 import { SEARCH_EVENTS } from '@client/search/queries'
 import { transformData } from '@client/search/transformer'
 import { IStoreState } from '@client/store'
+import { SEARCH_RESULT_SORT } from '@client/utils/constants'
 import { Scope, SCOPES } from '@opencrvs/commons/client'
 import { SearchEventsQuery } from '@client/utils/gateway'
 import { getUserLocation, UserDetails } from '@client/utils/userUtils'
@@ -348,7 +349,8 @@ function SearchResultView(props: ISearchResultProps) {
                           !canSearchAnywhere() && userDetails
                             ? getUserLocation(userDetails).id
                             : ''
-                      }
+                      },
+                      sort: SEARCH_RESULT_SORT
                     }
                   }
                 ],
@@ -478,7 +480,8 @@ function SearchResultView(props: ISearchResultProps) {
               contactEmail:
                 searchType === SearchCriteria.EMAIL ? searchText : '',
               name: searchType === SearchCriteria.NAME ? searchText : ''
-            }
+            },
+            sort: SEARCH_RESULT_SORT
           }}
           fetchPolicy="cache-and-network"
         >

--- a/packages/search/src/features/search/search.test.ts
+++ b/packages/search/src/features/search/search.test.ts
@@ -89,6 +89,78 @@ describe('search tests', () => {
         { name: 'John Williams', score: 1.0700248 }
       ])
     })
+    it('finds several relevant hits when searching with a name that has a typo in it: Jonh instead of John', async () => {
+      const t = await setupTestCases(setup)
+
+      const dataset = [
+        {
+          compositionId: uuid(),
+          event: EVENT.BIRTH,
+          name: 'John Smith',
+          childFirstNames: 'John',
+          childFamilyName: 'Smith'
+        },
+        {
+          compositionId: uuid(),
+          event: EVENT.BIRTH,
+          name: 'John Johnson',
+          childFirstNames: 'John',
+          childFamilyName: 'Johnson'
+        },
+        {
+          compositionId: uuid(),
+          event: EVENT.BIRTH,
+          name: 'John Williams',
+          childFirstNames: 'John',
+          childFamilyName: 'Williams'
+        },
+        {
+          compositionId: uuid(),
+          event: EVENT.BIRTH,
+          name: 'Jane Doe',
+          childFirstNames: 'Jane',
+          childFamilyName: 'Doe'
+        },
+        {
+          compositionId: uuid(),
+          event: EVENT.BIRTH,
+          name: 'Michael Jackson',
+          childFirstNames: 'Michael',
+          childFamilyName: 'Jackson'
+        },
+        {
+          compositionId: uuid(),
+          event: EVENT.BIRTH,
+          name: 'Peter Pan',
+          childFirstNames: 'Peter',
+          childFamilyName: 'Pan'
+        }
+      ]
+
+      await addRecords({ records: dataset, client: t.elasticClient })
+
+      const searchParams = await formatSearchParams(
+        {
+          parameters: {
+            name: 'Jonh'
+          }
+        },
+        false
+      )
+
+      const searchResult = await t.elasticClient.search(searchParams)
+
+      const hits = searchResult.hits.hits.map((hit) => ({
+        name: (hit._source as { name: string }).name,
+        score: hit._score
+      }))
+
+      expect(hits).toEqual([
+        { name: 'John Smith', score: 1.5595812 },
+        { name: 'John Johnson', score: 1.5595812 },
+        { name: 'John Williams', score: 1.5595812 }
+      ])
+    })
     it('finds several hits when searching with a more specific name John Smith, but the score for John Smith is higher than other hits', async () => {
       const t = await setupTestCases(setup)
 
@@ -145,6 +217,78 @@ describe('search tests', () => {
         { name: 'John Smith', score: 4.6819434 },
         { name: 'John Johnson', score: 1.0700248 },
         { name: 'John Williams', score: 1.0700248 }
+      ])
+    })
+    it('finds relevant hits when searching with a more specific name that has a typo: Jon Smyth instead of John Smith', async () => {
+      const t = await setupTestCases(setup)
+
+      const dataset = [
+        {
+          compositionId: uuid(),
+          event: EVENT.BIRTH,
+          name: 'John Smith',
+          childFirstNames: 'John',
+          childFamilyName: 'Smith'
+        },
+        {
+          compositionId: uuid(),
+          event: EVENT.BIRTH,
+          name: 'John Johnson',
+          childFirstNames: 'John',
+          childFamilyName: 'Johnson'
+        },
+        {
+          compositionId: uuid(),
+          event: EVENT.BIRTH,
+          name: 'John Williams',
+          childFirstNames: 'John',
+          childFamilyName: 'Williams'
+        },
+        {
+          compositionId: uuid(),
+          event: EVENT.BIRTH,
+          name: 'Jane Doe',
+          childFirstNames: 'Jane',
+          childFamilyName: 'Doe'
+        },
+        {
+          compositionId: uuid(),
+          event: EVENT.BIRTH,
+          name: 'Michael Jackson',
+          childFirstNames: 'Michael',
+          childFamilyName: 'Jackson'
+        },
+        {
+          compositionId: uuid(),
+          event: EVENT.BIRTH,
+          name: 'Peter Pan',
+          childFirstNames: 'Peter',
+          childFamilyName: 'Pan'
+        }
+      ]
+
+      await addRecords({ records: dataset, client: t.elasticClient })
+
+      const searchParams = await formatSearchParams(
+        {
+          parameters: {
+            name: 'Jon Smyth'
+          }
+        },
+        false
+      )
+
+      const searchResult = await t.elasticClient.search(searchParams)
+
+      const hits = searchResult.hits.hits.map((hit) => ({
+        name: (hit._source as { name: string }).name,
+        score: hit._score
+      }))
+
+      expect(hits).toEqual([
+        { name: 'John Smith', score: 5.0833626 },
+        { name: 'John Johnson', score: 1.3862941 },
+        { name: 'John Williams', score: 1.3862941 }
       ])
     })
     it('finds the Marriage event with a lower score when only the witness name is used for search', async () => {
@@ -231,7 +375,95 @@ describe('search tests', () => {
           brideFamilyName: 'Collins',
           groomFirstNames: 'James',
           groomFamilyName: 'Ford',
-          score: 0.5753642
+          score: 0.2876821
+        }
+      ])
+    })
+    it('finds the Marriage event with a typo in the witness name: Micheal Andreus instead of Michael Andrews', async () => {
+      const t = await setupTestCases(setup)
+
+      const dataset = [
+        {
+          compositionId: uuid(),
+          event: EVENT.BIRTH,
+          name: 'John Smith',
+          childFirstNames: 'John',
+          childFamilyName: 'Smith'
+        },
+        {
+          compositionId: uuid(),
+          event: EVENT.BIRTH,
+          name: 'John Johnson',
+          childFirstNames: 'John',
+          childFamilyName: 'Johnson'
+        },
+        {
+          compositionId: uuid(),
+          event: EVENT.BIRTH,
+          name: 'John Williams',
+          childFirstNames: 'John',
+          childFamilyName: 'Williams'
+        },
+        {
+          compositionId: uuid(),
+          event: EVENT.BIRTH,
+          name: 'Jane Doe',
+          childFirstNames: 'Jane',
+          childFamilyName: 'Doe'
+        },
+        {
+          compositionId: uuid(),
+          event: EVENT.MARRIAGE,
+          brideFirstNames: 'Grace',
+          brideFamilyName: 'Collins',
+          groomFirstNames: 'James',
+          groomFamilyName: 'Ford',
+          witnessOneFirstNames: 'Michael',
+          witnessOneFamilyName: 'Andrews'
+        }
+      ]
+
+      await addRecords({ records: dataset, client: t.elasticClient })
+
+      const searchParams = await formatSearchParams(
+        {
+          parameters: {
+            name: 'Micheal Andreus'
+          }
+        },
+        false
+      )
+
+      const searchResult = await t.elasticClient.search(searchParams)
+
+      const hits = searchResult.hits.hits.map((hit) => {
+        const {
+          brideFirstNames,
+          brideFamilyName,
+          groomFirstNames,
+          groomFamilyName
+        } = hit._source as {
+          brideFirstNames: string
+          brideFamilyName: string
+          groomFirstNames: string
+          groomFamilyName: string
+        }
+        return {
+          brideFirstNames,
+          brideFamilyName,
+          groomFirstNames,
+          groomFamilyName,
+          score: hit._score
+        }
+      })
+
+      expect(hits).toEqual([
+        {
+          brideFirstNames: 'Grace',
+          brideFamilyName: 'Collins',
+          groomFirstNames: 'James',
+          groomFamilyName: 'Ford',
+          score: 0.24658465
         }
       ])
     })
@@ -318,7 +550,94 @@ describe('search tests', () => {
           brideFamilyName: 'Collins',
           groomFirstNames: 'James',
           groomFamilyName: 'Ford',
-          score: 6.9043703
+          score: 1.7260926
+        }
+      ])
+    })
+    it('finds the same Marriage event with a typo in bride and groom names used for search: Greece Colins James Fjord instead of Grace Collins James Ford', async () => {
+      const t = await setupTestCases(setup)
+
+      const dataset = [
+        {
+          compositionId: uuid(),
+          event: EVENT.BIRTH,
+          name: 'John Smith',
+          childFirstNames: 'John',
+          childFamilyName: 'Smith'
+        },
+        {
+          compositionId: uuid(),
+          event: EVENT.BIRTH,
+          name: 'John Johnson',
+          childFirstNames: 'John',
+          childFamilyName: 'Johnson'
+        },
+        {
+          compositionId: uuid(),
+          event: EVENT.BIRTH,
+          name: 'John Williams',
+          childFirstNames: 'John',
+          childFamilyName: 'Williams'
+        },
+        {
+          compositionId: uuid(),
+          event: EVENT.BIRTH,
+          name: 'Jane Doe',
+          childFirstNames: 'Jane',
+          childFamilyName: 'Doe'
+        },
+        {
+          compositionId: uuid(),
+          event: EVENT.MARRIAGE,
+          brideFirstNames: 'Grace',
+          brideFamilyName: 'Collins',
+          groomFirstNames: 'James',
+          groomFamilyName: 'Ford',
+          witnessOneFirstNames: 'Michael',
+          witnessOneFamilyName: 'Andrews'
+        }
+      ]
+
+      await addRecords({ records: dataset, client: t.elasticClient })
+
+      const searchParams = await formatSearchParams(
+        {
+          parameters: {
+            name: 'Greece Colins James Fjord'
+          }
+        },
+        false
+      )
+
+      const searchResult = await t.elasticClient.search(searchParams)
+
+      const hits = searchResult.hits.hits.map((hit) => {
+        const {
+          brideFirstNames,
+          brideFamilyName,
+          groomFirstNames,
+          groomFamilyName
+        } = hit._source as {
+          brideFirstNames: string
+          brideFamilyName: string
+          groomFirstNames: string
+          groomFamilyName: string
+        }
+        return {
+          brideFirstNames,
+          brideFamilyName,
+          groomFirstNames,
+          groomFamilyName,
+          score: hit._score
+        }
+      })
+      expect(hits).toEqual([
+        {
+          brideFirstNames: 'Grace',
+          brideFamilyName: 'Collins',
+          groomFirstNames: 'James',
+          groomFamilyName: 'Ford',
+          score: 1.7260926
         }
       ])
     })
@@ -455,6 +774,71 @@ describe('search tests', () => {
 
       expect(hits).toEqual([{ name: 'Robert Smith', score: 0.2876821 }])
     })
+    it('finds a Death event when searching with only an informant name that has a typo: Jorge Pipe instead of George Pope', async () => {
+      const t = await setupTestCases(setup)
+
+      const dataset = [
+        {
+          compositionId: uuid(),
+          event: EVENT.BIRTH,
+          name: 'John Smith',
+          childFirstNames: 'John',
+          childFamilyName: 'Smith'
+        },
+        {
+          compositionId: uuid(),
+          event: EVENT.BIRTH,
+          name: 'John Johnson',
+          childFirstNames: 'John',
+          childFamilyName: 'Johnson'
+        },
+        {
+          compositionId: uuid(),
+          event: EVENT.BIRTH,
+          name: 'John Williams',
+          childFirstNames: 'John',
+          childFamilyName: 'Williams'
+        },
+        {
+          compositionId: uuid(),
+          event: EVENT.BIRTH,
+          name: 'Jane Doe',
+          childFirstNames: 'Jane',
+          childFamilyName: 'Doe'
+        },
+        {
+          compositionId: uuid(),
+          event: EVENT.DEATH,
+          name: 'Robert Smith',
+          deceasedFirstNames: 'Robert',
+          deceasedFamilyName: 'Smith',
+          informantFirstNames: 'George',
+          informantFamilyName: 'Pope',
+          spouseFirstNames: 'Lily',
+          spouseFamilyName: 'Smith'
+        }
+      ]
+
+      await addRecords({ records: dataset, client: t.elasticClient })
+
+      const searchParams = await formatSearchParams(
+        {
+          parameters: {
+            name: 'Jorge Pipe'
+          }
+        },
+        false
+      )
+
+      const searchResult = await t.elasticClient.search(searchParams)
+
+      const hits = searchResult.hits.hits.map((hit) => ({
+        name: (hit._source as { name: string }).name,
+        score: hit._score
+      }))
+
+      expect(hits).toEqual([{ name: 'Robert Smith', score: 0.21576157 }])
+    })
     it('finds the same Death event with a higher score when searching with name of deceased', async () => {
       const t = await setupTestCases(setup)
 
@@ -521,6 +905,74 @@ describe('search tests', () => {
       expect(hits).toEqual([
         { name: 'Robert Smith', score: 6.7852893 },
         { name: 'John Smith', score: 2.6264062 }
+      ])
+    })
+    it('finds the same Death event with typo in name of deceased: Robber Smyth instead of Robert Smith', async () => {
+      const t = await setupTestCases(setup)
+
+      const dataset = [
+        {
+          compositionId: uuid(),
+          event: EVENT.BIRTH,
+          name: 'John Smith',
+          childFirstNames: 'John',
+          childFamilyName: 'Smith'
+        },
+        {
+          compositionId: uuid(),
+          event: EVENT.BIRTH,
+          name: 'John Johnson',
+          childFirstNames: 'John',
+          childFamilyName: 'Johnson'
+        },
+        {
+          compositionId: uuid(),
+          event: EVENT.BIRTH,
+          name: 'John Williams',
+          childFirstNames: 'John',
+          childFamilyName: 'Williams'
+        },
+        {
+          compositionId: uuid(),
+          event: EVENT.BIRTH,
+          name: 'Jane Doe',
+          childFirstNames: 'Jane',
+          childFamilyName: 'Doe'
+        },
+        {
+          compositionId: uuid(),
+          event: EVENT.DEATH,
+          name: 'Robert Smith',
+          deceasedFirstNames: 'Robert',
+          deceasedFamilyName: 'Smith',
+          informantFirstNames: 'George',
+          informantFamilyName: 'Pope',
+          spouseFirstNames: 'Lily',
+          spouseFamilyName: 'Smith'
+        }
+      ]
+
+      await addRecords({ records: dataset, client: t.elasticClient })
+
+      const searchParams = await formatSearchParams(
+        {
+          parameters: {
+            name: 'Robber Smyth'
+          }
+        },
+        false
+      )
+
+      const searchResult = await t.elasticClient.search(searchParams)
+
+      const hits = searchResult.hits.hits.map((hit) => ({
+        name: (hit._source as { name: string }).name,
+        score: hit._score
+      }))
+
+      expect(hits).toEqual([
+        { name: 'Robert Smith', score: 4.8737135 },
+        { name: 'John Smith', score: 2.101125 }
       ])
     })
     it('does not find any hits when searching with a name that does not match any of the name fields', async () => {

--- a/packages/search/src/features/search/search.test.ts
+++ b/packages/search/src/features/search/search.test.ts
@@ -1,0 +1,356 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+import { OPENCRVS_INDEX_NAME } from '@search/constants'
+import { formatSearchParams } from './service'
+import { createHandlerSetup, SetupFn } from '@search/test/createHandlerSetup'
+import { EVENT } from '@opencrvs/commons'
+import * as elasticsearch from '@elastic/elasticsearch'
+import { v4 as uuid } from 'uuid'
+
+jest.setTimeout(10 * 60 * 1000)
+
+const setupTestCases = async (setupFn: SetupFn) => {
+  const { elasticClient } = await setupFn()
+
+  return {
+    elasticClient
+  }
+}
+
+describe('search tests', () => {
+  const { setup, cleanup, shutdown } = createHandlerSetup()
+  afterEach(cleanup)
+  afterAll(shutdown)
+
+  describe('standard advanced search', () => {
+    it('finds several hits with identical scores when searching with only a first name John', async () => {
+      const t = await setupTestCases(setup)
+
+      await addRecords({ client: t.elasticClient })
+
+      const allDocumentsCountCheck = await t.elasticClient.search(
+        {
+          index: OPENCRVS_INDEX_NAME,
+          body: {
+            query: { match_all: {} }
+          }
+        },
+        {
+          meta: true,
+          ignore: [404]
+        }
+      )
+
+      expect(allDocumentsCountCheck).toHaveProperty('body.hits.total.value', 12)
+
+      const searchParams = await formatSearchParams(
+        {
+          parameters: {
+            name: 'John'
+          }
+        },
+        false
+      )
+
+      const searchResult = await t.elasticClient.search(searchParams)
+
+      expect(searchResult).toHaveProperty('hits.total.value', 3)
+
+      const scores = searchResult.hits.hits.map((hit) => hit._score) as number[]
+
+      expect(scores[0]).toEqual(scores[1])
+      expect(scores[0]).toEqual(scores[2])
+    })
+    it('finds several hits when searching with a more specific name John Davis, but the score for John Davis is higher than other hits', async () => {
+      const t = await setupTestCases(setup)
+
+      await addRecords({ client: t.elasticClient })
+
+      const allDocumentsCountCheck = await t.elasticClient.search(
+        {
+          index: OPENCRVS_INDEX_NAME,
+          body: {
+            query: { match_all: {} }
+          }
+        },
+        {
+          meta: true,
+          ignore: [404]
+        }
+      )
+
+      expect(allDocumentsCountCheck).toHaveProperty('body.hits.total.value', 12)
+
+      const searchParams = await formatSearchParams(
+        {
+          parameters: {
+            name: 'John Davis'
+          }
+        },
+        false
+      )
+
+      const searchResult = await t.elasticClient.search(searchParams)
+
+      expect(searchResult).toHaveProperty('hits.total.value', 3)
+
+      const scores = searchResult.hits.hits.map((hit) => hit._score) as number[]
+
+      expect(scores[0]).toBeGreaterThan(scores[1])
+      expect(scores[0]).toBeGreaterThan(scores[2])
+      expect(scores[1]).toEqual(scores[2])
+    })
+    it('finds a single hit when searching with a bride and groom name', async () => {
+      const t = await setupTestCases(setup)
+
+      await addRecords({ client: t.elasticClient })
+
+      const allDocumentsCountCheck = await t.elasticClient.search(
+        {
+          index: OPENCRVS_INDEX_NAME,
+          body: {
+            query: { match_all: {} }
+          }
+        },
+        {
+          meta: true,
+          ignore: [404]
+        }
+      )
+
+      expect(allDocumentsCountCheck).toHaveProperty('body.hits.total.value', 12)
+
+      const searchParams = await formatSearchParams(
+        {
+          parameters: {
+            name: 'Jane Andrews James Ford'
+          }
+        },
+        false
+      )
+
+      const searchResult = await t.elasticClient.search(searchParams)
+
+      expect(searchResult).toHaveProperty('hits.total.value', 1)
+    })
+    it('finds two hits across Birth and Death events when searching with only a last name Smith', async () => {
+      const t = await setupTestCases(setup)
+
+      await addRecords({ client: t.elasticClient })
+
+      const allDocumentsCountCheck = await t.elasticClient.search(
+        {
+          index: OPENCRVS_INDEX_NAME,
+          body: {
+            query: { match_all: {} }
+          }
+        },
+        {
+          meta: true,
+          ignore: [404]
+        }
+      )
+
+      expect(allDocumentsCountCheck).toHaveProperty('body.hits.total.value', 12)
+
+      const searchParams = await formatSearchParams(
+        {
+          parameters: {
+            name: 'Smith'
+          }
+        },
+        false
+      )
+
+      const searchResult = await t.elasticClient.search(searchParams)
+
+      expect(searchResult).toHaveProperty('hits.total.value', 2)
+    })
+    it('finds a single hit of a Death event when searching with only a spouse name Lily Pope', async () => {
+      const t = await setupTestCases(setup)
+
+      await addRecords({ client: t.elasticClient })
+
+      const allDocumentsCountCheck = await t.elasticClient.search(
+        {
+          index: OPENCRVS_INDEX_NAME,
+          body: {
+            query: { match_all: {} }
+          }
+        },
+        {
+          meta: true,
+          ignore: [404]
+        }
+      )
+
+      expect(allDocumentsCountCheck).toHaveProperty('body.hits.total.value', 12)
+
+      const searchParams = await formatSearchParams(
+        {
+          parameters: {
+            name: 'Lily Pope'
+          }
+        },
+        false
+      )
+
+      const searchResult = await t.elasticClient.search(searchParams)
+
+      expect(searchResult).toHaveProperty('hits.total.value', 1)
+    })
+    it('does not find any hits when searching with a name that does not match any of the name fields', async () => {
+      const t = await setupTestCases(setup)
+
+      await addRecords({ client: t.elasticClient })
+
+      const allDocumentsCountCheck = await t.elasticClient.search(
+        {
+          index: OPENCRVS_INDEX_NAME,
+          body: {
+            query: { match_all: {} }
+          }
+        },
+        {
+          meta: true,
+          ignore: [404]
+        }
+      )
+
+      expect(allDocumentsCountCheck).toHaveProperty('body.hits.total.value', 12)
+
+      const searchParams = await formatSearchParams(
+        {
+          parameters: {
+            name: 'Voldemort'
+          }
+        },
+        false
+      )
+
+      const searchResult = await t.elasticClient.search(searchParams)
+
+      expect(searchResult).toHaveProperty('hits.total.value', 0)
+    })
+  })
+})
+
+const childFirstNames = [
+  'John',
+  'Emma',
+  'Noah',
+  'Olivia',
+  'Aiden',
+  'Ava',
+  'Caden',
+  'John',
+  'John',
+  'Johnny'
+]
+
+const motherFirstNames = [
+  'Jessica',
+  'Ashley',
+  'Sarah',
+  'Amanda',
+  'Jennifer',
+  'Emily',
+  'Melissa',
+  'Nicole',
+  'Stephanie',
+  'Elizabeth'
+]
+
+const familyNames = [
+  'Smith',
+  'Johnson',
+  'Williams',
+  'Brown',
+  'Johnson',
+  'Garcia',
+  'Miller',
+  'Davis',
+  'Rodriguez',
+  'Martinez'
+]
+
+const generateBirthRecord = (id: string, i: number) => {
+  const familyName = familyNames[i]
+  return {
+    compositionId: id,
+    childFirstNames: childFirstNames[i],
+    childFamilyName: familyName,
+    name: `${childFirstNames[i]} ${familyName}`,
+    motherFirstNames: motherFirstNames[i],
+    motherFamilyName: familyName,
+    event: EVENT.BIRTH
+  }
+}
+
+const addRecords = async ({ client }: { client: elasticsearch.Client }) => {
+  const bulkOperations: any[] = []
+
+  for (let i = 0; i < 10; i++) {
+    const id = uuid()
+    const record = generateBirthRecord(id, i)
+
+    bulkOperations.push(
+      { index: { _index: OPENCRVS_INDEX_NAME, _id: id } },
+      record
+    )
+  }
+
+  const deathRecordId = uuid()
+  const deathRecord = {
+    event: EVENT.DEATH,
+    compositionId: deathRecordId,
+    name: 'Robert Smith',
+    deceasedFirstNames: 'Robert',
+    deceasedFamilyName: 'Smith',
+    informantFirstNames: 'George',
+    informantFamilyName: 'Henry',
+    spouseFirstNames: 'Lily',
+    spouseFamilyName: 'Pope'
+  }
+
+  const marriageRecordId = uuid()
+  const marriageRecord = {
+    event: EVENT.MARRIAGE,
+    compositionId: marriageRecordId,
+    brideFirstNames: 'Jane',
+    brideFamilyName: 'Andrews',
+    groomFirstNames: 'James',
+    groomFamilyName: 'Ford',
+    witnessOneFirstNames: 'Michael',
+    witnessOneFamilyName: 'Andrews'
+  }
+
+  bulkOperations.push(
+    { index: { _index: OPENCRVS_INDEX_NAME, _id: deathRecordId } },
+    deathRecord
+  )
+  bulkOperations.push(
+    { index: { _index: OPENCRVS_INDEX_NAME, _id: marriageRecordId } },
+    marriageRecord
+  )
+
+  try {
+    const bulkResponse = await client.bulk({ body: bulkOperations })
+
+    if (bulkResponse.errors) {
+      console.error('Some records failed to index:', bulkResponse.items)
+    } else {
+      await client.indices.refresh({ index: OPENCRVS_INDEX_NAME })
+    }
+  } catch (error) {
+    console.error('Failed to perform bulk insert:', error)
+  }
+}

--- a/packages/search/src/features/search/service.test.ts
+++ b/packages/search/src/features/search/service.test.ts
@@ -253,8 +253,7 @@ describe('elasticsearch params formatter', () => {
                             'witnessTwoFirstNames',
                             'witnessTwoFamilyName'
                           ],
-                          type: 'cross_fields',
-                          operator: 'and'
+                          fuzziness: 'AUTO'
                         }
                       }
                     }

--- a/packages/search/src/features/search/service.test.ts
+++ b/packages/search/src/features/search/service.test.ts
@@ -204,15 +204,7 @@ describe('elasticsearch params formatter', () => {
                           fields: [
                             'name^3',
                             'childFirstNames^2',
-                            'childFamilyName'
-                          ],
-                          fuzziness: 'AUTO'
-                        }
-                      },
-                      should: {
-                        multi_match: {
-                          query: 'sadman anik',
-                          fields: [
+                            'childFamilyName',
                             'informantFirstNames',
                             'informantFamilyName',
                             'motherFirstNames',
@@ -234,15 +226,7 @@ describe('elasticsearch params formatter', () => {
                           fields: [
                             'name^3',
                             'deceasedFirstNames^2',
-                            'deceasedFamilyName'
-                          ],
-                          fuzziness: 'AUTO'
-                        }
-                      },
-                      should: {
-                        multi_match: {
-                          query: 'sadman anik',
-                          fields: [
+                            'deceasedFamilyName',
                             'informantFirstNames',
                             'informantFamilyName',
                             'spouseFirstNames',
@@ -263,22 +247,14 @@ describe('elasticsearch params formatter', () => {
                             'brideFirstNames^6',
                             'brideFamilyName^6',
                             'groomFirstNames^6',
-                            'groomFamilyName^6'
-                          ],
-                          type: 'cross_fields',
-                          operator: 'and'
-                        }
-                      },
-                      should: {
-                        multi_match: {
-                          query: 'sadman anik',
-                          fields: [
+                            'groomFamilyName^6',
                             'witnessOneFirstNames',
                             'witnessOneFamilyName',
                             'witnessTwoFirstNames',
                             'witnessTwoFamilyName'
                           ],
-                          fuzziness: 'AUTO'
+                          type: 'cross_fields',
+                          operator: 'and'
                         }
                       }
                     }

--- a/packages/search/src/features/search/service.test.ts
+++ b/packages/search/src/features/search/service.test.ts
@@ -93,6 +93,7 @@ describe('elasticsearch params formatter', () => {
         createdBy: 'EMPTY_STRING',
         from: 0,
         size: 10,
+        sortColumn: 'dateOfDeclaration',
         sort: SortOrder.ASC
       },
       false
@@ -192,37 +193,104 @@ describe('elasticsearch params formatter', () => {
           filter: [],
           must: [
             {
-              multi_match: {
-                query: 'sadman anik',
-                fields: [
-                  'childFirstNames',
-                  'childFamilyName',
-                  'motherFirstNames',
-                  'motherFamilyName',
-                  'fatherFirstNames',
-                  'fatherFamilyName',
-                  'informantFirstNames',
-                  'informantFamilyName',
-                  'deceasedFirstNames',
-                  'deceasedFamilyName',
-                  'spouseFirstNames',
-                  'spouseFamilyName',
-                  'brideFirstNames',
-                  'brideFamilyName',
-                  'groomFirstNames',
-                  'groomFamilyName',
-                  'witnessOneFirstNames',
-                  'witnessOneFamilyName',
-                  'witnessTwoFirstNames',
-                  'witnessTwoFamilyName'
+              bool: {
+                should: [
+                  {
+                    bool: {
+                      filter: { term: { event: 'birth' } },
+                      must: {
+                        multi_match: {
+                          query: 'sadman anik',
+                          fields: [
+                            'name^3',
+                            'childFirstNames^2',
+                            'childFamilyName'
+                          ],
+                          fuzziness: 'AUTO'
+                        }
+                      },
+                      should: {
+                        multi_match: {
+                          query: 'sadman anik',
+                          fields: [
+                            'informantFirstNames',
+                            'informantFamilyName',
+                            'motherFirstNames',
+                            'motherFamilyName',
+                            'fatherFirstNames',
+                            'fatherFamilyName'
+                          ],
+                          fuzziness: 'AUTO'
+                        }
+                      }
+                    }
+                  },
+                  {
+                    bool: {
+                      filter: { term: { event: 'death' } },
+                      must: {
+                        multi_match: {
+                          query: 'sadman anik',
+                          fields: [
+                            'name^3',
+                            'deceasedFirstNames^2',
+                            'deceasedFamilyName'
+                          ],
+                          fuzziness: 'AUTO'
+                        }
+                      },
+                      should: {
+                        multi_match: {
+                          query: 'sadman anik',
+                          fields: [
+                            'informantFirstNames',
+                            'informantFamilyName',
+                            'spouseFirstNames',
+                            'spouseFamilyName'
+                          ],
+                          fuzziness: 'AUTO'
+                        }
+                      }
+                    }
+                  },
+                  {
+                    bool: {
+                      filter: { term: { event: 'marriage' } },
+                      must: {
+                        multi_match: {
+                          query: 'sadman anik',
+                          fields: [
+                            'brideFirstNames^6',
+                            'brideFamilyName^6',
+                            'groomFirstNames^6',
+                            'groomFamilyName^6'
+                          ],
+                          type: 'cross_fields',
+                          operator: 'and'
+                        }
+                      },
+                      should: {
+                        multi_match: {
+                          query: 'sadman anik',
+                          fields: [
+                            'witnessOneFirstNames',
+                            'witnessOneFamilyName',
+                            'witnessTwoFirstNames',
+                            'witnessTwoFamilyName'
+                          ],
+                          fuzziness: 'AUTO'
+                        }
+                      }
+                    }
+                  }
                 ],
-                fuzziness: 'AUTO'
+                minimum_should_match: 1
               }
             }
           ]
         }
       },
-      sort: [{ dateOfDeclaration: { order: 'asc', unmapped_type: 'keyword' } }]
+      sort: []
     })
   })
 })

--- a/packages/search/src/features/search/service.ts
+++ b/packages/search/src/features/search/service.ts
@@ -25,19 +25,23 @@ export async function formatSearchParams(
     createdBy = '',
     from = 0,
     size = DEFAULT_SIZE,
-    sortColumn = 'dateOfDeclaration',
+    sortColumn,
     sortBy,
     parameters
   } = searchPayload
 
-  const sort = sortBy ?? [
-    {
+  const sort = []
+
+  if (sortBy) {
+    sort.push(...sortBy)
+  } else if (sortColumn) {
+    sort.push({
       [sortColumn === 'name' ? 'name.keyword' : sortColumn]: {
         order: searchPayload.sort ?? SortOrder.ASC,
         unmapped_type: 'keyword'
       }
-    }
-  ]
+    })
+  }
   const query = await advancedQueryBuilder(
     parameters,
     createdBy,

--- a/packages/search/src/features/search/utils.test.ts
+++ b/packages/search/src/features/search/utils.test.ts
@@ -124,8 +124,7 @@ describe('elasticsearch db helper', () => {
                           'witnessTwoFirstNames',
                           'witnessTwoFamilyName'
                         ],
-                        type: 'cross_fields',
-                        operator: 'and'
+                        fuzziness: 'AUTO'
                       }
                     }
                   }

--- a/packages/search/src/features/search/utils.test.ts
+++ b/packages/search/src/features/search/utils.test.ts
@@ -75,15 +75,7 @@ describe('elasticsearch db helper', () => {
                         fields: [
                           'name^3',
                           'childFirstNames^2',
-                          'childFamilyName'
-                        ],
-                        fuzziness: 'AUTO'
-                      }
-                    },
-                    should: {
-                      multi_match: {
-                        query: 'John Doe',
-                        fields: [
+                          'childFamilyName',
                           'informantFirstNames',
                           'informantFamilyName',
                           'motherFirstNames',
@@ -105,15 +97,7 @@ describe('elasticsearch db helper', () => {
                         fields: [
                           'name^3',
                           'deceasedFirstNames^2',
-                          'deceasedFamilyName'
-                        ],
-                        fuzziness: 'AUTO'
-                      }
-                    },
-                    should: {
-                      multi_match: {
-                        query: 'John Doe',
-                        fields: [
+                          'deceasedFamilyName',
                           'informantFirstNames',
                           'informantFamilyName',
                           'spouseFirstNames',
@@ -134,22 +118,14 @@ describe('elasticsearch db helper', () => {
                           'brideFirstNames^6',
                           'brideFamilyName^6',
                           'groomFirstNames^6',
-                          'groomFamilyName^6'
-                        ],
-                        type: 'cross_fields',
-                        operator: 'and'
-                      }
-                    },
-                    should: {
-                      multi_match: {
-                        query: 'John Doe',
-                        fields: [
+                          'groomFamilyName^6',
                           'witnessOneFirstNames',
                           'witnessOneFamilyName',
                           'witnessTwoFirstNames',
                           'witnessTwoFamilyName'
                         ],
-                        fuzziness: 'AUTO'
+                        type: 'cross_fields',
+                        operator: 'and'
                       }
                     }
                   }

--- a/packages/search/src/features/search/utils.test.ts
+++ b/packages/search/src/features/search/utils.test.ts
@@ -46,4 +46,120 @@ describe('elasticsearch db helper', () => {
       }
     })
   })
+  it('should create a query that searches by name', async () => {
+    const newQuery = await advancedQueryBuilder(
+      {
+        trackingId: '',
+        nationalId: '',
+        registrationNumber: '',
+        contactNumber: '',
+        contactEmail: '',
+        name: 'John Doe'
+      },
+      '',
+      false
+    )
+    expect(newQuery).toEqual({
+      bool: {
+        filter: [],
+        must: [
+          {
+            bool: {
+              should: [
+                {
+                  bool: {
+                    filter: { term: { event: 'birth' } },
+                    must: {
+                      multi_match: {
+                        query: 'John Doe',
+                        fields: [
+                          'name^3',
+                          'childFirstNames^2',
+                          'childFamilyName'
+                        ],
+                        fuzziness: 'AUTO'
+                      }
+                    },
+                    should: {
+                      multi_match: {
+                        query: 'John Doe',
+                        fields: [
+                          'informantFirstNames',
+                          'informantFamilyName',
+                          'motherFirstNames',
+                          'motherFamilyName',
+                          'fatherFirstNames',
+                          'fatherFamilyName'
+                        ],
+                        fuzziness: 'AUTO'
+                      }
+                    }
+                  }
+                },
+                {
+                  bool: {
+                    filter: { term: { event: 'death' } },
+                    must: {
+                      multi_match: {
+                        query: 'John Doe',
+                        fields: [
+                          'name^3',
+                          'deceasedFirstNames^2',
+                          'deceasedFamilyName'
+                        ],
+                        fuzziness: 'AUTO'
+                      }
+                    },
+                    should: {
+                      multi_match: {
+                        query: 'John Doe',
+                        fields: [
+                          'informantFirstNames',
+                          'informantFamilyName',
+                          'spouseFirstNames',
+                          'spouseFamilyName'
+                        ],
+                        fuzziness: 'AUTO'
+                      }
+                    }
+                  }
+                },
+                {
+                  bool: {
+                    filter: { term: { event: 'marriage' } },
+                    must: {
+                      multi_match: {
+                        query: 'John Doe',
+                        fields: [
+                          'brideFirstNames^6',
+                          'brideFamilyName^6',
+                          'groomFirstNames^6',
+                          'groomFamilyName^6'
+                        ],
+                        type: 'cross_fields',
+                        operator: 'and'
+                      }
+                    },
+                    should: {
+                      multi_match: {
+                        query: 'John Doe',
+                        fields: [
+                          'witnessOneFirstNames',
+                          'witnessOneFamilyName',
+                          'witnessTwoFirstNames',
+                          'witnessTwoFamilyName'
+                        ],
+                        fuzziness: 'AUTO'
+                      }
+                    }
+                  }
+                }
+              ],
+              minimum_should_match: 1
+            }
+          }
+        ]
+      }
+    })
+  })
 })

--- a/packages/search/src/features/search/utils.ts
+++ b/packages/search/src/features/search/utils.ts
@@ -46,14 +46,10 @@ export async function advancedQueryBuilder(
               must: {
                 multi_match: {
                   query: params.name,
-                  fields: ['name^3', 'childFirstNames^2', 'childFamilyName'],
-                  fuzziness: 'AUTO'
-                }
-              },
-              should: {
-                multi_match: {
-                  query: params.name,
                   fields: [
+                    'name^3',
+                    'childFirstNames^2',
+                    'childFamilyName',
                     'informantFirstNames',
                     'informantFamilyName',
                     'motherFirstNames',
@@ -75,15 +71,7 @@ export async function advancedQueryBuilder(
                   fields: [
                     'name^3',
                     'deceasedFirstNames^2',
-                    'deceasedFamilyName'
-                  ],
-                  fuzziness: 'AUTO'
-                }
-              },
-              should: {
-                multi_match: {
-                  query: params.name,
-                  fields: [
+                    'deceasedFamilyName',
                     'informantFirstNames',
                     'informantFamilyName',
                     'spouseFirstNames',
@@ -104,22 +92,14 @@ export async function advancedQueryBuilder(
                     'brideFirstNames^6',
                     'brideFamilyName^6',
                     'groomFirstNames^6',
-                    'groomFamilyName^6'
-                  ],
-                  type: 'cross_fields',
-                  operator: 'and'
-                }
-              },
-              should: {
-                multi_match: {
-                  query: params.name,
-                  fields: [
+                    'groomFamilyName^6',
                     'witnessOneFirstNames',
                     'witnessOneFamilyName',
                     'witnessTwoFirstNames',
                     'witnessTwoFamilyName'
                   ],
-                  fuzziness: 'AUTO'
+                  type: 'cross_fields',
+                  operator: 'and'
                 }
               }
             }

--- a/packages/search/src/features/search/utils.ts
+++ b/packages/search/src/features/search/utils.ts
@@ -98,8 +98,7 @@ export async function advancedQueryBuilder(
                     'witnessTwoFirstNames',
                     'witnessTwoFamilyName'
                   ],
-                  type: 'cross_fields',
-                  operator: 'and'
+                  fuzziness: 'AUTO'
                 }
               }
             }

--- a/packages/search/src/features/search/utils.ts
+++ b/packages/search/src/features/search/utils.ts
@@ -38,31 +38,51 @@ export async function advancedQueryBuilder(
 
   if (params.name) {
     must.push({
-      multi_match: {
-        query: params.name,
-        fields: [
-          'childFirstNames',
-          'childFamilyName',
-          'motherFirstNames',
-          'motherFamilyName',
-          'fatherFirstNames',
-          'fatherFamilyName',
-          'informantFirstNames',
-          'informantFamilyName',
-          'deceasedFirstNames',
-          'deceasedFamilyName',
-          'spouseFirstNames',
-          'spouseFamilyName',
-          'brideFirstNames',
-          'brideFamilyName',
-          'groomFirstNames',
-          'groomFamilyName',
-          'witnessOneFirstNames',
-          'witnessOneFamilyName',
-          'witnessTwoFirstNames',
-          'witnessTwoFamilyName'
+      bool: {
+        should: [
+          {
+            query_string: {
+              query: params.name,
+              default_field: 'name'
+            }
+          },
+          {
+            multi_match: {
+              query: params.name,
+              fields: [
+                'brideFirstNames^3',
+                'brideFamilyName^3',
+                'groomFirstNames^3',
+                'groomFamilyName^3'
+              ],
+              type: 'cross_fields',
+              operator: 'and'
+            }
+          },
+          {
+            multi_match: {
+              query: params.name,
+              fields: [
+                'motherFirstNames',
+                'motherFamilyName',
+                'fatherFirstNames',
+                'fatherFamilyName',
+                'informantFirstNames',
+                'informantFamilyName',
+                'deceasedFirstNames',
+                'deceasedFamilyName',
+                'spouseFirstNames',
+                'spouseFamilyName',
+                'witnessOneFirstNames',
+                'witnessOneFamilyName',
+                'witnessTwoFirstNames',
+                'witnessTwoFamilyName'
+              ],
+              fuzziness: 'AUTO'
+            }
+          }
         ],
-        fuzziness: 'AUTO'
+        minimum_should_match: 1
       }
     })
   }

--- a/packages/search/src/features/search/utils.ts
+++ b/packages/search/src/features/search/utils.ts
@@ -41,44 +41,87 @@ export async function advancedQueryBuilder(
       bool: {
         should: [
           {
-            query_string: {
-              query: params.name,
-              default_field: 'name'
+            bool: {
+              filter: { term: { event: 'birth' } },
+              must: {
+                multi_match: {
+                  query: params.name,
+                  fields: ['name^3', 'childFirstNames^2', 'childFamilyName'],
+                  fuzziness: 'AUTO'
+                }
+              },
+              should: {
+                multi_match: {
+                  query: params.name,
+                  fields: [
+                    'informantFirstNames',
+                    'informantFamilyName',
+                    'motherFirstNames',
+                    'motherFamilyName',
+                    'fatherFirstNames',
+                    'fatherFamilyName'
+                  ],
+                  fuzziness: 'AUTO'
+                }
+              }
             }
           },
           {
-            multi_match: {
-              query: params.name,
-              fields: [
-                'brideFirstNames^3',
-                'brideFamilyName^3',
-                'groomFirstNames^3',
-                'groomFamilyName^3'
-              ],
-              type: 'cross_fields',
-              operator: 'and'
+            bool: {
+              filter: { term: { event: 'death' } },
+              must: {
+                multi_match: {
+                  query: params.name,
+                  fields: [
+                    'name^3',
+                    'deceasedFirstNames^2',
+                    'deceasedFamilyName'
+                  ],
+                  fuzziness: 'AUTO'
+                }
+              },
+              should: {
+                multi_match: {
+                  query: params.name,
+                  fields: [
+                    'informantFirstNames',
+                    'informantFamilyName',
+                    'spouseFirstNames',
+                    'spouseFamilyName'
+                  ],
+                  fuzziness: 'AUTO'
+                }
+              }
             }
           },
           {
-            multi_match: {
-              query: params.name,
-              fields: [
-                'motherFirstNames',
-                'motherFamilyName',
-                'fatherFirstNames',
-                'fatherFamilyName',
-                'informantFirstNames',
-                'informantFamilyName',
-                'deceasedFirstNames',
-                'deceasedFamilyName',
-                'spouseFirstNames',
-                'spouseFamilyName',
-                'witnessOneFirstNames',
-                'witnessOneFamilyName',
-                'witnessTwoFirstNames',
-                'witnessTwoFamilyName'
-              ],
-              fuzziness: 'AUTO'
+            bool: {
+              filter: { term: { event: 'marriage' } },
+              must: {
+                multi_match: {
+                  query: params.name,
+                  fields: [
+                    'brideFirstNames^6',
+                    'brideFamilyName^6',
+                    'groomFirstNames^6',
+                    'groomFamilyName^6'
+                  ],
+                  type: 'cross_fields',
+                  operator: 'and'
+                }
+              },
+              should: {
+                multi_match: {
+                  query: params.name,
+                  fields: [
+                    'witnessOneFirstNames',
+                    'witnessOneFamilyName',
+                    'witnessTwoFirstNames',
+                    'witnessTwoFamilyName'
+                  ],
+                  fuzziness: 'AUTO'
+                }
+              }
             }
           }
         ],


### PR DESCRIPTION
## Description

Link to the GitHub issue #9272 

Context and description of fix:
The existing [ES query](https://github.com/opencrvs/opencrvs-core/blob/develop/packages/search/src/features/search/utils.ts#L39C3-L68C4) for quick name searches was way to broad.
This PR modifies the ES query for quick name searches.

In addition the results for quick name searches were sorted by `dateOfDeclaration`, which seems a bit odd as we would want to see ES hits with the highest score on top instead. This PR also removes the default sorting criteria of Quick searches if a `sortColumn` is not provided

[Screen Recording](https://www.loom.com/share/7041e50a5c94471db364a4000202bbcd?sid=cb459d3f-c4aa-4c36-b6c6-8400c8cfe30c)


## Checklist

- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [x] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
