### PR TITLE
Use previous action annotation data as default for current action annotation

### DIFF
--- a/packages/client/src/v2-events/features/events/actions/register/Review.tsx
+++ b/packages/client/src/v2-events/features/events/actions/register/Review.tsx
@@ -67,8 +67,7 @@ export function Review() {
 
   const previousAnnotation = getActionAnnotation({
     event,
-    actionType: ActionType.REGISTER,
-    drafts: []
+    actionType: ActionType.REGISTER
   })
 
   const { setAnnotation, getAnnotation } = useActionAnnotation()

--- a/packages/client/src/v2-events/features/events/actions/validate/Review.tsx
+++ b/packages/client/src/v2-events/features/events/actions/validate/Review.tsx
@@ -61,8 +61,7 @@ export function Review() {
 
   const previousAnnotation = getActionAnnotation({
     event,
-    actionType: ActionType.VALIDATE,
-    drafts: []
+    actionType: ActionType.VALIDATE
   })
 
   const annotation = getAnnotation(previousAnnotation)

--- a/packages/client/src/v2-events/features/workqueues/EventOverview/components/ActionMenuStories/ActionMenu.common.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/components/ActionMenuStories/ActionMenu.common.tsx
@@ -218,6 +218,9 @@ export function createStoriesFromScenarios(
         },
         name: name,
         parameters: {
+          chromatic: {
+            disableSnapshot: true
+          },
           layout: 'centered',
           msw: {
             handlers: {

--- a/packages/commons/src/events/state/index.ts
+++ b/packages/commons/src/events/state/index.ts
@@ -270,11 +270,11 @@ export function getAnnotationFromDrafts(drafts: Draft[]) {
 export function getActionAnnotation({
   event,
   actionType,
-  drafts
+  drafts = []
 }: {
   event: EventDocument
   actionType: ActionType
-  drafts: Draft[]
+  drafts?: Draft[]
 }): EventState {
   const activeActions = getAcceptedActions(event)
   const action = activeActions.find(


### PR DESCRIPTION
## Description

Resolves https://github.com/opencrvs/opencrvs-core/issues/9275
E2e test: https://github.com/opencrvs/opencrvs-farajaland/pull/1359

Use previous action annotation data as default values for current action annotation. This means that on birth declaration, the signature and comment will be persisted.

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
