### PR TITLE
Fix migration issue discovered when restoring an OpenCRVS instace with a large number of records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [1.6.4](https://github.com/opencrvs/opencrvs-core/compare/v1.6.1...v1.6.4)
 
+- Fix migration issue discovered when restoring an OpenCRVS instace with a large number of records [#9116](https://github.com/opencrvs/opencrvs-core/issues/9116)
+
 ## [1.6.3](https://github.com/opencrvs/opencrvs-core/compare/v1.6.1...v1.6.3)
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [1.6.4](https://github.com/opencrvs/opencrvs-core/compare/v1.6.1...v1.6.4)
 
-- Fix migration issue discovered when restoring an OpenCRVS instace with a large number of records [#9116](https://github.com/opencrvs/opencrvs-core/issues/9116)
+- Fix migration issue discovered when restoring an OpenCRVS instance with a large number of records. `$push used too much memory and cannot spill to disk. Memory limit: 104857600 bytes` [#9116](https://github.com/opencrvs/opencrvs-core/issues/9116)
 
 ## [1.6.3](https://github.com/opencrvs/opencrvs-core/compare/v1.6.1...v1.6.3)
 

--- a/packages/search/src/features/records/service.ts
+++ b/packages/search/src/features/records/service.ts
@@ -428,19 +428,8 @@ export const aggregateRecords = ({
           }
         ]
       : []),
-    {
-      $group: {
-        _id: null,
-        composition: { $push: '$$ROOT' }
-      }
-    },
-    { $project: { _id: 0 } },
-    { $unwind: '$composition' },
-    {
-      $addFields: {
-        bundle: ['$composition']
-      }
-    },
+    { $addFields: { bundle: ['$$ROOT'], composition: '$$ROOT' } },
+    { $project: { bundle: 1, composition: 1 } },
 
     ...(includeHistoryResources
       ? [


### PR DESCRIPTION
Reduce record aggregation query memory usage by not grouping all records into a single array

## Description

Resolves: https://github.com/opencrvs/opencrvs-core/issues/9116

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [x] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
