### PR TITLE
Fix "Uncaught TypeError: Cannot read properties of undefined" when updating custom field address

### DIFF
--- a/packages/client/src/views/CorrectionForm/utils.ts
+++ b/packages/client/src/views/CorrectionForm/utils.ts
@@ -456,7 +456,7 @@ export const renderValue = (
     const sectionData = draftData[sectionId]
 
     if (
-      sectionData[camelCase(`countryPrimary ${sectionId}`)] ===
+      sectionData?.[camelCase(`countryPrimary ${sectionId}`)] ===
       window.config.COUNTRY
     ) {
       const dynamicOption: IDynamicOptions = {
@@ -480,7 +480,7 @@ export const renderValue = (
     }
 
     if (
-      sectionData[camelCase(`countrySecondary ${sectionId}`)] ===
+      sectionData?.[camelCase(`countrySecondary ${sectionId}`)] ===
       window.config.COUNTRY
     ) {
       const dynamicOption: IDynamicOptions = {

--- a/packages/client/src/views/RegisterForm/review/ReviewSection.tsx
+++ b/packages/client/src/views/RegisterForm/review/ReviewSection.tsx
@@ -429,7 +429,7 @@ const renderValue = (
     const sectionData = draftData[sectionId]
 
     if (
-      sectionData[camelCase(`countryPrimary ${sectionId}`)] ===
+      sectionData?.[camelCase(`countryPrimary ${sectionId}`)] ===
       window.config.COUNTRY
     ) {
       const dynamicOption: IDynamicOptions = {
@@ -453,7 +453,7 @@ const renderValue = (
     }
 
     if (
-      sectionData[camelCase(`countrySecondary ${sectionId}`)] ===
+      sectionData?.[camelCase(`countrySecondary ${sectionId}`)] ===
       window.config.COUNTRY
     ) {
       const dynamicOption: IDynamicOptions = {


### PR DESCRIPTION
## Description
A `custom section` containing a `custom address field` was `hidden` from the field agent.

After submitting a declaration, the registration agent will review the record and encode the details needed for the custom section. When a custom address field was updated and the registration agent goes back to the review page, it throws `Uncaught TypeError: Cannot read properties of undefined (reading 'countryPrimarySectionName')`

Link this pull request to the GitHub issue: https://github.com/opencrvs/opencrvs-core/issues/9215

## Checklist

- [X] I have linked the correct Github issue under "Development"
- [X] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
