### PR TITLE
Use configured fallback title if actual title resolves to empty string

### DIFF
--- a/packages/client/src/v2-events/features/workqueues/Workqueue.tsx
+++ b/packages/client/src/v2-events/features/workqueues/Workqueue.tsx
@@ -178,10 +178,17 @@ function Workqueue({
 
       const titleColumnId = workqueueConfig.columns[0].id
 
-      const title = flattenedIntl.formatMessage(
+      const formattedTitle = flattenedIntl.formatMessage(
         eventConfig.title,
         flattenEventIndex(event)
       )
+
+      const fallbackTitle = eventConfig.fallbackTitle
+        ? intl.formatMessage(eventConfig.fallbackTitle)
+        : null
+
+      const useFallbackTitle = formattedTitle.trim() === ''
+      const title = useFallbackTitle ? fallbackTitle : formattedTitle
 
       const TitleColumn =
         width > theme.grid.breakpoints.lg ? (
@@ -214,6 +221,7 @@ function Workqueue({
           TitleColumn
         ) : (
           <TextButton
+            color={useFallbackTitle ? 'red' : 'primary'}
             onClick={() => {
               return navigate(
                 ROUTES.V2.EVENTS.OVERVIEW.buildPath({

--- a/packages/client/src/v2-events/features/workqueues/Workqueue.tsx
+++ b/packages/client/src/v2-events/features/workqueues/Workqueue.tsx
@@ -269,6 +269,7 @@ function Workqueue({
         isSorted: sortedCol === column.id
       })
     )
+
     const allColumns = configuredColumns.concat(getDefaultColumns())
 
     if (width > theme.grid.breakpoints.lg) {
@@ -281,6 +282,7 @@ function Workqueue({
   const totalPages = workqueue.length ? Math.round(workqueue.length / limit) : 0
 
   const isShowPagination = totalPages >= 1
+
   return (
     <WQContentWrapper
       error={false}

--- a/packages/commons/src/events/EventConfig.ts
+++ b/packages/commons/src/events/EventConfig.ts
@@ -34,6 +34,9 @@ export const EventConfig = z
       ),
     dateOfEvent: z.object({ fieldId: z.string() }).optional(),
     title: TranslationConfig,
+    fallbackTitle: TranslationConfig.optional().describe(
+      'This is a fallback title if actual title resolves to empty string'
+    ),
     summary: SummaryConfig,
     label: TranslationConfig,
     actions: z.array(ActionConfig),


### PR DESCRIPTION
## Description

Resolves https://github.com/opencrvs/opencrvs-core/issues/9412

Use configured fallback title if actual title resolves to empty string

<img width="1724" alt="Screenshot 2025-05-07 at 14 06 21" src="https://github.com/user-attachments/assets/654dbdcd-5ea7-4d88-9ab6-d328e3712788" />

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
