### PR TITLE
fix: Remove PractitionerRole from Hearth bundle on every view and download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Filter out inactive locations in the Organisations menu [#8782](https://github.com/opencrvs/opencrvs-core/issues/8782)
 - Improve quick search results when searching by name [#9272](https://github.com/opencrvs/opencrvs-core/issues/9272)
+- Fix practitioner role history entries from being created with every view and download [#9462](https://github.com/opencrvs/opencrvs-core/issues/9462)
 
 ## [1.7.1](https://github.com/opencrvs/opencrvs-core/compare/v1.7.0...v1.7.1)
 

--- a/packages/migration/src/migrations/hearth/20250508091242-remove-duplicate-practitioner-role.ts
+++ b/packages/migration/src/migrations/hearth/20250508091242-remove-duplicate-practitioner-role.ts
@@ -9,65 +9,80 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 
-import { Db } from 'mongodb'
+import { Db, MongoClient } from 'mongodb'
 
 // Migration to remove redundant historical entries in PractitionerRole_history
 // but also handles the case where a Practioner may change their role and change it back
 // e.g. From Registrar to Registration Agent and back to Registrar
 
-export const up = async (db: Db) => {
+export const up = async (db: Db, client: MongoClient) => {
   const collection = db.collection('PractitionerRole_history')
+  const session = client.startSession()
 
-  const docs = await collection
-    .find(
-      {
-        practitioner: { $exists: true },
-        code: { $exists: true },
-        'code.0.coding.0.code': { $exists: true },
-        'meta.lastUpdated': { $exists: true }
-      },
-      {
-        projection: {
-          practitioner: 1,
-          code: 1,
-          meta: 1
+  try {
+    await session.withTransaction(async () => {
+      const cursor = collection
+        .find(
+          {
+            practitioner: { $exists: true },
+            code: { $exists: true },
+            'code.0.coding.0.code': { $exists: true },
+            'meta.lastUpdated': { $exists: true }
+          },
+          {
+            projection: {
+              practitioner: 1,
+              code: 1,
+              meta: 1
+            }
+          }
+        )
+        .sort({ 'practitioner.reference': 1, 'meta.lastUpdated': 1 })
+
+      const toDelete: any[] = []
+
+      let prevId: string | undefined
+      let prevRole: string | undefined
+
+      while (await cursor.hasNext()) {
+        const doc = await cursor.next()
+        if (!doc) continue
+
+        const practitionerId = doc.practitioner?.reference
+        const role = doc.code?.[0]?.coding?.[0]?.code
+
+        if (!practitionerId || !role) continue
+
+        if (practitionerId !== prevId) {
+          prevId = practitionerId
+          prevRole = role
+          continue
+        }
+
+        if (role === prevRole) {
+          toDelete.push(doc._id)
+        } else {
+          prevRole = role
         }
       }
-    )
-    .sort({ 'practitioner.reference': 1, 'meta.lastUpdated': 1 })
-    .toArray()
+      const batches = createBatches(toDelete, 1000)
 
-  const toDelete: any[] = []
-
-  let prevId: string | undefined
-  let prevRole: string | undefined
-
-  for (let i = 0; i < docs.length; i++) {
-    const doc = docs[i]
-    const practitionerId = doc.practitioner?.reference
-    const role = doc.code?.[0]?.coding?.[0]?.code
-
-    if (!practitionerId || !role) continue
-
-    if (practitionerId !== prevId) {
-      prevId = practitionerId
-      prevRole = role
-      continue
-    }
-
-    if (role === prevRole) {
-      toDelete.push(doc._id)
-    } else {
-      prevRole = role
-    }
-  }
-
-  if (toDelete.length) {
-    const result = await collection.deleteMany({ _id: { $in: toDelete } })
-    console.log(`Deleted ${result.deletedCount} redundant historical entries.`)
-  } else {
-    console.log('No redundant entries found.')
+      for (const batch of batches) {
+        await collection.deleteMany({ _id: { $in: batch } })
+        console.log(`Deleted batch of ${batch.length} duplicates`)
+      }
+    })
+  } finally {
+    await session.endSession()
   }
 }
 
 export const down = async () => {}
+
+function createBatches<T>(array: T[], batchSize: number): T[][] {
+  const result = []
+  for (let i = 0; i < array.length; i += batchSize) {
+    result.push(array.slice(i, i + batchSize))
+  }
+  return result
+}

--- a/packages/migration/src/migrations/hearth/20250508091242-remove-duplicate-practitioner-role.ts
+++ b/packages/migration/src/migrations/hearth/20250508091242-remove-duplicate-practitioner-role.ts
@@ -1,0 +1,73 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+
+import { Db } from 'mongodb'
+
+// Migration to remove redundant historical entries in PractitionerRole_history
+// but also handles the case where a Practioner may change their role and change it back
+// e.g. From Registrar to Registration Agent and back to Registrar
+
+export const up = async (db: Db) => {
+  const collection = db.collection('PractitionerRole_history')
+
+  const docs = await collection
+    .find(
+      {
+        practitioner: { $exists: true },
+        code: { $exists: true },
+        'code.0.coding.0.code': { $exists: true },
+        'meta.lastUpdated': { $exists: true }
+      },
+      {
+        projection: {
+          practitioner: 1,
+          code: 1,
+          meta: 1
+        }
+      }
+    )
+    .sort({ 'practitioner.reference': 1, 'meta.lastUpdated': 1 })
+    .toArray()
+
+  const toDelete: any[] = []
+
+  let prevId: string | undefined
+  let prevRole: string | undefined
+
+  for (let i = 0; i < docs.length; i++) {
+    const doc = docs[i]
+    const practitionerId = doc.practitioner?.reference
+    const role = doc.code?.[0]?.coding?.[0]?.code
+
+    if (!practitionerId || !role) continue
+
+    if (practitionerId !== prevId) {
+      prevId = practitionerId
+      prevRole = role
+      continue
+    }
+
+    if (role === prevRole) {
+      toDelete.push(doc._id)
+    } else {
+      prevRole = role
+    }
+  }
+
+  if (toDelete.length) {
+    const result = await collection.deleteMany({ _id: { $in: toDelete } })
+    console.log(`Deleted ${result.deletedCount} redundant historical entries.`)
+  } else {
+    console.log('No redundant entries found.')
+  }
+}
+
+export const down = async () => {}

--- a/packages/workflow/src/records/state-transitions.ts
+++ b/packages/workflow/src/records/state-transitions.ts
@@ -339,8 +339,7 @@ export async function toViewed<T extends ValidRecord>(
           (e) => e.resource.resourceType === 'Task'
         )[0].fullUrl,
         resource: viewedTask
-      },
-      practitionerRoleEntry
+      }
     ]
   }
 
@@ -428,13 +427,10 @@ export async function toDownloaded(
     practitionerDetailsBundle
   ) as ValidRecord
 
-  const downloadedBundleWithResources: Bundle<SavedTask | PractitionerRole> = {
+  const downloadedBundleWithResources: Bundle<SavedTask> = {
     resourceType: 'Bundle',
     type: 'document',
-    entry: [
-      { resource: downloadedTask },
-      { resource: practitionerRoleEntry.resource }
-    ]
+    entry: [{ resource: downloadedTask }]
   }
 
   return { downloadedRecord, downloadedBundleWithResources }


### PR DESCRIPTION
## Description

fixes: https://github.com/opencrvs/opencrvs-core/pull/9491

On view and download, a bundle with the Task and PractitionerRole was sent to Hearth.
This caused the PractitionerRole to be updated and created an additional PractitionerRole_history entry every time. 10 views meant 10 new PractitionerRole_history entries.

Semantically, PractitionerRole should only be updated if the role changes.
However, the comments in the code imply that the role is required for the declaration history view.

On inspection of the history code in the type resolver, to get the role of the user at the time of the task, it just calls a function to get the role history of the user and finds the correct role at the timestamp of the task:
https://github.com/opencrvs/opencrvs-core/blob/7a382177187187a1121cbe423d11ec368242c4f5/packages/gateway/src/features/registration/type-resolvers.ts#L1662
https://github.com/opencrvs/opencrvs-core/blob/7a382177187187a1121cbe423d11ec368242c4f5/packages/commons/src/fhir/practitioner.ts#L87

I've tested this by performing actions, changing the role of the user and taking further actions. With the changes in this PR, the correct roles are still displayed alongside their respective actions:

![image](https://github.com/user-attachments/assets/74856f74-0973-4b18-8232-7dbe57bffcf3)

Included a migration to remove existing duplicate PractitionerRole_history entries that exist because of the bug.

## Other notes

Each of the functions, `toViewed` and `toDownloaded` creates 2 bundles. I've left the PractitionerRole in the bundle sent to the audit table as it doesn't seem to be an issue and is outside of the scope of this PR. 

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [x] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
