### PR TITLE
Do not upload .git with the cache artifact

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -244,6 +244,7 @@ jobs:
           include-hidden-files: true
           path: |
             .
+            !**/.git
             !**/node_modules
   lint-client:
     name: Lint client

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -164,6 +164,8 @@ jobs:
   prepare-client-tests:
     name: Prepare client tests
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     outputs:
       chromatic_required: ${{ steps.detect-changes.outputs.chromatic_required }}
     steps:


### PR DESCRIPTION
## Description
This change prevents our temporary Git access tokens for momentarily leaking into the cached artefact. There's a small period when the token is valid and could be abused by a malicious actor
