### PR TITLE
fix: Switch from valkey to redis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### New features
 
 - **Kubernetes support for local development** Introduced Tiltfile for OpenCRVS deployment on local Kubernetes cluster. Check https://github.com/opencrvs/infrastructure for more information.
-- **Redis replaced with Valkey**, version was bumped from 5 to 8. [#6720](https://github.com/opencrvs/opencrvs-core/issues/6720)
 
 ### Improvements
 

--- a/docker-compose.deps.yml
+++ b/docker-compose.deps.yml
@@ -14,7 +14,7 @@ services:
     restart: unless-stopped
 
   redis:
-    image: docker.io/bitnami/valkey:8.1
+    image: docker.io/bitnami/redis:8.0
     restart: unless-stopped
     environment:
       - ALLOW_EMPTY_PASSWORD=yes


### PR DESCRIPTION
## Description

Backgroung for this PR is documented at https://redis.io/blog/agplv3/

Slack link: https://opencrvsworkspace.slack.com/archives/C07M2FETFFB/p1746432546347569

Related PRs:
- https://github.com/opencrvs/e2e/pull/54
- https://github.com/opencrvs/opencrvs-farajaland/pull/1377

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths): https://github.com/opencrvs/e2e/actions/runs/14927653690/job/41936217581 Test completed with issue, problem is with events-v2
- [x] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly: N/A
