### PR TITLE
Use zustand form and annotation data when initialising action forms

### DIFF
--- a/packages/client/src/v2-events/features/drafts/useDrafts.ts
+++ b/packages/client/src/v2-events/features/drafts/useDrafts.ts
@@ -112,6 +112,7 @@ export function useDrafts() {
 
   const localDraft = localDraftStore((drafts) => drafts.draft)
   const createDraft = useCreateDraft()
+
   return {
     setLocalDraft: setDraft,
     getLocalDraftOrDefault: getLocalDraftOrDefault,

--- a/packages/client/src/v2-events/features/events/actions/declare/Pages.interaction.stories.tsx
+++ b/packages/client/src/v2-events/features/events/actions/declare/Pages.interaction.stories.tsx
@@ -22,10 +22,14 @@ import {
 import { AppRouter } from '@client/v2-events/trpc'
 import { ROUTES, routesConfig } from '@client/v2-events/routes'
 import { tennisClubMembershipEventDocument } from '@client/v2-events/features/events/fixtures'
+import { useEventFormData } from '../../useEventFormData'
 import { Pages } from './index'
 
 const meta: Meta<typeof Pages> = {
-  title: 'Declare/Interaction'
+  title: 'Declare/Interaction',
+  beforeEach: () => {
+    useEventFormData.setState({ formValues: {} })
+  }
 }
 
 export default meta

--- a/packages/client/src/v2-events/features/events/actions/declare/Review.interaction.stories.tsx
+++ b/packages/client/src/v2-events/features/events/actions/declare/Review.interaction.stories.tsx
@@ -64,8 +64,6 @@ const eventDocument = generateEventDocument({
 
 const eventId = eventDocument.id
 
-const draft = generateEventDraftDocument(eventId, ActionType.REGISTER)
-
 const mockUser = {
   id: '67bda93bfc07dee78ae558cf',
   name: [
@@ -310,6 +308,9 @@ export const ReviewForFieldAgentCompleteInteraction: Story = {
 }
 
 export const ReviewForFieldAgentIncompleteInteraction: Story = {
+  beforeEach: () => {
+    useEventFormData.setState({ formValues: {} })
+  },
   loaders: [
     () => {
       declarationTrpcMsw.events.reset()
@@ -389,11 +390,6 @@ export const ReviewForFieldAgentIncompleteInteraction: Story = {
 }
 
 export const ChangeFieldInReview: Story = {
-  beforeEach: () => {
-    useEventFormData.setState({
-      formValues: getCurrentEventState(declareEventDocument).declaration
-    })
-  },
   parameters: {
     reactRouter: {
       router: routesConfig,
@@ -406,7 +402,7 @@ export const ChangeFieldInReview: Story = {
       handlers: {
         drafts: [
           tRPCMsw.event.draft.list.query(() => {
-            return [draft]
+            return [generateEventDraftDocument(eventId, ActionType.REGISTER)]
           })
         ],
         events: [

--- a/packages/client/src/v2-events/features/events/actions/declare/Review.interaction.stories.tsx
+++ b/packages/client/src/v2-events/features/events/actions/declare/Review.interaction.stories.tsx
@@ -78,6 +78,10 @@ const mockUser = {
 }
 
 export const ReviewForLocalRegistrarCompleteInteraction: Story = {
+  beforeEach: () => {
+    // For this test, we want to have empty form values in zustand state
+    useEventFormData.setState({ formValues: {} })
+  },
   loaders: [
     () => {
       declarationTrpcMsw.events.reset()
@@ -309,6 +313,7 @@ export const ReviewForFieldAgentCompleteInteraction: Story = {
 
 export const ReviewForFieldAgentIncompleteInteraction: Story = {
   beforeEach: () => {
+    // For this test, we want to have empty form values in zustand state
     useEventFormData.setState({ formValues: {} })
   },
   loaders: [

--- a/packages/client/src/v2-events/features/events/components/Action/AnnotationAction.tsx
+++ b/packages/client/src/v2-events/features/events/components/Action/AnnotationAction.tsx
@@ -106,6 +106,9 @@ function AnnotationActionComponent({ children, actionType }: Props) {
   }, [eventDrafts])
 
   useEffect(() => {
+    // Use the annotation values from the zustand state, so that filled form state is not lost
+    // If user e.g. enters the 'screen lock' flow while filling form.
+    // Then use annotation values from drafts.
     setAnnotation({ ...annotation, ...actionAnnotation })
 
     return () => {

--- a/packages/client/src/v2-events/features/events/components/Action/AnnotationAction.tsx
+++ b/packages/client/src/v2-events/features/events/components/Action/AnnotationAction.tsx
@@ -106,8 +106,7 @@ function AnnotationActionComponent({ children, actionType }: Props) {
   }, [eventDrafts])
 
   useEffect(() => {
-    // TODO CIHAN: fix this too
-    setAnnotation(actionAnnotation)
+    setAnnotation({ ...annotation, ...actionAnnotation })
 
     return () => {
       /*

--- a/packages/client/src/v2-events/features/events/components/Action/AnnotationAction.tsx
+++ b/packages/client/src/v2-events/features/events/components/Action/AnnotationAction.tsx
@@ -106,6 +106,7 @@ function AnnotationActionComponent({ children, actionType }: Props) {
   }, [eventDrafts])
 
   useEffect(() => {
+    // TODO CIHAN: fix this too
     setAnnotation(actionAnnotation)
 
     return () => {

--- a/packages/client/src/v2-events/features/events/components/Action/AnnotationAction.tsx
+++ b/packages/client/src/v2-events/features/events/components/Action/AnnotationAction.tsx
@@ -14,6 +14,7 @@ import { useTypedParams } from 'react-router-typesafe-routes/dom'
 import {
   ActionType,
   createEmptyDraft,
+  deepMerge,
   findActiveDrafts,
   getAnnotationFromDrafts
 } from '@opencrvs/commons/client'
@@ -109,7 +110,9 @@ function AnnotationActionComponent({ children, actionType }: Props) {
     // Use the annotation values from the zustand state, so that filled form state is not lost
     // If user e.g. enters the 'screen lock' flow while filling form.
     // Then use annotation values from drafts.
-    setAnnotation({ ...annotation, ...actionAnnotation })
+    const initialAnnotation = deepMerge(annotation || {}, actionAnnotation)
+
+    setAnnotation(initialAnnotation)
 
     return () => {
       /*

--- a/packages/client/src/v2-events/features/events/components/Action/AnnotationAction.tsx
+++ b/packages/client/src/v2-events/features/events/components/Action/AnnotationAction.tsx
@@ -78,9 +78,7 @@ function AnnotationActionComponent({ children, actionType }: Props) {
   /*
    * Initialize the form state
    */
-  const setInitialAnnotation = useActionAnnotation(
-    (state) => state.setInitialAnnotation
-  )
+  const setAnnotation = useActionAnnotation((state) => state.setAnnotation)
 
   const eventDrafts = drafts
     .filter((d) => d.eventId === event.id)
@@ -108,7 +106,7 @@ function AnnotationActionComponent({ children, actionType }: Props) {
   }, [eventDrafts])
 
   useEffect(() => {
-    setInitialAnnotation(actionAnnotation)
+    setAnnotation(actionAnnotation)
 
     return () => {
       /*

--- a/packages/client/src/v2-events/features/events/components/Action/DeclarationAction.tsx
+++ b/packages/client/src/v2-events/features/events/components/Action/DeclarationAction.tsx
@@ -199,6 +199,9 @@ function DeclarationActionComponent({ children, actionType }: Props) {
        * staged drafts the user has for this event id and type
        */
       setLocalDraft(null)
+
+      // TODO CIHAN: do we want or need to do this?
+      // setFormValues({})
     }
 
     /*

--- a/packages/client/src/v2-events/features/events/components/Action/DeclarationAction.tsx
+++ b/packages/client/src/v2-events/features/events/components/Action/DeclarationAction.tsx
@@ -121,10 +121,7 @@ function DeclarationActionComponent({ children, actionType }: Props) {
    * Initialize the form state
    */
   const setFormValues = useEventFormData((state) => state.setFormValues)
-
-  const setInitialAnnotation = useActionAnnotation(
-    (state) => state.setInitialAnnotation
-  )
+  const setAnnotation = useActionAnnotation((state) => state.setAnnotation)
 
   const eventDrafts = drafts
     .filter((d) => d.eventId === event.id)
@@ -150,10 +147,6 @@ function DeclarationActionComponent({ children, actionType }: Props) {
   const eventStateWithDrafts = useMemo(
     () => getCurrentEventStateWithDrafts(event, eventDrafts),
     [eventDrafts, event]
-  )
-
-  const initialForm = useEventFormData((state) =>
-    state.getFormValues(eventStateWithDrafts.declaration)
   )
 
   const actionAnnotation = useMemo(() => {
@@ -192,8 +185,13 @@ function DeclarationActionComponent({ children, actionType }: Props) {
   }, [event, actionType])
 
   useEffect(() => {
-    setFormValues(initialForm)
-    setInitialAnnotation({ ...previousActionAnnotation, ...actionAnnotation })
+    setFormValues({ ...formValues, ...eventStateWithDrafts.declaration })
+
+    setAnnotation({
+      ...annotation,
+      ...previousActionAnnotation,
+      ...actionAnnotation
+    })
 
     return () => {
       /*

--- a/packages/client/src/v2-events/features/events/components/Action/DeclarationAction.tsx
+++ b/packages/client/src/v2-events/features/events/components/Action/DeclarationAction.tsx
@@ -18,7 +18,8 @@ import {
   getActionAnnotation,
   DeclarationUpdateActionType,
   ActionType,
-  Action
+  Action,
+  deepMerge
 } from '@opencrvs/commons/client'
 import { withSuspense } from '@client/v2-events/components/withSuspense'
 import { useEventFormData } from '@client/v2-events/features/events/useEventFormData'
@@ -188,13 +189,19 @@ function DeclarationActionComponent({ children, actionType }: Props) {
     // Use the form values from the zustand state, so that filled form state is not lost
     // If user e.g. enters the 'screen lock' flow while filling form.
     // Then use form values from drafts.
-    setFormValues({ ...formValues, ...eventStateWithDrafts.declaration })
+    const initialFormValues = deepMerge(
+      formValues || {},
+      eventStateWithDrafts.declaration
+    )
 
-    setAnnotation({
-      ...annotation,
-      ...previousActionAnnotation,
-      ...actionAnnotation
-    })
+    setFormValues(initialFormValues)
+
+    const initialAnnotation = deepMerge(
+      deepMerge(annotation || {}, previousActionAnnotation),
+      actionAnnotation
+    )
+
+    setAnnotation(initialAnnotation)
 
     return () => {
       /*
@@ -202,9 +209,6 @@ function DeclarationActionComponent({ children, actionType }: Props) {
        * staged drafts the user has for this event id and type
        */
       setLocalDraft(null)
-
-      // TODO CIHAN: do we want or need to do this?
-      // setFormValues({})
     }
 
     /*

--- a/packages/client/src/v2-events/features/events/components/Action/DeclarationAction.tsx
+++ b/packages/client/src/v2-events/features/events/components/Action/DeclarationAction.tsx
@@ -120,10 +120,7 @@ function DeclarationActionComponent({ children, actionType }: Props) {
   /*
    * Initialize the form state
    */
-
-  const setInitialFormValues = useEventFormData(
-    (state) => state.setInitialFormValues
-  )
+  const setFormValues = useEventFormData((state) => state.setFormValues)
 
   const setInitialAnnotation = useActionAnnotation(
     (state) => state.setInitialAnnotation
@@ -153,6 +150,10 @@ function DeclarationActionComponent({ children, actionType }: Props) {
   const eventStateWithDrafts = useMemo(
     () => getCurrentEventStateWithDrafts(event, eventDrafts),
     [eventDrafts, event]
+  )
+
+  const initialForm = useEventFormData((state) =>
+    state.getFormValues(eventStateWithDrafts.declaration)
   )
 
   const actionAnnotation = useMemo(() => {
@@ -191,7 +192,7 @@ function DeclarationActionComponent({ children, actionType }: Props) {
   }, [event, actionType])
 
   useEffect(() => {
-    setInitialFormValues(eventStateWithDrafts.declaration)
+    setFormValues(initialForm)
     setInitialAnnotation({ ...previousActionAnnotation, ...actionAnnotation })
 
     return () => {

--- a/packages/client/src/v2-events/features/events/components/Action/DeclarationAction.tsx
+++ b/packages/client/src/v2-events/features/events/components/Action/DeclarationAction.tsx
@@ -185,6 +185,9 @@ function DeclarationActionComponent({ children, actionType }: Props) {
   }, [event, actionType])
 
   useEffect(() => {
+    // Use the form values from the zustand state, so that filled form state is not lost
+    // If user e.g. enters the 'screen lock' flow while filling form.
+    // Then use form values from drafts.
     setFormValues({ ...formValues, ...eventStateWithDrafts.declaration })
 
     setAnnotation({

--- a/packages/client/src/v2-events/features/events/useActionAnnotation.ts
+++ b/packages/client/src/v2-events/features/events/useActionAnnotation.ts
@@ -21,7 +21,6 @@ import { EventState, deepDropNulls } from '@opencrvs/commons/client'
 interface ActionAnnotationProps {
   annotation?: EventState
   setAnnotation: (data: EventState) => void
-  setInitialAnnotation: (data: EventState) => void
   getAnnotation: (initialValues?: EventState) => EventState
   getTouchedFields: () => Record<string, boolean>
   clear: () => void
@@ -50,10 +49,6 @@ export const useActionAnnotation = create<ActionAnnotationProps>()(
     getAnnotation: (initialValues?: EventState) =>
       get().annotation || deepDropNulls(initialValues ?? {}),
     setAnnotation: (data: EventState) => {
-      const annotation = removeUndefinedKeys(data)
-      return set(() => ({ annotation }))
-    },
-    setInitialAnnotation: (data: EventState) => {
       const annotation = removeUndefinedKeys(data)
       return set(() => ({ annotation }))
     },

--- a/packages/client/src/v2-events/features/events/useEventFormData.ts
+++ b/packages/client/src/v2-events/features/events/useEventFormData.ts
@@ -17,7 +17,6 @@ import { EventState, FieldValue } from '@opencrvs/commons/client'
 interface EventFormData {
   formValues: null | EventState
   setFormValues: (data: EventState) => void
-  setInitialFormValues: (data: EventState) => void
   getFormValues: (initialValues?: EventState) => EventState
   getTouchedFields: () => Record<string, boolean>
   touchedFields: FormikTouched<Record<string, FieldValue>>
@@ -49,18 +48,15 @@ function removeUndefinedKeys(data: EventState) {
 export const useEventFormData = create<EventFormData>()((set, get) => ({
   formValues: {},
   touchedFields: {},
-  getFormValues: (initialValues?: EventState) =>
-    get().formValues || initialValues || {},
-  setFormValues: (data: EventState) => {
-    const formValues = removeUndefinedKeys(data)
+  getFormValues: (initialValues?: EventState) => {
+    // console.log('getFormValues', get().formValues, initialValues)
+    return get().formValues || initialValues || {}
+  },
+  setFormValues: (form: EventState) => {
+    const formValues = removeUndefinedKeys(form)
     return set(() => ({ formValues }))
   },
-  setInitialFormValues: (data: EventState) => {
-    return set(() => ({ formValues: removeUndefinedKeys(data) }))
-  },
-  setAllTouchedFields: (fields) => {
-    return set(() => ({ touchedFields: fields }))
-  },
+  setAllTouchedFields: (fields) => set(() => ({ touchedFields: fields })),
   getTouchedFields: () =>
     Object.fromEntries(
       Object.entries(get().getFormValues()).map(([key]) => [key, true])

--- a/packages/client/src/v2-events/features/events/useEventFormData.ts
+++ b/packages/client/src/v2-events/features/events/useEventFormData.ts
@@ -48,10 +48,8 @@ function removeUndefinedKeys(data: EventState) {
 export const useEventFormData = create<EventFormData>()((set, get) => ({
   formValues: {},
   touchedFields: {},
-  getFormValues: (initialValues?: EventState) => {
-    // console.log('getFormValues', get().formValues, initialValues)
-    return get().formValues || initialValues || {}
-  },
+  getFormValues: (initialValues?: EventState) =>
+    get().formValues || initialValues || {},
   setFormValues: (form: EventState) => {
     const formValues = removeUndefinedKeys(form)
     return set(() => ({ formValues }))


### PR DESCRIPTION
## Description

Resolves: https://github.com/opencrvs/opencrvs-core/issues/9288

* Use form and annotation values from zustand states (`useEventFormData` and `useActionAnnotation`) when initialising action forms. This means that state will be sustained through, for example, the screen lock / pin code mechanism.
* Refactor `useEventFormData` and `useActionAnnotation`, remove unneeded initial state setting functions
* Fix some test cases which used event form data from state, even though they shouldn't

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
