### PR TITLE
fix: use get over find to combat flakiness

### DIFF
--- a/packages/client/src/v2-events/features/events/actions/register/Review.interaction.stories.tsx
+++ b/packages/client/src/v2-events/features/events/actions/register/Review.interaction.stories.tsx
@@ -214,7 +214,7 @@ export const ReviewForLocalRegistrarArchiveInteraction: Story = {
     })
 
     await step('Add description', async () => {
-      const modal = within(await canvas.findByRole('dialog'))
+      const modal = within(canvas.getByRole('dialog'))
 
       await waitFor(async () =>
         expect(modal.getByRole('textbox')).toBeInTheDocument()


### PR DESCRIPTION
## Description
use get over find to combat flakiness. `find` within `within` seems to be a footgun