### PR TITLE
feat(ocrvs-9523): user.create/user.update scopes can define roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 - **TimeField component with AM/PM support**: The `TimeField` component now supports both 12-hour (AM/PM) and 24-hour formats through a new prop, `use12HourFormat: boolean`. The logic has been refactored into two separate components, `TimeInput24` and `TimeInput12`. The `TimeField` component automatically selects the appropriate component based on the prop. [#8336](https://github.com/opencrvs/opencrvs-core/issues/8336)
+- **Configurable Scopes**: Introduce a new syntax for scopes which provides more customizability to the SI's via scopes. Two new scopes `user.create[role=a|b|c]` & `user.update[role=d|e|f]` are getting included in this release which can be used to restrict what the role of a newly created or updated user can be set to by the user of a particular role. Gradually most of the existing scopes will be migrated to use this new syntax.
 
 ### Bug fixes
 

--- a/packages/client/src/user/userReducer.ts
+++ b/packages/client/src/user/userReducer.ts
@@ -36,7 +36,7 @@ import { gqlToDraftTransformer } from '@client/transformer'
 import { GET_USER, SEARCH_USERS } from '@client/user/queries'
 import { IUserAuditForm, userAuditForm } from '@client/user/user-audit'
 import { getToken, getTokenPayload } from '@client/utils/authUtils'
-import { parseScope } from '@opencrvs/commons/client'
+import { findScope } from '@opencrvs/commons/client'
 import { UserRole } from '@client/utils/gateway'
 
 import type { GQLQuery } from '@client/utils/gateway-deprecated-do-not-use'
@@ -405,16 +405,10 @@ export const userFormReducer: LoopReducer<IUserFormState, UserFormAction> = (
       const { loggedInUserScopes, userRoles } = action.payload
 
       const creatableRoleIds =
-        loggedInUserScopes
-          .map((rawScope) => parseScope(rawScope))
-          .find((parsedScope) => parsedScope?.type === 'user.create')?.options
-          ?.role ?? []
+        findScope(loggedInUserScopes, 'user.create')?.options?.role ?? []
 
       const editableRoleIds =
-        loggedInUserScopes
-          .map((rawScope) => parseScope(rawScope))
-          .find((parsedScope) => parsedScope?.type === 'user.edit')?.options
-          ?.role ?? []
+        findScope(loggedInUserScopes, 'user.edit')?.options?.role ?? []
 
       const allowedRoleIds = [...creatableRoleIds, ...editableRoleIds]
 

--- a/packages/client/src/views/SysAdmin/Team/user/userCreation/CreateNewUser.test.tsx
+++ b/packages/client/src/views/SysAdmin/Team/user/userCreation/CreateNewUser.test.tsx
@@ -232,13 +232,20 @@ describe('edit user tests', () => {
   ]
 
   beforeEach(async () => {
-    setScopes([SCOPES.USER_CREATE], store)
+    setScopes(
+      [
+        SCOPES.USER_CREATE,
+        'user.create[role=FIELD_AGENT|REGISTRATION_AGENT]',
+        'user.edit[role=LOCAL_REGISTRAR]'
+      ],
+      store
+    )
     ;(roleQueries.fetchRoles as Mock).mockReturnValue(mockRoles)
     store.dispatch(offlineDataReady(mockOfflineDataDispatch))
     await flushPromises()
   })
 
-  it('check user role update', async () => {
+  it('should only generate allowed roles in the options', async () => {
     const section = store
       .getState()
       .userForm.userForm?.sections.find((section) => section.id === 'user')
@@ -248,7 +255,11 @@ describe('edit user tests', () => {
     const field = group.fields.find(
       (field) => field.name === 'role'
     ) as ISelectFormFieldWithOptions
-    expect(field.options).not.toEqual([])
+    expect(field.options.map((o) => o.value)).toEqual([
+      'FIELD_AGENT',
+      'REGISTRATION_AGENT',
+      'LOCAL_REGISTRAR'
+    ])
   })
 
   describe('when user is in update form page', () => {

--- a/packages/commons/src/authentication.ts
+++ b/packages/commons/src/authentication.ts
@@ -14,7 +14,7 @@ import decode from 'jwt-decode'
 import { Nominal } from './nominal'
 import { z } from 'zod'
 
-import { Scope, SCOPES } from './scopes'
+import { RawScopes, Scope, SCOPES } from './scopes'
 export { Scope, SCOPES, scopes, parseScope } from './scopes'
 
 /** All the scopes system/integration can be assigned to */
@@ -198,17 +198,21 @@ export interface ITokenPayload {
   scope: Scope[]
 }
 
-export function hasScope(authHeader: IAuthHeader, scope: Scope) {
+export function getScopes(authHeader: IAuthHeader): RawScopes[] {
   if (!authHeader || !authHeader.Authorization) {
-    return false
+    return []
   }
   const tokenPayload = getTokenPayload(authHeader.Authorization.split(' ')[1])
-  return (tokenPayload.scope && tokenPayload.scope.indexOf(scope) > -1) || false
+  return tokenPayload.scope || []
+}
+
+export function hasScope(authHeader: IAuthHeader, scope: Scope) {
+  return getScopes(authHeader).includes(scope)
 }
 
 export function inScope(authHeader: IAuthHeader, scopes: Scope[]) {
-  const matchedScope = scopes.find((scope) => hasScope(authHeader, scope))
-  return !!matchedScope
+  const tokenScopes = getScopes(authHeader)
+  return scopes.some((scope) => tokenScopes.includes(scope))
 }
 
 export const getTokenPayload = (token: string): ITokenPayload => {

--- a/packages/commons/src/authentication.ts
+++ b/packages/commons/src/authentication.ts
@@ -15,7 +15,7 @@ import { Nominal } from './nominal'
 import { z } from 'zod'
 
 import { RawScopes, Scope, SCOPES } from './scopes'
-export { Scope, SCOPES, scopes, parseScope } from './scopes'
+export * from './scopes'
 
 /** All the scopes system/integration can be assigned to */
 export const SYSTEM_INTEGRATION_SCOPES = {

--- a/packages/commons/src/scopes.ts
+++ b/packages/commons/src/scopes.ts
@@ -232,6 +232,20 @@ const ConfigurableScopes = z.discriminatedUnion('type', [
   EditUserScope
 ])
 
+type ConfigurableScopes = z.infer<typeof ConfigurableScopes>
+
+export function findScope(
+  scopes: string[],
+  scopeType: ConfigurableScopes['type']
+) {
+  return scopes
+    .map((rawScope) => parseScope(rawScope))
+    .find(
+      (parsedScope): parsedScope is ConfigurableScopes =>
+        parsedScope?.type === scopeType
+    )
+}
+
 export function parseScope(scope: string) {
   const maybeLiteralScope = LiteralScopes.safeParse(scope)
   if (maybeLiteralScope.success) {

--- a/packages/commons/src/scopes.ts
+++ b/packages/commons/src/scopes.ts
@@ -220,7 +220,17 @@ const CreateUserScope = z.object({
   })
 })
 
-const ConfigurableScopes = z.discriminatedUnion('type', [CreateUserScope])
+const EditUserScope = z.object({
+  type: z.literal('user.edit'),
+  options: z.object({
+    role: z.array(z.string())
+  })
+})
+
+const ConfigurableScopes = z.discriminatedUnion('type', [
+  CreateUserScope,
+  EditUserScope
+])
 
 export function parseScope(scope: string) {
   const maybeLiteralScope = LiteralScopes.safeParse(scope)

--- a/packages/gateway/src/features/user/root-resolvers.test.ts
+++ b/packages/gateway/src/features/user/root-resolvers.test.ts
@@ -1065,7 +1065,20 @@ describe('User root resolvers', () => {
   describe('createOrUpdateUser mutation', () => {
     const authHeaderSysAdmin = {
       Authorization: `Bearer ${jwt.sign(
-        { scope: [SCOPES.USER_CREATE] },
+        { scope: [SCOPES.USER_CREATE, 'user.create[role=LOCAL_REGISTRAR]'] },
+        readFileSync('./test/cert.key'),
+        {
+          subject: 'ba7022f0ff4822',
+          algorithm: 'RS256',
+          issuer: 'opencrvs:auth-service',
+          audience: 'opencrvs:gateway-user'
+        }
+      )}`
+    }
+
+    const authHeaderSysAdminWithoutSuppliedRole = {
+      Authorization: `Bearer ${jwt.sign(
+        { scope: [SCOPES.USER_CREATE, 'user.create[role=REGISTRATION_AGENT]'] },
         readFileSync('./test/cert.key'),
         {
           subject: 'ba7022f0ff4822',
@@ -1077,7 +1090,12 @@ describe('User root resolvers', () => {
     }
     const authHeaderLocalSysAdmin = {
       Authorization: `Bearer ${jwt.sign(
-        { scope: [SCOPES.USER_CREATE_MY_JURISDICTION] },
+        {
+          scope: [
+            SCOPES.USER_CREATE_MY_JURISDICTION,
+            'user.create[role=LOCAL_REGISTRAR]'
+          ]
+        },
         readFileSync('./test/cert.key'),
         {
           subject: 'ba7022f0ff4822',
@@ -1135,6 +1153,28 @@ describe('User root resolvers', () => {
       expect(response).toEqual({
         username: 'someUser123'
       })
+    })
+
+    it('fails to create user for sysadmin if the role is not creatable by the user', async () => {
+      fetchJSONMock.mockReturnValueOnce(
+        Promise.resolve(DEFAULT_ROLES_DEFINITION)
+      )
+      fetch.mockResponseOnce(
+        JSON.stringify({
+          username: 'someUser123'
+        }),
+        { status: 201 }
+      )
+
+      expect(
+        resolvers.Mutation!.createOrUpdateUser(
+          {},
+          { user },
+          { headers: authHeaderSysAdminWithoutSuppliedRole }
+        )
+      ).rejects.toThrowError(
+        'A user with role "LOCAL_REGISTRAR" can not be created or updated by this user'
+      )
     })
 
     it('allows creating users in offices under the jurisdiction of the local sysadmin', async () => {

--- a/packages/gateway/src/features/user/root-resolvers.ts
+++ b/packages/gateway/src/features/user/root-resolvers.ts
@@ -43,7 +43,7 @@ import { validateAttachments } from '@gateway/utils/validators'
 import { postMetrics } from '@gateway/features/metrics/service'
 import { uploadBase64ToMinio } from '@gateway/features/documents/service'
 import { rateLimitedResolver } from '@gateway/rate-limit'
-import { getScopes, parseScope, SCOPES } from '@opencrvs/commons/authentication'
+import { findScope, getScopes, SCOPES } from '@opencrvs/commons/authentication'
 import { UserInputError } from '@gateway/utils/graphql-errors'
 
 export const resolvers: GQLResolver = {
@@ -336,16 +336,10 @@ export const resolvers: GQLResolver = {
       if (user.role) {
         const scopes = getScopes(authHeader)
         const creatableRoleIds =
-          scopes
-            .map((rawScope) => parseScope(rawScope))
-            .find((parsedScope) => parsedScope?.type === 'user.create')?.options
-            ?.role ?? []
+          findScope(scopes, 'user.create')?.options?.role ?? []
 
         const editableRoleIds =
-          scopes
-            .map((rawScope) => parseScope(rawScope))
-            .find((parsedScope) => parsedScope?.type === 'user.edit')?.options
-            ?.role ?? []
+          findScope(scopes, 'user.edit')?.options?.role ?? []
 
         if (![...creatableRoleIds, ...editableRoleIds].includes(user.role)) {
           throw new Error(


### PR DESCRIPTION
## Description

During user creation/update, the allowed roles are determined using the roles defined in user.create/user.update scope.

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [x] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
