### PR TITLE
Chore: Add "child nid" & "mother address same as father's" supported form field config validations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Filter out inactive locations in the Organisations menu [#8782](https://github.com/opencrvs/opencrvs-core/issues/8782)
 - Improve quick search results when searching by name [#9272](https://github.com/opencrvs/opencrvs-core/issues/9272)
 - Fix practitioner role history entries from being created with every view and download [#9462](https://github.com/opencrvs/opencrvs-core/issues/9462)
+- Fix a child's NID form field cannot be added eithe rmanually or via ESignet. A father section cannot be placed before a mother section if you wish to use a radio button to control mapping addresses from one individual to aother to make data entry easier [#9582](https://github.com/opencrvs/opencrvs-core/issues/9582)
 
 ## [1.7.1](https://github.com/opencrvs/opencrvs-core/compare/v1.7.0...v1.7.1)
 

--- a/packages/config/src/handlers/forms/validation.ts
+++ b/packages/config/src/handlers/forms/validation.ts
@@ -215,6 +215,8 @@ const OPTIONAL_FIELDS_IN_SECTION: Record<string, string[] | undefined> = {
   child: [
     'middleNameEng',
     'attendantAtBirth',
+    'iD',
+    'childNidVerification',
     'birthType',
     'weightAtBirth',
     ...OPTIONAL_EVENT_ADDRESS_FIELDS.map((field) => `${field}Placeofbirth`)
@@ -231,6 +233,7 @@ const OPTIONAL_FIELDS_IN_SECTION: Record<string, string[] | undefined> = {
     'occupation',
     'educationalAttainment',
     'nationality',
+    'primaryAddressSameAsOtherPrimary',
     ...OPTIONAL_PRIMARY_ADDRESS_FIELDS.map((field) => `${field}Mother`)
   ],
   father: [


### PR DESCRIPTION
## Description

Countries like Somalia have a form field for Child's NID that means that not just the work completed for https://github.com/opencrvs/opencrvs-core/pull/7469 is needed, a form filed is required.

Countries like Sri Lanka want to put the fathers details page first but cannot as they cant have a radio button that says mother's address is the same as the fathers.

https://github.com/opencrvs/opencrvs-core/issues/9582

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [x] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
