### PR TITLE
Add custom fullHonorificName on the user management page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - **TimeField component with AM/PM support**: The `TimeField` component now supports both 12-hour (AM/PM) and 24-hour formats through a new prop, `use12HourFormat: boolean`. The logic has been refactored into two separate components, `TimeInput24` and `TimeInput12`. The `TimeField` component automatically selects the appropriate component based on the prop. [#8336](https://github.com/opencrvs/opencrvs-core/issues/8336)
 - **Configurable Scopes**: Introduce a new syntax for scopes which provides more customizability to the SI's via scopes. Two new scopes `user.create[role=a|b|c]` & `user.update[role=d|e|f]` are getting included in this release which can be used to restrict what the role of a newly created or updated user can be set to by the user of a particular role. Gradually most of the existing scopes will be migrated to use this new syntax.
+- **New Full Honorific Name Field**: An optional `fullHonorificName` field has been added to the user management page to capture the complete name of a user including their title or honorific. This field can be used for display purposes, including rendering the name appropriately on certificates.
 
 ### Bug fixes
 

--- a/packages/client/src/forms/register/mappings/query/registration-mappings.ts
+++ b/packages/client/src/forms/register/mappings/query/registration-mappings.ts
@@ -160,6 +160,12 @@ const getUserRole = (history: History): MessageDescriptor => {
   )
 }
 
+const getUserFullHonorificName = (history: History): string => {
+  return (
+    history?.user?.fullHonorificName || ''
+  )
+}
+
 const getUserSignature = (history: History): string => {
   return history?.signature?.data as string
 }
@@ -209,7 +215,8 @@ export const userTransformer =
         date: history.date,
         ...locationHierarchy,
         signature: getUserSignature(history),
-        comments: history.comments?.[0]?.comment
+        comments: history.comments?.[0]?.comment,
+        fullHonorificName: getUserFullHonorificName(history)
       } as IFormSectionData
     }
   }

--- a/packages/client/src/forms/user/fieldDefinitions/createUser.ts
+++ b/packages/client/src/forms/user/fieldDefinitions/createUser.ts
@@ -144,6 +144,15 @@ function userSectionFormType(): ISerializedFormSection {
             }
           },
           {
+            name: 'email',
+            type: TEXT,
+            label: userFormMessages.email,
+            required:
+              window.config.USER_NOTIFICATION_DELIVERY_METHOD === 'email',
+            initialValue: '',
+            validator: [{ operation: 'emailAddressFormat' }]
+          },
+          {
             name: 'fullHonorificName',
             type: TEXT,
             label: userFormMessages.fullHonorificName,

--- a/packages/client/src/forms/user/fieldDefinitions/createUser.ts
+++ b/packages/client/src/forms/user/fieldDefinitions/createUser.ts
@@ -144,13 +144,12 @@ function userSectionFormType(): ISerializedFormSection {
             }
           },
           {
-            name: 'email',
+            name: 'fullHonorificName',
             type: TEXT,
-            label: userFormMessages.email,
-            required:
-              window.config.USER_NOTIFICATION_DELIVERY_METHOD === 'email',
+            label: userFormMessages.fullHonorificName,
+            required: false,
             initialValue: '',
-            validator: [{ operation: 'emailAddressFormat' }]
+            validator: []
           },
           {
             name: 'seperator',

--- a/packages/client/src/i18n/messages/views/userForm.ts
+++ b/packages/client/src/i18n/messages/views/userForm.ts
@@ -69,6 +69,11 @@ export const messages = {
     description: 'Input label for email address',
     id: 'form.field.label.email'
   },
+  fullHonorificName: {
+    defaultMessage: 'Full Honorific Name',
+    description: 'Input label for full honorific name',
+    id: 'form.field.label.fullHonorificName'
+  },
   accountDetails: {
     defaultMessage: 'Account details',
     description: 'Account details section',

--- a/packages/client/src/profile/queries.ts
+++ b/packages/client/src/profile/queries.ts
@@ -27,6 +27,7 @@ const FETCH_USER = gql`
       practitionerId
       mobile
       email
+      fullHonorificName
       role {
         label {
           id

--- a/packages/client/src/user/queries.ts
+++ b/packages/client/src/user/queries.ts
@@ -24,6 +24,7 @@ export const SEARCH_USERS = gql`
         }
         mobile
         email
+        fullHonorificName
         primaryOffice {
           id
         }
@@ -99,6 +100,7 @@ export const GET_USER = gql`
       username
       mobile
       email
+      fullHonorificName
       identifier {
         system
         value

--- a/packages/client/src/utils/gateway.ts
+++ b/packages/client/src/utils/gateway.ts
@@ -2207,6 +2207,7 @@ export type User = {
   identifier?: Maybe<Identifier>
   localRegistrar?: Maybe<LocalRegistrar>
   mobile?: Maybe<Scalars['String']>
+  fullHonorificName?: Maybe<Scalars['String']>
   name: Array<HumanName>
   practitionerId: Scalars['String']
   primaryOffice: Location
@@ -2260,6 +2261,7 @@ export type UserInput = {
   id?: InputMaybe<Scalars['ID']>
   identifier?: InputMaybe<Array<InputMaybe<UserIdentifierInput>>>
   mobile?: InputMaybe<Scalars['String']>
+  fullHonorificName?: InputMaybe<Scalars['String']>
   name: Array<HumanNameInput>
   password?: InputMaybe<Scalars['String']>
   primaryOffice?: InputMaybe<Scalars['String']>
@@ -2691,6 +2693,7 @@ export type FetchUserQuery = {
     practitionerId: string
     mobile?: string | null
     email?: string | null
+    fullHonorificName?: string | null
     status: Status
     role: {
       __typename?: 'UserRole'
@@ -2980,6 +2983,7 @@ export type SearchUsersQuery = {
       id: string
       mobile?: string | null
       email?: string | null
+      fullHonorificName?: string | null
       status: Status
       underInvestigation?: boolean | null
       name: Array<{
@@ -3056,6 +3060,7 @@ export type GetUserQuery = {
     username?: string | null
     mobile?: string | null
     email?: string | null
+    fullHonorificName?: string | null
     status: Status
     underInvestigation?: boolean | null
     practitionerId: string

--- a/packages/client/src/views/DataProvider/birth/queries.ts
+++ b/packages/client/src/views/DataProvider/birth/queries.ts
@@ -294,6 +294,7 @@ const GET_BIRTH_REGISTRATION_FOR_REVIEW = gql`
             data
             type
           }
+          fullHonorificName
         }
         signature {
           data
@@ -585,6 +586,7 @@ export const GET_BIRTH_REGISTRATION_FOR_CERTIFICATE = gql`
             data
             type
           }
+          fullHonorificName
         }
         signature {
           data

--- a/packages/client/src/views/DataProvider/death/queries.ts
+++ b/packages/client/src/views/DataProvider/death/queries.ts
@@ -363,6 +363,7 @@ const GET_DEATH_REGISTRATION_FOR_REVIEW = gql`
             data
             type
           }
+          fullHonorificName
         }
         signature {
           data
@@ -644,6 +645,7 @@ export const GET_DEATH_REGISTRATION_FOR_CERTIFICATION = gql`
             data
             type
           }
+          fullHonorificName
         }
         signature {
           data

--- a/packages/gateway/src/features/user/root-resolvers.ts
+++ b/packages/gateway/src/features/user/root-resolvers.ts
@@ -716,7 +716,8 @@ function createOrUpdateUserPayload(
     ...(user.mobile && { mobile: user.mobile as string }),
     device: user.device as string,
     signature: user.signature,
-    ...(user.username && { username: user.username })
+    ...(user.username && { username: user.username }),
+    fullHonorificName: user.fullHonorificName
   }
   if (user.id) {
     userPayload.id = user.id

--- a/packages/gateway/src/features/user/schema.graphql
+++ b/packages/gateway/src/features/user/schema.graphql
@@ -41,6 +41,7 @@ input UserInput {
   status: Status
   role: String
   email: String
+  fullHonorificName: String
   primaryOffice: String
   device: String
   signature: SignatureInput
@@ -79,6 +80,7 @@ type User {
   mobile: String
   role: UserRole!
   email: String
+  fullHonorificName: String
   status: Status!
   underInvestigation: Boolean
   primaryOffice: Location!

--- a/packages/gateway/src/features/user/type-resolvers.ts
+++ b/packages/gateway/src/features/user/type-resolvers.ts
@@ -58,6 +58,7 @@ export interface IUserModelData {
   email: string
   emailForNotification?: string
   mobile?: string
+  fullHonorificName?: string
   status: string
   role: string
   creationDate?: string

--- a/packages/gateway/src/graphql/schema.d.ts
+++ b/packages/gateway/src/graphql/schema.d.ts
@@ -260,6 +260,7 @@ export interface GQLUser {
   mobile?: string
   role: GQLUserRole
   email?: string
+  fullHonorificName?: string
   status: GQLStatus
   underInvestigation?: boolean
   primaryOffice: GQLLocation
@@ -584,6 +585,7 @@ export interface GQLUserInput {
   status?: GQLStatus
   role?: string
   email?: string
+  fullHonorificName?: string
   primaryOffice?: string
   device?: string
   signature?: GQLSignatureInput
@@ -4260,6 +4262,7 @@ export interface GQLUserTypeResolver<TParent = any> {
   mobile?: UserToMobileResolver<TParent>
   role?: UserToRoleResolver<TParent>
   email?: UserToEmailResolver<TParent>
+  fullHonorificName?: UserToFullHonorificNameResolver<TParent>
   status?: UserToStatusResolver<TParent>
   underInvestigation?: UserToUnderInvestigationResolver<TParent>
   primaryOffice?: UserToPrimaryOfficeResolver<TParent>
@@ -4336,6 +4339,15 @@ export interface UserToRoleResolver<TParent = any, TResult = any> {
 }
 
 export interface UserToEmailResolver<TParent = any, TResult = any> {
+  (
+    parent: TParent,
+    args: {},
+    context: Context,
+    info: GraphQLResolveInfo
+  ): TResult
+}
+
+export interface UserToFullHonorificNameResolver<TParent = any, TResult = any> {
   (
     parent: TParent,
     args: {},

--- a/packages/gateway/src/graphql/schema.graphql
+++ b/packages/gateway/src/graphql/schema.graphql
@@ -390,6 +390,7 @@ type User {
   mobile: String
   role: UserRole!
   email: String
+  fullHonorificName: String
   status: Status!
   underInvestigation: Boolean
   primaryOffice: Location!
@@ -701,6 +702,7 @@ input UserInput {
   status: Status
   role: String
   email: String
+  fullHonorificName: String
   primaryOffice: String
   device: String
   signature: SignatureInput

--- a/packages/user-mgnt/src/features/updateUser/handler.ts
+++ b/packages/user-mgnt/src/features/updateUser/handler.ts
@@ -68,6 +68,7 @@ export default async function updateUser(
   existingUser.name = user.name
   existingUser.email = user.email
   existingUser.mobile = user.mobile
+  existingUser.fullHonorificName = user.fullHonorificName
   existingUser.emailForNotification = user.emailForNotification
   existingUser.signature = user.signature
   existingUser.localRegistrar = user.localRegistrar

--- a/packages/user-mgnt/src/model/user.ts
+++ b/packages/user-mgnt/src/model/user.ts
@@ -126,6 +126,7 @@ export interface IUser {
   username: string
   email: string
   mobile?: string
+  fullHonorificName?: string
   emailForNotification?: string
   passwordHash: string
   oldPasswordHash?: string
@@ -299,6 +300,7 @@ const userSchema = new Schema({
   email: { type: String },
   emailForNotification: { type: String, unique: true, sparse: true },
   mobile: { type: String, unique: true, sparse: true },
+  fullHonorificName: { type: String },
   passwordHash: { type: String, required: true },
   oldPasswordHash: { type: String },
   salt: { type: String, required: true },

--- a/packages/workflow/src/records/user.ts
+++ b/packages/workflow/src/records/user.ts
@@ -38,6 +38,7 @@ interface IUserModelData {
   email: string
   emailForNotification?: string
   mobile?: string
+  fullHonorificName?: string
   status: string
   role: IUserRole
   creationDate?: string


### PR DESCRIPTION
## Description

Added a custom `fullHonorificName` on the user management page that can be used in the certificate

Pull request to the GitHub issue: https://github.com/opencrvs/opencrvs-core/issues/8706
Countryconfig: https://github.com/opencrvs/opencrvs-countryconfig/pull/750

## Checklist

- [X] I have linked the correct Github issue under "release-v1.7.2"
- [X] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [x] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
