### PR TITLE
Move event attachments back to MinIO root

### DIFF
--- a/packages/client/.storybook/default-request-handlers.ts
+++ b/packages/client/.storybook/default-request-handlers.ts
@@ -372,7 +372,7 @@ export const handlers = {
     })
   ],
   files: [
-    http.get('/api/presigned-url/event-attachments/:filename', async (req) => {
+    http.get('/api/presigned-url/:filename', async (req) => {
       return HttpResponse.json({
         presignedURL: `http://localhost:3535/ocrvs/tree.svg`
       })
@@ -380,9 +380,7 @@ export const handlers = {
     http.post('/api/upload', async (req) => {
       const formData = await req.request.formData()
 
-      return HttpResponse.text(
-        `event-attachments/${formData.get('transactionId')}.jpg`
-      )
+      return HttpResponse.text(`${formData.get('transactionId')}.jpg`)
     }),
     http.delete('/api/files/:filename', async (request) => {
       return HttpResponse.text('OK')

--- a/packages/client/src/v2-events/features/files/useFileUpload.ts
+++ b/packages/client/src/v2-events/features/files/useFileUpload.ts
@@ -79,11 +79,8 @@ export function getFullUrl(filename: string) {
   throw new Error('MINIO_URL is not defined')
 }
 
-async function getPresignedUrl(
-  fileUri: string,
-  minioFolder = '/event-attachments/'
-) {
-  const url = `/api/presigned-url${minioFolder}` + fileUri
+async function getPresignedUrl(fileUri: string) {
+  const url = `/api/presigned-url/` + fileUri
   const response = await fetch(url, {
     method: 'GET',
     headers: {
@@ -132,9 +129,8 @@ export async function removeCached(filename: string) {
   return cache.delete(getFullUrl(filename))
 }
 
-export async function precacheFile(filename: string, minioFolder?: string) {
-  const presignedUrl = (await getPresignedUrl(filename, minioFolder))
-    .presignedURL
+export async function precacheFile(filename: string) {
+  const presignedUrl = (await getPresignedUrl(filename)).presignedURL
   const response = await fetch(presignedUrl)
   const blob = await response.blob()
   const file = new File([blob], filename, { type: blob.type })

--- a/packages/client/src/v2-events/hooks/useUsers.ts
+++ b/packages/client/src/v2-events/hooks/useUsers.ts
@@ -29,7 +29,7 @@ setQueryDefaults(trpcOptionsProxy.user.get, {
     const user = await queryOptions.queryFn(...params)
 
     if (user.signatureFilename) {
-      await precacheFile(user.signatureFilename, '/')
+      await precacheFile(user.signatureFilename)
       return {
         ...user,
         signatureFilename: getFullUrl(user.signatureFilename)
@@ -57,7 +57,7 @@ setQueryDefaults(trpcOptionsProxy.user.list, {
     await Promise.allSettled(
       users.map(async (user) => {
         if (user.signatureFilename) {
-          return precacheFile(user.signatureFilename, '/')
+          return precacheFile(user.signatureFilename)
         }
         return user
       })

--- a/packages/documents/src/features/deleteDocument/handler.ts
+++ b/packages/documents/src/features/deleteDocument/handler.ts
@@ -29,10 +29,7 @@ export async function deleteDocument(
       )
     )
 
-  const stat = await minioClient.statObject(
-    MINIO_BUCKET,
-    'event-attachments/' + filename
-  )
+  const stat = await minioClient.statObject(MINIO_BUCKET, filename)
   const createdBy = stat.metaData['created-by']
 
   if (createdBy !== userId)
@@ -41,7 +38,7 @@ export async function deleteDocument(
         `request failed: user with id ${userId} does not have permission to delete this document`
       )
       .code(403)
-  await minioClient.removeObject(MINIO_BUCKET, 'event-attachments/' + filename)
+  await minioClient.removeObject(MINIO_BUCKET, filename)
 
   return h.response().code(204)
 }

--- a/packages/documents/src/features/uploadDocument/handler.ts
+++ b/packages/documents/src/features/uploadDocument/handler.ts
@@ -63,16 +63,11 @@ export async function fileUploadHandler(
   const extension = file.hapi.filename.split('.').pop()
   const filename = `${transactionId}.${extension}`
 
-  await minioClient.putObject(
-    MINIO_BUCKET,
-    'event-attachments/' + filename,
-    file,
-    {
-      'created-by': userId
-    }
-  )
+  await minioClient.putObject(MINIO_BUCKET, filename, file, {
+    'created-by': userId
+  })
 
-  return 'event-attachments/' + filename
+  return filename
 }
 
 export async function fileExistsHandler(
@@ -80,10 +75,7 @@ export async function fileExistsHandler(
   h: Hapi.ResponseToolkit
 ) {
   const { filename } = request.params
-  const exists = await minioClient.statObject(
-    MINIO_BUCKET,
-    'event-attachments/' + filename
-  )
+  const exists = await minioClient.statObject(MINIO_BUCKET, filename)
   if (!exists) {
     return notFound('File not found')
   }


### PR DESCRIPTION
This is a temporary measure so that V1-V2 data migration doesn't have to move all legacy files
