### PR TITLE
Allow booleanTransformer to be used as a certificate handlebar transformer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bug fixes
 
+- Allow booleanTransformer to be used as a certificate handlebar template transformer [#9631](https://github.com/opencrvs/opencrvs-core/issues/9631)
+
 ## [1.7.2](https://github.com/opencrvs/opencrvs-core/compare/v1.7.1...v1.7.2)
 
 ### New features

--- a/packages/client/src/forms/register/mappings/query/field-mappings.ts
+++ b/packages/client/src/forms/register/mappings/query/field-mappings.ts
@@ -600,6 +600,9 @@ export const booleanTransformer = (
   sectionId: SectionId,
   field: IFormField
 ) => {
+  if (!transformedData[sectionId]) {
+    transformedData[sectionId] = {}
+  }
   // graphql boolean ignored unless forced like this
   if (queryData && queryData[sectionId] && field && field.name) {
     transformedData[sectionId][field.name] = queryData[sectionId][field.name]


### PR DESCRIPTION
## Description

With this change, booleanTransformer can be used as a certificate template transformer.  This supports a handlebar detailsExist in a cert

Resolves: #9631 

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [x] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
