### PR TITLE
fix: Return local number if number is in local format already

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bug fixes
 
+- Fix international to local number conversion from failing if the number was already local [#9634](https://github.com/opencrvs/opencrvs-core/issues/9634)
+
 ## [1.7.2](https://github.com/opencrvs/opencrvs-core/compare/v1.7.1...v1.7.2)
 
 ### New features

--- a/packages/client/src/forms/register/mappings/query/registration-mappings.test.ts
+++ b/packages/client/src/forms/register/mappings/query/registration-mappings.test.ts
@@ -10,16 +10,25 @@
  */
 
 import { convertToLocal } from './registration-mappings'
+describe('convertToLocal', () => {
+  describe('given number in international format', () => {
+    it('replaces country code and returns local format', async () => {
+      expect(convertToLocal('+260211000000', 'ZMB')).toBe('0211000000')
+      expect(convertToLocal('+358504700715', 'FIN')).toBe('0504700715')
+      expect(convertToLocal('+237666666666', 'CMR')).toBe('666666666')
+      expect(convertToLocal('+8801700000000', 'BGD')).toBe('01700000000')
+      expect(convertToLocal('+260211000000')).toBe('0211000000')
+      expect(convertToLocal('+358504700715')).toBe('0504700715')
+      expect(convertToLocal('+237666666666')).toBe('666666666')
+      expect(convertToLocal('+8801700000000')).toBe('01700000000')
+    })
+  })
 
-describe('phone number conversion from international format back to local format', () => {
-  it('replaces country code', async () => {
-    expect(convertToLocal('+260211000000', 'ZMB')).toBe('0211000000')
-    expect(convertToLocal('+358504700715', 'FIN')).toBe('0504700715')
-    expect(convertToLocal('+237666666666', 'CMR')).toBe('666666666')
-    expect(convertToLocal('+8801700000000', 'BGD')).toBe('01700000000')
-    expect(convertToLocal('+260211000000')).toBe('0211000000')
-    expect(convertToLocal('+358504700715')).toBe('0504700715')
-    expect(convertToLocal('+237666666666')).toBe('666666666')
-    expect(convertToLocal('+8801700000000')).toBe('01700000000')
+  describe('given number in local format with country code', () => {
+    it('returns the local number', async () => {
+      expect(convertToLocal('0835114899', 'ZAF')).toBe('0835114899')
+      expect(convertToLocal('0650310707', 'SOM')).toBe('0650310707')
+      expect(convertToLocal('650310707', 'SOM')).toBe('0650310707')
+    })
   })
 })


### PR DESCRIPTION
It's possible to enter local numbers for default users when setting up openCRVS.

Previously this code was throwing an exception for local numbers when editing the user.

This refactor allows local numbers to be parsed at local.

Fixes: https://github.com/opencrvs/opencrvs-core/issues/9634
