### PR TITLE
fix: use helper to find the role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Improve quick search results when searching by name [#9272](https://github.com/opencrvs/opencrvs-core/issues/9272)
 - Fix practitioner role history entries from being created with every view and download [#9462](https://github.com/opencrvs/opencrvs-core/issues/9462)
 - Fix a child's NID form field cannot be added eithe rmanually or via ESignet. A father section cannot be placed before a mother section if you wish to use a radio button to control mapping addresses from one individual to aother to make data entry easier [#9582](https://github.com/opencrvs/opencrvs-core/issues/9582)
+- Fix the role of the certifier unable to get resolved for new users which in turn caused the download of the declaration to fail [#9643](https://github.com/opencrvs/opencrvs-core/issues/9643)
 
 ## [1.7.1](https://github.com/opencrvs/opencrvs-core/compare/v1.7.0...v1.7.1)
 

--- a/packages/gateway/src/features/registration/type-resolvers.ts
+++ b/packages/gateway/src/features/registration/type-resolvers.ts
@@ -1369,18 +1369,10 @@ export const typeResolvers: GQLResolver = {
         await context.dataSources.fhirAPI.getPractionerRoleHistory(
           practitionerRoleId
         )
-      const result = practitionerRoleHistory.find(
-        (it) =>
-          it?.meta?.lastUpdated &&
-          task.lastModified &&
-          it?.meta?.lastUpdated <= task.lastModified!
+      const roleId = getUserRoleFromHistory(
+        practitionerRoleHistory,
+        task.lastModified
       )
-
-      const targetCode = result?.code?.find((element) => {
-        return element.coding?.[0].system === 'http://opencrvs.org/specs/roles'
-      })
-
-      const roleId = targetCode?.coding?.[0].code
       const userResponse =
         await context.dataSources.usersAPI.getUserByPractitionerId(
           practitionerId


### PR DESCRIPTION
The helper function ensures that the first role is returned as the fallback if none found at the given point in time.
