### PR TITLE
fix: remove test files from production build

### DIFF
--- a/packages/events/Dockerfile
+++ b/packages/events/Dockerfile
@@ -5,7 +5,7 @@ USER node
 
 WORKDIR /app/packages/events
 COPY --chown=node:node packages/events/*.json /app/packages/events/
-RUN yarn install --frozen-lockfile
+RUN NODE_ENV=production yarn install --frozen-lockfile
 COPY --chown=node:node packages/events /app/packages/events
 RUN yarn build
 

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint -c eslint.config.js --fix --max-warnings=0",
     "precommit": "lint-staged",
     "test:compilation": "tsc --noEmit",
-    "build": "tsc && tsc -p tsconfig.router.json",
+    "build": "tsc -p tsconfig.build.json && tsc -p tsconfig.router.json",
     "build:clean": "rm -rf build"
   },
   "dependencies": {

--- a/packages/events/tsconfig.build.json
+++ b/packages/events/tsconfig.build.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": [],
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "build",
+    "acceptance-tests",
+    "src/tests/**.ts",
+    "src/**/*.test.ts"
+  ],
+}


### PR DESCRIPTION
In Postgres migration, some linting development time dependencies can't be built without Python, as they don't have a pre-built binary for Node 22 yet. This makes the Docker image build fail as the image doesn't have Python.

This raises a question why we even add development dependencies to the production build. This PR fixes that.