### PR TITLE
fix: continue unassigning other declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@
 - Filter out inactive locations in the Organisations menu [#8782](https://github.com/opencrvs/opencrvs-core/issues/8782)
 - Improve quick search results when searching by name [#9272](https://github.com/opencrvs/opencrvs-core/issues/9272)
 - Fix practitioner role history entries from being created with every view and download [#9462](https://github.com/opencrvs/opencrvs-core/issues/9462)
-- Fix a child's NID form field cannot be added eithe rmanually or via ESignet. A father section cannot be placed before a mother section if you wish to use a radio button to control mapping addresses from one individual to aother to make data entry easier [#9582](https://github.com/opencrvs/opencrvs-core/issues/9582)
+- Fix a child's NID form field cannot be added either manually or via ESignet. A father section cannot be placed before a mother section if you wish to use a radio button to control mapping addresses from one individual to another to make data entry easier [#9582](https://github.com/opencrvs/opencrvs-core/issues/9582)
+- Fix one failing unassign blocking all other unassign actions from continuing
 
 ## [1.7.1](https://github.com/opencrvs/opencrvs-core/compare/v1.7.0...v1.7.1)
 

--- a/packages/client/src/declarations/index.ts
+++ b/packages/client/src/declarations/index.ts
@@ -1920,6 +1920,18 @@ export const declarationsReducer: LoopReducer<IDeclarationsState, Action> = (
           )
         )
       }
+      if (declarationNextToUnassign) {
+        return loop(
+          state,
+          Cmd.action(
+            executeUnassignDeclaration(
+              declarationNextToUnassign.id,
+              action.payload.client,
+              action.payload.refetchQueries
+            )
+          )
+        )
+      }
       return state
     }
 


### PR DESCRIPTION
## Description

One failing unassign was blocking all the other unassign actions from continuing

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
