### PR TITLE
dont log stack trace

### DIFF
--- a/packages/events/src/index.ts
+++ b/packages/events/src/index.ts
@@ -53,8 +53,7 @@ const trpcConfig: Parameters<typeof createHTTPHandler>[0] = {
   },
   onError: ({ req, error }) => {
     logger.warn(
-      `Error for request: ${stringifyRequest(req)}. Error: '${error.message}'`,
-      error.stack
+      `Error for request: ${stringifyRequest(req)}. Error: '${error.message}'`
     )
   },
   createContext: async function createContext(opts) {


### PR DESCRIPTION
Example error log: `@opencrvs/events: [13:17:43.257] WARN: Error for request: 'POST /events'. Error: 'FORBIDDEN'`