### PR TITLE
Optimize AdvancedSearch state init with lazy loading for active tab only

### DIFF
--- a/packages/client/src/v2-events/features/events/AdvancedSearch/TabSearch.tsx
+++ b/packages/client/src/v2-events/features/events/AdvancedSearch/TabSearch.tsx
@@ -13,6 +13,7 @@ import styled from 'styled-components'
 import { useIntl, defineMessages } from 'react-intl'
 import { useNavigate } from 'react-router-dom'
 import { stringify } from 'query-string'
+import { useEffect, useRef, useState } from 'react'
 import { Accordion } from '@opencrvs/components'
 import { Icon } from '@opencrvs/components/lib/Icon'
 import { Button } from '@opencrvs/components/lib/Button'
@@ -175,26 +176,30 @@ function buildSearchSections({
 
 export function TabSearch({
   currentEvent,
-  fieldValues
+  fieldValues,
+  onChange
 }: {
   currentEvent: EventConfig
-  fieldValues?: EventState
+  fieldValues: EventState
+  onChange: (updatedForm: EventState) => void
 }) {
   const intl = useIntl()
   const navigate = useNavigate()
 
-  const [formValues, setFormValues] = React.useState<EventState>(
-    fieldValues ?? {}
-  )
+  const [formValues, setFormValues] = useState<EventState>(fieldValues)
 
-  const prevEventId = React.useRef(currentEvent.id)
+  const prevEventId = useRef(currentEvent.id)
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (prevEventId.current !== currentEvent.id) {
-      setFormValues({})
+      setFormValues(fieldValues)
       prevEventId.current = currentEvent.id
     }
-  }, [currentEvent])
+  }, [currentEvent, fieldValues])
+
+  useEffect(() => {
+    onChange(formValues)
+  }, [formValues, onChange])
 
   const enhancedEvent = enhanceEventFieldsWithSearchFieldConfig(currentEvent)
 


### PR DESCRIPTION
## Description

In registration details section, field data from one event is visible in another.
[#9655](https://github.com/opencrvs/opencrvs-core/issues/9655)

Data disappears on section hide yet search uses previously entered parameters
[#9659](https://github.com/opencrvs/opencrvs-core/issues/9659)

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
