### PR TITLE
PR e2e deployment uses base branch as farajaland branch

### DIFF
--- a/.github/workflows/build-images-from-branch.yml
+++ b/.github/workflows/build-images-from-branch.yml
@@ -135,7 +135,7 @@ jobs:
   security-scans-pr:
     needs: [build, base]
     runs-on: ubuntu-24.04
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'develop'
     strategy:
       matrix:
         service: ${{ fromJSON(needs.base.outputs.services) }}

--- a/.github/workflows/build-images-from-branch.yml
+++ b/.github/workflows/build-images-from-branch.yml
@@ -135,7 +135,7 @@ jobs:
   security-scans-pr:
     needs: [build, base]
     runs-on: ubuntu-24.04
-    if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'develop'
+    if: github.event_name == 'pull_request' && (github.event.pull_request.base.ref == 'develop' || github.event.pull_request.base.ref == 'main')
     strategy:
       matrix:
         service: ${{ fromJSON(needs.base.outputs.services) }}

--- a/.github/workflows/deploy-to-feature-environment.yml
+++ b/.github/workflows/deploy-to-feature-environment.yml
@@ -132,7 +132,7 @@ jobs:
             core.setOutput('stack', slugify('${{ env.BRANCH_NAME }}'));
 
   trigger-build:
-    if: ${{ (github.event_name == 'workflow_dispatch') || (!contains(github.actor, 'bot') && github.event.pull_request.head.repo.fork == false) }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (!contains(github.actor, 'bot') && github.event.pull_request.head.repo.fork == false && github.event.pull_request.base.ref == 'develop') }}
     needs: generate_stack_name_and_branch
     uses: ./.github/workflows/build-images-from-branch.yml
     with:

--- a/.github/workflows/deploy-to-feature-environment.yml
+++ b/.github/workflows/deploy-to-feature-environment.yml
@@ -168,10 +168,11 @@ jobs:
         run: |
           FARAJALAND_REPO=https://github.com/opencrvs/opencrvs-farajaland
           BASE_BRANCH="${{ github.base_ref || 'develop' }}"
+
           if git ls-remote $FARAJALAND_REPO refs/heads/${{ env.BRANCH_NAME }} | grep -q "${{ env.BRANCH_NAME }}"; then
             COMMIT_HASH=$(git ls-remote $FARAJALAND_REPO refs/heads/${{ env.BRANCH_NAME }} | cut -c1-7)
             echo "Branch ${{ env.BRANCH_NAME }} exists in opencrvs-farajaland repo: $COMMIT_HASH"
-          else if git ls-remote $FARAJALAND_REPO refs/heads/$BASE_BRANCH | grep -q "$BASE_BRANCH"; then
+          elif git ls-remote $FARAJALAND_REPO refs/heads/$BASE_BRANCH | grep -q "$BASE_BRANCH"; then
             COMMIT_HASH=$(git ls-remote $FARAJALAND_REPO refs/heads/$BASE_BRANCH | cut -c1-7)
             echo "Branch ${{ env.BRANCH_NAME }} doesn't exist in opencrvs-farajaland repo. Will use commit hash: '$COMMIT_HASH' from base branch: '$BASE_BRANCH'"
           else

--- a/.github/workflows/deploy-to-feature-environment.yml
+++ b/.github/workflows/deploy-to-feature-environment.yml
@@ -132,7 +132,7 @@ jobs:
             core.setOutput('stack', slugify('${{ env.BRANCH_NAME }}'));
 
   trigger-build:
-    if: ${{ github.event_name == 'workflow_dispatch' || (!contains(github.actor, 'bot') && github.event.pull_request.head.repo.fork == false && github.event.pull_request.base.ref == 'develop') }}
+    if: ${{ (github.event_name == 'workflow_dispatch') || (!contains(github.actor, 'bot') && github.event.pull_request.head.repo.fork == false) }}
     needs: generate_stack_name_and_branch
     uses: ./.github/workflows/build-images-from-branch.yml
     with:

--- a/.github/workflows/deploy-to-feature-environment.yml
+++ b/.github/workflows/deploy-to-feature-environment.yml
@@ -11,9 +11,9 @@ name: Deploy PR to feature environment
 on:
   pull_request:
     types:
-        - labeled
-        - opened
-        - synchronize
+      - labeled
+      - opened
+      - synchronize
   workflow_dispatch:
     inputs:
       pr_number:
@@ -63,10 +63,10 @@ jobs:
         id: PR_pull
         if: github.event_name == 'pull_request'
         run: |
-            pr_number=${{ github.event.pull_request.number }}
-            response=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/issues/${pr_number}")
-            labels=$(echo "$response" | jq '.labels | map(.name) | join(",")' | sed 's/"//g')
-            echo pr_labels=$labels >> $GITHUB_OUTPUT
+          pr_number=${{ github.event.pull_request.number }}
+          response=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/issues/${pr_number}")
+          labels=$(echo "$response" | jq '.labels | map(.name) | join(",")' | sed 's/"//g')
+          echo pr_labels=$labels >> $GITHUB_OUTPUT
 
       - name: Get input data (when triggered by event)
         if: github.event_name != 'workflow_dispatch'
@@ -167,12 +167,17 @@ jobs:
       - name: Check if branch exists in opencrvs-farajaland repo
         run: |
           FARAJALAND_REPO=https://github.com/opencrvs/opencrvs-farajaland
+          BASE_BRANCH="${{ github.base_ref || 'develop' }}"
+
           if git ls-remote $FARAJALAND_REPO refs/heads/${{ env.BRANCH_NAME }} | grep -q "${{ env.BRANCH_NAME }}"; then
             COMMIT_HASH=$(git ls-remote $FARAJALAND_REPO refs/heads/${{ env.BRANCH_NAME }} | cut -c1-7)
             echo "Branch ${{ env.BRANCH_NAME }} exists in opencrvs-farajaland repo: $COMMIT_HASH"
+          else if git ls-remote $FARAJALAND_REPO refs/heads/$BASE_BRANCH | grep -q "$BASE_BRANCH"; then
+            COMMIT_HASH=$(git ls-remote $FARAJALAND_REPO refs/heads/$BASE_BRANCH | cut -c1-7)
+            echo "Branch ${{ env.BRANCH_NAME }} doesn't exist in opencrvs-farajaland repo. Will use commit hash: '$COMMIT_HASH' from base branch: '$BASE_BRANCH'"
           else
             COMMIT_HASH=$(git ls-remote $FARAJALAND_REPO refs/heads/develop | cut -c1-7)
-            echo "Branch ${{ env.BRANCH_NAME }} doesn't exist in opencrvs-farajaland repo: $COMMIT_HASH"
+            echo "Branch ${{ env.BRANCH_NAME }} doesn't exist in opencrvs-farajaland repo. Will use commit hash: '$COMMIT_HASH' from 'develop' branch"
           fi
           echo "FARAJALAND_COMMIT_HASH=${COMMIT_HASH}" >> $GITHUB_ENV
       - name: Parse the stack name

--- a/.github/workflows/deploy-to-feature-environment.yml
+++ b/.github/workflows/deploy-to-feature-environment.yml
@@ -168,7 +168,6 @@ jobs:
         run: |
           FARAJALAND_REPO=https://github.com/opencrvs/opencrvs-farajaland
           BASE_BRANCH="${{ github.base_ref || 'develop' }}"
-
           if git ls-remote $FARAJALAND_REPO refs/heads/${{ env.BRANCH_NAME }} | grep -q "${{ env.BRANCH_NAME }}"; then
             COMMIT_HASH=$(git ls-remote $FARAJALAND_REPO refs/heads/${{ env.BRANCH_NAME }} | cut -c1-7)
             echo "Branch ${{ env.BRANCH_NAME }} exists in opencrvs-farajaland repo: $COMMIT_HASH"


### PR DESCRIPTION
Add support to core PR e2e deployment for using the PR base/target farajaland branch if found. This means that the e2e deployments on PRs will resolve the opencrvs-farajaland branch thus:

1. Use branch with same name as PR branch if found
2. Use branch with same name as PR base/target branch if found
3. Fallback to develop branch