### PR TITLE
fix: don't show hidden fields in print view

### DIFF
--- a/packages/client/src/views/PrintRecord/Body.tsx
+++ b/packages/client/src/views/PrintRecord/Body.tsx
@@ -39,7 +39,8 @@ import {
   IAttachment,
   IDocumentUploaderWithOptionsFormField,
   BULLET_LIST,
-  DIVIDER
+  DIVIDER,
+  HIDDEN
 } from '@client/forms'
 import {
   getConditionalActionsForField,
@@ -658,6 +659,11 @@ export function PrintRecordBody(props: PrintRecordTableProps) {
   }
   function isVisibleField(field: IFormField, section: IFormSection) {
     const { declaration: draft } = props
+
+    if (field.type === HIDDEN) {
+      return false
+    }
+
     const conditionalActions = getConditionalActionsForField(
       field,
       draft.data[section.id] || {},


### PR DESCRIPTION
## Description

Don't show hidden fields in the declaration print preview similar to the review section

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
