### PR TITLE
Disable 'Continue' button on review page if no corrections made

### DIFF
--- a/packages/client/src/v2-events/features/events/actions/correct/request/CorrectionRequest.stories.tsx
+++ b/packages/client/src/v2-events/features/events/actions/correct/request/CorrectionRequest.stories.tsx
@@ -13,6 +13,7 @@ import { createTRPCMsw, httpLink } from '@vafanassieff/msw-trpc'
 import React, { useEffect } from 'react'
 import { Outlet } from 'react-router-dom'
 import superjson from 'superjson'
+import { expect, waitFor, within } from '@storybook/test'
 import { ActionType } from '@opencrvs/commons/client'
 import { testDataGenerator } from '@client/tests/test-data-generators'
 import { useDrafts } from '@client/v2-events/features/drafts/useDrafts'
@@ -52,6 +53,39 @@ function FormClear() {
   return <Outlet />
 }
 
+export const ReviewWithoutChanges: Story = {
+  parameters: {
+    reactRouter: {
+      router: {
+        path: '/',
+        element: <Outlet />,
+        children: [router]
+      },
+      initialPath: ROUTES.V2.EVENTS.REQUEST_CORRECTION.REVIEW.buildPath({
+        eventId: tennisClubMembershipEventDocument.id
+      })
+    },
+    msw: {
+      handlers: {
+        event: [
+          tRPCMsw.event.get.query(() => {
+            return tennisClubMembershipEventDocument
+          })
+        ]
+      }
+    }
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await waitFor(async () => {
+      await expect(
+        canvas.getByRole('button', { name: 'Continue' })
+      ).toBeDisabled()
+    })
+  }
+}
+
 export const ReviewWithChanges: Story = {
   parameters: {
     reactRouter: {
@@ -73,6 +107,14 @@ export const ReviewWithChanges: Story = {
         ]
       }
     }
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await waitFor(async () => {
+      await expect(
+        canvas.getByRole('button', { name: 'Continue' })
+      ).toBeEnabled()
+    })
   }
 }
 

--- a/packages/client/src/v2-events/features/events/actions/correct/request/Review.tsx
+++ b/packages/client/src/v2-events/features/events/actions/correct/request/Review.tsx
@@ -13,6 +13,7 @@ import React from 'react'
 import { useIntl } from 'react-intl'
 import { useNavigate } from 'react-router-dom'
 import { useTypedParams } from 'react-router-typesafe-routes/dom'
+import { isEqual } from 'lodash'
 import { ActionType, getDeclaration } from '@opencrvs/commons/client'
 import { PrimaryButton } from '@opencrvs/components/lib/buttons'
 import { buttonMessages } from '@client/i18n/messages'
@@ -41,7 +42,7 @@ export function Review() {
   const form = getFormValues()
   const previousFormValues = event.declaration
   const valuesHaveChanged = Object.entries(form).some(
-    ([key, value]) => previousFormValues[key] !== value
+    ([key, value]) => !isEqual(previousFormValues[key], value)
   )
   const intlWithData = useIntlFormatMessageWithFlattenedParams()
 


### PR DESCRIPTION
Resolves: https://github.com/opencrvs/opencrvs-core/issues/9764

This was not working correctly before, since comparison with `!==` does not work for all values.

Also add test.