### PR TITLE
Add 'correction-requested' custom flag for event state

### DIFF
--- a/packages/client/src/v2-events/features/events/actions/correct/request/CorrectionRequest.stories.tsx
+++ b/packages/client/src/v2-events/features/events/actions/correct/request/CorrectionRequest.stories.tsx
@@ -13,6 +13,7 @@ import { createTRPCMsw, httpLink } from '@vafanassieff/msw-trpc'
 import React, { useEffect } from 'react'
 import { Outlet } from 'react-router-dom'
 import superjson from 'superjson'
+import { expect, waitFor, within } from '@storybook/test'
 import { ActionType } from '@opencrvs/commons/client'
 import { testDataGenerator } from '@client/tests/test-data-generators'
 import { useDrafts } from '@client/v2-events/features/drafts/useDrafts'
@@ -52,6 +53,39 @@ function FormClear() {
   return <Outlet />
 }
 
+export const ReviewWithoutChanges: Story = {
+  parameters: {
+    reactRouter: {
+      router: {
+        path: '/',
+        element: <Outlet />,
+        children: [router]
+      },
+      initialPath: ROUTES.V2.EVENTS.REQUEST_CORRECTION.REVIEW.buildPath({
+        eventId: tennisClubMembershipEventDocument.id
+      })
+    },
+    msw: {
+      handlers: {
+        event: [
+          tRPCMsw.event.get.query(() => {
+            return tennisClubMembershipEventDocument
+          })
+        ]
+      }
+    }
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await waitFor(async () => {
+      await expect(
+        canvas.getByRole('button', { name: 'Continue' })
+      ).toBeDisabled()
+    })
+  }
+}
+
 export const ReviewWithChanges: Story = {
   parameters: {
     reactRouter: {
@@ -73,6 +107,14 @@ export const ReviewWithChanges: Story = {
         ]
       }
     }
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await waitFor(async () => {
+      await expect(
+        canvas.getByRole('button', { name: 'Continue' })
+      ).toBeEnabled()
+    })
   }
 }
 

--- a/packages/client/src/v2-events/features/events/actions/correct/request/Review.tsx
+++ b/packages/client/src/v2-events/features/events/actions/correct/request/Review.tsx
@@ -27,26 +27,25 @@ import { ROUTES } from '@client/v2-events/routes'
 import { makeFormFieldIdFormikCompatible } from '@client/v2-events/components/forms/utils'
 
 export function Review() {
-  const { eventId } = useTypedParams(ROUTES.V2.EVENTS.REQUEST_CORRECTION.REVIEW)
-  const events = useEvents()
   const intl = useIntl()
   const navigate = useNavigate()
 
+  const { eventId } = useTypedParams(ROUTES.V2.EVENTS.REQUEST_CORRECTION.REVIEW)
+  const events = useEvents()
   const event = events.getEventState.useSuspenseQuery(eventId)
-
-  const { eventConfiguration: config } = useEventConfiguration(event.type)
-  const formConfig = getDeclaration(config)
+  const { eventConfiguration } = useEventConfiguration(event.type)
+  const formConfig = getDeclaration(eventConfiguration)
 
   const getFormValues = useEventFormData((state) => state.getFormValues)
-
   const form = getFormValues()
   const previousFormValues = event.declaration
   const valuesHaveChanged = Object.entries(form).some(
     ([key, value]) => !isEqual(previousFormValues[key], value)
   )
+
   const intlWithData = useIntlFormatMessageWithFlattenedParams()
 
-  const actionConfig = config.actions.find(
+  const actionConfig = eventConfiguration.actions.find(
     (action) => action.type === ActionType.REQUEST_CORRECTION
   )
 

--- a/packages/client/src/v2-events/features/events/actions/correct/request/Review.tsx
+++ b/packages/client/src/v2-events/features/events/actions/correct/request/Review.tsx
@@ -13,6 +13,7 @@ import React from 'react'
 import { useIntl } from 'react-intl'
 import { useNavigate } from 'react-router-dom'
 import { useTypedParams } from 'react-router-typesafe-routes/dom'
+import { isEqual } from 'lodash'
 import { ActionType, getDeclaration } from '@opencrvs/commons/client'
 import { PrimaryButton } from '@opencrvs/components/lib/buttons'
 import { buttonMessages } from '@client/i18n/messages'
@@ -41,7 +42,7 @@ export function Review() {
   const form = getFormValues()
   const previousFormValues = event.declaration
   const valuesHaveChanged = Object.entries(form).some(
-    ([key, value]) => previousFormValues[key] !== value
+    ([key, value]) => !isEqual(previousFormValues[key], value)
   )
   const intlWithData = useIntlFormatMessageWithFlattenedParams()
 

--- a/packages/client/src/v2-events/features/workqueues/EventOverview/components/ActionMenuStories/RegistrationAgentInteraction/CorrectionRequested.stories.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/components/ActionMenuStories/RegistrationAgentInteraction/CorrectionRequested.stories.tsx
@@ -1,0 +1,95 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+import type { Meta } from '@storybook/react'
+import { ActionType } from '@opencrvs/commons/client'
+import { AssignmentStatus } from '@client/v2-events/utils'
+import { ActionMenu } from '../../ActionMenu'
+import {
+  baseMeta,
+  getHiddenActions,
+  createStoriesFromScenarios,
+  AssertType,
+  Scenario,
+  UserRoles
+} from '../ActionMenu.common'
+
+export default {
+  ...baseMeta,
+  title: 'ActionMenu/RegistrationAgent/CorrectionRequested'
+} as Meta<typeof ActionMenu>
+
+const correctionRequestedScenariosForRegistrationAgent: Scenario[] = [
+  {
+    name: 'Unassigned',
+    actions: [
+      ActionType.CREATE,
+      AssignmentStatus.ASSIGNED_TO_SELF,
+      ActionType.DECLARE,
+      ActionType.VALIDATE,
+      ActionType.REGISTER,
+      ActionType.UNASSIGN,
+      ActionType.REQUEST_CORRECTION
+    ],
+    expected: {
+      ...getHiddenActions(),
+      [ActionType.ASSIGN]: AssertType.ENABLED,
+      [ActionType.READ]: AssertType.ENABLED,
+      [ActionType.PRINT_CERTIFICATE]: AssertType.DISABLED,
+      [ActionType.REQUEST_CORRECTION]: AssertType.DISABLED
+    }
+  },
+  {
+    name: 'AssignedToSelf',
+    actions: [
+      ActionType.CREATE,
+      AssignmentStatus.ASSIGNED_TO_SELF,
+      ActionType.DECLARE,
+      ActionType.VALIDATE,
+      ActionType.REGISTER,
+      ActionType.REQUEST_CORRECTION
+    ],
+    expected: {
+      ...getHiddenActions(),
+      [ActionType.UNASSIGN]: AssertType.ENABLED,
+      [ActionType.READ]: AssertType.ENABLED,
+      [ActionType.PRINT_CERTIFICATE]: AssertType.ENABLED,
+      [ActionType.REQUEST_CORRECTION]: AssertType.DISABLED
+    }
+  },
+  {
+    name: 'AssignedToOthers',
+    actions: [
+      ActionType.CREATE,
+      AssignmentStatus.ASSIGNED_TO_SELF,
+      ActionType.DECLARE,
+      ActionType.VALIDATE,
+      ActionType.REGISTER,
+      ActionType.UNASSIGN,
+      AssignmentStatus.ASSIGNED_TO_OTHERS,
+      ActionType.REQUEST_CORRECTION
+    ],
+    expected: {
+      ...getHiddenActions(),
+      [ActionType.READ]: AssertType.ENABLED,
+      [ActionType.PRINT_CERTIFICATE]: AssertType.DISABLED,
+      [ActionType.REQUEST_CORRECTION]: AssertType.DISABLED
+    }
+  }
+]
+
+const stories = createStoriesFromScenarios(
+  correctionRequestedScenariosForRegistrationAgent,
+  UserRoles.REGISTRATION_AGENT
+)
+
+export const Unassigned = stories['Unassigned']
+export const AssignedToSelf = stories['AssignedToSelf']
+export const AssignedToOthers = stories['AssignedToOthers']

--- a/packages/client/src/v2-events/features/workqueues/EventOverview/components/useActionMenuItems.ts
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/components/useActionMenuItems.ts
@@ -20,7 +20,8 @@ import {
   SCOPES,
   ACTION_ALLOWED_SCOPES,
   hasAnyOfScopes,
-  IndexMap
+  IndexMap,
+  CustomFlags
 } from '@opencrvs/commons/client'
 import { useEvents } from '@client/v2-events/features/events/useEvents/useEvents'
 import { ROUTES } from '@client/v2-events/routes'
@@ -273,7 +274,9 @@ export function useActionMenuItems(event: EventIndex, scopes: Scope[]) {
           })
         )
       },
-      disabled: !eventIsAssignedToSelf
+      disabled:
+        !eventIsAssignedToSelf ||
+        event.flags.includes(CustomFlags.CORRECTION_REQUESTED)
     }
   } satisfies Partial<Record<ActionType, ActionConfig>>
 

--- a/packages/commons/src/events/EventMetadata.ts
+++ b/packages/commons/src/events/EventMetadata.ts
@@ -44,7 +44,8 @@ const eventStatusValues = [
 export const EventStatusEnum = z.enum(eventStatusValues)
 
 export const CustomFlags = {
-  CERTIFICATE_PRINTED: 'certificate-printed'
+  CERTIFICATE_PRINTED: 'certificate-printed',
+  CORRECTION_REQUESTED: 'correction-requested'
 } as const
 export type CustomFlags = (typeof CustomFlags)[keyof typeof CustomFlags]
 

--- a/packages/commons/src/events/state/flags.ts
+++ b/packages/commons/src/events/state/flags.ts
@@ -1,0 +1,65 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+import { ActionType } from '../ActionType'
+import { Action, ActionStatus } from '../ActionDocument'
+import { CustomFlags, Flag } from '../EventMetadata'
+
+const customFlagChecks: Record<
+  CustomFlags,
+  (sortedActions: Action[]) => boolean
+> = {
+  [CustomFlags.CERTIFICATE_PRINTED]: (sortedActions) => {
+    return sortedActions.reduce<boolean>((prev, { type }) => {
+      if (type === ActionType.PRINT_CERTIFICATE) {
+        return true
+      }
+      if (type === ActionType.APPROVE_CORRECTION) {
+        return false
+      }
+      return prev
+    }, false)
+  },
+  [CustomFlags.CORRECTION_REQUESTED]: (sortedActions) => {
+    // @TODO: After the correction approval/rejection is implemented, we need to update this to check if the correction request is finished
+    return sortedActions.some(
+      ({ type }) => type === ActionType.REQUEST_CORRECTION
+    )
+  }
+}
+
+export function getFlagsFromActions(actions: Action[]): Flag[] {
+  const sortedActions = actions.sort((a, b) =>
+    a.createdAt.localeCompare(b.createdAt)
+  )
+
+  const actionStatus = sortedActions.reduce(
+    (actionStatuses, { type, status }) => ({
+      ...actionStatuses,
+      [type]: status
+    }),
+    {} as Record<ActionType, ActionStatus>
+  )
+
+  const flags = Object.entries(actionStatus)
+    .filter(([, status]) => status !== ActionStatus.Accepted)
+    .map(([type, status]) => {
+      const flag = `${type.toLowerCase()}:${status.toLowerCase()}`
+      return flag satisfies Flag
+    })
+
+  Object.entries(customFlagChecks).forEach(([flag, check]) => {
+    if (check(sortedActions)) {
+      flags.push(flag)
+    }
+  })
+
+  return flags
+}

--- a/packages/commons/src/events/state/index.ts
+++ b/packages/commons/src/events/state/index.ts
@@ -19,11 +19,12 @@ import {
 } from '../ActionDocument'
 import { EventDocument } from '../EventDocument'
 import { EventIndex } from '../EventIndex'
-import { CustomFlags, EventStatus, Flag, ZodDate } from '../EventMetadata'
+import { EventStatus, ZodDate } from '../EventMetadata'
 import { Draft } from '../Draft'
 import { deepMerge, findActiveDrafts } from '../utils'
 import { getDeclarationActionUpdateMetadata, getLegalStatuses } from './utils'
 import { EventConfig } from '../EventConfig'
+import { getFlagsFromActions } from './flags'
 
 export function getStatusFromActions(actions: Array<Action>) {
   // If the event has any rejected action, we consider the event to be rejected.
@@ -64,45 +65,6 @@ export function getStatusFromActions(actions: Array<Action>) {
         return status
     }
   }, EventStatus.CREATED)
-}
-
-function getFlagsFromActions(actions: Action[]): Flag[] {
-  const sortedactions = actions.sort((a, b) =>
-    a.createdAt.localeCompare(b.createdAt)
-  )
-  const actionStatus = sortedactions.reduce(
-    (actionStatuses, { type, status }) => ({
-      ...actionStatuses,
-      [type]: status
-    }),
-    {} as Record<ActionType, ActionStatus>
-  )
-
-  const flags = Object.entries(actionStatus)
-    .filter(([, status]) => status !== ActionStatus.Accepted)
-    .map(([type, status]) => {
-      const flag = `${type.toLowerCase()}:${status.toLowerCase()}`
-      return flag satisfies Flag
-    })
-
-  const isCertificatePrinted = sortedactions.reduce<boolean>(
-    (prev, { type }) => {
-      if (type === ActionType.PRINT_CERTIFICATE) {
-        return true
-      }
-      if (type === ActionType.APPROVE_CORRECTION) {
-        return false
-      }
-      return prev
-    },
-    false
-  )
-
-  if (isCertificatePrinted) {
-    flags.push(CustomFlags.CERTIFICATE_PRINTED)
-  }
-
-  return flags
 }
 
 export function getAssignedUserFromActions(actions: Array<ActionDocument>) {


### PR DESCRIPTION
## Description

* Add `correction-requested` custom flag for event state
  * The check for resolving this to false if correction is accepted/rejected will be implemented when the acception/rejection is done
* Disable the 'Request correction' action from action menu if flag is true

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
