### PR TITLE
chore: use MINIO_BUCKET through window.config

### DIFF
--- a/packages/client/.storybook/preview-head.html
+++ b/packages/client/.storybook/preview-head.html
@@ -6,6 +6,7 @@
     AUTH_URL: 'http://localhost:7070/auth/',
     MINIO_BUCKET: 'ocrvs',
     MINIO_URL: 'http://localhost:3535/ocrvs/',
+    MINIO_BASE_URL: 'http://localhost:3535',
     COUNTRY_CONFIG_URL: 'http://localhost:3040',
     COUNTRY: 'FAR',
     LANGUAGES: 'en,fr',

--- a/packages/client/src/setupTests.ts
+++ b/packages/client/src/setupTests.ts
@@ -34,6 +34,7 @@ const config = {
   LOGIN_URL: 'http://localhost:3020',
   AUTH_URL: 'http://localhost:4040',
   MINIO_BUCKET: 'ocrvs',
+  MINIO_BASE_URL: 'http://localhost:3535',
   COUNTRY_CONFIG_URL: 'http://localhost:3040',
   APPLICATION_NAME: 'Farajaland CRVS',
   BIRTH: {

--- a/packages/client/src/v2-events/cache.ts
+++ b/packages/client/src/v2-events/cache.ts
@@ -14,14 +14,6 @@ import { joinValues } from './utils'
 /* Must match the one defined src-sw.ts */
 export const CACHE_NAME = 'workbox-runtime'
 
-function withPostfix(str: string, postfix: string) {
-  if (str.endsWith(postfix)) {
-    return str
-  }
-
-  return str + postfix
-}
-
 /**
  * Files are stored in MinIO. Files should be accessed via unsigned URLs, utilizing browser cache and aggressively precaching them.
  * @returns unsigned URL to the file in MinIO. Assumes file has been cached.

--- a/packages/client/src/v2-events/cache.ts
+++ b/packages/client/src/v2-events/cache.ts
@@ -9,6 +9,8 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 
+import { joinValues } from './utils'
+
 /* Must match the one defined src-sw.ts */
 export const CACHE_NAME = 'workbox-runtime'
 
@@ -25,12 +27,16 @@ function withPostfix(str: string, postfix: string) {
  * @returns unsigned URL to the file in MinIO. Assumes file has been cached.
  */
 export function getUnsignedFileUrl(filename: string) {
-  const minioURL = window.config.MINIO_URL
-  if (minioURL && typeof minioURL === 'string') {
-    return new URL(filename, withPostfix(minioURL, '/')).toString()
+  try {
+    return new URL(
+      joinValues([window.config.MINIO_BUCKET, filename], '/'),
+      window.config.MINIO_BASE_URL
+    ).toString()
+  } catch (error) {
+    throw new Error(
+      `Failed to build file url from: MINIO_BUCKET: ${window.config.MINIO_BUCKET}, MINIO_BASE_URL: ${window.config.MINIO_BASE_URL}`
+    )
   }
-
-  throw new Error('MINIO_URL is not defined')
 }
 
 /**

--- a/packages/client/src/v2-events/features/files/cache.ts
+++ b/packages/client/src/v2-events/features/files/cache.ts
@@ -21,8 +21,6 @@ import {
 import { removeCached } from '@client/v2-events/cache'
 import { precacheFile } from './useFileUpload'
 
-const FILE_STORAGE_BUCKET = 'ocrvs'
-
 /**
  *
  * @param storageKey - minio path including the bucket details. e.g. /ocrvs/signature.png
@@ -30,14 +28,20 @@ const FILE_STORAGE_BUCKET = 'ocrvs'
  *
  */
 function extractFilenameFromStorageKey(storageKey: string) {
-  const regex = new RegExp(`^/${FILE_STORAGE_BUCKET}/([^/?#]+)`)
-  const match = storageKey.match(regex)
+  try {
+    const regex = new RegExp(`^/${window.config.MINIO_BUCKET}/([^/?#]+)`)
+    const match = storageKey.match(regex)
 
-  if (match && match[1]) {
-    return match[1]
+    if (match && match[1]) {
+      return match[1]
+    }
+    // Since the key is defined in the window (external to us), we want to ensure we do not crash because of manual changes to the config.
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error extracting filename from storage key:', error)
+
+    return undefined
   }
-
-  return undefined
 }
 
 export function getFilenamesFromActionDocument(


### PR DESCRIPTION
## Description

- Use bucket variable from window.config (in order to get e2e working)
- Add try catches 

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
