### PR TITLE
Changing the setup script to use develop instead of master breaks it

### DIFF
--- a/development-environment/setup-countryconfig.sh
+++ b/development-environment/setup-countryconfig.sh
@@ -34,7 +34,7 @@ echo
 
 cd ../
 
-BRANCH=develop
+BRANCH=master
 
 
 git clone --branch $BRANCH --depth 1 https://github.com/opencrvs/opencrvs-countryconfig.git


### PR DESCRIPTION
## Description

I’m noticing that this [PR](https://github.com/opencrvs/opencrvs-core/pull/8004
) has broken the [bash setup.sh](https://documentation.opencrvs.org/setup/3.-installation/3.1-set-up-a-development-environment/3.1.2-install-opencrvs-locally) script for setting up a local development environment: 

The IPP group are unable to run the script because this branch should be **master**, not develop


