### PR TITLE
feat: Build OpenCRVS release images for arm devices (#9455)

### DIFF
--- a/.github/workflows/build-images-from-branch.yml
+++ b/.github/workflows/build-images-from-branch.yml
@@ -124,6 +124,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/build-images-from-branch.yml
+++ b/.github/workflows/build-images-from-branch.yml
@@ -39,6 +39,12 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Set version and branch
         id: set-version-and-branch
         run: |
@@ -78,6 +84,7 @@ jobs:
       - name: Build and push base image
         uses: docker/build-push-action@v6
         with:
+          platforms: linux/amd64,linux/arm64
           file: packages/Dockerfile.base
           context: .
           push: true
@@ -120,6 +127,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
+          platforms: linux/amd64,linux/arm64
           file: packages/${{ matrix.service }}/Dockerfile
           build-args: |
             VERSION=${{ needs.base.outputs.version }}
@@ -135,7 +143,7 @@ jobs:
   security-scans-pr:
     needs: [build, base]
     runs-on: ubuntu-24.04
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && (github.event.pull_request.base.ref == 'develop' || github.event.pull_request.base.ref == 'main')
     strategy:
       matrix:
         service: ${{ fromJSON(needs.base.outputs.services) }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 - **Kubernetes support for local development** Introduced Tiltfile for OpenCRVS deployment on local Kubernetes cluster. Check https://github.com/opencrvs/infrastructure for more information.
+- Build OpenCRVS release images for arm devices [#9455](https://github.com/opencrvs/opencrvs-core/issues/9455)
 
 ### Bug fixes
 - When the building the graphql payload from form data, we now check if a field was changed. If so then include it in the payload even if it might have been changed to an empty value.[#9369](https://github.com/opencrvs/opencrvs-core/issues/9369)

--- a/packages/Dockerfile.base
+++ b/packages/Dockerfile.base
@@ -12,11 +12,11 @@ WORKDIR /app
 COPY --chown=node:node *.json .
 COPY --chown=node:node yarn.lock .
 
-RUN yarn install --production --frozen-lockfile
+RUN yarn install --production --frozen-lockfile --network-timeout 600000
 
 COPY --chown=node:node packages/commons /app/packages/commons
 
 WORKDIR /app/packages/commons
 
-RUN yarn install --frozen-lockfile
+RUN yarn install --frozen-lockfile --network-timeout 600000
 RUN yarn build

--- a/packages/auth/Dockerfile
+++ b/packages/auth/Dockerfile
@@ -5,7 +5,7 @@ USER node
 
 WORKDIR /app/packages/auth
 COPY --chown=node:node packages/auth/*.json /app/packages/auth/
-RUN yarn install --frozen-lockfile
+RUN yarn install --frozen-lockfile --network-timeout 600000
 COPY --chown=node:node packages/auth /app/packages/auth
 RUN yarn build
 

--- a/packages/client/Dockerfile
+++ b/packages/client/Dockerfile
@@ -9,13 +9,13 @@ COPY --chown=node:node packages/events /app/packages/events
 WORKDIR /app/packages/components
 COPY --chown=node:node packages/components /app/packages/components
 
-RUN yarn install --frozen-lockfile  && yarn build
+RUN yarn install --frozen-lockfile --network-timeout 600000 && yarn build
 ENV CONTENT_SECURITY_POLICY_WILDCARD "{{CONTENT_SECURITY_POLICY_WILDCARD}}"
 ENV COUNTRY_CONFIG_URL_INTERNAL "{{COUNTRY_CONFIG_URL_INTERNAL}}"
 ENV GATEWAY_URL_INTERNAL "{{GATEWAY_URL_INTERNAL}}"
 WORKDIR /app/packages/client
 COPY --chown=node:node packages/client /app/packages/client
-RUN yarn install --frozen-lockfile && yarn build
+RUN yarn install --frozen-lockfile --network-timeout 600000 && yarn build
 
 FROM nginx:1.27
 RUN apt-get update && apt-get upgrade -y

--- a/packages/config/Dockerfile
+++ b/packages/config/Dockerfile
@@ -5,7 +5,7 @@ USER node
 
 WORKDIR /app/packages/config
 COPY --chown=node:node packages/config/*.json /app/packages/config/
-RUN yarn install --frozen-lockfile
+RUN yarn install --frozen-lockfile --network-timeout 600000
 COPY --chown=node:node packages/config /app/packages/config
 RUN yarn build
 

--- a/packages/data-seeder/Dockerfile
+++ b/packages/data-seeder/Dockerfile
@@ -5,6 +5,6 @@ USER node
 
 WORKDIR /app/packages/data-seeder
 COPY --chown=node:node packages/data-seeder/*.json /app/packages/data-seeder/
-RUN yarn install --frozen-lockfile
+RUN yarn install --frozen-lockfile --network-timeout 600000
 COPY --chown=node:node packages/data-seeder /app/packages/data-seeder
 ENTRYPOINT [ "yarn","seed" ]

--- a/packages/documents/Dockerfile
+++ b/packages/documents/Dockerfile
@@ -5,7 +5,7 @@ USER node
 
 WORKDIR /app/packages/documents
 COPY --chown=node:node packages/documents/*.json /app/packages/documents/
-RUN yarn install --frozen-lockfile
+RUN yarn install --frozen-lockfile --network-timeout 600000
 COPY --chown=node:node packages/documents /app/packages/documents
 RUN yarn build
 

--- a/packages/events/Dockerfile
+++ b/packages/events/Dockerfile
@@ -5,7 +5,7 @@ USER node
 
 WORKDIR /app/packages/events
 COPY --chown=node:node packages/events/*.json /app/packages/events/
-RUN yarn install --frozen-lockfile
+RUN yarn install --frozen-lockfile --network-timeout 600000
 COPY --chown=node:node packages/events /app/packages/events
 RUN yarn build
 

--- a/packages/gateway/Dockerfile
+++ b/packages/gateway/Dockerfile
@@ -8,7 +8,7 @@ COPY --chown=node:node packages/events /app/packages/events
 WORKDIR /app/packages/gateway
 COPY --chown=node:node packages/gateway/*.json /app/packages/gateway/
 
-RUN yarn install --frozen-lockfile
+RUN yarn install --frozen-lockfile --network-timeout 600000
 COPY --chown=node:node packages/gateway /app/packages/gateway
 RUN yarn build
 

--- a/packages/login/Dockerfile
+++ b/packages/login/Dockerfile
@@ -8,11 +8,11 @@ ENV COUNTRY_CONFIG_URL_INTERNAL "{{COUNTRY_CONFIG_URL_INTERNAL}}"
 
 WORKDIR /app/packages/components
 COPY --chown=node:node packages/components /app/packages/components
-RUN yarn install --frozen-lockfile && yarn build
+RUN yarn install --frozen-lockfile --network-timeout 600000 && yarn build
 
 WORKDIR /app/packages/login
 COPY --chown=node:node packages/login /app/packages/login
-RUN yarn install --frozen-lockfile && yarn build
+RUN yarn install --frozen-lockfile --network-timeout 600000 && yarn build
 
 # Step 2. Build the actual image
 

--- a/packages/metrics/Dockerfile
+++ b/packages/metrics/Dockerfile
@@ -5,6 +5,6 @@ USER node
 
 WORKDIR /app/packages/metrics
 COPY --chown=node:node packages/metrics /app/packages/metrics
-RUN yarn install --frozen-lockfile && yarn build
+RUN yarn install --frozen-lockfile --network-timeout 600000 && yarn build
 
 CMD ["yarn", "start:prod"]

--- a/packages/migration/Dockerfile
+++ b/packages/migration/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /app/packages/migration
 
 COPY --chown=node:node packages/migration /app/packages/migration
 
-RUN yarn install --frozen-lockfile
+RUN yarn install --frozen-lockfile --network-timeout 600000
 RUN yarn build
 
 WORKDIR /app/packages/migration

--- a/packages/notification/Dockerfile
+++ b/packages/notification/Dockerfile
@@ -5,6 +5,6 @@ USER node
 
 WORKDIR /app/packages/notification
 COPY --chown=node:node packages/notification /app/packages/notification
-RUN yarn install --frozen-lockfile && yarn build
+RUN yarn install --frozen-lockfile --network-timeout 600000 && yarn build
 
 CMD [ "yarn", "start:prod" ]

--- a/packages/search/Dockerfile
+++ b/packages/search/Dockerfile
@@ -5,7 +5,7 @@ USER node
 
 WORKDIR /app/packages/search
 COPY --chown=node:node packages/search /app/packages/search
-RUN yarn install --frozen-lockfile && yarn build
+RUN yarn install --frozen-lockfile --network-timeout 600000 && yarn build
 
 
 CMD [ "yarn", "start:prod" ]

--- a/packages/user-mgnt/Dockerfile
+++ b/packages/user-mgnt/Dockerfile
@@ -5,6 +5,6 @@ USER node
 
 WORKDIR /app/packages/user-mgnt
 COPY --chown=node:node packages/user-mgnt /app/packages/user-mgnt
-RUN yarn install --frozen-lockfile && yarn build
+RUN yarn install --frozen-lockfile --network-timeout 600000 && yarn build
 
 CMD ["yarn", "start:prod"]

--- a/packages/webhooks/Dockerfile
+++ b/packages/webhooks/Dockerfile
@@ -5,6 +5,6 @@ USER node
 
 WORKDIR /app/packages/webhooks
 COPY --chown=node:node packages/webhooks /app/packages/webhooks
-RUN yarn install --frozen-lockfile && yarn build
+RUN yarn install --frozen-lockfile --network-timeout 600000 && yarn build
 
 CMD [ "yarn", "start:prod" ]

--- a/packages/workflow/Dockerfile
+++ b/packages/workflow/Dockerfile
@@ -5,6 +5,6 @@ USER node
 
 WORKDIR /app/packages/workflow
 COPY --chown=node:node packages/workflow /app/packages/workflow
-RUN yarn install --frozen-lockfile && yarn build
+RUN yarn install --frozen-lockfile --network-timeout 600000 && yarn build
 
 CMD [ "yarn", "start:prod" ]


### PR DESCRIPTION
## Description

More context under the issue: https://github.com/opencrvs/opencrvs-core/issues/9455

**NOTE:** This PR is part of rolling migration to Kubernetes


## Checklist

- [ ] I have linked the correct Github issue under "Development": https://github.com/opencrvs/opencrvs-core/issues/9455
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [x] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly


## Test results

Initial build without cache: https://github.com/opencrvs/opencrvs-core/actions/runs/15704701303/job/44247664954
![image](https://github.com/user-attachments/assets/5810d6c2-d68c-49cb-bbae-0625f91c12f8)

Timeout issue:
https://github.com/opencrvs/opencrvs-core/actions/runs/15707090046
To fix the issue with timeout for arm architecture we add `--network-timeout 600000`

## Results

Produced artifacts:
Example base image: https://github.com/opencrvs/opencrvs-core/pkgs/container/ocrvs-base/440264637?tag=f412520
<img width="764" alt="image" src="https://github.com/user-attachments/assets/ab1ba019-b1ea-46f3-a986-61cd8cb419c0" />

Results after adding timeout: https://github.com/opencrvs/opencrvs-core/actions/runs/15707819580/job/44257778110

Results before adding timeout: https://github.com/opencrvs/opencrvs-core/actions/runs/15707090046

Timeout was added to all images, even only 4 of them failed to make script more robust in the future.
