### PR TITLE
[OCRVS-9722] Fix wrong reference of bride familyName when parsing GQL data

### DIFF
--- a/packages/client/src/views/RecordAudit/utils.ts
+++ b/packages/client/src/views/RecordAudit/utils.ts
@@ -449,7 +449,7 @@ export const getGQLDeclaration = (
       })} & ${getLocalisedName(intl, {
         firstNames: data.bride.name[0]?.firstNames,
         middleName: data.bride.name[0]?.middleName,
-        familyName: data.bride.name[0]?.firstNames
+        familyName: data.bride.name[0]?.familyName
       })}`
     } else if (data.groom?.name) {
       name = getLocalisedName(intl, {


### PR DESCRIPTION
## Before

![image](https://github.com/user-attachments/assets/1650a8b9-ec96-40ea-a56f-8da6343dba64)

## After

![image](https://github.com/user-attachments/assets/b6af4ef1-080f-4f02-9bea-08120d5b8016)
