### PR TITLE
Add validation to Notify API

### DIFF
--- a/packages/commons/src/conditionals/validate.ts
+++ b/packages/commons/src/conditionals/validate.ts
@@ -143,6 +143,11 @@ export const errorMessages = {
     defaultMessage: 'Invalid input',
     description: 'Error message when generic field is invalid',
     id: 'v2.error.invalid'
+  },
+  unexpectedField: {
+    defaultMessage: 'Unexpected field',
+    description: 'Error message when field is not expected',
+    id: 'v2.error.unexpectedField'
   }
 }
 

--- a/packages/commons/src/events/ActionType.ts
+++ b/packages/commons/src/events/ActionType.ts
@@ -86,10 +86,12 @@ const declarationUpdateActionValues = [
   ...declarationActionValues,
   ActionTypes.enum.REQUEST_CORRECTION
 ] as const
+
 /** Actions that can modify declaration data. Request can be corrected after declaring it. */
 export const DeclarationUpdateActions = ActionTypes.extract(
   declarationUpdateActionValues
 )
+
 export type DeclarationUpdateActionType = z.infer<
   typeof DeclarationUpdateActions
 >

--- a/packages/events/src/router/event/__snapshots__/event.actions.notify.test.ts.snap
+++ b/packages/events/src/router/event/__snapshots__/event.actions.notify.test.ts.snap
@@ -1,27 +1,15 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`event.actions.notify > NOTIFY action fails if invalid value is sent 1`] = `[TRPCError: [{"message":"Please enter a valid date","id":"applicant.dob","value":"2050-01-01"}]]`;
+
+exports[`event.actions.notify > NOTIFY action fails if payload includes field that is not in the declaration 1`] = `[TRPCError: [{"message":"Unexpected field","id":"foo.bar","value":"hello"}]]`;
+
+exports[`event.actions.notify > NOTIFY action fails if payload includes field with unexpected type 1`] = `[TRPCError: [{"message":"Invalid input","id":"applicant.firstname","value":999999}]]`;
+
 exports[`event.actions.notify > allows sending partial payload as NOTIFY action 1`] = `
 {
-  "applicant.address": {
-    "addressType": "DOMESTIC",
-    "country": "FAR",
-    "district": "5ef450bc-712d-48ad-93f3-8da0fa453baa",
-    "number": "55",
-    "province": "a45b982a-5c7b-4bd9-8fd8-a42d0994054c",
-    "residentialArea": "Example Residential Area",
-    "street": "Example Street",
-    "town": "Example Town",
-    "urbanOrRural": "URBAN",
-    "zipCode": "123456",
-  },
-  "applicant.age": 19,
-  "applicant.dobUnknown": true,
-  "applicant.image": {
-    "filename": "4f095fc4-4312-4de2-aa38-86dcc0f71044.png",
-    "originalFilename": "abcd.png",
-    "type": "image/png",
-  },
-  "recommender.none": true,
+  "applicant.dob": "2025-05-16",
+  "applicant.firstname": "John",
 }
 `;
 

--- a/packages/events/src/router/event/actions/index.ts
+++ b/packages/events/src/router/event/actions/index.ts
@@ -47,20 +47,17 @@ import {
  * @interface ActionProcedureConfig
  * @property {z.ZodType} inputSchema - The Zod schema for validating the action input
  * @property {z.ZodType | undefined} notifyApiPayloadSchema - Schema for notify API response payload if applicable. This will be sent either in the initial HTTP 200 response, or when the action is asynchronously accepted.
- * @property {boolean} validatePayload - Whether the payload should be strictly validated against the inputSchema schema
  * @property {OpenApiMeta} [meta] - Meta information, incl. OpenAPI definition
  */
 interface ActionProcedureConfig {
   inputSchema: z.ZodType
   notifyApiPayloadSchema: z.ZodType | undefined
-  validatePayload: boolean
   meta?: OpenApiMeta
 }
 
 const ACTION_PROCEDURE_CONFIG = {
   [ActionType.NOTIFY]: {
     notifyApiPayloadSchema: undefined,
-    validatePayload: false,
     inputSchema: NotifyActionInput,
     meta: {
       openapi: {
@@ -74,32 +71,26 @@ const ACTION_PROCEDURE_CONFIG = {
   },
   [ActionType.DECLARE]: {
     notifyApiPayloadSchema: undefined,
-    validatePayload: true,
     inputSchema: DeclareActionInput
   },
   [ActionType.VALIDATE]: {
     notifyApiPayloadSchema: undefined,
-    validatePayload: true,
     inputSchema: ValidateActionInput
   },
   [ActionType.REGISTER]: {
     notifyApiPayloadSchema: z.object({ registrationNumber: z.string() }),
-    validatePayload: true,
     inputSchema: RegisterActionInput
   },
   [ActionType.REJECT]: {
     notifyApiPayloadSchema: undefined,
-    validatePayload: true,
     inputSchema: RejectDeclarationActionInput
   },
   [ActionType.ARCHIVE]: {
     notifyApiPayloadSchema: undefined,
-    validatePayload: true,
     inputSchema: ArchiveActionInput
   },
   [ActionType.PRINT_CERTIFICATE]: {
     notifyApiPayloadSchema: undefined,
-    validatePayload: true,
     inputSchema: PrintCertificateActionInput
   }
 } satisfies Partial<Record<ActionType, ActionProcedureConfig>>
@@ -135,7 +126,7 @@ export function getDefaultActionProcedures(
 ): ActionProcedure {
   const actionConfig = ACTION_PROCEDURE_CONFIG[actionType]
 
-  const { notifyApiPayloadSchema, validatePayload, inputSchema } = actionConfig
+  const { notifyApiPayloadSchema, inputSchema } = actionConfig
 
   let acceptInputFields = z.object({ actionId: z.string() })
 
@@ -157,11 +148,7 @@ export function getDefaultActionProcedures(
       .input(inputSchema)
       .use(middleware.eventTypeAuthorization)
       .use(middleware.requireAssignment)
-      .use(
-        validatePayload
-          ? middleware.validateAction(actionType)
-          : async ({ next }) => next()
-      )
+      .use(middleware.validateAction(actionType))
       .output(EventDocument)
       .mutation(async ({ ctx, input }) => {
         const { token, user } = ctx
@@ -229,11 +216,7 @@ export function getDefaultActionProcedures(
     accept: systemProcedure
       .use(requireScopesMiddleware)
       .input(inputSchema.merge(acceptInputFields))
-      .use(
-        validatePayload
-          ? middleware.validateAction(actionType)
-          : async ({ next }) => next()
-      )
+      .use(middleware.validateAction(actionType))
       .mutation(async ({ ctx, input }) => {
         const { token, user } = ctx
         const { eventId, actionId } = input

--- a/packages/events/src/router/event/event.actions.notify.test.ts
+++ b/packages/events/src/router/event/event.actions.notify.test.ts
@@ -13,6 +13,7 @@ import { TRPCError } from '@trpc/server'
 import {
   ActionType,
   getAcceptedActions,
+  getUUID,
   SCOPES,
   TENNIS_CLUB_MEMBERSHIP
 } from '@opencrvs/commons'
@@ -85,10 +86,17 @@ describe('event.actions.notify', () => {
 
     const event = await client.event.create(generator.event.create())
 
-    const response = await client.event.actions.notify.request(
-      generator.event.actions.notify(event.id)
-    )
+    const payload = {
+      type: ActionType.NOTIFY,
+      eventId: event.id,
+      transactionId: getUUID(),
+      declaration: {
+        'applicant.firstname': 'John',
+        'applicant.dob': '2025-05-16'
+      }
+    }
 
+    const response = await client.event.actions.notify.request(payload)
     const activeActions = getAcceptedActions(response)
 
     expect(
@@ -99,6 +107,73 @@ describe('event.actions.notify', () => {
     expect(
       activeActions.find((action) => action.type === ActionType.UNASSIGN)
     ).toBeDefined()
+  })
+
+  test(`${ActionType.NOTIFY} action fails if payload includes field with unexpected type`, async () => {
+    const { user, generator } = await setupTestCase()
+    const client = createTestClient(user, [
+      SCOPES.RECORD_SUBMIT_INCOMPLETE,
+      SCOPES.RECORD_DECLARE
+    ])
+
+    const event = await client.event.create(generator.event.create())
+    const payload = {
+      type: ActionType.NOTIFY,
+      eventId: event.id,
+      transactionId: getUUID(),
+      declaration: {
+        'applicant.firstname': 999999
+      }
+    }
+
+    await expect(
+      client.event.actions.notify.request(payload)
+    ).rejects.toMatchSnapshot()
+  })
+
+  test(`${ActionType.NOTIFY} action fails if payload includes field that is not in the declaration`, async () => {
+    const { user, generator } = await setupTestCase()
+    const client = createTestClient(user, [
+      SCOPES.RECORD_SUBMIT_INCOMPLETE,
+      SCOPES.RECORD_DECLARE
+    ])
+
+    const event = await client.event.create(generator.event.create())
+    const payload = {
+      type: ActionType.NOTIFY,
+      eventId: event.id,
+      transactionId: getUUID(),
+      declaration: {
+        'foo.bar': 'hello'
+      }
+    }
+
+    await expect(
+      client.event.actions.notify.request(payload)
+    ).rejects.toMatchSnapshot()
+  })
+
+  test(`${ActionType.NOTIFY} action fails if invalid value is sent`, async () => {
+    const { user, generator } = await setupTestCase()
+    const client = createTestClient(user, [
+      SCOPES.RECORD_SUBMIT_INCOMPLETE,
+      SCOPES.RECORD_DECLARE
+    ])
+
+    const event = await client.event.create(generator.event.create())
+    const payload = {
+      type: ActionType.NOTIFY,
+      eventId: event.id,
+      transactionId: getUUID(),
+      declaration: {
+        // applicant.dob can not be in the future
+        'applicant.dob': '2050-01-01'
+      }
+    }
+
+    await expect(
+      client.event.actions.notify.request(payload)
+    ).rejects.toMatchSnapshot()
   })
 
   test(`${ActionType.NOTIFY} is idempotent`, async () => {

--- a/packages/events/src/router/middleware/validate/index.ts
+++ b/packages/events/src/router/middleware/validate/index.ts
@@ -213,30 +213,59 @@ function validateNotifyAction({
     fields.flatMap((field) => field)
   )
 
-  // TODO CIHAN annotation
+  const reviewFields = getActionReviewFields(eventConfig, ActionType.DECLARE)
 
-  return Object.entries(declaration).flatMap(([key, value]) => {
-    const field = formFields.find((f) => f.id === key)
+  const annotationErrors = Object.entries(annotation).flatMap(
+    ([key, value]) => {
+      const field = reviewFields.find((f) => f.id === key)
 
-    if (!field) {
-      return {
-        message: errorMessages.unexpectedField.defaultMessage,
-        id: key,
-        value
+      if (!field) {
+        return {
+          message: errorMessages.unexpectedField.defaultMessage,
+          id: key,
+          value
+        }
       }
+
+      const fieldErrors = runFieldValidations({
+        field,
+        values: annotation
+      })
+
+      return fieldErrors.errors.map((error) => ({
+        message: error.message.defaultMessage,
+        id: field.id,
+        value: annotation[field.id]
+      }))
     }
+  )
 
-    const fieldErrors = runFieldValidations({
-      field,
-      values: declaration
-    })
+  const declarationErrors = Object.entries(declaration).flatMap(
+    ([key, value]) => {
+      const field = formFields.find((f) => f.id === key)
 
-    return fieldErrors.errors.map((error) => ({
-      message: error.message.defaultMessage,
-      id: field.id,
-      value: declaration[field.id]
-    }))
-  })
+      if (!field) {
+        return {
+          message: errorMessages.unexpectedField.defaultMessage,
+          id: key,
+          value
+        }
+      }
+
+      const fieldErrors = runFieldValidations({
+        field,
+        values: declaration
+      })
+
+      return fieldErrors.errors.map((error) => ({
+        message: error.message.defaultMessage,
+        id: field.id,
+        value: declaration[field.id]
+      }))
+    }
+  )
+
+  return [...annotationErrors, ...declarationErrors]
 }
 
 export function validateAction(actionType: ActionType) {


### PR DESCRIPTION
## Description

E2e tests: https://github.com/opencrvs/opencrvs-farajaland/pull/1462

* Add payload validation to Notify API
* Minor improvement to `validateAction()`
* Add tests

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
