### PR TITLE
Handle requests with missing auth header gracefully

### DIFF
--- a/packages/events/src/context.ts
+++ b/packages/events/src/context.ts
@@ -157,7 +157,17 @@ export async function resolveUserDetails(
 
 export async function createContext({ req }: { req: IncomingMessage }) {
   const normalizedHeaders = normalizeHeaders(req.headers)
-  const token = TokenWithBearer.parse(normalizedHeaders.authorization)
+  let token: TokenWithBearer
+
+  try {
+    token = TokenWithBearer.parse(normalizedHeaders.authorization)
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  } catch (_) {
+    throw new TRPCError({
+      code: 'UNAUTHORIZED',
+      message: 'Authorization token is missing'
+    })
+  }
 
   const user = await resolveUserDetails(token)
   return { token, user }

--- a/packages/events/src/server.test.ts
+++ b/packages/events/src/server.test.ts
@@ -188,3 +188,27 @@ test('Throws with malformed token', async () => {
     new TRPCError({ code: 'UNAUTHORIZED' })
   )
 })
+
+test('UNAUTHORIZED error is thrown when authorization header is missing', async () => {
+  expect(serverInstance).toBeDefined()
+  expect(url).toBeDefined()
+
+  await expect(
+    customClient.event.create.mutate(
+      {
+        transactionId: getUUID(),
+        type: TENNIS_CLUB_MEMBERSHIP
+      },
+      {
+        context: {
+          headers: {}
+        }
+      }
+    )
+  ).rejects.toThrow(
+    new TRPCError({
+      code: 'UNAUTHORIZED',
+      message: 'Authorization token is missing'
+    })
+  )
+})


### PR DESCRIPTION
## Description

When Authorization header is missing, throw HTTP 401 Unauthorized instead of HTTP 500

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
