### PR TITLE
[OCRVS-9200] Make search index by id query fail if nothing is found

### DIFF
--- a/packages/client/src/v2-events/features/events/useEvents/useEvents.ts
+++ b/packages/client/src/v2-events/features/events/useEvents/useEvents.ts
@@ -70,6 +70,8 @@ export function useEvents() {
           ...trpc.event.search.queryOptions(query),
           queryKey: trpc.event.search.queryKey(query),
           enabled: !findLocalEventIndex(id),
+          staleTime: 0,
+          refetchOnMount: true,
           initialData: () => {
             const eventIndex = findLocalEventIndex(id)
             return eventIndex ? [eventIndex] : undefined
@@ -82,9 +84,22 @@ export function useEvents() {
           clauses: [{ id }]
         } satisfies QueryType
 
+        const options = trpc.event.search.queryOptions(query)
+
         return useSuspenseQuery({
           ...trpc.event.search.queryOptions(query),
           queryKey: trpc.event.search.queryKey(query),
+          queryFn: async (...args) => {
+            const queryFn = options.queryFn
+            if (!queryFn) {
+              throw new Error('Query function is not defined')
+            }
+            const res = await queryFn(...args)
+            if (res.length === 0) {
+              throw new Error(`No event found with id: ${id}`)
+            }
+            return res
+          },
           initialData: () => {
             const eventIndex = findLocalEventIndex(id)
             return eventIndex ? [eventIndex] : undefined


### PR DESCRIPTION
Revalidate search caches on remount. Continues #9200 
