### PR TITLE
fix: Run e2e tests from dedicated branch based on PR branch

### DIFF
--- a/.github/workflows/deploy-to-feature-environment.yml
+++ b/.github/workflows/deploy-to-feature-environment.yml
@@ -38,6 +38,7 @@ jobs:
       keep_e2e: ${{ steps.set_branch_and_pr_number.outputs.keep_e2e }}
       author: ${{ steps.get_author.outputs.AUTHOR }}
       slugified_branch: ${{ steps.slugify_bname.outputs.stack }}
+      e2e_branch: ${{ steps.get_e2e_branch.outputs.branch }}
     steps:
       - uses: actions/checkout@v3
 
@@ -95,7 +96,19 @@ jobs:
         if: ${{ github.event_name != 'workflow_dispatch' }}
         run: |
           echo "BRANCH_NAME=$(echo ${{ github.head_ref }})" >> $GITHUB_ENV
+      - name: Get e2e branch
+        id: get_e2e_branch
+        run: |
+          e2e_repo_url="https://github.com/opencrvs/e2e.git"
 
+          if git ls-remote --heads "$e2e_repo_url" | grep -q "refs/heads/${{ github.head_ref }}"; then
+            e2e_branch=${{ github.head_ref }}
+          elif git ls-remote --heads "$e2e_repo_url" | grep -q "refs/heads/${{ github.base_ref }}"; then
+            e2e_branch="${{ github.base_ref }}"
+          else
+            e2e_branch="develop"
+          fi
+          echo "branch=$e2e_branch" >> $GITHUB_OUTPUT
       - name: Get PR Author
         id: get_author
         env:
@@ -192,6 +205,7 @@ jobs:
           PR Head Commit Hash: ${{ env.HEAD_COMMIT_HASH }}
           Farajaland Commit Hash: ${{ env.FARAJALAND_COMMIT_HASH }}
           Keep e2e: ${{ needs.generate_stack_name_and_branch.outputs.keep_e2e }}
+          E2E Branch: ${{ needs.generate_stack_name_and_branch.outputs.e2e_branch }}
           Stack: ${{ steps.generate_stack.outputs.stack }}
           """
 
@@ -211,7 +225,8 @@ jobs:
                 'core-image-tag': '${{ env.HEAD_COMMIT_HASH }}',
                 'countryconfig-image-tag': '${{ env.FARAJALAND_COMMIT_HASH }}',
                 stack: '${{  steps.generate_stack.outputs.stack  }}',
-                'keep-e2e': '${{ needs.generate_stack_name_and_branch.outputs.keep_e2e }}'
+                'keep-e2e': '${{ needs.generate_stack_name_and_branch.outputs.keep_e2e }}',
+                'branch': '${{ needs.generate_stack_name_and_branch.outputs.e2e_branch }}'
               }
             });
 


### PR DESCRIPTION
## Description

Related issue: https://github.com/opencrvs/opencrvs-core/issues/6501

Goal of this PR is to be able to run e2e tests from branch different from develop

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly

## Testing

Run when head (and base) branch doesn't exist in e2e:
![image](https://github.com/user-attachments/assets/7badfe16-5470-424b-8676-5bd56438478e)

Run when base branch exist in e2e:
![image](https://github.com/user-attachments/assets/14cad11f-5029-4180-bb43-2413724f8d23)


Run when head branch exists in e2e:
![image](https://github.com/user-attachments/assets/bf86085a-96d3-4da2-b209-aaeae7d590e0)
