### PR TITLE
Allow excluding certain declaration fields from configuration, fix bug on correction review page

### DIFF
--- a/packages/client/src/i18n/messages/views/correction.ts
+++ b/packages/client/src/i18n/messages/views/correction.ts
@@ -380,7 +380,7 @@ const messagesToDefine = {
   },
   correctionApprovalDialogTitle: {
     id: 'v2.correction.correctionForApprovalDialog.title',
-    defaultMessage: 'Send record correction for approval ?',
+    defaultMessage: 'Send record correction for approval?',
     description:
       'The title for the dialog when record correction sent by registration agent for approval'
   }

--- a/packages/client/src/i18n/messages/views/correction.ts
+++ b/packages/client/src/i18n/messages/views/correction.ts
@@ -377,6 +377,12 @@ const messagesToDefine = {
     id: 'v2.correction.summary.change',
     defaultMessage: 'Change',
     description: 'Change link label'
+  },
+  correctionApprovalDialogTitle: {
+    id: 'v2.correction.correctionForApprovalDialog.title',
+    defaultMessage: 'Send record correction for approval ?',
+    description:
+      'The title for the dialog when record correction sent by registration agent for approval'
   }
 }
 

--- a/packages/client/src/v2-events/components/forms/FormFieldGenerator/FormFieldGenerator.interaction.stories.tsx
+++ b/packages/client/src/v2-events/components/forms/FormFieldGenerator/FormFieldGenerator.interaction.stories.tsx
@@ -169,8 +169,6 @@ export const UpdateCondtionalValues: StoryObj<typeof FormFieldGenerator> = {
   }
 }
 
-const styles = ['defensive', 'allrounder', 'hard-hitter'] as const
-
 const tennisStyleFields = [
   {
     id: 'tennis.style',

--- a/packages/client/src/v2-events/components/forms/FormFieldGenerator/FormFieldGenerator.tsx
+++ b/packages/client/src/v2-events/components/forms/FormFieldGenerator/FormFieldGenerator.tsx
@@ -65,6 +65,7 @@ interface FormFieldGeneratorProps {
   /** Default field values. Might equal to declaration, when a declaration form is rendered. */
   initialValues?: EventState
   onAllFieldsValidated?: (success: boolean) => void
+  isCorrection?: boolean
 }
 
 export const FormFieldGenerator: React.FC<FormFieldGeneratorProps> = React.memo(
@@ -78,7 +79,8 @@ export const FormFieldGenerator: React.FC<FormFieldGeneratorProps> = React.memo(
     validateAllFields = false,
     readonlyMode,
     id,
-    onAllFieldsValidated
+    onAllFieldsValidated,
+    isCorrection = false
   }) => {
     const { setAllTouchedFields, touchedFields: initialTouchedFields } =
       useEventFormData()
@@ -144,6 +146,7 @@ export const FormFieldGenerator: React.FC<FormFieldGeneratorProps> = React.memo(
               fieldsToShowValidationErrors={fieldsToShowValidationErrors}
               id={id}
               initialValues={initialValues}
+              isCorrection={isCorrection}
               readonlyMode={readonlyMode}
               resetForm={formikProps.resetForm}
               setAllTouchedFields={setAllTouchedFields}

--- a/packages/client/src/v2-events/components/forms/FormFieldGenerator/FormSectionComponent.tsx
+++ b/packages/client/src/v2-events/components/forms/FormFieldGenerator/FormSectionComponent.tsx
@@ -63,6 +63,10 @@ type AllProps = {
    * this callback is called with success true if all fields are valid, or false if there are any validation errors.
    */
   onAllFieldsValidated?: (success: boolean) => void
+  /**
+   * If isCorrection is true, fields with configuration option 'isCorrectable' set to false will be disabled.
+   */
+  isCorrection?: boolean
 } & UsedFormikProps
 
 /**
@@ -142,7 +146,8 @@ export function FormSectionComponent({
   setErrors,
   validateAllFields,
   fieldsToShowValidationErrors,
-  onAllFieldsValidated
+  onAllFieldsValidated,
+  isCorrection = false
 }: AllProps) {
   const intl = useIntl()
   const prevValuesRef = useRef(values)
@@ -309,7 +314,10 @@ export function FormSectionComponent({
           return null
         }
 
-        const isDisabled = !isFieldEnabled(field, completeForm)
+        const isDisabled =
+          !isFieldEnabled(field, completeForm) ||
+          (isCorrection && field.isCorrectable === false)
+
         const visibleError = errors[field.id]?.errors[0]?.message
         const error = visibleError ? intl.formatMessage(visibleError) : ''
 

--- a/packages/client/src/v2-events/components/forms/FormFieldGenerator/FormSectionComponent.tsx
+++ b/packages/client/src/v2-events/components/forms/FormFieldGenerator/FormSectionComponent.tsx
@@ -64,7 +64,7 @@ type AllProps = {
    */
   onAllFieldsValidated?: (success: boolean) => void
   /**
-   * If isCorrection is true, fields with configuration option 'isCorrectable' set to false will be disabled.
+   * If isCorrection is true, fields with configuration option 'uncorrectable' set to true will be disabled.
    */
   isCorrection?: boolean
 } & UsedFormikProps
@@ -316,7 +316,7 @@ export function FormSectionComponent({
 
         const isDisabled =
           !isFieldEnabled(field, completeForm) ||
-          (isCorrection && field.isCorrectable === false)
+          (isCorrection && field.uncorrectable)
 
         const visibleError = errors[field.id]?.errors[0]?.message
         const error = visibleError ? intl.formatMessage(visibleError) : ''

--- a/packages/client/src/v2-events/features/events/actions/correct/request/Pages.tsx
+++ b/packages/client/src/v2-events/features/events/actions/correct/request/Pages.tsx
@@ -47,13 +47,13 @@ export function Pages() {
   const formPages = getDeclarationPages(configuration)
 
   const filteredFormPages = formPages
+    // Filter out pages where all fields have 'isCorrectable' set to false or are non-interactive
     .filter(
-      // Filter out pages where all fields have 'isCorrectable' set to false
-      (page) => !page.fields.every((field) => field.isCorrectable === false)
-    )
-    .filter(
-      // Filter out pages that only contain non-interactive fields
-      (page) => !page.fields.every((field) => isNonInteractiveFieldType(field))
+      (page) =>
+        !page.fields.every(
+          (field) =>
+            field.isCorrectable === false || isNonInteractiveFieldType(field)
+        )
     )
 
   const currentPageId =

--- a/packages/client/src/v2-events/features/events/actions/correct/request/Pages.tsx
+++ b/packages/client/src/v2-events/features/events/actions/correct/request/Pages.tsx
@@ -46,7 +46,7 @@ export function Pages() {
 
   const formPages = getDeclarationPages(configuration)
 
-  // Filter out pages where all fields have 'isCorrectable' set to false or are non-interactive
+  // Filter out pages where all fields either have 'isCorrectable' set to false or are non-interactive
   const filteredFormPages = formPages.filter(
     (page) =>
       !page.fields.every(

--- a/packages/client/src/v2-events/features/events/actions/correct/request/Pages.tsx
+++ b/packages/client/src/v2-events/features/events/actions/correct/request/Pages.tsx
@@ -46,15 +46,14 @@ export function Pages() {
 
   const formPages = getDeclarationPages(configuration)
 
-  const filteredFormPages = formPages
-    // Filter out pages where all fields have 'isCorrectable' set to false or are non-interactive
-    .filter(
-      (page) =>
-        !page.fields.every(
-          (field) =>
-            field.isCorrectable === false || isNonInteractiveFieldType(field)
-        )
-    )
+  // Filter out pages where all fields have 'isCorrectable' set to false or are non-interactive
+  const filteredFormPages = formPages.filter(
+    (page) =>
+      !page.fields.every(
+        (field) =>
+          field.isCorrectable === false || isNonInteractiveFieldType(field)
+      )
+  )
 
   const currentPageId =
     filteredFormPages.find((p) => p.id === pageId)?.id ||

--- a/packages/client/src/v2-events/features/events/actions/correct/request/Pages.tsx
+++ b/packages/client/src/v2-events/features/events/actions/correct/request/Pages.tsx
@@ -29,7 +29,7 @@ import { useEventFormNavigation } from '@client/v2-events/features/events/useEve
 import { FormLayout } from '@client/v2-events/layouts'
 import { ROUTES } from '@client/v2-events/routes'
 
-  // Filter out pages where all fields either have 'uncorrectable' set to true or are non-interactive
+// Filter out pages where all fields either have 'uncorrectable' set to true or are non-interactive
 function getCorrectablePages(formPages: PageConfig[]) {
   return formPages.filter(
     (page) =>
@@ -37,6 +37,7 @@ function getCorrectablePages(formPages: PageConfig[]) {
         (field) => field.uncorrectable || isNonInteractiveFieldType(field)
       )
   )
+}
 
 export function Pages() {
   const { eventId, pageId } = useTypedParams(ROUTES.V2.EVENTS.REGISTER.PAGES)
@@ -58,8 +59,7 @@ export function Pages() {
   const correctablePages = getCorrectablePages(formPages)
 
   const currentPageId =
-    correctablePages.find((p) => p.id === pageId)?.id ||
-    correctablePages[0]?.id
+    correctablePages.find((p) => p.id === pageId)?.id || correctablePages[0]?.id
 
   if (!currentPageId) {
     throw new Error('Form does not have any pages')

--- a/packages/client/src/v2-events/features/events/actions/correct/request/Review.tsx
+++ b/packages/client/src/v2-events/features/events/actions/correct/request/Review.tsx
@@ -79,6 +79,7 @@ export function Review() {
       <ReviewComponent.Body
         form={form}
         formConfig={formConfig}
+        isCorrection={true}
         previousFormValues={previousFormValues}
         title={intlWithData.formatMessage(
           actionConfig.label,

--- a/packages/client/src/v2-events/features/events/actions/correct/request/Review.tsx
+++ b/packages/client/src/v2-events/features/events/actions/correct/request/Review.tsx
@@ -12,16 +12,11 @@
 import React from 'react'
 import { useIntl } from 'react-intl'
 import { useNavigate } from 'react-router-dom'
-import { isEqual } from 'lodash'
 import {
   useTypedParams,
   useTypedSearchParams
 } from 'react-router-typesafe-routes/dom'
-import {
-  ActionType,
-  getDeclaration,
-  isFieldVisible
-} from '@opencrvs/commons/client'
+import { ActionType, getDeclaration } from '@opencrvs/commons/client'
 import { PrimaryButton } from '@opencrvs/components/lib/buttons'
 import { getCurrentEventState } from '@opencrvs/commons/client'
 import { buttonMessages } from '@client/i18n/messages'

--- a/packages/client/src/v2-events/features/events/actions/correct/request/Review.tsx
+++ b/packages/client/src/v2-events/features/events/actions/correct/request/Review.tsx
@@ -17,7 +17,11 @@ import {
   useTypedParams,
   useTypedSearchParams
 } from 'react-router-typesafe-routes/dom'
-import { ActionType, getDeclaration } from '@opencrvs/commons/client'
+import {
+  ActionType,
+  getDeclaration,
+  isFieldVisible
+} from '@opencrvs/commons/client'
 import { PrimaryButton } from '@opencrvs/components/lib/buttons'
 import { getCurrentEventState } from '@opencrvs/commons/client'
 import { buttonMessages } from '@client/i18n/messages'
@@ -30,6 +34,7 @@ import { FormLayout } from '@client/v2-events/layouts'
 import { ROUTES } from '@client/v2-events/routes'
 import { makeFormFieldIdFormikCompatible } from '@client/v2-events/components/forms/utils'
 import { validationErrorsInActionFormExist } from '@client/v2-events/components/forms/validation'
+import { hasFieldChanged } from './Summary/CorrectionDetails'
 
 export function Review() {
   const { eventId } = useTypedParams(ROUTES.V2.EVENTS.REQUEST_CORRECTION.REVIEW)
@@ -53,9 +58,12 @@ export function Review() {
   const form = getFormValues()
 
   const previousFormValues = eventIndex.declaration
-  const valuesHaveChanged = Object.entries(form).some(
-    ([key, value]) => !isEqual(previousFormValues[key], value)
+
+  const formFields = formConfig.pages.flatMap((page) => page.fields)
+  const changedFields = formFields.filter((f) =>
+    hasFieldChanged(f, form, previousFormValues)
   )
+  const anyValuesHaveChanged = changedFields.length > 0
 
   const intlWithData = useIntlFormatMessageWithFlattenedParams()
 
@@ -100,7 +108,7 @@ export function Review() {
       >
         <PrimaryButton
           key="continue_button"
-          disabled={!valuesHaveChanged || incomplete}
+          disabled={!anyValuesHaveChanged || incomplete}
           id="continue_button"
           onClick={() => {
             navigate(

--- a/packages/client/src/v2-events/features/events/actions/correct/request/Summary/CorrectionDetails.tsx
+++ b/packages/client/src/v2-events/features/events/actions/correct/request/Summary/CorrectionDetails.tsx
@@ -20,6 +20,7 @@ import {
   ActionType,
   EventDocument,
   EventState,
+  FieldConfig,
   getCurrentEventState,
   getDeclaration,
   isFieldVisible
@@ -34,6 +35,19 @@ import { ROUTES } from '@client/v2-events/routes'
 const CorrectionSectionTitle = styled(Text)`
   margin: 20px 0;
 `
+
+export function hasFieldChanged(
+  f: FieldConfig,
+  form: EventState,
+  previousFormValues: EventState
+) {
+  const wasVisible = isFieldVisible(f, previousFormValues)
+  const isVisible = isFieldVisible(f, form)
+  const visibilityChanged = wasVisible !== isVisible
+  const valueHasChanged = !isEqual(previousFormValues[f.id], form[f.id])
+
+  return isVisible && (valueHasChanged || visibilityChanged)
+}
 
 /*
  * Correction details component which is used both on the correction request summary page,
@@ -146,17 +160,7 @@ export function CorrectionDetails({
 
       {formConfig.pages.map((page) => {
         const changedFields = page.fields
-          .filter((f) => {
-            const wasVisible = isFieldVisible(f, previousFormValues)
-            const isVisible = isFieldVisible(f, form)
-            const visibilityChanged = wasVisible !== isVisible
-            const valueHasChanged = !isEqual(
-              previousFormValues[f.id],
-              form[f.id]
-            )
-
-            return isVisible && (valueHasChanged || visibilityChanged)
-          })
+          .filter((f) => hasFieldChanged(f, form, previousFormValues))
           .map((f) => {
             const originalOutput = Output({
               field: f,

--- a/packages/client/src/v2-events/features/events/actions/correct/request/Summary/Summary.tsx
+++ b/packages/client/src/v2-events/features/events/actions/correct/request/Summary/Summary.tsx
@@ -211,7 +211,7 @@ export function Summary() {
         title={intl.formatMessage(
           scopes?.includes(SCOPES.RECORD_REGISTRATION_CORRECT)
             ? correctionMessages.correctRecordDialogTitle
-            : correctionMessages.correctionForApprovalDialogTitle
+            : correctionMessages.correctionApprovalDialogTitle
         )}
         onClose={togglePrompt}
       >

--- a/packages/client/src/v2-events/features/events/components/Pages.tsx
+++ b/packages/client/src/v2-events/features/events/components/Pages.tsx
@@ -37,7 +37,9 @@ export function Pages({
   setFormData,
   eventConfig,
   declaration,
-  validateBeforeNextPage = false
+  validateBeforeNextPage = false,
+  // When isCorrection is true, we should disabled fields with 'isCorrectable' set to false, or skip pages where all fields have 'isCorrectable' set to false
+  isCorrection = false
 }: {
   form: EventState
   setFormData: (dec: EventState) => void
@@ -50,6 +52,7 @@ export function Pages({
   eventConfig?: EventConfig
   declaration?: EventState
   validateBeforeNextPage?: boolean
+  isCorrection?: boolean
 }) {
   const intl = useIntl()
   const visiblePages = formPages.filter((page) => isPageVisible(page, form))
@@ -115,6 +118,7 @@ export function Pages({
       // As initial values we use both the provided declaration data (previously saved to the event)
       // and the form data (which is currently being edited).
       initialValues={{ ...declaration, ...form }}
+      isCorrection={isCorrection}
       validateAllFields={validateAllFields}
       onAllFieldsValidated={(success) => {
         setValidateAllFields(false)

--- a/packages/client/src/v2-events/features/events/components/Pages.tsx
+++ b/packages/client/src/v2-events/features/events/components/Pages.tsx
@@ -38,7 +38,7 @@ export function Pages({
   eventConfig,
   declaration,
   validateBeforeNextPage = false,
-  // When isCorrection is true, we should disabled fields with 'isCorrectable' set to false, or skip pages where all fields have 'isCorrectable' set to false
+  // When isCorrection is true, we should disabled fields with 'uncorrectable' set to true, or skip pages where all fields have 'uncorrectable' set to true
   isCorrection = false
 }: {
   form: EventState

--- a/packages/client/src/v2-events/features/events/components/Review.tsx
+++ b/packages/client/src/v2-events/features/events/components/Review.tsx
@@ -395,15 +395,15 @@ function FormReview({
                       valueDisplay,
                       isCorrectable
                     }) => {
-                      const shouldShowEditLink =
-                        !readonlyMode &&
-                        (!isCorrection || isCorrectable !== false)
+                      const shouldHideEditLink =
+                        readonlyMode ||
+                        (isCorrection && isCorrectable === false)
 
                       return (
                         <ListReview.Row
                           key={id}
                           actions={
-                            shouldShowEditLink && (
+                            !shouldHideEditLink && (
                               <Link
                                 data-testid={`change-button-${id}`}
                                 onClick={(e) => {

--- a/packages/client/src/v2-events/features/events/components/Review.tsx
+++ b/packages/client/src/v2-events/features/events/components/Review.tsx
@@ -355,13 +355,13 @@ function FormReview({
             }
           )
 
-          const anyFieldsAreCorrectable = displayedFields.some(
-            (field) => field.isCorrectable !== false
+          const hasCorrectableFields = displayedFields.some(
+            (field) => !field.uncorrectable
           )
 
           // If the page has any correctable fields, show the change all link
           const showChangeAllLink =
-            !readonlyMode && (!isCorrection || anyFieldsAreCorrectable)
+            !readonlyMode && (!isCorrection || hasCorrectableFields)
 
           return (
             <DeclarationDataContainer
@@ -393,11 +393,10 @@ function FormReview({
                       label,
                       errorDisplay,
                       valueDisplay,
-                      isCorrectable
+                      uncorrectable
                     }) => {
                       const shouldHideEditLink =
-                        readonlyMode ||
-                        (isCorrection && isCorrectable === false)
+                        readonlyMode || (isCorrection && uncorrectable)
 
                       return (
                         <ListReview.Row

--- a/packages/commons/src/conditionals/validate.ts
+++ b/packages/commons/src/conditionals/validate.ts
@@ -210,6 +210,11 @@ export const errorMessages = {
     defaultMessage: 'Unexpected field',
     description: 'Error message when field is not expected',
     id: 'v2.error.unexpectedField'
+  },
+  correctionNotAllowed: {
+    defaultMessage: 'Correction not allowed for field',
+    description: 'Error message when correction is not allowed for field',
+    id: 'v2.error.correctionNotAllowed'
   }
 }
 

--- a/packages/commons/src/events/FieldConfig.ts
+++ b/packages/commons/src/events/FieldConfig.ts
@@ -58,9 +58,9 @@ const BaseField = z.object({
   validation: z.array(ValidationConfig).default([]).optional(),
   helperText: TranslationConfig.optional(),
   hideLabel: z.boolean().default(false).optional(),
-  isCorrectable: z
+  uncorrectable: z
     .boolean()
-    .default(true)
+    .default(false)
     .optional()
     .describe(
       'Indicates if the field can be changed during a record correction.'

--- a/packages/commons/src/events/FieldConfig.ts
+++ b/packages/commons/src/events/FieldConfig.ts
@@ -11,7 +11,6 @@
 import { z } from 'zod'
 import { Conditional, FieldConditional } from './Conditional'
 import { TranslationConfig } from './TranslationConfig'
-
 import { FieldType } from './FieldType'
 import {
   CheckboxFieldValue,
@@ -38,8 +37,6 @@ export const FieldReference = z
   })
   .describe('Reference to a field by its ID')
 
-const ParentReference = FieldReference.optional()
-
 export const ValidationConfig = z.object({
   validator: Conditional,
   message: TranslationConfig
@@ -49,7 +46,7 @@ export type ValidationConfig = z.infer<typeof ValidationConfig>
 
 const BaseField = z.object({
   id: FieldId,
-  parent: ParentReference,
+  parent: FieldReference.optional(),
   conditionals: z.array(FieldConditional).default([]).optional(),
   required: z.boolean().default(false).optional(),
   placeholder: TranslationConfig.optional(),

--- a/packages/commons/src/events/FieldConfig.ts
+++ b/packages/commons/src/events/FieldConfig.ts
@@ -48,14 +48,14 @@ export type ValidationConfig = z.infer<typeof ValidationConfig>
 
 const BaseField = z.object({
   id: FieldId,
+  label: TranslationConfig,
   parent: FieldReference.optional().describe(
     'Reference to a parent field. If a field has a parent, it will be reset when the parent field is changed.'
   ),
-  conditionals: z.array(FieldConditional).default([]).optional(),
   required: z.boolean().default(false).optional(),
+  conditionals: z.array(FieldConditional).default([]).optional(),
   placeholder: TranslationConfig.optional(),
   validation: z.array(ValidationConfig).default([]).optional(),
-  label: TranslationConfig,
   helperText: TranslationConfig.optional(),
   hideLabel: z.boolean().default(false).optional(),
   isCorrectable: z

--- a/packages/commons/src/events/FieldConfig.ts
+++ b/packages/commons/src/events/FieldConfig.ts
@@ -56,7 +56,14 @@ const BaseField = z.object({
   validation: z.array(ValidationConfig).default([]).optional(),
   label: TranslationConfig,
   helperText: TranslationConfig.optional(),
-  hideLabel: z.boolean().default(false).optional()
+  hideLabel: z.boolean().default(false).optional(),
+  isCorrectable: z
+    .boolean()
+    .default(true)
+    .optional()
+    .describe(
+      'Indicates if the field can be changed during a record correction.'
+    )
 })
 
 export type BaseField = z.infer<typeof BaseField>

--- a/packages/commons/src/events/FieldConfig.ts
+++ b/packages/commons/src/events/FieldConfig.ts
@@ -8,6 +8,8 @@
  *
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
+
+/* eslint-disable max-lines */
 import { z } from 'zod'
 import { Conditional, FieldConditional } from './Conditional'
 import { TranslationConfig } from './TranslationConfig'
@@ -46,7 +48,9 @@ export type ValidationConfig = z.infer<typeof ValidationConfig>
 
 const BaseField = z.object({
   id: FieldId,
-  parent: FieldReference.optional(),
+  parent: FieldReference.optional().describe(
+    'Reference to a parent field. If a field has a parent, it will be reset when the parent field is changed.'
+  ),
   conditionals: z.array(FieldConditional).default([]).optional(),
   required: z.boolean().default(false).optional(),
   placeholder: TranslationConfig.optional(),
@@ -589,6 +593,7 @@ export type LocationField = z.infer<typeof Location>
 export type RadioField = z.infer<typeof RadioGroup>
 export type AddressField = z.infer<typeof Address>
 export type NumberField = z.infer<typeof NumberField>
+
 export type FieldConfig = Inferred
 
 export type FieldProps<T extends FieldType> = Extract<FieldConfig, { type: T }>

--- a/packages/commons/src/events/test.utils.ts
+++ b/packages/commons/src/events/test.utils.ts
@@ -9,7 +9,7 @@
  *
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
-import { merge, omitBy, isString } from 'lodash'
+import { merge, omitBy, isString, omit } from 'lodash'
 import addDays from 'date-fns/addDays'
 import { tennisClubMembershipEvent } from '../fixtures'
 import { getUUID, UUID } from '../uuid'
@@ -524,10 +524,13 @@ export function eventPayloadGenerator(rng: () => number) {
           transactionId: input.transactionId ?? getUUID(),
           declaration:
             input.declaration ??
-            generateActionDeclarationInput(
-              tennisClubMembershipEvent,
-              ActionType.REQUEST_CORRECTION,
-              rng
+            omit(
+              generateActionDeclarationInput(
+                tennisClubMembershipEvent,
+                ActionType.REQUEST_CORRECTION,
+                rng
+              ),
+              ['applicant.email']
             ),
           annotation:
             input.annotation ??

--- a/packages/commons/src/fixtures/forms.ts
+++ b/packages/commons/src/fixtures/forms.ts
@@ -750,7 +750,7 @@ export const TENNIS_CLUB_DECLARATION_FORM = defineDeclarationForm({
           id: 'applicant.email',
           type: 'EMAIL',
           required: false,
-          isCorrectable: false,
+          uncorrectable: true,
           conditionals: [],
           label: {
             defaultMessage: "Applicant's email",

--- a/packages/commons/src/fixtures/forms.ts
+++ b/packages/commons/src/fixtures/forms.ts
@@ -750,6 +750,7 @@ export const TENNIS_CLUB_DECLARATION_FORM = defineDeclarationForm({
           id: 'applicant.email',
           type: 'EMAIL',
           required: false,
+          isCorrectable: false,
           conditionals: [],
           label: {
             defaultMessage: "Applicant's email",

--- a/packages/events/src/router/event/__snapshots__/event.actions.correction.test.ts.snap
+++ b/packages/events/src/router/event/__snapshots__/event.actions.correction.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`REQUEST_CORRECTION Prevents adding birth date in future 1`] = `[TRPCError: [{"message":"Please enter a valid date","id":"applicant.dob","value":"2040-02-01"}]]`;
 
-exports[`REQUEST_CORRECTION prevents correcting a field which is configured as isCorrectable: false 1`] = `[TRPCError: [{"message":"Correction not allowed for field","id":"applicant.email","value":"john.doe@example.com"}]]`;
+exports[`REQUEST_CORRECTION prevents correcting a field which is configured as uncorrectable: true 1`] = `[TRPCError: [{"message":"Correction not allowed for field","id":"applicant.email","value":"john.doe@example.com"}]]`;
 
 exports[`REQUEST_CORRECTION validation error message contains all the offending fields 1`] = `[TRPCError: [{"message":"Invalid date field","id":"applicant.dob","value":"02-02"},{"message":"Please enter a valid date","id":"applicant.dob","value":"02-02"}]]`;
 

--- a/packages/events/src/router/event/__snapshots__/event.actions.correction.test.ts.snap
+++ b/packages/events/src/router/event/__snapshots__/event.actions.correction.test.ts.snap
@@ -2,6 +2,8 @@
 
 exports[`REQUEST_CORRECTION Prevents adding birth date in future 1`] = `[TRPCError: [{"message":"Please enter a valid date","id":"applicant.dob","value":"2040-02-01"}]]`;
 
+exports[`REQUEST_CORRECTION prevents correcting a field which is configured as isCorrectable: false 1`] = `[TRPCError: [{"message":"Correction not allowed for field","id":"applicant.email","value":"john.doe@example.com"}]]`;
+
 exports[`REQUEST_CORRECTION validation error message contains all the offending fields 1`] = `[TRPCError: [{"message":"Invalid date field","id":"applicant.dob","value":"02-02"},{"message":"Please enter a valid date","id":"applicant.dob","value":"02-02"}]]`;
 
 exports[`REQUEST_CORRECTION when mandatory field is invalid, conditional hidden fields are still skipped 1`] = `[TRPCError: [{"message":"Invalid date field","id":"applicant.dob","value":"02-1-2024"},{"message":"Please enter a valid date","id":"applicant.dob","value":"02-1-2024"}]]`;

--- a/packages/events/src/router/event/event.actions.correction.test.ts
+++ b/packages/events/src/router/event/event.actions.correction.test.ts
@@ -258,7 +258,7 @@ test(`${ActionType.REQUEST_CORRECTION} Prevents adding birth date in future`, as
   ).rejects.matchSnapshot()
 })
 
-test('REQUEST_CORRECTION prevents correcting a field which is configured as isCorrectable: false', async () => {
+test('REQUEST_CORRECTION prevents correcting a field which is configured as uncorrectable: true', async () => {
   const { user, generator } = await setupTestCase()
   const client = createTestClient(user)
 

--- a/packages/events/src/router/event/event.actions.correction.test.ts
+++ b/packages/events/src/router/event/event.actions.correction.test.ts
@@ -10,6 +10,7 @@
  */
 
 import { TRPCError } from '@trpc/server'
+import { omit } from 'lodash'
 import {
   ActionType,
   AddressType,
@@ -164,7 +165,7 @@ test(`${ActionType.REQUEST_CORRECTION} when mandatory field is invalid, conditio
 
   const data = generator.event.actions.correction.request(event.id, {
     declaration: {
-      'applicant.dob': '02-1-2024',
+      'applicant.dob': '02-1-2024', // Invalid date
       'applicant.dobUnknown': false,
       'applicant.name': {
         firstname: 'John',
@@ -257,6 +258,25 @@ test(`${ActionType.REQUEST_CORRECTION} Prevents adding birth date in future`, as
   ).rejects.matchSnapshot()
 })
 
+test('REQUEST_CORRECTION prevents correcting a field which is configured as isCorrectable: false', async () => {
+  const { user, generator } = await setupTestCase()
+  const client = createTestClient(user)
+
+  const event = await createEvent(client, generator, [
+    ActionType.DECLARE,
+    ActionType.VALIDATE,
+    ActionType.REGISTER
+  ])
+
+  const payload = generator.event.actions.correction.request(event.id, {
+    declaration: { 'applicant.email': 'john.doe@example.com' }
+  })
+
+  await expect(
+    client.event.actions.correction.request(payload)
+  ).rejects.matchSnapshot()
+})
+
 describe('when a correction request exists', () => {
   let withCorrectionRequest: EventDocument
   let client: ReturnType<typeof createTestClient>
@@ -273,20 +293,26 @@ describe('when a correction request exists', () => {
       ActionType.REGISTER
     ])
 
+    const declarationPayload = omit(
+      {
+        ...generateActionDeclarationInput(
+          tennisClubMembershipEvent,
+          ActionType.DECLARE,
+          rng
+        ),
+        'applicant.name': {
+          firstname: 'Johnny',
+          surname: 'Doe'
+        }
+      },
+      // Omit applicant.email, since it is configured as not correctable
+      ['applicant.email']
+    )
+
     withCorrectionRequest = await client.event.actions.correction.request(
       generator.event.actions.correction.request(event.id, {
         keepAssignment: true,
-        declaration: {
-          ...generateActionDeclarationInput(
-            tennisClubMembershipEvent,
-            ActionType.DECLARE,
-            rng
-          ),
-          'applicant.name': {
-            firstname: 'Johnny',
-            surname: 'Doe'
-          }
-        }
+        declaration: declarationPayload
       })
     )
   })
@@ -304,6 +330,7 @@ describe('when a correction request exists', () => {
           requestId
         )
       )
+
     expect(withApprovedCorrectionRequest.actions.slice(-2)).toEqual([
       expect.objectContaining({
         type: ActionType.APPROVE_CORRECTION,

--- a/packages/events/src/router/middleware/validate/index.ts
+++ b/packages/events/src/router/middleware/validate/index.ts
@@ -273,7 +273,7 @@ function validateNotifyAction({
 
 /*
  * For request correction, we need to validate that the payload does not contain fields that are configured as not correctable,
- * i.e. configured with the 'isCorrectable' flag set to false.
+ * i.e. configured with the 'uncorrectable' flag set to true.
  */
 function validateCorrectableFields({
   eventConfig,
@@ -284,9 +284,7 @@ function validateCorrectableFields({
 }) {
   const declarationConfig = getDeclaration(eventConfig)
   const formFields = declarationConfig.pages.flatMap(({ fields }) => fields)
-  const nonCorrecrableFields = formFields.filter(
-    (field) => field.isCorrectable === false
-  )
+  const nonCorrecrableFields = formFields.filter((field) => field.uncorrectable)
 
   const errors = Object.entries(declarationUpdate).flatMap(([key, value]) => {
     const field = formFields.find((f) => f.id === key)


### PR DESCRIPTION
## Description

Resolves https://github.com/opencrvs/opencrvs-core/issues/9735
CC PR: https://github.com/opencrvs/opencrvs-countryconfig/pull/844
e2e tests: https://github.com/opencrvs/opencrvs-farajaland/pull/1492

- Add support for `isCorrectable` for form fields, this is true by default
- If in correction flow, disable fields with `isCorrectable: false`
- If in correction flow, hide/skip pages if all its fields either have `isCorrectable: false` or are non-interactive fields (such as paragraphs, dividers, etc)
- If in correction flow, hide change buttons on review page for fields with `isCorrectable: false`
- Fix bug on correction review page, where the continue button was enabled even though no changes were present
- Add new title translation for correction request confirmation modal
- Minor refactoring, remove some unused code

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
