### PR TITLE
fix: resolve dateOfEvent in outbox

### DIFF
--- a/packages/client/src/v2-events/features/events/Search/SearchResult.tsx
+++ b/packages/client/src/v2-events/features/events/Search/SearchResult.tsx
@@ -408,14 +408,19 @@ export const SearchResultComponent = ({
      * Apply pending drafts to the event index.
      * This is necessary to show the most up to date information in the workqueue.
      */
-    .map((event) =>
-      deepDropNulls(
+    .map((event) => {
+      const eventConfig = eventConfigs.find(({ id }) => id === event.type)
+      if (!eventConfig) {
+        throw new Error('Event configuration not found for event:' + event.type)
+      }
+      return deepDropNulls(
         applyDraftsToEventIndex(
           event,
-          drafts.filter((d) => d.eventId === event.id)
+          drafts.filter((d) => d.eventId === event.id),
+          eventConfig
         )
       )
-    )
+    })
 
   const dataWithTitle = dataWithDraft.map((event) => {
     const eventConfig = eventConfigs.find(({ id }) => id === event.type)

--- a/packages/client/src/v2-events/features/events/useEvents/outbox.ts
+++ b/packages/client/src/v2-events/features/events/useEvents/outbox.ts
@@ -14,7 +14,7 @@ import * as z from 'zod'
 import {
   deepMerge,
   getCurrentEventState,
-  resolveDateOfEvent
+  applyDeclarationToEventIndex
 } from '@opencrvs/commons/client'
 import { EventState } from '@opencrvs/commons/client'
 import { queryClient, useTRPC } from '@client/v2-events/trpc'
@@ -44,7 +44,7 @@ export function useOutbox() {
         return null
       }
 
-      const { eventId, declaration: updatedDeclaration } = parsedVariables.data
+      const { eventId, declaration } = parsedVariables.data
 
       const event = queryClient.getQueryData(trpc.event.get.queryKey(eventId))
 
@@ -61,16 +61,13 @@ export function useOutbox() {
 
       const eventState = getCurrentEventState(event, eventConfiguration)
 
-      // Merge the declaration from mutation to get optimistic declaration
-      const declaration = deepMerge(
-        eventState.declaration,
-        updatedDeclaration || {}
-      )
-
       return {
-        ...eventState,
-        dateOfEvent: resolveDateOfEvent(event, declaration, eventConfiguration),
-        declaration,
+        // Merge the declaration from mutation to get optimistic declaration
+        ...applyDeclarationToEventIndex(
+          eventState,
+          declaration ?? {},
+          eventConfiguration
+        ),
         meta: mutation.options.meta
       }
     })

--- a/packages/client/src/v2-events/features/events/useEvents/procedures/create.ts
+++ b/packages/client/src/v2-events/features/events/useEvents/procedures/create.ts
@@ -88,14 +88,14 @@ setMutationDefaults(trpcOptionsProxy.event.create, {
     }
 
     setEventData(newEvent.transactionId, optimisticEvent)
-    setEventListData((eventIndices) =>
-      eventIndices?.concat(
-        getCurrentEventState(
-          optimisticEvent,
-          findLocalEventConfig(optimisticEvent.type) ?? {}
-        )
-      )
-    )
+    setEventListData((eventIndices) => {
+      const eventConfig = findLocalEventConfig(optimisticEvent.type)
+      return eventConfig
+        ? eventIndices?.concat(
+            getCurrentEventState(optimisticEvent, eventConfig)
+          )
+        : eventIndices
+    })
     return optimisticEvent
   },
   onSuccess: async (response, _variables, context) => {

--- a/packages/client/src/v2-events/features/workqueues/EventOverview/EventOverview.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/EventOverview.tsx
@@ -122,7 +122,7 @@ function EventOverviewProtected({
   const drafts = getRemoteDrafts(eventIndex.id)
 
   const eventWithDrafts = deepDropNulls(
-    applyDraftsToEventIndex(eventIndex, drafts)
+    applyDraftsToEventIndex(eventIndex, drafts, eventConfiguration)
   )
   const { getUser } = useUsers()
   const intl = useIntl()

--- a/packages/client/src/v2-events/layouts/EventOverview/index.tsx
+++ b/packages/client/src/v2-events/layouts/EventOverview/index.tsx
@@ -119,7 +119,9 @@ export function EventOverviewLayout({
           mobileTitle={flattenedIntl.formatMessage(
             eventConfiguration.title,
             flattenEventIndex(
-              deepDropNulls(applyDraftsToEventIndex(eventIndex, drafts))
+              deepDropNulls(
+                applyDraftsToEventIndex(eventIndex, drafts, eventConfiguration)
+              )
             )
           )}
         />


### PR DESCRIPTION
## Description

As `dateOfEvent` could be configured, it needs to be resolved separately in outbox. The reason being, first time declarations only have "CREATE" action in the `EventDocument` which doesn't include the latest `declaration` values. So `getCurrentEvent` state is unable to resolve `dateOfEvent`

includes a fix for #8449
![image](https://github.com/user-attachments/assets/f6aa0079-c5b1-4c27-943b-097c7e394495)


## Checklist

- [x] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
