### PR TITLE
support creating draft even with incomplete name field

### DIFF
--- a/packages/commons/src/events/CompositeFieldValue.ts
+++ b/packages/commons/src/events/CompositeFieldValue.ts
@@ -70,8 +70,8 @@ export const NameFieldValue = z.object({
 
 export const NameFieldUpdateValue = z
   .object({
-    firstname: z.string(),
-    surname: z.string(),
+    firstname: z.string().nullish(),
+    surname: z.string().nullish(),
     middlename: z.string().nullish()
   })
   .or(z.null())


### PR DESCRIPTION
## Description

## 🐛 Bug Fix: Draft Not Saved When Full Name Is Incomplete

### Issue

When creating a declaration and only providing a first name or last name (not both), the draft is not saved correctly. Instead of remaining in "My drafts", the record is prematurely moved to the "Assigned to you" workqueue with the title `"No name provided"`.

### Steps to Reproduce

1. Login as FA, RA, or Registrar.
2. Start a new declaration and fill in all required fields **except full name**.
3. Provide only a first name or a surname in the Name field.
4. Save the draft.
5. Observe that:
   - The draft briefly appears in “My drafts”
   - Then title changes to `No name provided`
   - Record moves to “Assigned to you” workqueue

### Expected Behavior

The declaration should remain in “My drafts” even when only a partial name (either first or last name) is provided.

---

### ✅ Solution

Updated the `NameFieldUpdateValue` schema to allow `nullish` values for both `firstname` and `surname`:

**Before:**

```ts
export const NameFieldUpdateValue = z
  .object({
    firstname: z.string(),
    surname: z.string(),
    middlename: z.string().nullish()
  })
  .or(z.null())
```

**After:**

```ts
export const NameFieldUpdateValue = z
  .object({
    firstname: z.string().nullish(),
    surname: z.string().nullish(),
    middlename: z.string().nullish()
  })
  .or(z.null())
```

This change ensures that partial names are no longer treated as invalid during draft saving.

---

### 🎯 Impact

- Drafts with partial names now save properly.
- Improves UX for field agents and registrars working with incomplete name data.


[Unable to save drafts properly when only first/ last name is provided](https://github.com/opencrvs/opencrvs-core/issues/9899)

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
