### PR TITLE
take shorter substr of branch name for e2e deployment

### DIFF
--- a/.github/workflows/deploy-to-feature-environment.yml
+++ b/.github/workflows/deploy-to-feature-environment.yml
@@ -139,7 +139,7 @@ jobs:
                 .trim()
                 .replace(/\s+/g, '-')
                 .replace(/-+/g, '-')
-                .substr(0, 35)
+                .substr(0, 30)
                 .replace(/[^a-zA-Z0-9]+$/g, '');
             }
             core.setOutput('stack', slugify('${{ env.BRANCH_NAME }}'));


### PR DESCRIPTION
We have been having issues with too long branch names failing on e2e deployment

E.g.:
https://github.com/opencrvs/e2e/actions/runs/16064279289

`failed to create config search-name-field-with-default-valu_***-on-deploy.1751616312: Error response from daemon: rpc error: code = InvalidArgument desc = invalid name, only 64 [a-zA-Z0-9-_.] characters allowed, and the start and end character must be [a-zA-Z0-9]`
