### PR TITLE
[OCRVS-9254] Download event to browser automatically if user has a remote draft open for said event

### DIFF
--- a/packages/client/src/v2-events/features/events/actions/register/Review.interaction.stories.tsx
+++ b/packages/client/src/v2-events/features/events/actions/register/Review.interaction.stories.tsx
@@ -185,6 +185,14 @@ export const ReviewForLocalRegistrarArchiveInteraction: Story = {
       })
     },
     chromatic: { disableSnapshot: true },
+    offline: {
+      /*
+       * Preload the event document to ensure as it has a remote draft
+       * and this test case assumes a scenario where user had previously
+       * downloaded the event document.
+       */
+      events: [declarationTrpcMsw.eventDocument]
+    },
     msw: {
       handlers: {
         drafts: declarationTrpcMsw.drafts.handlers,

--- a/packages/client/src/v2-events/features/workqueues/EventOverview/components/useActionMenuItems.ts
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/components/useActionMenuItems.ts
@@ -28,7 +28,6 @@ import { ROUTES } from '@client/v2-events/routes'
 import { useAuthentication } from '@client/utils/userUtils'
 import { AssignmentStatus, getAssignmentStatus } from '@client/v2-events/utils'
 import { getScope } from '@client/profile/profileSelectors'
-import { findLocalEventDocument } from '@client/v2-events/features/events/useEvents/api'
 
 const STATUSES_THAT_CAN_BE_ASSIGNED: EventStatus[] = [
   EventStatus.enum.NOTIFIED,


### PR DESCRIPTION
## Description

I wasn't exactly sure what caused the documents of a draft to go missing. Previously in OpenCRVS however, if you nuked your local storage, you automatically lost everything including the draft itself.

I changed the logic now so that if there's a draft the server knows about, owned by you, then those event documents are downloaded to your browser automatically. 

This is based on the following assumptions:
- It's not possible someone else would have taken over the event document. Someone adding an action to a record should have cleared all draft from the record. If that was the case you would never receive the draft to your browser

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [x] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
