### PR TITLE
[OCRVS-9946] Clear user's local events data when they logout

### DIFF
--- a/packages/client/.storybook/preview.tsx
+++ b/packages/client/.storybook/preview.tsx
@@ -21,7 +21,7 @@ import { testDataGenerator } from '@client/tests/test-data-generators'
 import { useApolloClient } from '@client/utils/apolloClient'
 import { ApolloProvider } from '@client/utils/ApolloProvider'
 import { queryClient, TRPCProvider } from '@client/v2-events/trpc'
-import { Provider } from 'react-redux'
+import { Provider, useSelector } from 'react-redux'
 import {
   createMemoryRouter,
   Outlet,
@@ -43,6 +43,7 @@ import {
 } from '@opencrvs/commons/client'
 import { tennisClubMembershipEventDocument } from '@client/v2-events/features/events/fixtures'
 import { EventConfig } from '@opencrvs/commons/client'
+import { getUserDetails } from '@client/profile/profileSelectors'
 WebFont.load({
   google: {
     families: ['Noto+Sans:600', 'Noto+Sans:500', 'Noto+Sans:400']
@@ -74,6 +75,15 @@ type WrapperProps = PropsWithChildren<{
   router?: RouteObject
 }>
 
+function WaitForUserDetails({ children }: PropsWithChildren<{}>) {
+  const currentUser = useSelector(getUserDetails)
+
+  if (!currentUser) {
+    return null
+  }
+  return children
+}
+
 function Wrapper({ store, router, initialPath, children }: WrapperProps) {
   const { client } = useApolloClient(store)
 
@@ -91,7 +101,9 @@ function Wrapper({ store, router, initialPath, children }: WrapperProps) {
                       element: (
                         <Page>
                           <NavigationHistoryProvider>
-                            <Outlet />
+                            <WaitForUserDetails>
+                              <Outlet />
+                            </WaitForUserDetails>
                           </NavigationHistoryProvider>
                         </Page>
                       ),

--- a/packages/client/src/profile/profileReducer.ts
+++ b/packages/client/src/profile/profileReducer.ts
@@ -30,7 +30,6 @@ import * as changeLanguageActions from '@client/i18n/actions'
 import { EMPTY_STRING } from '@client/utils/constants'
 import { serviceApi } from '@client/profile/serviceApi'
 import { IStoreState } from '@client/store'
-import { queryClient } from '@client/v2-events/trpc'
 
 export type ProfileState = {
   authenticated: boolean
@@ -70,13 +69,6 @@ export const profileReducer: LoopReducer<
         },
         Cmd.list(
           [
-            Cmd.run(async () => {
-              /*
-               * Clears Events v2 query and mutation cache
-               */
-              queryClient.clear()
-              queryClient.getMutationCache().clear()
-            }),
             Cmd.run(() => removeToken()),
             Cmd.run(() => removeUserDetails()),
             Cmd.run(

--- a/packages/client/src/utils/authUtils.ts
+++ b/packages/client/src/utils/authUtils.ts
@@ -34,11 +34,11 @@ export function storeToken(token: string) {
   localStorage.setItem('opencrvs', token)
 }
 
-export function removeToken() {
+export async function removeToken() {
   const token = getToken()
   if (token) {
     try {
-      authApi.invalidateToken(token)
+      await authApi.invalidateToken(token)
     } catch (err) {
       Sentry.captureException(err)
     }

--- a/packages/client/src/utils/userUtils.ts
+++ b/packages/client/src/utils/userUtils.ts
@@ -32,7 +32,7 @@ export async function storeUserDetails(userDetails: UserDetails) {
   storage.setItem(USER_DETAILS, JSON.stringify(userDetails))
 }
 export async function removeUserDetails() {
-  storage.removeItem(USER_DETAILS)
+  return storage.removeItem(USER_DETAILS)
 }
 
 export function getIndividualNameObj(

--- a/packages/client/src/v2-events/layouts/sidebar/Sidebar.tsx
+++ b/packages/client/src/v2-events/layouts/sidebar/Sidebar.tsx
@@ -94,7 +94,7 @@ export const Sidebar = ({
 
   const logout = async () => {
     await storage.removeItem(SCREEN_LOCK)
-    removeToken()
+    await removeToken()
     await removeUserDetails()
     window.location.assign(
       `${window.config.LOGIN_URL}?lang=${await storage.getItem('language')}&redirectTo=${window.location.origin}${ROUTES.V2.buildPath({})}`

--- a/packages/client/src/v2-events/trpc.tsx
+++ b/packages/client/src/v2-events/trpc.tsx
@@ -27,8 +27,10 @@ import {
 } from '@trpc/tanstack-react-query'
 import React from 'react'
 import superjson from 'superjson'
+import { useSelector } from 'react-redux'
 import { storage } from '@client/storage'
 import { getToken } from '@client/utils/authUtils'
+import { getUserDetails } from '@client/profile/profileSelectors'
 
 const { TRPCProvider: TRPCProviderRaw, useTRPC } =
   createTRPCContext<AppRouter>()
@@ -69,22 +71,23 @@ function getQueryClient() {
   })
 }
 
-function createIDBPersister(idbValidKey = 'reactQuery') {
+function createIDBPersister(storageIdentifier: string) {
+  const fullStorageIdentifier = `react-query-${storageIdentifier}`
   return {
     persistClient: async (client) => {
-      await storage.setItem(idbValidKey, client)
+      await storage.setItem(fullStorageIdentifier, client)
     },
     restoreClient: async () => {
-      const client = await storage.getItem<PersistedClient>(idbValidKey)
+      const client = await storage.getItem<PersistedClient>(
+        fullStorageIdentifier
+      )
       return client || undefined
     },
     removeClient: async () => {
-      await storage.removeItem(idbValidKey)
+      await storage.removeItem(fullStorageIdentifier)
     }
   } satisfies Persister
 }
-
-const persister = createIDBPersister()
 
 export const trpcClient = getTrpcClient()
 
@@ -95,11 +98,19 @@ export const trpcOptionsProxy = createTRPCOptionsProxy({
 })
 
 export function TRPCProvider({ children }: { children: React.ReactNode }) {
+  const currentUser = useSelector(getUserDetails)
+
+  if (!currentUser) {
+    throw new Error(
+      'TRPCProvider cannot be initialised without user details. Make sure user details are fetched before the provider is rendered'
+    )
+  }
+
   return (
     <PersistQueryClientProvider
       client={queryClient}
       persistOptions={{
-        persister,
+        persister: createIDBPersister(currentUser.id),
         buster: 'persisted-indexed-db',
         maxAge: undefined,
         dehydrateOptions: {

--- a/packages/client/src/v2-events/trpc.tsx
+++ b/packages/client/src/v2-events/trpc.tsx
@@ -97,20 +97,18 @@ export const trpcOptionsProxy = createTRPCOptionsProxy({
   client: trpcClient
 })
 
-export function TRPCProvider({ children }: { children: React.ReactNode }) {
-  const currentUser = useSelector(getUserDetails)
-
-  if (!currentUser) {
-    throw new Error(
-      'TRPCProvider cannot be initialised without user details. Make sure user details are fetched before the provider is rendered'
-    )
-  }
-
+export function TRPCProvider({
+  children,
+  storeIdentifier = 'DEFAULT_IDENTIFIER_FOR_TESTS_ONLY__THIS_SHOULD_NEVER_SHOW_OUTSIDE_STORYBOOK'
+}: {
+  children: React.ReactNode
+  storeIdentifier?: string
+}) {
   return (
     <PersistQueryClientProvider
       client={queryClient}
       persistOptions={{
-        persister: createIDBPersister(currentUser.id),
+        persister: createIDBPersister(storeIdentifier),
         buster: 'persisted-indexed-db',
         maxAge: undefined,
         dehydrateOptions: {


### PR DESCRIPTION
## Description

The problem was, we didn't clear React Query when user logged out. 
I also discovered another flakiness issue with the original OpenCRVS logout – it seems data clearing was ran in parallel with the browser redirects which might have caused tokens not invalidated properly and in some cases local data not clearing out correctly.


## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [x] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
