### PR TITLE
Fix migration of PractitionerRole and history to match new role names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.7.4](https://github.com/opencrvs/opencrvs-core/compare/v1.7.3...v1.7.4)
+
+### Bug fixes
+
+- Fixed historical roles displaying incorrectly in task history after migration to v1.7 [#9989](https://github.com/opencrvs/opencrvs-core/issues/9989)
+
 ## [1.7.3](https://github.com/opencrvs/opencrvs-core/compare/v1.7.2...v1.7.3)
 
 ### New features
@@ -9,7 +15,6 @@
 - Allow booleanTransformer to be used as a certificate handlebar template transformer [#9631](https://github.com/opencrvs/opencrvs-core/issues/9631)
 - Fix international to local number conversion from failing if the number was already local [#9634](https://github.com/opencrvs/opencrvs-core/issues/9634)
 - Pre-select default certificate option in print certificate collector form [#9935](https://github.com/opencrvs/opencrvs-core/issues/9935)
-
 
 ## [1.7.2](https://github.com/opencrvs/opencrvs-core/compare/v1.7.1...v1.7.2)
 

--- a/packages/migration/src/migrations/hearth/20250716162802-update-practitioner-role-history-collection-for-new-userroles.ts
+++ b/packages/migration/src/migrations/hearth/20250716162802-update-practitioner-role-history-collection-for-new-userroles.ts
@@ -14,7 +14,7 @@ import { Db, MongoClient } from 'mongodb'
 
 export const up = async (db: Db, client: MongoClient) => {
   const documents = await db
-    .collection('PractitionerRole')
+    .collection('PractitionerRole_history')
     .find({ 'code.coding.system': 'http://opencrvs.org/specs/types' })
     .toArray()
 
@@ -27,7 +27,7 @@ export const up = async (db: Db, client: MongoClient) => {
     const filteredCode = transformRoleCodes(doc)
 
     await db
-      .collection('PractitionerRole')
+      .collection('PractitionerRole_history')
       .updateOne({ _id: doc._id }, { $set: { code: filteredCode } })
   }
   console.log('Documents updated.')

--- a/packages/migration/src/utils/role-helper.ts
+++ b/packages/migration/src/utils/role-helper.ts
@@ -145,3 +145,66 @@ export const updatePractitionerRoleCodeAggregate = [
     }
   }
 ]
+
+/**
+ * Transform role code based on the english label to match how the scripts will generate new roles from aliases
+ */
+export const transformRoleCodes = (doc: any) => {
+  const updatedCode = [...doc.code]
+
+  // Find the types system code and extract the English label
+  const typesCodeEntry = doc.code.find((c: any) =>
+    c?.coding?.find((cod: any) => cod?.system === typeSystemUrl)
+  )
+
+  const typesCoding = typesCodeEntry?.coding?.find(
+    (cod: any) => cod?.system === typeSystemUrl
+  )
+
+  if (typesCoding?.code) {
+    try {
+      const labelArray = JSON.parse(typesCoding.code)
+
+      const englishLabel = labelArray?.find(
+        (item: any) => item?.lang === 'en' && item?.label
+      )
+
+      if (englishLabel?.label) {
+        const transformedLabel = englishLabel.label
+          .toUpperCase()
+          .replace(/ /g, '_')
+
+        // Find and update the roles system code
+        const rolesCodeIndex = updatedCode.findIndex((c: any) =>
+          c?.coding?.find((cod: any) => cod?.system === roleSystemUrl)
+        )
+
+        if (rolesCodeIndex !== -1) {
+          const rolesCodingIndex = updatedCode[rolesCodeIndex].coding.findIndex(
+            (cod: any) => cod?.system === roleSystemUrl
+          )
+
+          if (rolesCodingIndex !== -1) {
+            updatedCode[rolesCodeIndex].coding[rolesCodingIndex].code =
+              transformedLabel
+          }
+        }
+      } else {
+        console.warn(
+          `Document ${doc._id}: No valid English label found in types code`
+        )
+      }
+    } catch (parseError) {
+      console.warn(
+        `Document ${doc._id}: Could not parse types code as JSON, skipping role update:`,
+        parseError
+      )
+    }
+  }
+
+  // Remove the types system from the code array
+  const filteredCode = updatedCode.filter((c: any) =>
+    c?.coding?.find((cod: any) => cod?.system !== typeSystemUrl)
+  )
+  return filteredCode
+}


### PR DESCRIPTION
## Description

Addresses: https://github.com/opencrvs/opencrvs-core/issues/9989
The migrations for roles in 1.7 did not include the PractionerRole and history collections so when the task history is viewed, it still references the previous system role rather than the new role based on the role alias.

The PractionerRole has two codes,:
- http://opencrvs.org/specs/roles - which contained the System role
- http://opencrvs.org/specs/types - which contained the alias in a json object

So to generate the correct role name, the english label in the `types` code can be used, using the same logic used to create the new role ids (`toUpperCase().replace(' ',  '_')`).

An existing migration removed the `types` code on the PractitionerRole so that had to be modified and another migration created to do the same on PractitionerRole_history.

#### Note
Usually modifying an existing migration would not have any effect, but no countries have gone live with v1.7 yet so the migration will still run. 

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [x] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
