### PR TITLE
fix: delete draft from query cache after delete action

### DIFF
--- a/packages/client/src/v2-events/features/events/useEvents/api.ts
+++ b/packages/client/src/v2-events/features/events/useEvents/api.ts
@@ -61,6 +61,10 @@ export function setDraftData(updater: (drafts: Draft[]) => Draft[]) {
   )
 }
 
+export function deleteDraft(id: string) {
+  setDraftData((drafts) => drafts.filter(({ eventId }) => eventId !== id))
+}
+
 export function findLocalEventIndex(id: string) {
   const queries = queryClient.getQueriesData<EventIndex>({
     queryKey: trpcOptionsProxy.event.search.queryKey()

--- a/packages/client/src/v2-events/features/events/useEvents/procedures/delete.ts
+++ b/packages/client/src/v2-events/features/events/useEvents/procedures/delete.ts
@@ -11,6 +11,7 @@
 
 import { useMutation } from '@tanstack/react-query'
 import {
+  deleteDraft,
   refetchEventsList,
   setEventListData
 } from '@client/v2-events/features/events/useEvents/api'
@@ -25,8 +26,9 @@ setMutationDefaults(trpcOptionsProxy.event.delete, {
     return true
   },
   retryDelay: 10000,
-  onSuccess: () => {
+  onSuccess: ({ id }) => {
     void refetchEventsList()
+    deleteDraft(id)
   },
   /*
    * This ensures that when the application is reloaded with pending mutations in IndexedDB, the


### PR DESCRIPTION
## Description
Problem: `draft.list` query's cache was stale. So deleted drafts would show up in `My drafts`.

Solution: In onsuccess of`action.delete`, delete the specific draft from `draft.list` query's cache. 

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
