### PR TITLE
fix: Login page is blocked by CSP policy

### DIFF
--- a/infrastructure/nginx-default.conf
+++ b/infrastructure/nginx-default.conf
@@ -1,3 +1,4 @@
+# DEPRECATED: THIS FILE IS NOT USED
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/packages/client/nginx.conf
+++ b/packages/client/nginx.conf
@@ -44,7 +44,7 @@ add_header X-Permitted-Cross-Domain-Policies master-only;
 # I need to change our application code so we can increase security by disabling 'unsafe-inline' 'unsafe-eval'
 # directives for css and js(if you have inline css or js, you will need to keep it too).
 # more: http://www.html5rocks.com/en/tutorials/security/content-security-policy/#inline-code-considered-harmful
-add_header Content-Security-Policy "default-src 'self'; font-src https://fonts.gstatic.com {{CONTENT_SECURITY_POLICY_WILDCARD}}; object-src 'none'; script-src 'self' https://sentry.io/api/embed/error-page/; style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; img-src 'self' data: http: https: ";
+add_header Content-Security-Policy "default-src 'self' {{CONTENT_SECURITY_POLICY_WILDCARD}}; font-src https://fonts.gstatic.com; object-src 'none'; script-src 'self' https://sentry.io/api/embed/error-page/; style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; img-src 'self' data: http: https: ";
 
 server {
     listen       80;

--- a/packages/login/nginx.conf
+++ b/packages/login/nginx.conf
@@ -44,7 +44,7 @@ add_header X-Permitted-Cross-Domain-Policies master-only;
 # I need to change our application code so we can increase security by disabling 'unsafe-inline' 'unsafe-eval'
 # directives for css and js(if you have inline css or js, you will need to keep it too).
 # more: http://www.html5rocks.com/en/tutorials/security/content-security-policy/#inline-code-considered-harmful
-add_header Content-Security-Policy "default-src 'self'; font-src https://fonts.gstatic.com {{CONTENT_SECURITY_POLICY_WILDCARD}}; object-src 'none'; script-src 'self' https://sentry.io/api/embed/error-page/; style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; img-src 'self' data: http: https: ";
+add_header Content-Security-Policy "default-src 'self' {{CONTENT_SECURITY_POLICY_WILDCARD}}; font-src https://fonts.gstatic.com; object-src 'none'; script-src 'self' https://sentry.io/api/embed/error-page/; style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; img-src 'self' data: http: https: ";
 
 server {
     listen       80;


### PR DESCRIPTION
## Description

Reported by @onnee04 at: https://opencrvsworkspace.slack.com/archives/C02P91N0E1W/p1752819095130959?thread_ts=1752735331.369909&cid=C02P91N0E1W

https://opencrvsworkspace.slack.com/files/U08C1G5SSJF/F095ZBF2BE3/20250718-0545-21.8269902.mp4

## Checklist

- [x] I have linked the correct Github issue under "Development": https://login.v18.opencrvs.dev/?lang=en
- [ ] I have tested the changes locally, and written appropriate tests: not relevant
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths): not relevant
- [ ] I have updated the changelog with this change (if applicable): not relevant
- [ ] I have updated the GitHub issue status accordingly: not relevant
