### PR TITLE
Implement file input output components

### DIFF
--- a/packages/client/src/v2-events/components/forms/inputs/FileInput/DocumentUploaderWithOption.tsx
+++ b/packages/client/src/v2-events/components/forms/inputs/FileInput/DocumentUploaderWithOption.tsx
@@ -251,12 +251,16 @@ function DocumentWithOptionOutput({
   value,
   config
 }: {
-  value: FileFieldWithOptionValue
+  value?: FileFieldWithOptionValue
   config: FileUploadWithOptions
 }) {
   const intl = useIntl()
   const [previewImage, setPreviewImage] =
     useState<FileFieldValueWithOption | null>(null)
+
+  if (!value || value.length === 0) {
+    return null
+  }
 
   return (
     <>

--- a/packages/client/src/v2-events/components/forms/inputs/FileInput/DocumentUploaderWithOption.tsx
+++ b/packages/client/src/v2-events/components/forms/inputs/FileInput/DocumentUploaderWithOption.tsx
@@ -15,18 +15,20 @@ import { useIntl } from 'react-intl'
 import {
   FileFieldValueWithOption,
   FileFieldWithOptionValue,
+  FileUploadWithOptions,
   MimeType,
   SelectOption
 } from '@opencrvs/commons/client'
 import { ErrorText } from '@opencrvs/components'
 import { useFileUpload } from '@client/v2-events/features/files/useFileUpload'
 import { Select } from '@client/v2-events/features/events/registered-fields/Select'
-import { formMessages as messages } from '@client/i18n/messages'
+import { buttonMessages, formMessages as messages } from '@client/i18n/messages'
 import { DocumentUploader } from './SimpleDocumentUploader'
 import { DocumentListPreview } from './DocumentListPreview'
 import { DocumentPreview } from './DocumentPreview'
 import { File } from './FileInput'
 import { useOnFileChange } from './useOnFileChange'
+import { SingleDocumentPreview } from './SingleDocumentPreview'
 
 const UploadWrapper = styled.div`
   width: 100%;
@@ -245,7 +247,45 @@ function DocumentUploaderWithOption({
   )
 }
 
-const DocumentWithOptionOutput = null
+function DocumentWithOptionOutput({
+  value,
+  config
+}: {
+  value: FileFieldWithOptionValue
+  config: FileUploadWithOptions
+}) {
+  const intl = useIntl()
+  const [previewImage, setPreviewImage] =
+    useState<FileFieldValueWithOption | null>(null)
+
+  return (
+    <>
+      {value.map((file) => {
+        const label = config.options.find((x) => x.value === file.option)?.label
+        return (
+          <SingleDocumentPreview
+            key={file.filename}
+            attachment={file}
+            label={label ? intl.formatMessage(label) : file.option}
+            onSelect={() => setPreviewImage(file)}
+          />
+        )
+      })}
+
+      {previewImage && (
+        <DocumentPreview
+          disableDelete={true}
+          goBack={() => {
+            setPreviewImage(null)
+          }}
+          previewImage={previewImage}
+          title={intl.formatMessage(buttonMessages.preview)}
+          onDelete={() => setPreviewImage(null)}
+        />
+      )}
+    </>
+  )
+}
 
 export const FileWithOption = {
   Input: DocumentUploaderWithOption,

--- a/packages/client/src/v2-events/components/forms/inputs/FileInput/FileInput.tsx
+++ b/packages/client/src/v2-events/components/forms/inputs/FileInput/FileInput.tsx
@@ -98,11 +98,15 @@ function FileOutput({
   value,
   config
 }: {
-  value: FileFieldValue
+  value?: FileFieldValue
   config: FileConfig
 }) {
   const intl = useIntl()
   const [previewImage, setPreviewImage] = useState<boolean>(false)
+
+  if (!value) {
+    return null
+  }
 
   return (
     <>

--- a/packages/client/src/v2-events/components/forms/inputs/FileInput/FileInput.tsx
+++ b/packages/client/src/v2-events/components/forms/inputs/FileInput/FileInput.tsx
@@ -9,10 +9,18 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 
-import React from 'react'
-import { FileFieldValue, MimeType } from '@opencrvs/commons/client'
+import React, { useState } from 'react'
+import { useIntl } from 'react-intl'
+import {
+  FileFieldValue,
+  MimeType,
+  File as FileConfig
+} from '@opencrvs/commons/client'
 import { useFileUpload } from '@client/v2-events/features/files/useFileUpload'
+import { buttonMessages } from '@client/i18n/messages'
 import { SimpleDocumentUploader } from './SimpleDocumentUploader'
+import { DocumentPreview } from './DocumentPreview'
+import { SingleDocumentPreview } from './SingleDocumentPreview'
 
 function FileInput({
   width,
@@ -86,7 +94,43 @@ function FileInput({
   )
 }
 
+function FileOutput({
+  value,
+  config
+}: {
+  value: FileFieldValue
+  config: FileConfig
+}) {
+  const intl = useIntl()
+  const [previewImage, setPreviewImage] = useState<boolean>(false)
+
+  return (
+    <>
+      <SingleDocumentPreview
+        attachment={value}
+        label={
+          config.configuration.fileName
+            ? intl.formatMessage(config.configuration.fileName)
+            : intl.formatMessage(config.label)
+        }
+        onSelect={() => setPreviewImage(true)}
+      />
+      {previewImage && (
+        <DocumentPreview
+          disableDelete={true}
+          goBack={() => {
+            setPreviewImage(false)
+          }}
+          previewImage={value}
+          title={intl.formatMessage(buttonMessages.preview)}
+          onDelete={() => setPreviewImage(false)}
+        />
+      )}
+    </>
+  )
+}
+
 export const File = {
   Input: FileInput,
-  Output: null
+  Output: FileOutput
 }

--- a/packages/client/src/v2-events/components/forms/inputs/FileInput/SingleDocumentPreview.tsx
+++ b/packages/client/src/v2-events/components/forms/inputs/FileInput/SingleDocumentPreview.tsx
@@ -20,7 +20,6 @@ const Wrapper = styled.div`
   max-width: 100%;
   & > *:last-child {
     margin-bottom: 8px;
-    border-bottom: 1.5px solid ${({ theme }) => theme.colors.grey100};
   }
 `
 const Container = styled.div`
@@ -29,7 +28,6 @@ const Container = styled.div`
   align-items: center;
   justify-content: space-between;
   gap: 4px;
-  border-top: 1.5px solid ${({ theme }) => theme.colors.grey100};
   height: 48px;
   padding: 0px 10px;
 `
@@ -80,15 +78,17 @@ export function SingleDocumentPreview({
               <span>{getFormattedLabelForDocType(label) || label}</span>
             </Link>
           </Label>
-          <Button
-            aria-label="Delete attachment"
-            id="preview_delete"
-            size="small"
-            type="icon"
-            onClick={() => onDelete && onDelete(attachment)}
-          >
-            <Icon color="red" name="Trash" size="small" />
-          </Button>
+          {onDelete && (
+            <Button
+              aria-label="Delete attachment"
+              id="preview_delete"
+              size="small"
+              type="icon"
+              onClick={() => onDelete(attachment)}
+            >
+              <Icon color="red" name="Trash" size="small" />
+            </Button>
+          )}
         </Container>
       )}
     </Wrapper>

--- a/packages/client/src/v2-events/features/events/components/Output.tsx
+++ b/packages/client/src/v2-events/features/events/components/Output.tsx
@@ -26,6 +26,7 @@ import {
   isEmailFieldType,
   isFacilityFieldType,
   isFileFieldType,
+  isFileFieldWithOptionType,
   isNumberFieldType,
   isOfficeFieldType,
   isPageHeaderFieldType,
@@ -57,6 +58,7 @@ import {
 import { File } from '@client/v2-events/components/forms/inputs/FileInput/FileInput'
 import { Name } from '@client/v2-events/features/events/registered-fields/Name'
 import { DateRangeField } from '@client/v2-events/features/events/registered-fields/DateRangeField'
+import { FileWithOption } from '@client/v2-events/components/forms/inputs/FileInput/DocumentUploaderWithOption'
 
 const Deleted = styled.del`
   color: ${({ theme }) => theme.colors.negative};
@@ -103,7 +105,11 @@ export function ValueOutput(field: { config: FieldConfig; value: FieldValue }) {
   }
 
   if (isFileFieldType(field)) {
-    return File.Output
+    return File.Output(field)
+  }
+
+  if (isFileFieldWithOptionType(field)) {
+    return FileWithOption.Output(field)
   }
 
   if (isBulletListFieldType(field)) {


### PR DESCRIPTION
## Description
<img width="1677" height="866" alt="Screenshot 2025-07-18 at 12 58 47 PM" src="https://github.com/user-attachments/assets/669719d2-3456-443c-93f9-e415a91b36d0" />

<img width="741" height="818" alt="Screenshot 2025-07-18 at 1 14 38 PM" src="https://github.com/user-attachments/assets/c9b8741a-1538-4839-b09d-6f57e3df7eec" />

[Correction summary should display uploaded files with preview](https://github.com/opencrvs/opencrvs-core/issues/9960)

Added output component for FileInput and DocumentUploadWithOption components. Now, wherever a file name is rendered, it is rendered with a clickable link, clicking on which will open an instant modalp review of that file.

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
