### PR TITLE
fix: Don't trigger deployment until images are build

### DIFF
--- a/.github/workflows/build-images-from-branch.yml
+++ b/.github/workflows/build-images-from-branch.yml
@@ -143,7 +143,7 @@ jobs:
               --amend ghcr.io/opencrvs/ocrvs-base:$TAG-arm64
             docker manifest push ghcr.io/opencrvs/ocrvs-base:$TAG
           done
-      - run: exit 1
+
   build:
     needs: [base,merge-manifest]
     strategy:
@@ -230,6 +230,7 @@ jobs:
               --amend ghcr.io/opencrvs/ocrvs-${{ matrix.service }}:$TAG-arm64
             docker manifest push ghcr.io/opencrvs/ocrvs-${{ matrix.service }}:$TAG
           done
+      - run: exit 1
 
   security-scans-pr:
     needs: [build, base]

--- a/.github/workflows/build-images-from-branch.yml
+++ b/.github/workflows/build-images-from-branch.yml
@@ -252,7 +252,7 @@ jobs:
           format: 'sarif'
           output: './trivy-results-base.sarif'
           exit-code: '0'
-
+      - run: exit 1
       - name: Gather Trivy output from newly build image
         uses: aquasecurity/trivy-action@0.28.0
         with:
@@ -285,7 +285,7 @@ jobs:
             trivy.yaml
             .trivyignore.yaml
           sparse-checkout-cone-mode: false
-
+      - run: exit 1
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.28.0
         with:

--- a/.github/workflows/build-images-from-branch.yml
+++ b/.github/workflows/build-images-from-branch.yml
@@ -18,7 +18,7 @@ on:
     outputs:
       build_status:
         description: build job output
-        value: ${{ jobs.build.result }}
+        value: ${{ jobs.merge-services-manifest.result }}
   workflow_dispatch:
     inputs:
       branch_name:
@@ -143,6 +143,7 @@ jobs:
               --amend ghcr.io/opencrvs/ocrvs-base:$TAG-arm64
             docker manifest push ghcr.io/opencrvs/ocrvs-base:$TAG
           done
+      - run: exit 1
   build:
     needs: [base,merge-manifest]
     strategy:

--- a/.github/workflows/build-images-from-branch.yml
+++ b/.github/workflows/build-images-from-branch.yml
@@ -15,6 +15,10 @@ on:
         description: Branch to build from
         required: true
         type: string
+    outputs:
+      build_status:
+        description: build job output
+        value: ${{ jobs.build.result }}
   workflow_dispatch:
     inputs:
       branch_name:

--- a/.github/workflows/build-images-from-branch.yml
+++ b/.github/workflows/build-images-from-branch.yml
@@ -87,6 +87,21 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GHCR_PUBLISH_TOKEN }}
+      - name: Build and push (with retry)
+        uses: Wandalen/wretry.action@v3.8.0
+        with:
+          attempt_limit: 3
+          action: docker/build-push-action@v6
+          with: |
+            file: packages/Dockerfile.base
+            push: true
+            context: .
+            tags: |
+              ghcr.io/opencrvs/ocrvs-base:${{ steps.set-version-and-branch.outputs.version }}${{ steps.arch_label.outputs.arch }}
+              ghcr.io/opencrvs/ocrvs-base:${{ steps.set-version-and-branch.outputs.branch }}${{ steps.arch_label.outputs.arch }}
+            cache-from: type=registry,ref=ghcr.io/opencrvs/ocrvs-base:${{ steps.set-version-and-branch.outputs.branch }}${{ steps.arch_label.outputs.arch }}
+            cache-to: type=inline
+
       - name: Build and push base image
         uses: docker/build-push-action@v6
         with:
@@ -164,20 +179,23 @@ jobs:
             echo "arch=" >> $GITHUB_OUTPUT
           fi
 
-      - name: Build and push
-        uses: docker/build-push-action@v6
+      - name: Build and push (with retry)
+        uses: Wandalen/wretry.action@v3.8.0
         with:
-          file: packages/${{ matrix.service }}/Dockerfile
-          build-args: |
-            VERSION=${{ needs.base.outputs.version }}
-            BRANCH=${{ needs.base.outputs.branch }}
-          push: true
-          context: .
-          tags: |
-            ghcr.io/opencrvs/ocrvs-${{ matrix.service }}:${{ needs.base.outputs.version }}${{ steps.arch_label.outputs.arch }}
-            ghcr.io/opencrvs/ocrvs-${{ matrix.service }}:${{ needs.base.outputs.branch }}${{ steps.arch_label.outputs.arch }}
-          cache-from: type=registry,ref=ghcr.io/opencrvs/ocrvs-${{ matrix.service }}:${{ needs.base.outputs.branch }}${{ steps.arch_label.outputs.arch }}
-          cache-to: type=inline
+          attempt_limit: 3
+          action: docker/build-push-action@v6
+          with: |
+            file: packages/${{ matrix.service }}/Dockerfile
+            build-args: |
+              VERSION=${{ needs.base.outputs.version }}
+              BRANCH=${{ needs.base.outputs.branch }}
+            push: true
+            context: .
+            tags: |
+              ghcr.io/opencrvs/ocrvs-${{ matrix.service }}:${{ needs.base.outputs.version }}${{ steps.arch_label.outputs.arch }}
+              ghcr.io/opencrvs/ocrvs-${{ matrix.service }}:${{ needs.base.outputs.branch }}${{ steps.arch_label.outputs.arch }}
+            cache-from: type=registry,ref=ghcr.io/opencrvs/ocrvs-${{ matrix.service }}:${{ needs.base.outputs.branch }}${{ steps.arch_label.outputs.arch }}
+            cache-to: type=inline
 
   merge-services-manifest:
     needs: [base,build]

--- a/.github/workflows/deploy-to-feature-environment.yml
+++ b/.github/workflows/deploy-to-feature-environment.yml
@@ -152,9 +152,9 @@ jobs:
     secrets: inherit
 
   trigger-e2e:
-    if: ${{ (github.event_name == 'workflow_dispatch') || (!contains(github.actor, 'bot') && github.event.pull_request.head.repo.fork == false) }}
+    if: needs.trigger-build.outputs.build_status == 'success'
     runs-on: ubuntu-24.04
-    needs: generate_stack_name_and_branch
+    needs: [generate_stack_name_and_branch, trigger-build]
     environment: ${{  needs.generate_stack_name_and_branch.outputs.slugified_branch  }}
     outputs:
       run_id: ${{ steps.dispatch_e2e.outputs.run_id }}

--- a/.github/workflows/deploy-to-feature-environment.yml
+++ b/.github/workflows/deploy-to-feature-environment.yml
@@ -152,7 +152,7 @@ jobs:
     secrets: inherit
 
   trigger-e2e:
-    if: needs.trigger-build.outputs.build_status == 'success'
+    if: always() && needs.trigger-build.outputs.build_status == 'success'
     runs-on: ubuntu-24.04
     needs: [generate_stack_name_and_branch, trigger-build]
     environment: ${{  needs.generate_stack_name_and_branch.outputs.slugified_branch  }}


### PR DESCRIPTION
## Description

Image build may fail in multiple cases, here are examples:
- code failure: https://github.com/opencrvs/opencrvs-core/actions/runs/16418818788/job/46392370784
- yarn package registry failure: https://github.com/opencrvs/opencrvs-core/actions/runs/16418818788/job/46391489072

Goal of this PR is to avoid triggering deployment unless all images are build and ready to deploy

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
