### PR TITLE
fix: update file name for reusable action

### DIFF
--- a/.github/workflows/build-images-from-branch-tag.yml
+++ b/.github/workflows/build-images-from-branch-tag.yml
@@ -15,6 +15,10 @@ on:
         description: Branch or Tag to build from
         required: true
         type: string
+      publish_release:
+        type: boolean
+        required: false
+        default: false
     outputs:
       build_status:
         description: build job output

--- a/.github/workflows/countryconfig-to-openapi.yml
+++ b/.github/workflows/countryconfig-to-openapi.yml
@@ -27,8 +27,11 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
-
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          command: yarn install --frozen-lockfile
       - name: Generate OpenAPI
         run: bash build.sh
         working-directory: packages/api-docs

--- a/.github/workflows/deploy-to-feature-environment.yml
+++ b/.github/workflows/deploy-to-feature-environment.yml
@@ -146,9 +146,9 @@ jobs:
   trigger-build:
     if: ${{ (github.event_name == 'workflow_dispatch') || (!contains(github.actor, 'bot') && github.event.pull_request.head.repo.fork == false) }}
     needs: generate_stack_name_and_branch
-    uses: ./.github/workflows/build-images-from-branch.yml
+    uses: ./.github/workflows/build-images-from-branch-tag.yml
     with:
-      branch_name: ${{  needs.generate_stack_name_and_branch.outputs.branch_name  }}
+      branch_tag_name: ${{ needs.generate_stack_name_and_branch.outputs.branch_name }}
     secrets: inherit
 
   trigger-e2e:


### PR DESCRIPTION
## Description

update file name for reusable action

Test results: Check attached workflows
<img width="856" height="482" alt="image" src="https://github.com/user-attachments/assets/43404eca-9b1c-4439-a6f1-c1afbea099e9" />

Workflow: https://github.com/opencrvs/opencrvs-core/actions/runs/16441803070?pr=10038
<img width="1504" height="341" alt="image" src="https://github.com/user-attachments/assets/f4f6fb1f-ee2e-40db-a9db-c23b174d34bd" />

A Job was properly handled:
<img width="846" height="627" alt="image" src="https://github.com/user-attachments/assets/2d809f71-1325-4694-a964-35c093f6d008" />
