### PR TITLE
Improve document selector output styling

### DIFF
--- a/packages/client/src/v2-events/components/forms/inputs/FileInput/DocumentUploaderWithOption.tsx
+++ b/packages/client/src/v2-events/components/forms/inputs/FileInput/DocumentUploaderWithOption.tsx
@@ -246,6 +246,12 @@ function DocumentUploaderWithOption({
   )
 }
 
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+`
+
 function DocumentWithOptionOutput({
   value,
   config
@@ -262,7 +268,7 @@ function DocumentWithOptionOutput({
   }
 
   return (
-    <>
+    <Wrapper>
       {value.map((file) => {
         const label = config.options.find((x) => x.value === file.option)?.label
         return (
@@ -274,7 +280,6 @@ function DocumentWithOptionOutput({
           />
         )
       })}
-
       {previewImage && (
         <DocumentPreview
           disableDelete={true}
@@ -286,7 +291,7 @@ function DocumentWithOptionOutput({
           onDelete={() => setPreviewImage(null)}
         />
       )}
-    </>
+    </Wrapper>
   )
 }
 

--- a/packages/client/src/v2-events/components/forms/inputs/FileInput/SimpleDocumentUploader.tsx
+++ b/packages/client/src/v2-events/components/forms/inputs/FileInput/SimpleDocumentUploader.tsx
@@ -32,6 +32,10 @@ export const DocumentUploader = styled(ImageUploader)<{ fullWidth?: boolean }>`
   }
 `
 
+const Preview = styled(SingleDocumentPreview)`
+  padding: 0px 10px 8px 10px;
+`
+
 const FieldDescription = styled.div`
   margin-top: 0px;
   margin-bottom: 6px;
@@ -104,7 +108,7 @@ export function SimpleDocumentUploader({
       {errorMessage && (touched || error) && (
         <ErrorText id="field-error">{errorMessage}</ErrorText>
       )}
-      <SingleDocumentPreview
+      <Preview
         attachment={file}
         label={label}
         onDelete={onDelete}

--- a/packages/client/src/v2-events/components/forms/inputs/FileInput/SingleDocumentPreview.tsx
+++ b/packages/client/src/v2-events/components/forms/inputs/FileInput/SingleDocumentPreview.tsx
@@ -18,9 +18,6 @@ import { ISelectOption } from '@opencrvs/components/lib/Select'
 
 const Wrapper = styled.div`
   max-width: 100%;
-  & > *:last-child {
-    margin-bottom: 8px;
-  }
 `
 const Container = styled.div`
   width: 100%;
@@ -28,7 +25,6 @@ const Container = styled.div`
   align-items: center;
   justify-content: space-between;
   gap: 4px;
-  padding: 0px 10px;
 `
 
 const Label = styled.div`
@@ -59,7 +55,8 @@ export function SingleDocumentPreview({
   label,
   onSelect,
   dropdownOptions,
-  onDelete
+  onDelete,
+  ...props
 }: Props) {
   function getFormattedLabelForDocType(docType: string) {
     const matchingOptionForDocType =
@@ -68,7 +65,7 @@ export function SingleDocumentPreview({
     return matchingOptionForDocType && matchingOptionForDocType.label
   }
   return (
-    <Wrapper id={`preview-list-${id}`}>
+    <Wrapper id={`preview-list-${id}`} {...props}>
       {attachment && label && (
         <Container>
           <Label>


### PR DESCRIPTION
## Description

Minor document selector output styling improvements.



After:

<img width="1512" height="1082" alt="Screenshot 2025-07-22 at 15 36 59" src="https://github.com/user-attachments/assets/9c432da0-1d04-4abb-ae29-2e70057916a0" />


## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
