### PR TITLE
Fix bug with displaying unchanged fields in correction summary

### DIFF
--- a/packages/client/src/v2-events/features/events/actions/correct/utils.ts
+++ b/packages/client/src/v2-events/features/events/actions/correct/utils.ts
@@ -20,10 +20,8 @@ export function hasFieldChanged(
   form: EventState,
   previousFormValues: EventState
 ) {
-  const wasVisible = isFieldVisible(f, previousFormValues)
   const isVisible = isFieldVisible(f, form)
-  const visibilityChanged = wasVisible !== isVisible
   const valueHasChanged = !isEqual(previousFormValues[f.id], form[f.id])
 
-  return isVisible && (valueHasChanged || visibilityChanged)
+  return isVisible && valueHasChanged
 }


### PR DESCRIPTION
## Description

Bug was caused by conditionally hidden, but unchanged fields becoming visible. We dont want to show them on the summary.

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
