### PR TITLE
Update migrations to remove special characters from role ids on generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 - Fixed historical roles displaying incorrectly in task history after migration to v1.7 [#9989](https://github.com/opencrvs/opencrvs-core/issues/9989)
+- Remove special characters from role ids on generation [#10049](https://github.com/opencrvs/opencrvs-core/issues/10049)
 
 ## [1.7.3](https://github.com/opencrvs/opencrvs-core/compare/v1.7.2...v1.7.3)
 

--- a/packages/migration/src/migrations/user-mgnt/20240628124653-remove-userroles.ts
+++ b/packages/migration/src/migrations/user-mgnt/20240628124653-remove-userroles.ts
@@ -39,10 +39,16 @@ export const up = async (db: Db, client: MongoClient) => {
             $addFields: {
               role: {
                 $toUpper: {
-                  $replaceAll: {
-                    input: { $arrayElemAt: ['$roleDetails.labels.label', 0] },
-                    find: ' ',
-                    replacement: '_'
+                  $function: {
+                    body: `
+                      function(label) {
+                        return label
+                          .replace(/[^a-zA-Z0-9 ]/g, '')
+                          .replace(/ /g, '_');
+                      }
+                    `,
+                    args: [{ $arrayElemAt: ['$roleDetails.labels.label', 0] }],
+                    lang: 'js'
                   }
                 }
               }

--- a/packages/migration/src/utils/role-helper.ts
+++ b/packages/migration/src/utils/role-helper.ts
@@ -171,6 +171,7 @@ export const transformRoleCodes = (doc: any) => {
 
       if (englishLabel?.label) {
         const transformedLabel = englishLabel.label
+          .replace(/[^a-zA-Z0-9 ]/g, '')
           .toUpperCase()
           .replace(/ /g, '_')
 


### PR DESCRIPTION
Fixes: https://github.com/opencrvs/opencrvs-core/issues/10049

During the automatic role upgrade, roles can be created with apostrophes. 
e.g.
v1.6 role: 
```
{
  systemRole: "REGISTRATION_AGENT",
  alias: "Registrar's Assistant"
}
```

The migration will create a new role of REGISTRAR'S_ASSISTANT.

This fixes the migrations to remove special characters.
Accompanying country-config PR: https://github.com/opencrvs/opencrvs-countryconfig/pull/893