### PR TITLE
fix: styles of `AccordionHeadingTitle`

### DIFF
--- a/packages/components/src/Accordion/Accordion.tsx
+++ b/packages/components/src/Accordion/Accordion.tsx
@@ -36,6 +36,7 @@ const AccordionHeader = styled.div`
 `
 
 const AccordionHeaderTitle = styled.div`
+  flex: 1;
   h2 {
     margin-top: 0;
     margin-bottom: 6px;


### PR DESCRIPTION
|Before (current `develop`)|After change of this PR|
|---|---|
|<img width="869" height="94" alt="image" src="https://github.com/user-attachments/assets/491788de-c563-4774-bd1d-d1fe59cc0648" />| <img width="884" height="107" alt="image" src="https://github.com/user-attachments/assets/b2a28eeb-801d-4081-9b13-474e26f1f2c7" />|
|<img width="851" height="104" alt="image" src="https://github.com/user-attachments/assets/38c6da97-d414-404f-bc33-e0cd8117509e" />|<img width="880" height="111" alt="image" src="https://github.com/user-attachments/assets/38f19935-2870-4b50-81f4-94fe8da46cbe" />|
