### PR TITLE
fix: temporarily use classic token

### DIFF
--- a/.github/workflows/trigger-e2e.yml
+++ b/.github/workflows/trigger-e2e.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.E2E_WORKFLOWS_TOKEN }}
+          github-token: ${{ secrets.E2E_TRIGGER_GITHUB_PAT }}
           script: |
             const result = await github.rest.repos.createDispatchEvent({
               owner: 'opencrvs',


### PR DESCRIPTION
## Description

The current fine grained token doesn't have the required permissions necessary to trigger a workflow in the Farajaland repo. Hence we are temporarily switching back to the classic token. All the workflow runs were failing here: https://github.com/opencrvs/opencrvs-core/actions/workflows/trigger-e2e.yml after the 1.8.0 changes (which included the fine-grained token migration) were merged in here: https://github.com/opencrvs/opencrvs-core/pull/9990/files#diff-a9962fd23da61530da9e70e640c51a8f4bc52f6e32d2d2dac3bd0185524b8390
