### PR TITLE
fix: subtract same days as the value

### DIFF
--- a/packages/commons/src/events/utils.ts
+++ b/packages/commons/src/events/utils.ts
@@ -405,16 +405,16 @@ export function timePeriodToDateRange(value: SelectDateRangeValue) {
   let startDate: Date
   switch (value) {
     case 'last7Days':
-      startDate = subDays(new Date(), 6)
+      startDate = subDays(new Date(), 7)
       break
     case 'last30Days':
-      startDate = subDays(new Date(), 29)
+      startDate = subDays(new Date(), 30)
       break
     case 'last90Days':
-      startDate = subDays(new Date(), 89)
+      startDate = subDays(new Date(), 90)
       break
     case 'last365Days':
-      startDate = subDays(new Date(), 364)
+      startDate = subDays(new Date(), 365)
       break
   }
   return {


### PR DESCRIPTION
## Description

We were subtracting one less than the value, e.g. for `last7days` we were subtracting 6 from the current date. Now we are subtracting the same as the value.

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
