### PR TITLE
Fix: Spinner prop 'color' can now use a colour from colors.ts

### DIFF
--- a/.github/workflows/deploy-to-feature-environment.yml
+++ b/.github/workflows/deploy-to-feature-environment.yml
@@ -108,6 +108,7 @@ jobs:
           else
             e2e_branch="develop"
           fi
+          echo "e2e branch name=${e2e_branch}"
           echo "branch=$e2e_branch" >> $GITHUB_OUTPUT
       - name: Get PR Author
         id: get_author

--- a/packages/client/src/v2-events/features/events/useEvents/api.ts
+++ b/packages/client/src/v2-events/features/events/useEvents/api.ts
@@ -61,6 +61,10 @@ export function setDraftData(updater: (drafts: Draft[]) => Draft[]) {
   )
 }
 
+export function deleteDraft(id: string) {
+  setDraftData((drafts) => drafts.filter(({ eventId }) => eventId !== id))
+}
+
 export function findLocalEventIndex(id: string) {
   const queries = queryClient.getQueriesData<EventIndex>({
     queryKey: trpcOptionsProxy.event.search.queryKey()

--- a/packages/client/src/v2-events/features/events/useEvents/procedures/delete.ts
+++ b/packages/client/src/v2-events/features/events/useEvents/procedures/delete.ts
@@ -11,6 +11,7 @@
 
 import { useMutation } from '@tanstack/react-query'
 import {
+  deleteDraft,
   refetchEventsList,
   setEventListData
 } from '@client/v2-events/features/events/useEvents/api'
@@ -25,8 +26,9 @@ setMutationDefaults(trpcOptionsProxy.event.delete, {
     return true
   },
   retryDelay: 10000,
-  onSuccess: () => {
+  onSuccess: ({ id }) => {
     void refetchEventsList()
+    deleteDraft(id)
   },
   /*
    * This ensures that when the application is reloaded with pending mutations in IndexedDB, the

--- a/packages/client/src/views/OfficeHome/LoadingIndicator.tsx
+++ b/packages/client/src/views/OfficeHome/LoadingIndicator.tsx
@@ -84,7 +84,7 @@ const LoadingIndicatorComp = ({
   <Wrapper>
     {isOnline && loading && (
       <LoadingContainer>
-        <Spinner id="Spinner" size={24} baseColor="#4C68C1" />
+        <Spinner id="Spinner" size={24} color="primary" />
       </LoadingContainer>
     )}
     <MobileViewContainer noDeclaration={noDeclaration}>

--- a/packages/client/src/views/SysAdmin/Config/Systems/Systems.tsx
+++ b/packages/client/src/views/SysAdmin/Config/Systems/Systems.tsx
@@ -395,7 +395,7 @@ export function SystemList() {
                 {intl.formatMessage(integrationMessages.clientSecret)}
               </Text>
               {refreshTokenLoading ? (
-                <Spinner baseColor="#4C68C1" id="Spinner" size={24} />
+                <Spinner color="primary" id="Spinner" size={24} />
               ) : refreshTokenData && refreshTokenData?.refreshSystemSecret ? (
                 <Stack justifyContent="space-between" alignItems="center">
                   <Text variant="reg16" element="span">

--- a/packages/components/src/Alert/Alert.tsx
+++ b/packages/components/src/Alert/Alert.tsx
@@ -108,7 +108,7 @@ export const Alert = ({
           {type === 'loading' && (
             <Spinner
               id="in-progress-floating-notification"
-              baseColor={colors.white}
+              color="white"
               size={20}
             />
           )}

--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -94,7 +94,7 @@ export const Button = ({
         <Spinner
           id="button-loading"
           size={24}
-          baseColor="currentColor"
+          color="currentColor"
           style={{ marginRight: '-6px' }}
         />
       )}

--- a/packages/components/src/Spinner/Spinner.stories.tsx
+++ b/packages/components/src/Spinner/Spinner.stories.tsx
@@ -17,7 +17,7 @@ const Template: Story<ISpinner> = (args) => <Spinner {...args} />
 export const SpinnerExample = Template.bind({})
 SpinnerExample.args = {
   id: 'Spinner',
-  baseColor: '#4C68C1'
+  color: 'primary'
 }
 
 export default {

--- a/packages/components/src/Spinner/Spinner.tsx
+++ b/packages/components/src/Spinner/Spinner.tsx
@@ -10,13 +10,16 @@
  */
 import * as React from 'react'
 import styled from 'styled-components'
+import { colors } from '../colors'
 
 export interface ISpinner extends React.HTMLAttributes<HTMLDivElement> {
   id: string
-  baseColor?: string
+  color?: ColorKey | string
   className?: string
   size?: number
 }
+
+type ColorKey = keyof typeof colors
 
 const StyledSpinner = styled.div<ISpinner>`
   width: ${({ size }) => (size ? `${size}px` : 'auto')};
@@ -28,8 +31,12 @@ const StyledSpinner = styled.div<ISpinner>`
     height: ${({ size }) => size}px;
 
     & circle {
-      stroke: ${({ baseColor }) =>
-        baseColor ? baseColor : ({ theme }) => theme.colors.primary};
+      stroke: ${({ color, theme }) =>
+        color
+          ? color in theme.colors
+            ? theme.colors[color as ColorKey]
+            : color
+          : theme.colors.primary};
       stroke-linecap: round;
       animation: dash 1.5s ease-in-out infinite;
     }
@@ -57,17 +64,11 @@ const StyledSpinner = styled.div<ISpinner>`
   }
 `
 
-export const Spinner = ({
-  id,
-  className,
-  baseColor,
-  size,
-  ...rest
-}: ISpinner) => (
+export const Spinner = ({ id, className, color, size, ...rest }: ISpinner) => (
   <StyledSpinner
     id={id}
     className={className}
-    baseColor={baseColor}
+    color={color}
     size={size ? size : 48}
     data-testid="spinner"
     {...rest}

--- a/packages/components/src/Toast/Toast.tsx
+++ b/packages/components/src/Toast/Toast.tsx
@@ -125,7 +125,7 @@ export function Toast({
         <SpinnerContainer>
           <Spinner
             id="in-progress-floating-notification"
-            baseColor={colors.white}
+            color="white"
             size={20}
           />
         </SpinnerContainer>


### PR DESCRIPTION
## Description

BaseColor only accepted a string so only hex colours could be used to change from the default theme 'primary' color

This ticket fixes Spinner so that a colour from the library can be used. 
Refactors instances that use a hex to use the primary colour defined in colors.ts

Keeps string as an option for Button which uses currentColor

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
