### PR TITLE
fix: action menu button to size medium

### DIFF
--- a/packages/client/src/views/RecordAudit/ActionMenu.tsx
+++ b/packages/client/src/views/RecordAudit/ActionMenu.tsx
@@ -137,7 +137,7 @@ export const ActionMenu: React.FC<{
     <>
       <DropdownMenu id="action">
         <DropdownMenu.Trigger asChild>
-          <PrimaryButton icon={() => <CaretDown />}>
+          <PrimaryButton size="medium" icon={() => <CaretDown />}>
             {intl.formatMessage(messages.action)}
           </PrimaryButton>
         </DropdownMenu.Trigger>


### PR DESCRIPTION
## Description

Fixes the Action menu button size to that defined in the designs

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
