### PR TITLE
fix: spinner color from ui library

### DIFF
--- a/packages/client/src/v2-events/components/LoadingIndicator.tsx
+++ b/packages/client/src/v2-events/components/LoadingIndicator.tsx
@@ -84,7 +84,7 @@ function LoadingIndicatorComp({
     <Wrapper>
       {isOnline && loading && (
         <LoadingContainer>
-          <Spinner baseColor="#4C68C1" id="Spinner" size={24} />
+          <Spinner color="primary" id="Spinner" size={24} />
         </LoadingContainer>
       )}
       <MobileViewContainer noDeclaration={noDeclaration}>

--- a/packages/client/src/views/OfficeHome/LoadingIndicator.tsx
+++ b/packages/client/src/views/OfficeHome/LoadingIndicator.tsx
@@ -84,7 +84,7 @@ const LoadingIndicatorComp = ({
   <Wrapper>
     {isOnline && loading && (
       <LoadingContainer>
-        <Spinner id="Spinner" size={24} baseColor="#4C68C1" />
+        <Spinner id="Spinner" size={24} color="primary" />
       </LoadingContainer>
     )}
     <MobileViewContainer noDeclaration={noDeclaration}>

--- a/packages/client/src/views/SysAdmin/Config/Systems/Systems.tsx
+++ b/packages/client/src/views/SysAdmin/Config/Systems/Systems.tsx
@@ -395,7 +395,7 @@ export function SystemList() {
                 {intl.formatMessage(integrationMessages.clientSecret)}
               </Text>
               {refreshTokenLoading ? (
-                <Spinner baseColor="#4C68C1" id="Spinner" size={24} />
+                <Spinner color="primary" id="Spinner" size={24} />
               ) : refreshTokenData && refreshTokenData?.refreshSystemSecret ? (
                 <Stack justifyContent="space-between" alignItems="center">
                   <Text variant="reg16" element="span">

--- a/packages/components/src/Alert/Alert.tsx
+++ b/packages/components/src/Alert/Alert.tsx
@@ -108,7 +108,7 @@ export const Alert = ({
           {type === 'loading' && (
             <Spinner
               id="in-progress-floating-notification"
-              baseColor={colors.white}
+              color="white"
               size={20}
             />
           )}

--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -94,7 +94,7 @@ export const Button = ({
         <Spinner
           id="button-loading"
           size={24}
-          baseColor="currentColor"
+          color="currentColor"
           style={{ marginRight: '-6px' }}
         />
       )}

--- a/packages/components/src/Spinner/Spinner.stories.tsx
+++ b/packages/components/src/Spinner/Spinner.stories.tsx
@@ -17,7 +17,7 @@ const Template: Story<ISpinner> = (args) => <Spinner {...args} />
 export const SpinnerExample = Template.bind({})
 SpinnerExample.args = {
   id: 'Spinner',
-  baseColor: '#4C68C1'
+  color: 'primary'
 }
 
 export default {

--- a/packages/components/src/Spinner/Spinner.tsx
+++ b/packages/components/src/Spinner/Spinner.tsx
@@ -10,13 +10,16 @@
  */
 import * as React from 'react'
 import styled from 'styled-components'
+import { colors } from '../colors'
 
 export interface ISpinner extends React.HTMLAttributes<HTMLDivElement> {
   id: string
-  baseColor?: string
+  color?: ColorKey | string
   className?: string
   size?: number
 }
+
+type ColorKey = keyof typeof colors
 
 const StyledSpinner = styled.div<ISpinner>`
   width: ${({ size }) => (size ? `${size}px` : 'auto')};
@@ -28,8 +31,12 @@ const StyledSpinner = styled.div<ISpinner>`
     height: ${({ size }) => size}px;
 
     & circle {
-      stroke: ${({ baseColor }) =>
-        baseColor ? baseColor : ({ theme }) => theme.colors.primary};
+      stroke: ${({ color, theme }) =>
+        color
+          ? color in theme.colors
+            ? theme.colors[color as ColorKey]
+            : color
+          : theme.colors.primary};
       stroke-linecap: round;
       animation: dash 1.5s ease-in-out infinite;
     }
@@ -57,17 +64,11 @@ const StyledSpinner = styled.div<ISpinner>`
   }
 `
 
-export const Spinner = ({
-  id,
-  className,
-  baseColor,
-  size,
-  ...rest
-}: ISpinner) => (
+export const Spinner = ({ id, className, color, size, ...rest }: ISpinner) => (
   <StyledSpinner
     id={id}
     className={className}
-    baseColor={baseColor}
+    color={color}
     size={size ? size : 48}
     data-testid="spinner"
     {...rest}

--- a/packages/components/src/Toast/Toast.tsx
+++ b/packages/components/src/Toast/Toast.tsx
@@ -125,7 +125,7 @@ export function Toast({
         <SpinnerContainer>
           <Spinner
             id="in-progress-floating-notification"
-            baseColor={colors.white}
+            color="white"
             size={20}
           />
         </SpinnerContainer>


### PR DESCRIPTION
## Description

BaseColor only accepted a string so only hex colours could be used to change from the default theme 'primary' color

This PR:
-  Fixes Spinner so that a colour from the library can be used
- Renames BaseColor prop to color
- Refactors instances that use a hex to use the primary colour defined in colors.ts
- Keeps string as an option for Button which uses currentColor

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
