### PR TITLE
Fix certificate printing signature and redirect

### DIFF
--- a/packages/client/src/v2-events/cache.ts
+++ b/packages/client/src/v2-events/cache.ts
@@ -11,7 +11,7 @@
 
 import {
   FullDocumentPath,
-  FullDocumentURL,
+  FullDocumentUrl,
   joinValues
 } from '@opencrvs/commons/client'
 
@@ -26,11 +26,11 @@ export function getFullDocumentPath(filename: string): FullDocumentPath {
  * Files are stored in MinIO. Files should be accessed via unsigned URLs, utilizing browser cache and aggressively precaching them.
  * @returns unsigned URL to the file in MinIO. Assumes file has been cached.
  */
-export function getUnsignedFileUrl(path: FullDocumentPath): FullDocumentURL {
+export function getUnsignedFileUrl(path: FullDocumentPath): FullDocumentUrl {
   return new URL(
     path,
     window.config.MINIO_BASE_URL
-  ).toString() as FullDocumentURL
+  ).toString() as FullDocumentUrl
 }
 
 /**

--- a/packages/client/src/v2-events/features/events/actions/print-certificate/PrintCertificate.interaction.stories.tsx
+++ b/packages/client/src/v2-events/features/events/actions/print-certificate/PrintCertificate.interaction.stories.tsx
@@ -8,19 +8,28 @@
  *
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
+import React from 'react'
 import type { Meta, StoryObj } from '@storybook/react'
+import { http, graphql, HttpResponse } from 'msw'
 import { createTRPCMsw, httpLink } from '@vafanassieff/msw-trpc'
 import superjson from 'superjson'
 
-import { within, userEvent, expect } from '@storybook/test'
-import { tennisClubMembershipEvent } from '@opencrvs/commons/client'
+import { within, userEvent, expect, waitFor } from '@storybook/test'
+import { Outlet } from 'react-router-dom'
+import {
+  ActionType,
+  generateEventDocument,
+  generateWorkqueues,
+  tennisClubMembershipEvent
+} from '@opencrvs/commons/client'
 import {
   tennisClubMembershipEventIndex,
   tennisClubMembershipEventDocument
 } from '@client/v2-events/features/events/fixtures'
 import { ROUTES, routesConfig } from '@client/v2-events/routes'
 import { AppRouter } from '@client/v2-events/trpc'
-import { setEventData, addLocalEventConfig } from '../../useEvents/api'
+import { testDataGenerator } from '@client/tests/test-data-generators'
+import { CERT_TEMPLATE_ID } from '../../useCertificateTemplateSelectorFieldConfig'
 import * as PrintCertificate from './index'
 
 const meta: Meta<typeof PrintCertificate.Review> = {
@@ -179,6 +188,106 @@ export const ContinuingAndGoingBack: Story = {
       await expect(
         await canvas.findByRole('button', { name: 'Yes, print certificate' })
       ).toBeInTheDocument()
+    })
+  }
+}
+
+const generator = testDataGenerator()
+
+export const RedirectAfterPrint: Story = {
+  parameters: {
+    test: {
+      // Since we cannot test the generated PDF, we can ignore the failed font request
+      dangerouslyIgnoreUnhandledErrors: true
+    },
+    msw: {
+      handlers: {
+        event: [
+          tRPCMsw.event.actions.printCertificate.request.mutation(() => {
+            return generateEventDocument({
+              configuration: tennisClubMembershipEvent,
+              actions: [
+                ActionType.DECLARE,
+                ActionType.VALIDATE,
+                ActionType.REGISTER,
+                ActionType.PRINT_CERTIFICATE
+              ]
+            })
+          })
+        ],
+        events: [
+          tRPCMsw.workqueue.config.list.query(() => {
+            return generateWorkqueues()
+          }),
+          tRPCMsw.workqueue.count.query((input) => {
+            return input.reduce((acc, { slug }) => {
+              return { ...acc, [slug]: 1 }
+            }, {})
+          })
+        ]
+      }
+    },
+    offline: {
+      events: [tennisClubMembershipEventDocument],
+
+      drafts: [
+        generator.event.draft({
+          eventId: tennisClubMembershipEventDocument.id,
+          actionType: ActionType.PRINT_CERTIFICATE,
+          annotation: {
+            [CERT_TEMPLATE_ID]: 'tennis-club-membership-certified-certificate',
+            'collector.requesterId': 'INFORMANT',
+            'collector.identity.verify': true,
+            templateId: 'v2.tennis-club-membership-certified-certificate'
+          }
+        })
+      ]
+    },
+    reactRouter: {
+      router: {
+        initialPath: '/',
+        element: <Outlet />,
+        children: [routesConfig]
+      },
+      initialPath: ROUTES.V2.EVENTS.PRINT_CERTIFICATE.REVIEW.buildPath(
+        {
+          eventId: tennisClubMembershipEventDocument.id
+        },
+        {
+          templateId: 'tennis-club-membership-certificate'
+        }
+      )
+    }
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+
+    await step('Prompts confirmation on print', async () => {
+      await userEvent.click(
+        await canvas.findByRole('button', { name: 'Yes, print certificate' })
+      )
+
+      await canvas.findByText('Print and issue certificate?')
+      await canvas.findByText(
+        'A Pdf of the certificate will open in a new tab for printing and issuing.'
+      )
+
+      await canvas.findByRole('button', { name: 'Cancel' })
+    })
+
+    await step('Redirects to overview after print', async () => {
+      await userEvent.click(
+        await canvas.findByRole('button', { name: 'Print' })
+      )
+
+      // Directs to overview page
+      await waitFor(
+        async () => {
+          await canvas.findByText('Assigned to')
+          await canvas.findByText('Certificate is ready to print')
+        },
+        { timeout: 7000 } // Generating the PDF takes a long time.
+      )
     })
   }
 }

--- a/packages/client/src/v2-events/features/events/actions/print-certificate/Review.tsx
+++ b/packages/client/src/v2-events/features/events/actions/print-certificate/Review.tsx
@@ -185,7 +185,7 @@ export function Review() {
   const { eventConfiguration } = useEventConfiguration(fullEvent.type)
   const formConfig = getPrintForm(eventConfiguration)
 
-  const { svgCode, handleCertify } = usePrintableCertificate({
+  const { svgCode, preparePdfCertificate } = usePrintableCertificate({
     event: fullEvent,
     config: eventConfiguration,
     locations,
@@ -262,8 +262,13 @@ export function Review() {
       </ResponsiveModal>
     ))
 
+    /**
+     * NOTE: We have separated the preparing and printing of the PDF certificate. Without the separation, user is already unassigned from the event and cache is cleared. @see preparePdfCertificate for more details.
+     */
     if (confirmed) {
       try {
+        const printCertificate = await preparePdfCertificate(fullEvent)
+
         await onlineActions.printCertificate.mutateAsync({
           fullEvent,
           eventId: fullEvent.id,
@@ -273,7 +278,7 @@ export function Review() {
           type: ActionType.PRINT_CERTIFICATE
         })
 
-        await handleCertify(fullEvent)
+        printCertificate()
 
         toast.custom(
           <Toast

--- a/packages/client/src/v2-events/features/events/actions/print-certificate/pdfUtils.ts
+++ b/packages/client/src/v2-events/features/events/actions/print-certificate/pdfUtils.ts
@@ -8,6 +8,7 @@
  *
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
+/* eslint-disable no-console */
 import {
   IntlShape,
   MessageDescriptor,
@@ -468,6 +469,13 @@ async function downloadAndEmbedImages(svgString: string): Promise<string> {
         const response = await fetch(href)
         const blob = await response.blob()
 
+        if (!response.ok) {
+          console.error('Failed to fetch image:', href)
+          console.error(
+            'Ensure the URL is correct and image is requested before cache is cleaned.'
+          )
+        }
+
         const base64 = await new Promise<string>((resolve, reject) => {
           const reader = new FileReader()
           reader.onload = () => resolve(reader.result as string)
@@ -575,7 +583,7 @@ interface PdfTemplate {
   fonts: Record<string, TFontFamilyTypes>
 }
 
-function createPDF(template: PdfTemplate): pdfMake.TCreatedPdf {
+function createPdf(template: PdfTemplate): pdfMake.TCreatedPdf {
   return pdfMake.createPdf(template.definition, undefined, template.fonts)
 }
 
@@ -583,7 +591,7 @@ export function printAndDownloadPdf(
   template: PdfTemplate,
   declarationId: string
 ) {
-  const pdf = createPDF(template)
+  const pdf = createPdf(template)
   if (isMobileDevice()) {
     pdf.download(`${declarationId}`)
   } else {

--- a/packages/client/src/v2-events/features/events/useEvents/api.ts
+++ b/packages/client/src/v2-events/features/events/useEvents/api.ts
@@ -222,6 +222,7 @@ async function deleteEventData(updatedEvent: EventDocument) {
   queryClient.removeQueries({
     queryKey: trpcOptionsProxy.event.get.queryKey(id)
   })
+
   await removeCachedFiles(updatedEvent)
 }
 

--- a/packages/client/src/v2-events/hooks/usePrintableCertificate.ts
+++ b/packages/client/src/v2-events/hooks/usePrintableCertificate.ts
@@ -104,7 +104,14 @@ export const usePrintableCertificate = ({
 
   const svgCode = addFontsToSvg(svgWithoutFonts, certificateFonts)
 
-  const handleCertify = async (updatedEvent: EventDocument) => {
+  /**
+   * NOTE: We have separated the preparing and printing of the PDF certificate. Without the separation, user is already unassigned from the event and cache is cleared. We end up losing the images in the PDF unless we run actions in correct order.
+   * 1. Prepare 2. Trigger print action 3. Open the PDF in a new window 4. Redirect user to workqueue.
+   *
+   * Prepares the PDF certificate by Resolves image urls to base64 and compiles the SVG template.
+   * @returns function that opens a new window with the PDF certificate
+   */
+  const preparePdfCertificate = async (updatedEvent: EventDocument) => {
     const { declaration: updatedDeclaration, ...updatedMetadata } =
       getCurrentEventState(updatedEvent, eventConfiguration)
     const declarationWithResolvedImages = await replaceMinioUrlWithBase64(
@@ -133,11 +140,11 @@ export const usePrintableCertificate = ({
       certificateFonts
     )
 
-    printAndDownloadPdf(pdfTemplate, event.id)
+    return () => printAndDownloadPdf(pdfTemplate, event.id)
   }
 
   return {
     svgCode,
-    handleCertify
+    preparePdfCertificate
   }
 }

--- a/packages/commons/src/documents.ts
+++ b/packages/commons/src/documents.ts
@@ -24,17 +24,17 @@ export function isBase64FileString(str: string) {
   return strSplit.length > 0 && strSplit[0] === 'data'
 }
 
-export const isMinioUrl = (url: string): url is FullDocumentURL =>
+export const isMinioUrl = (url: string): url is FullDocumentUrl =>
   MINIO_REGEX.test(url)
 
-export const FullDocumentURL = z
+export const FullDocumentUrl = z
   .string()
-  .brand('FullDocumentURL')
+  .brand('FullDocumentUrl')
   .describe(
     'A full url with protocol, host, bucket name, starting from the root of the S3 server, https://minio/bucket-name/document-id.jpg'
   )
 
-export type FullDocumentURL = z.infer<typeof FullDocumentURL>
+export type FullDocumentUrl = z.infer<typeof FullDocumentUrl>
 
 export const FullDocumentPath = z
   .string()

--- a/packages/commons/src/events/state/index.ts
+++ b/packages/commons/src/events/state/index.ts
@@ -29,7 +29,7 @@ import { UUID } from '../../uuid'
 import {
   DocumentPath,
   FullDocumentPath,
-  FullDocumentURL
+  FullDocumentUrl
 } from '../../documents'
 
 export function getStatusFromActions(actions: Array<Action>) {
@@ -138,7 +138,7 @@ type NonNullableDeep<T> = T extends [unknown, ...unknown[]] // <-- ✨ tiny chan
       ? T
       : T extends DocumentPath
         ? T
-        : T extends FullDocumentURL
+        : T extends FullDocumentUrl
           ? T
           : T extends (infer U)[]
             ? NonNullableDeep<U>[]


### PR DESCRIPTION
## Description
- Get certificate images before busting cache in order to render the images
- Ensure redirection works after printing
- Rename variables based on the syleguide convention

![printing](https://github.com/user-attachments/assets/fdeb9c88-a80f-4ea4-a6c2-0934ab26394c)

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
