### PR TITLE
fix: tweak email & name field analyzers in elasticsearch

### DIFF
--- a/packages/commons/src/conditionals/conditionals.test.ts
+++ b/packages/commons/src/conditionals/conditionals.test.ts
@@ -747,15 +747,15 @@ describe('"valid name" conditionals', () => {
       ).toBe(true)
     })
 
-    it('should pass when name contains an underscore', () => {
-      const validName = 'John_Doe'
+    it('should fail when name contains an underscore', () => {
+      const invalidName = 'John_Doe'
       const params = {
-        $form: { 'child.firstName': validName },
+        $form: { 'child.firstName': invalidName },
         $now: formatISO(new Date(), { representation: 'date' })
       }
       expect(
         validate(field('child.firstName').isValidEnglishName(), params)
-      ).toBe(true)
+      ).toBe(false)
     })
 
     it('should pass when name contains a number', () => {

--- a/packages/commons/src/conditionals/conditionals.ts
+++ b/packages/commons/src/conditionals/conditionals.ts
@@ -382,9 +382,9 @@ export function createFieldConditionals(fieldId: string) {
           [fieldId]: {
             type: 'string',
             pattern:
-              "^[\\p{Script=Latin}0-9'._-]*(\\([\\p{Script=Latin}0-9'._-]+\\))?[\\p{Script=Latin}0-9'._-]*( [\\p{Script=Latin}0-9'._-]*(\\([\\p{Script=Latin}0-9'._-]+\\))?[\\p{Script=Latin}0-9'._-]*)*$",
+              "^[\\p{Script=Latin}0-9'.-]*(\\([\\p{Script=Latin}0-9'.-]+\\))?[\\p{Script=Latin}0-9'.-]*( [\\p{Script=Latin}0-9'.-]*(\\([\\p{Script=Latin}0-9'.-]+\\))?[\\p{Script=Latin}0-9'.-]*)*$",
             description:
-              "Name must contain only letters, numbers, and allowed special characters ('._-). No double spaces."
+              "Name must contain only letters, numbers, and allowed special characters ('.-). No double spaces."
           }
         }
       }),

--- a/packages/events/src/router/event/event.search.test.ts
+++ b/packages/events/src/router/event/event.search.test.ts
@@ -496,7 +496,7 @@ test.skip('Returns events that match the name field criteria of applicant', asyn
   expect(fetchedEvents).toHaveLength(2)
 })
 
-test('properly returns search by name even when there is an undercore in someones name', async () => {
+test('Should not match partially when searching with emails against name field', async () => {
   const { user, generator } = await setupTestCase()
   const client = createTestClient(user, [
     'search[event=tennis-club-membership,access=all]',
@@ -506,7 +506,7 @@ test('properly returns search by name even when there is an undercore in someone
 
   const record1 = {
     'applicant.name': {
-      firstname: 'Matt_Johnson',
+      firstname: 'Matt',
       surname: 'Doe'
     },
     'applicant.dob': '2000-01-01',
@@ -531,14 +531,16 @@ test('properly returns search by name even when there is an undercore in someone
 
   const fetchedEvents = await client.event.search({
     type: 'and',
-    clauses: [{ data: { 'applicant.name': { type: 'fuzzy', term: 'Matt' } } }]
+    clauses: [
+      {
+        data: {
+          'applicant.name': { type: 'fuzzy', term: 'matt.doe@gmail.com' }
+        }
+      }
+    ]
   })
 
-  expect(fetchedEvents).toHaveLength(1)
-
-  expect(
-    getMixedPath(fetchedEvents[0].declaration, 'applicant.name.firstname')
-  ).toBe('Matt_Johnson')
+  expect(fetchedEvents).toHaveLength(0)
 })
 test('Returns events that match date of birth of applicant', async () => {
   const { user, generator } = await setupTestCase()

--- a/packages/events/src/service/indexing/indexing.ts
+++ b/packages/events/src/service/indexing/indexing.ts
@@ -143,9 +143,9 @@ function mapFieldTypeToElasticsearch(field: FieldConfig) {
       return {
         type: 'object',
         properties: {
-          firstname: { type: 'text', analyzer: 'human_name' },
-          surname: { type: 'text', analyzer: 'human_name' },
-          __fullname: { type: 'text', analyzer: 'human_name' }
+          firstname: { type: 'text', analyzer: 'classic' },
+          surname: { type: 'text', analyzer: 'classic' },
+          __fullname: { type: 'text', analyzer: 'classic' }
         }
       }
     case FieldType.FILE_WITH_OPTIONS:
@@ -194,22 +194,6 @@ export async function createIndex(
   await client.indices.create({
     index: indexName,
     body: {
-      // Define a custom normalizer to make keyword fields case-insensitive by applying a lowercase filter
-      settings: {
-        analysis: {
-          analyzer: {
-            /*
-             * Human name can contain
-             * Special characters including hyphens, underscores and spaces
-             */
-            human_name: {
-              type: 'custom',
-              tokenizer: 'standard',
-              filter: ['lowercase', 'word_delimiter']
-            }
-          }
-        }
-      },
       mappings: {
         properties: {
           id: { type: 'keyword' },

--- a/packages/events/src/service/indexing/indexing.ts
+++ b/packages/events/src/service/indexing/indexing.ts
@@ -87,8 +87,7 @@ function mapFieldTypeToElasticsearch(field: FieldConfig) {
     case FieldType.EMAIL:
       return {
         type: 'keyword',
-        // apply custom normalyzer
-        normalizer: 'lowercase_normalizer'
+        normalizer: 'lowercase'
       }
     case FieldType.DIVIDER:
     case FieldType.RADIO_GROUP:
@@ -198,12 +197,6 @@ export async function createIndex(
       // Define a custom normalizer to make keyword fields case-insensitive by applying a lowercase filter
       settings: {
         analysis: {
-          normalizer: {
-            lowercase_normalizer: {
-              type: 'custom',
-              filter: ['lowercase']
-            }
-          },
           analyzer: {
             /*
              * Human name can contain


### PR DESCRIPTION
## Description

- The custom normalizer used for email fields is equivalent to the built-in `lowercase` normalizer
- Remove `_` from the list of allowed characters in names
- Switching to the `classic` analyzer from the custom `human_name` analyzer as the `word_delimiter` filter was causing more issues than it solved. The classic tokenizer is a grammar based tokenizer that is good for English language documents. This tokenizer has heuristics for special treatment of acronyms, company names, email addresses, and internet host names.

This PR addresses both #10018 & #10041 

https://github.com/opencrvs/opencrvs-countryconfig/pull/911

N.B.: This fix requires a reset of environment.

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
