### PR TITLE
[OCRVS-10125] Only fetch workqueues when online

### DIFF
--- a/packages/client/src/v2-events/hooks/useWorkqueue.ts
+++ b/packages/client/src/v2-events/hooks/useWorkqueue.ts
@@ -65,7 +65,7 @@ export const useWorkqueue = (workqueueSlug: string) => {
       return {
         useSuspenseQuery: () =>
           searchEvent.useSuspenseQuery(deserializedQuery, {
-            networkMode: 'always'
+            networkMode: 'offlineFirst'
           }),
         useQuery: () => searchEvent.useQuery(deserializedQuery)
       }


### PR DESCRIPTION
## Description

This bug was caused by workqueue initialising a HTTP request even when the browser was offline.
I changed the fetching logic so it primarily tries to use 

A way to reproduce the bug was for instance
1. Start a new declaration and go offline
2.  `["event", "search"]` delete queries prefixed like this. These are the workqueue searches
3. Submit a declaration
4. App should now crash

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [x] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
