### PR TITLE
chore: prevent console from getting cleared

### DIFF
--- a/packages/commons/package.json
+++ b/packages/commons/package.json
@@ -26,7 +26,7 @@
     "build:default": "tsc --project tsconfig.build.json",
     "build:esm": "tsc --project tsconfig.esm.build.json",
     "build": "yarn build:default && yarn build:esm",
-    "build:watch": "concurrently \"tsc --watch --project tsconfig.build.json\" \"tsc --watch --project tsconfig.esm.build.json\"",
+    "build:watch": "concurrently \"tsc --watch --preserveWatchOutput --project tsconfig.build.json\" \"tsc --watch --preserveWatchOutput --project tsconfig.esm.build.json\"",
     "build:clean": "rm -rf build"
   },
   "private": true,

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "clean": "rimraf lib",
-    "start": "concurrently 'storybook dev --ci -p 6060' 'tsc -w'",
+    "start": "concurrently 'storybook dev --ci -p 6060' 'tsc -w --preserveWatchOutput'",
     "build": "yarn clean && tsc",
     "lint": "yarn lint:css",
     "test": "tsc",


### PR DESCRIPTION
Running tsc with watch clears output by default unless the preserveWatchOutput flag is provided.