### PR TITLE
[OCRVS-10005] Make name subfields require at least one character to be valid

### DIFF
--- a/packages/client/src/v2-events/features/events/actions/declare/Review.interaction.stories.tsx
+++ b/packages/client/src/v2-events/features/events/actions/declare/Review.interaction.stories.tsx
@@ -559,7 +559,6 @@ export const ReviewForIncompleteNameInteraction: Story = {
 
       const surnameInput = await canvas.findByTestId('text__surname')
       await userEvent.clear(surnameInput)
-      await userEvent.tab()
 
       const backToReviewButton = await canvas.findByText('Back to review')
       await userEvent.click(backToReviewButton)

--- a/packages/client/src/v2-events/features/events/actions/declare/Review.interaction.stories.tsx
+++ b/packages/client/src/v2-events/features/events/actions/declare/Review.interaction.stories.tsx
@@ -482,6 +482,92 @@ export const ReviewForFieldAgentIncompleteInteraction: Story = {
   }
 }
 
+export const ReviewForIncompleteNameInteraction: Story = {
+  name: 'Declaration shows as incomplete when surname is left out',
+  beforeEach: () => {
+    // For this test, we want to have empty form values in zustand state
+    useEventFormData.setState({ formValues: {} })
+  },
+  loaders: [
+    () => {
+      declarationTrpcMsw.events.reset()
+      declarationTrpcMsw.drafts.reset()
+    },
+    async () => {
+      window.localStorage.setItem('opencrvs', generator.user.token.fieldAgent)
+      //  Intermittent failures starts to happen when global state gets out of whack.
+      // // This is a workaround to ensure that the state is reset when similar tests are run in parallel.
+      await new Promise((resolve) => setTimeout(resolve, 50))
+    }
+  ],
+  parameters: {
+    reactRouter: {
+      router: routesConfig,
+      initialPath: ROUTES.V2.EVENTS.DECLARE.REVIEW.buildPath({
+        eventId: declareEventDocument.id
+      })
+    },
+    chromatic: { disableSnapshot: true },
+    msw: {
+      handlers: {
+        drafts: declarationTrpcMsw.drafts.handlers,
+        events: [
+          tRPCMsw.event.search.query((input) => {
+            return [
+              getCurrentEventState(
+                declarationTrpcMsw.eventDocument,
+                tennisClubMembershipEvent
+              )
+            ]
+          }),
+          ...declarationTrpcMsw.events.handlers
+        ],
+        user: [
+          graphql.query('fetchUser', () => {
+            return HttpResponse.json({
+              data: {
+                getUser: generator.user.registrationAgent()
+              }
+            })
+          }),
+          tRPCMsw.user.list.query(([id]) => {
+            return [mockUser]
+          }),
+          tRPCMsw.user.get.query((id) => {
+            return mockUser
+          })
+        ]
+      }
+    }
+  },
+  play: async ({ canvasElement, step }) => {
+    await step('Modal has scope based content', async () => {
+      const canvas = within(canvasElement)
+      const changeButton = await canvas.findByTestId(
+        'change-button-applicant.name',
+        {},
+        { timeout: 5000 }
+      )
+      await userEvent.click(changeButton)
+      const modal = within(await canvas.findByRole('dialog'))
+
+      const confirmEditButton = await modal.findByRole('button', {
+        name: 'Continue'
+      })
+
+      await userEvent.click(confirmEditButton)
+
+      const surnameInput = await canvas.findByTestId('text__surname')
+      await userEvent.clear(surnameInput)
+      await userEvent.tab()
+
+      const backToReviewButton = await canvas.findByText('Back to review')
+      await userEvent.click(backToReviewButton)
+      await canvas.findByText('Declaration incomplete')
+    })
+  }
+}
+
 export const ChangeFieldInReview: Story = {
   beforeEach: () => {
     /*

--- a/packages/client/src/v2-events/features/events/actions/declare/Review.interaction.stories.tsx
+++ b/packages/client/src/v2-events/features/events/actions/declare/Review.interaction.stories.tsx
@@ -193,6 +193,38 @@ export const ReviewForLocalRegistrarCompleteInteraction: Story = {
   }
 }
 
+const msw = {
+  handlers: {
+    drafts: declarationTrpcMsw.drafts.handlers,
+    events: [
+      tRPCMsw.event.search.query((input) => {
+        return [
+          getCurrentEventState(
+            declarationTrpcMsw.eventDocument,
+            tennisClubMembershipEvent
+          )
+        ]
+      }),
+      ...declarationTrpcMsw.events.handlers
+    ],
+    user: [
+      graphql.query('fetchUser', () => {
+        return HttpResponse.json({
+          data: {
+            getUser: generator.user.registrationAgent()
+          }
+        })
+      }),
+      tRPCMsw.user.list.query(([id]) => {
+        return [mockUser]
+      }),
+      tRPCMsw.user.get.query((id) => {
+        return mockUser
+      })
+    ]
+  }
+}
+
 export const ReviewForRegistrationAgentCompleteInteraction: Story = {
   loaders: [
     () => {
@@ -217,37 +249,7 @@ export const ReviewForRegistrationAgentCompleteInteraction: Story = {
       })
     },
     chromatic: { disableSnapshot: true },
-    msw: {
-      handlers: {
-        drafts: declarationTrpcMsw.drafts.handlers,
-        events: [
-          tRPCMsw.event.search.query((input) => {
-            return [
-              getCurrentEventState(
-                declarationTrpcMsw.eventDocument,
-                tennisClubMembershipEvent
-              )
-            ]
-          }),
-          ...declarationTrpcMsw.events.handlers
-        ],
-        user: [
-          graphql.query('fetchUser', () => {
-            return HttpResponse.json({
-              data: {
-                getUser: generator.user.registrationAgent()
-              }
-            })
-          }),
-          tRPCMsw.user.list.query(([id]) => {
-            return [mockUser]
-          }),
-          tRPCMsw.user.get.query((id) => {
-            return mockUser
-          })
-        ]
-      }
-    }
+    msw: msw
   },
   play: async ({ canvasElement, step }) => {
     await step('Modal has scope based content', async () => {
@@ -304,37 +306,7 @@ export const ReviewForFieldAgentCompleteInteraction: Story = {
       })
     },
     chromatic: { disableSnapshot: true },
-    msw: {
-      handlers: {
-        drafts: declarationTrpcMsw.drafts.handlers,
-        events: [
-          tRPCMsw.event.search.query((input) => {
-            return [
-              getCurrentEventState(
-                declarationTrpcMsw.eventDocument,
-                tennisClubMembershipEvent
-              )
-            ]
-          }),
-          ...declarationTrpcMsw.events.handlers
-        ],
-        user: [
-          graphql.query('fetchUser', () => {
-            return HttpResponse.json({
-              data: {
-                getUser: generator.user.registrationAgent()
-              }
-            })
-          }),
-          tRPCMsw.user.list.query(([id]) => {
-            return [mockUser]
-          }),
-          tRPCMsw.user.get.query((id) => {
-            return mockUser
-          })
-        ]
-      }
-    }
+    msw: msw
   },
   play: async ({ canvasElement, step }) => {
     await step('Modal has scope based content', async () => {
@@ -508,37 +480,7 @@ export const ReviewForIncompleteNameInteraction: Story = {
       })
     },
     chromatic: { disableSnapshot: true },
-    msw: {
-      handlers: {
-        drafts: declarationTrpcMsw.drafts.handlers,
-        events: [
-          tRPCMsw.event.search.query((input) => {
-            return [
-              getCurrentEventState(
-                declarationTrpcMsw.eventDocument,
-                tennisClubMembershipEvent
-              )
-            ]
-          }),
-          ...declarationTrpcMsw.events.handlers
-        ],
-        user: [
-          graphql.query('fetchUser', () => {
-            return HttpResponse.json({
-              data: {
-                getUser: generator.user.registrationAgent()
-              }
-            })
-          }),
-          tRPCMsw.user.list.query(([id]) => {
-            return [mockUser]
-          }),
-          tRPCMsw.user.get.query((id) => {
-            return mockUser
-          })
-        ]
-      }
-    }
+    msw: msw
   },
   play: async ({ canvasElement, step }) => {
     await step('Modal has scope based content', async () => {

--- a/packages/commons/src/events/CompositeFieldValue.ts
+++ b/packages/commons/src/events/CompositeFieldValue.ts
@@ -64,8 +64,8 @@ export const UrbanAddressUpdateValue = AdminStructure.extend({
 })
 
 export const NameFieldValue = z.object({
-  firstname: z.string(),
-  surname: z.string(),
+  firstname: z.string().min(1),
+  surname: z.string().min(1),
   middlename: z.string().optional()
 })
 


### PR DESCRIPTION
## Description

An empty field inside `NAME` never triggered an error because:
1. Zod type allowed for empty strings
2. The component itself can emit empty string values i.e. `{firstname: 'Riku', surname: ''}`
3. `validEnglishName` validation doesn't require any length for the string

I opted for fixing the first one because configuring a name field with `required: true` but without supplying a custom validator should be a valid configuration. This rules out fixing number 3.  Another option would have been making the NAME component so it never emits empty strings but it would imply the caller of the component cannot know if a user just emptied out the input vs if it was never touched.

```
{
  id: 'applicant.name',
  type: FieldType.NAME,
  required: true
}
```

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
