### PR TITLE
[OCRVS-10151] Ensure form state is not cleared without explicit user action

### DIFF
--- a/packages/client/src/v2-events/features/drafts/useDrafts.ts
+++ b/packages/client/src/v2-events/features/drafts/useDrafts.ts
@@ -77,7 +77,7 @@ interface DraftStore {
   getLocalDraftOrDefault: (draft: Draft) => Draft
 }
 
-const localDraftStore = create<DraftStore>()(
+export const localDraftStore = create<DraftStore>()(
   persist(
     (set, get) => ({
       draft: null,

--- a/packages/client/src/v2-events/features/events/EventSelection.tsx
+++ b/packages/client/src/v2-events/features/events/EventSelection.tsx
@@ -150,7 +150,7 @@ function EventSelector() {
 
 function EventSelection() {
   const intl = useIntl()
-  const { goToHome } = useEventFormNavigation()
+  const { closeActionView } = useEventFormNavigation()
 
   return (
     <Frame
@@ -162,7 +162,7 @@ function EventSelection() {
               id="goBack"
               size="small"
               type="secondary"
-              onClick={goToHome}
+              onClick={() => closeActionView()}
             >
               <Icon name="X" />
               {intl.formatMessage(messages.exitButton)}
@@ -171,7 +171,7 @@ function EventSelection() {
           desktopTitle={intl.formatMessage(messages.registerNewEventTitle)}
           mobileLeft={<Icon name="Draft" size="large" />}
           mobileRight={
-            <Button size="medium" type="icon" onClick={goToHome}>
+            <Button size="medium" type="icon" onClick={() => closeActionView()}>
               <Icon name="X" />
             </Button>
           }

--- a/packages/client/src/v2-events/features/events/actions/correct/request/Summary/Summary.tsx
+++ b/packages/client/src/v2-events/features/events/actions/correct/request/Summary/Summary.tsx
@@ -194,7 +194,7 @@ export function Summary() {
       transactionId: generateTransactionId(),
       annotation: annotationForm
     })
-    eventFormNavigation.goToHome()
+    eventFormNavigation.closeActionView()
   }, [
     form,
     fields,
@@ -226,7 +226,7 @@ export function Summary() {
       <ActionPageLight
         hideBackground
         goBack={() => navigate(-1)}
-        goHome={() => eventFormNavigation.goToHome()}
+        goHome={() => eventFormNavigation.closeActionView()}
         id="corrector_form"
         title={intl.formatMessage(correctionMessages.title)}
       >

--- a/packages/client/src/v2-events/features/events/actions/declare/Pages.interaction.stories.tsx
+++ b/packages/client/src/v2-events/features/events/actions/declare/Pages.interaction.stories.tsx
@@ -362,6 +362,9 @@ export const FilledPagesVisibleInReview: Story = {
         event: [
           tRPCMsw.event.get.query(() => {
             return undeclaredDraftEvent
+          }),
+          tRPCMsw.event.search.query((input) => {
+            return []
           })
         ]
       }

--- a/packages/client/src/v2-events/features/events/actions/declare/Pages.interaction.stories.tsx
+++ b/packages/client/src/v2-events/features/events/actions/declare/Pages.interaction.stories.tsx
@@ -21,10 +21,12 @@ import {
   tennisClubMembershipEvent,
   UUID
 } from '@opencrvs/commons/client'
-import { AppRouter, trpcOptionsProxy } from '@client/v2-events/trpc'
+import { AppRouter } from '@client/v2-events/trpc'
 import { ROUTES, routesConfig } from '@client/v2-events/routes'
 import { tennisClubMembershipEventDocument } from '@client/v2-events/features/events/fixtures'
+import { localDraftStore } from '@client/v2-events/features/drafts/useDrafts'
 import { useEventFormData } from '../../useEventFormData'
+import { useActionAnnotation } from '../../useActionAnnotation'
 import { Pages } from './index'
 
 // Use an undeclared draft event for tests
@@ -44,6 +46,8 @@ const meta: Meta<typeof Pages> = {
   },
   beforeEach: () => {
     useEventFormData.setState({ formValues: {} })
+    useActionAnnotation.setState({})
+    localDraftStore.getState().setDraft(null)
   }
 }
 

--- a/packages/client/src/v2-events/features/events/actions/declare/Pages.tsx
+++ b/packages/client/src/v2-events/features/events/actions/declare/Pages.tsx
@@ -37,7 +37,7 @@ export function Pages() {
   const events = useEvents()
   const navigate = useNavigate()
   const drafts = useDrafts()
-  const { modal, redirectToOrigin } = useEventFormNavigation()
+  const { modal, closeActionView } = useEventFormNavigation()
   const { saveAndExitModal, handleSaveAndExit } = useSaveAndExitModal()
   const { getFormValues, setFormValues } = useEventFormData()
   const formValues = getFormValues()
@@ -97,7 +97,7 @@ export function Pages() {
       onSaveAndExit={async () =>
         handleSaveAndExit(() => {
           drafts.submitLocalDraft()
-          redirectToOrigin(searchParams.workqueue)
+          closeActionView(searchParams.workqueue)
         })
       }
     >

--- a/packages/client/src/v2-events/features/events/actions/declare/Review.tsx
+++ b/packages/client/src/v2-events/features/events/actions/declare/Review.tsx
@@ -56,7 +56,7 @@ export function Review() {
   const navigate = useNavigate()
   const [modal, openModal] = useModal()
   const { formatMessage } = useIntlFormatMessageWithFlattenedParams()
-  const { redirectToOrigin } = useEventFormNavigation()
+  const { closeActionView } = useEventFormNavigation()
   const { saveAndExitModal, handleSaveAndExit } = useSaveAndExitModal()
 
   const event = events.getEvent.getFromCache(eventId)
@@ -138,7 +138,7 @@ export function Review() {
 
     if (confirmedDeclaration) {
       reviewActionConfiguration.onConfirm(eventId)
-      redirectToOrigin(slug)
+      closeActionView(slug)
     }
   }
 
@@ -168,7 +168,7 @@ export function Review() {
           reason: { message, isDuplicate }
         })
       }
-      redirectToOrigin(slug)
+      closeActionView(slug)
     }
   }
 
@@ -178,7 +178,7 @@ export function Review() {
       onSaveAndExit={async () =>
         handleSaveAndExit(() => {
           drafts.submitLocalDraft()
-          redirectToOrigin(slug)
+          closeActionView(slug)
         })
       }
     >

--- a/packages/client/src/v2-events/features/events/actions/register/Pages.tsx
+++ b/packages/client/src/v2-events/features/events/actions/register/Pages.tsx
@@ -41,7 +41,7 @@ export function Pages() {
   const { saveAndExitModal, handleSaveAndExit } = useSaveAndExitModal()
   const navigate = useNavigate()
   const drafts = useDrafts()
-  const { modal, redirectToOrigin } = useEventFormNavigation()
+  const { modal, closeActionView } = useEventFormNavigation()
   const event = events.getEvent.getFromCache(eventId)
   const { eventConfiguration: configuration } = useEventConfiguration(
     event.type
@@ -74,7 +74,7 @@ export function Pages() {
       onSaveAndExit={async () =>
         handleSaveAndExit(() => {
           drafts.submitLocalDraft()
-          redirectToOrigin(searchParams.workqueue)
+          closeActionView(searchParams.workqueue)
         })
       }
     >

--- a/packages/client/src/v2-events/features/events/actions/register/Review.tsx
+++ b/packages/client/src/v2-events/features/events/actions/register/Review.tsx
@@ -63,7 +63,7 @@ export function Review() {
   const drafts = useDrafts()
   const [modal, openModal] = useModal()
   const navigate = useNavigate()
-  const { redirectToOrigin } = useEventFormNavigation()
+  const { closeActionView: closeActionView } = useEventFormNavigation()
   const { saveAndExitModal, handleSaveAndExit } = useSaveAndExitModal()
   const { formatMessage } = useIntlFormatMessageWithFlattenedParams()
 
@@ -153,7 +153,7 @@ export function Review() {
         transactionId: uuid(),
         annotation
       })
-      redirectToOrigin(slug)
+      closeActionView(slug)
     }
   }
 
@@ -184,7 +184,7 @@ export function Review() {
         })
       }
 
-      redirectToOrigin(slug)
+      closeActionView(slug)
     }
   }
 
@@ -194,7 +194,7 @@ export function Review() {
       onSaveAndExit={async () =>
         handleSaveAndExit(() => {
           drafts.submitLocalDraft()
-          redirectToOrigin(slug)
+          closeActionView(slug)
         })
       }
     >

--- a/packages/client/src/v2-events/features/events/actions/validate/Pages.tsx
+++ b/packages/client/src/v2-events/features/events/actions/validate/Pages.tsx
@@ -41,7 +41,7 @@ export function Pages() {
   const { formValues: form } = useSubscribeEventFormData()
   const navigate = useNavigate()
   const drafts = useDrafts()
-  const { modal, redirectToOrigin } = useEventFormNavigation()
+  const { modal, closeActionView } = useEventFormNavigation()
   const { saveAndExitModal, handleSaveAndExit } = useSaveAndExitModal()
 
   const event = events.getEvent.getFromCache(eventId)
@@ -76,7 +76,7 @@ export function Pages() {
       onSaveAndExit={async () =>
         handleSaveAndExit(() => {
           drafts.submitLocalDraft()
-          redirectToOrigin(searchParams.workqueue)
+          closeActionView(searchParams.workqueue)
         })
       }
     >

--- a/packages/client/src/v2-events/features/events/actions/validate/Review.tsx
+++ b/packages/client/src/v2-events/features/events/actions/validate/Review.tsx
@@ -58,7 +58,7 @@ export function Review() {
   const drafts = useDrafts()
   const [modal, openModal] = useModal()
   const navigate = useNavigate()
-  const { redirectToOrigin } = useEventFormNavigation()
+  const { closeActionView } = useEventFormNavigation()
 
   const event = events.getEvent.findFromCache(eventId).data
 
@@ -164,7 +164,7 @@ export function Review() {
 
     if (confirmedValidation) {
       reviewActionConfiguration.onConfirm(eventId)
-      redirectToOrigin(slug)
+      closeActionView(slug)
     }
   }
 
@@ -194,7 +194,7 @@ export function Review() {
           reason: { message, isDuplicate }
         })
       }
-      redirectToOrigin(slug)
+      closeActionView(slug)
     }
   }
 
@@ -204,7 +204,7 @@ export function Review() {
       onSaveAndExit={async () =>
         handleSaveAndExit(() => {
           drafts.submitLocalDraft()
-          redirectToOrigin(slug)
+          closeActionView(slug)
         })
       }
     >

--- a/packages/client/src/v2-events/features/events/components/Action/AnnotationAction.tsx
+++ b/packages/client/src/v2-events/features/events/components/Action/AnnotationAction.tsx
@@ -114,15 +114,6 @@ function AnnotationActionComponent({ children, actionType }: Props) {
 
     setAnnotation(initialAnnotation)
 
-    return () => {
-      /*
-       * When user leaves the action, remove all
-       * staged drafts the user has for this event id and type
-       */
-      setLocalDraft(null)
-      clearAnnotation()
-    }
-
     /*
      * This is fine to only run once on mount and unmount as
      * At the point of this code being run, there absolutely must be an event that has already been

--- a/packages/client/src/v2-events/features/events/components/Action/DeclarationAction.tsx
+++ b/packages/client/src/v2-events/features/events/components/Action/DeclarationAction.tsx
@@ -229,16 +229,6 @@ function DeclarationActionComponent({ children, actionType }: Props) {
 
     setAnnotation(initialAnnotation)
 
-    return () => {
-      /*
-       * When user leaves the action, remove all
-       * staged drafts the user has for this event id and type
-       */
-      setLocalDraft(null)
-      clearForm()
-      clearAnnotation()
-    }
-
     /*
      * This is fine to only run once on mount and unmount as
      * At the point of this code being run, there absolutely must be an event that has already been

--- a/packages/client/src/v2-events/features/events/useEventFormData.ts
+++ b/packages/client/src/v2-events/features/events/useEventFormData.ts
@@ -43,22 +43,31 @@ function removeUndefinedKeys(data: EventState) {
  * @property {function} getTouchedFields - Retrieves the fields that have been touched.
  * @property {function} clear - Clears the form values.
  */
-export const useEventFormData = create<EventFormData>()((set, get) => ({
-  formValues: {},
-  touchedFields: {},
-  getFormValues: (initialValues?: EventState) =>
-    get().formValues || initialValues || {},
-  setFormValues: (form: EventState) => {
-    const formValues = removeUndefinedKeys(form)
-    return set(() => ({ formValues }))
-  },
-  setAllTouchedFields: (fields) => set(() => ({ touchedFields: fields })),
-  getTouchedFields: () =>
-    Object.fromEntries(
-      Object.entries(get().getFormValues()).map(([key]) => [key, true])
-    ),
-  clear: () => set(() => ({ formValues: {}, touchedFields: {} }))
-}))
+export const useEventFormData = create<EventFormData>()((set, get) => {
+  return {
+    formValues: {},
+    touchedFields: {},
+
+    getFormValues: (initialValues?: EventState) =>
+      get().formValues || initialValues || {},
+
+    setFormValues: (form: EventState) => {
+      const formValues = removeUndefinedKeys(form)
+      return set(() => ({ formValues }))
+    },
+
+    setAllTouchedFields: (fields) => set(() => ({ touchedFields: fields })),
+
+    getTouchedFields: () =>
+      Object.fromEntries(
+        Object.entries(get().getFormValues()).map(([key]) => [key, true])
+      ),
+
+    clear: () => {
+      set(() => ({ formValues: {}, touchedFields: {} }))
+    }
+  }
+})
 /**
  * Based on https://github.com/pmndrs/zustand?tab=readme-ov-file#transient-updates-for-often-occurring-state-changes
  *

--- a/packages/client/src/v2-events/features/events/useEventFormNavigation.tsx
+++ b/packages/client/src/v2-events/features/events/useEventFormNavigation.tsx
@@ -17,6 +17,8 @@ import { ROUTES } from '@client/v2-events/routes'
 import { useModal } from '@client/v2-events/hooks/useModal'
 import { useDrafts } from '@client/v2-events/features/drafts/useDrafts'
 import { useEvents } from './useEvents/useEvents'
+import { useEventFormData } from './useEventFormData'
+import { useActionAnnotation } from './useActionAnnotation'
 
 const modalMessages = defineMessages({
   cancel: {
@@ -57,6 +59,10 @@ export function useEventFormNavigation() {
   const remoteDrafts = getAllRemoteDrafts()
   const deleteEvent = events.deleteEvent.useMutation()
 
+  const { setLocalDraft } = useDrafts()
+  const clearForm = useEventFormData((state) => state.clear)
+  const clearAnnotation = useActionAnnotation((state) => state.clear)
+
   const [modal, openModal] = useModal()
 
   function goToHome() {
@@ -65,6 +71,22 @@ export function useEventFormNavigation() {
 
   function goToWorkqueue(slug: string) {
     navigate(ROUTES.V2.WORKQUEUES.WORKQUEUE.buildPath({ slug }))
+  }
+
+  function clearEphemeralFormState() {
+    setLocalDraft(null)
+    clearForm()
+    clearAnnotation()
+  }
+
+  function createNewDeclaration() {
+    clearEphemeralFormState()
+    navigate(ROUTES.V2.EVENTS.CREATE.path)
+  }
+
+  function closeActionView(workqueueToGoBackTo?: string) {
+    workqueueToGoBackTo ? goToWorkqueue(workqueueToGoBackTo) : goToHome()
+    clearEphemeralFormState()
   }
 
   async function exit(event: EventIndex) {
@@ -114,7 +136,7 @@ export function useEventFormNavigation() {
       deleteEvent.mutate({ eventId: event.id })
     }
 
-    goToHome()
+    closeActionView()
   }
 
   async function deleteDeclaration(eventId: string) {
@@ -162,15 +184,12 @@ export function useEventFormNavigation() {
     }
   }
 
-  function redirectToOrigin(slug?: string) {
-    slug ? goToWorkqueue(slug) : goToHome()
-  }
-
   return {
     exit,
     modal,
     goToHome,
+    createNewDeclaration,
     deleteDeclaration,
-    redirectToOrigin
+    closeActionView
   }
 }

--- a/packages/client/src/v2-events/features/events/useEventFormNavigation.tsx
+++ b/packages/client/src/v2-events/features/events/useEventFormNavigation.tsx
@@ -180,14 +180,13 @@ export function useEventFormNavigation() {
 
     if (deleteConfirm) {
       deleteEvent.mutate({ eventId })
-      goToHome()
+      closeActionView()
     }
   }
 
   return {
     exit,
     modal,
-    goToHome,
     createNewDeclaration,
     deleteDeclaration,
     closeActionView

--- a/packages/client/src/v2-events/layouts/form/FormHeader.tsx
+++ b/packages/client/src/v2-events/layouts/form/FormHeader.tsx
@@ -45,7 +45,8 @@ export function FormHeader({
   appbarIcon?: React.ReactNode
 }) {
   const intl = useIntl()
-  const { modal, exit, goToHome, deleteDeclaration } = useEventFormNavigation()
+  const { modal, exit, closeActionView, deleteDeclaration } =
+    useEventFormNavigation()
 
   const { eventId } = useTypedParams(route)
 
@@ -124,7 +125,7 @@ export function FormHeader({
               data-testid="exit-button"
               size="small"
               type="icon"
-              onClick={goToHome}
+              onClick={() => closeActionView()}
             >
               <Icon name="X" />
             </Button>
@@ -169,7 +170,7 @@ export function FormHeader({
               />
             </>
           ) : (
-            <Button size="small" type="icon" onClick={goToHome}>
+            <Button size="small" type="icon" onClick={() => closeActionView()}>
               <Icon name="X" />
             </Button>
           )}

--- a/packages/client/src/v2-events/layouts/workqueues/index.tsx
+++ b/packages/client/src/v2-events/layouts/workqueues/index.tsx
@@ -20,19 +20,19 @@ import { ProfileMenu } from '@client/components/ProfileMenu'
 import { useWorkqueueConfigurations } from '@client/v2-events/features/events/useWorkqueueConfiguration'
 import { advancedSearchMessages } from '@client/v2-events/features/events/Search/AdvancedSearch'
 import { SearchToolbar } from '@client/v2-events/features/events/components/SearchToolbar'
+import { useEventFormNavigation } from '@client/v2-events/features/events/useEventFormNavigation'
 import { Hamburger } from '../sidebar/Hamburger'
 import { Sidebar } from '../sidebar/Sidebar'
 
 export function DesktopCenter() {
-  const navigate = useNavigate()
+  const { createNewDeclaration } = useEventFormNavigation()
+
   return (
     <Stack gap={16}>
       <Button
         id="header-new-event"
         type="iconPrimary"
-        onClick={() => {
-          navigate(ROUTES.V2.EVENTS.CREATE.path)
-        }}
+        onClick={() => createNewDeclaration()}
       >
         <Plus />
       </Button>


### PR DESCRIPTION
## Description

Removes `unmount` based logic around when form state is cleared and replaces it with explicit function instead

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [x] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
