### PR TITLE
✨ Handle previous value lookup for fields sharing the same label in correction view

### DIFF
--- a/packages/client/src/v2-events/features/events/actions/correct/request/Summary/CorrectionDetails.tsx
+++ b/packages/client/src/v2-events/features/events/actions/correct/request/Summary/CorrectionDetails.tsx
@@ -305,7 +305,9 @@ export function CorrectionDetails({
             const originalOutput = Output({
               field: f,
               value: previousFormValues[f.id],
-              showPreviouslyMissingValuesAsChanged: false
+              showPreviouslyMissingValuesAsChanged: false,
+              previousForm: previousFormValues,
+              formConfig
             })
 
             const correctionOutput = Output({

--- a/packages/client/src/v2-events/features/events/components/Output.tsx
+++ b/packages/client/src/v2-events/features/events/components/Output.tsx
@@ -263,6 +263,7 @@ export function Output({
     // will be visible while the previous value is hidden due to conditionals.
     // When comparing to a previous form, check all fields with the same label and compare
     // their values to detect changes, even if the active field ID is different.
+    // IMPROVEMENT TODO: https://github.com/opencrvs/opencrvs-core/issues/10206
     const previousValueWithSameLabel = findPreviousValueWithSameLabel(
       field,
       previousForm,

--- a/packages/client/src/v2-events/features/events/components/Review.tsx
+++ b/packages/client/src/v2-events/features/events/components/Review.tsx
@@ -308,11 +308,14 @@ function FormReview({
               const value = form[field.id]
               const previousValue = previousForm[field.id]
 
+              // previousForm, formConfig are used to find previous values with the same label if required
               const valueDisplay = Output({
                 field,
                 previousValue,
                 showPreviouslyMissingValuesAsChanged,
-                value
+                value,
+                previousForm,
+                formConfig
               })
 
               const error = runFieldValidations({

--- a/packages/commons/src/conditionals/validate.ts
+++ b/packages/commons/src/conditionals/validate.ts
@@ -170,6 +170,18 @@ export function isFieldVisible(
   return isFieldConditionMet(field, form, ConditionalType.SHOW)
 }
 
+export function getOnlyVisibleFormValues(
+  field: FieldConfig[],
+  form: EventState
+) {
+  return field.reduce((acc, f) => {
+    if (isFieldVisible(f, form) && form[f.id] !== undefined) {
+      acc[f.id] = form[f.id]
+    }
+    return acc
+  }, {} as EventState)
+}
+
 function isFieldEmptyAndNotRequired(field: FieldConfig, form: ActionUpdate) {
   const fieldValue = form[field.id]
   return !field.required && (fieldValue === undefined || fieldValue === '')


### PR DESCRIPTION
## 📝 Overview

This PR fixes an issue in the correction workflow where multiple fields share the **same label** but have **different field IDs**.  
In correction view, only one such field is visible at a time due to conditionals, causing previous values under other IDs to be missed during comparison.

---

## 🐞 Problem

- Fields like `child.birthLocation` and `child.address.privateHome` share the same label **"Location of birth"** but have different IDs.
- In correction view, only one is visible; previous form data may have values under a different field ID with the same label.
- This leads to missing changes or inaccurate display of previous values.

---

## 🔧 Solution

- Added `findPreviousValueWithSameLabel()` to find previous values across all fields sharing the same label on the current page.
- Updated the `Output` component to fallback to this function if no direct previous value exists.
- Introduced `getOnlyVisibleFormValues()` utility to filter form data by visibility conditionals.
- Updated event state aggregation to include only visible fields for cleaner data handling.

---

## 🎯 Benefits

- ✅ Correction view correctly detects changes even if field IDs differ but labels match.
- ✅ Prevents hidden or missed previous values, enhancing user clarity.
- ✅ Keeps aggregated event state data clean and consistent by excluding hidden fields.

---

## 🧪 Testing

- Manual testing for correction scenarios with shared label fields.
- Verified existing validation and rendering remain intact.
- Recommended: add storybook tests for the solved scenario.

---


<img width="888" height="900" alt="1" src="https://github.com/user-attachments/assets/5e82a33a-f2f3-4385-be11-b3b56d555b2f" />
<img width="1014" height="896" alt="2" src="https://github.com/user-attachments/assets/15492794-c9b5-4699-adf6-8c4bb2e26b41" />

Issue: https://github.com/opencrvs/opencrvs-core/issues/10140
Farajaland e2e PR: https://github.com/opencrvs/opencrvs-farajaland/pull/1604

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
