### PR TITLE
feat: add event id as part of file path when possible

### DIFF
--- a/packages/client/src/v2-events/features/files/useFileUpload.ts
+++ b/packages/client/src/v2-events/features/files/useFileUpload.ts
@@ -32,7 +32,7 @@ interface UploadFileParams {
   file: File
   meta: {
     transactionId: string
-    eventId?: string
+    path?: string
     referenceId: string
   }
 }
@@ -45,8 +45,8 @@ async function uploadFile({
   formData.append('file', file)
   formData.append('transactionId', meta.transactionId)
 
-  if (meta.eventId) {
-    formData.append('eventId', meta.eventId)
+  if (meta.path) {
+    formData.append('path', meta.path)
   }
 
   const response = await fetch('/api/upload', {
@@ -167,13 +167,13 @@ export function useFileUpload(fieldId: string, options: Options = {}) {
 
   const upload = useMutation({
     mutationFn: async (variables: UploadFileParams) =>
-      uploadFile({ ...variables, meta: { ...variables.meta, eventId } }),
+      uploadFile({ ...variables, meta: { ...variables.meta, path: eventId } }),
     mutationKey: [UPLOAD_MUTATION_KEY, fieldId],
     onMutate: async ({ file, meta }) => {
       const extension = file.name.split('.').pop()
       const temporaryFilename = `${meta.transactionId}.${extension}`
       const filePathWithDirectory = joinValues(
-        [meta.eventId, temporaryFilename],
+        [meta.path, temporaryFilename],
         '/'
       )
       const path = getFullDocumentPath(filePathWithDirectory)
@@ -216,7 +216,7 @@ export function useFileUpload(fieldId: string, options: Options = {}) {
         meta: {
           transactionId: uuid(),
           referenceId,
-          eventId
+          path: eventId
         }
       })
     }

--- a/packages/client/src/v2-events/features/files/useFileUpload.ts
+++ b/packages/client/src/v2-events/features/files/useFileUpload.ts
@@ -11,7 +11,13 @@
 
 import { useMutation } from '@tanstack/react-query'
 import { v4 as uuid } from 'uuid'
-import { FullDocumentPath, joinUrlPaths } from '@opencrvs/commons/client'
+import { useParams } from 'react-router-dom'
+import {
+  DocumentPath,
+  FullDocumentPath,
+  joinUrlPaths,
+  joinValues
+} from '@opencrvs/commons/client'
 import { getToken } from '@client/utils/authUtils'
 import { queryClient } from '@client/v2-events/trpc'
 import {
@@ -22,17 +28,26 @@ import {
 } from '@client/v2-events/cache'
 import { fetchFileFromUrl } from '@client/utils/imageUtils'
 
+interface UploadFileParams {
+  file: File
+  meta: {
+    transactionId: string
+    eventId?: string
+    referenceId: string
+  }
+}
+
 async function uploadFile({
   file,
-  transactionId
-}: {
-  file: File
-  transactionId: string
-  id: string
-}): Promise<{ url: string }> {
+  meta
+}: UploadFileParams): Promise<{ url: string }> {
   const formData = new FormData()
   formData.append('file', file)
-  formData.append('transactionId', transactionId)
+  formData.append('transactionId', meta.transactionId)
+
+  if (meta.eventId) {
+    formData.append('eventId', meta.eventId)
+  }
 
   const response = await fetch('/api/upload', {
     method: 'POST',
@@ -145,22 +160,34 @@ interface Options {
 }
 
 export function useFileUpload(fieldId: string, options: Options = {}) {
+  // Introduce `eventId` to the params to allow uploading files related to a specific event.
+  // Main goal is to allow uploading files in the context of an event, which is helpful when we need to clean up orphans.
+  // Start with good enough: Components do not need to pass `eventId` explicitly, it is automatically derived from the URL params without forcing low-level components to know about events concept.
+  const { eventId } = useParams()
+
   const upload = useMutation({
-    mutationFn: uploadFile,
+    mutationFn: async (variables: UploadFileParams) =>
+      uploadFile({ ...variables, meta: { ...variables.meta, eventId } }),
     mutationKey: [UPLOAD_MUTATION_KEY, fieldId],
-    onMutate: async ({ file, transactionId, id }) => {
+    onMutate: async ({ file, meta }) => {
       const extension = file.name.split('.').pop()
-      const temporaryFilename = `${transactionId}.${extension}`
-      const path = getFullDocumentPath(temporaryFilename)
+      const temporaryFilename = `${meta.transactionId}.${extension}`
+      const filePathWithDirectory = joinValues(
+        [meta.eventId, temporaryFilename],
+        '/'
+      )
+      const path = getFullDocumentPath(filePathWithDirectory)
       const url = getUnsignedFileUrl(path)
       await cacheFile({ url, file })
 
+      // NOTE: In the long run, client should not reverse-engineer the file path.
+      // It should be read from the server response.
       options.onSuccess?.({
         ...file,
         originalFilename: file.name,
         type: file.type,
         path,
-        id
+        id: meta.referenceId
       })
     }
   })
@@ -181,13 +208,16 @@ export function useFileUpload(fieldId: string, options: Options = {}) {
      * Uploads a file with an optional identifier.
      *
      * @param file - The file to be uploaded.
-     * @param id An optional identifier for the file. Allows the caller to track the file when its upload completes.
+     * @param referenceId An optional identifier for the file. Allows the caller to track the file when its upload completes.
      */
-    uploadFile: (file: File, id = 'default') => {
+    uploadFile: (file: File, referenceId = 'default') => {
       return upload.mutate({
         file,
-        transactionId: uuid(),
-        id
+        meta: {
+          transactionId: uuid(),
+          referenceId,
+          eventId
+        }
       })
     }
   }

--- a/packages/documents/src/features/uploadDocument/handler.test.ts
+++ b/packages/documents/src/features/uploadDocument/handler.test.ts
@@ -49,12 +49,12 @@ describe('fileExistsHandler', () => {
   })
 
   it('Separates bucket from file paths with multiple directories', async () => {
-    const eventId = 'event-12345'
+    const path = 'event-12345'
     const transactionId = 'transaction-12345'
 
     const res = await server.server.inject({
       method: 'GET',
-      url: `/files/${MINIO_BUCKET}/${eventId}/${transactionId}.txt`,
+      url: `/files/${MINIO_BUCKET}/${path}/${transactionId}.txt`,
       headers: {
         authorization: `Bearer ${token}`
       }
@@ -62,18 +62,18 @@ describe('fileExistsHandler', () => {
 
     const [bucket, filename] = minioStatMock.mock.calls[0]
     expect(bucket).toBe(MINIO_BUCKET)
-    expect(filename).toBe(`${eventId}/${transactionId}.txt`)
+    expect(filename).toBe(`${path}/${transactionId}.txt`)
 
     expect(res.statusCode).toBe(200)
   })
 
   it('Separates bucket from file', async () => {
-    const eventId = 'event-12345'
+    const path = 'event-12345'
     const transactionId = 'transaction-12345'
 
     const res = await server.server.inject({
       method: 'GET',
-      url: `/files/${MINIO_BUCKET}/${eventId}/${transactionId}.txt`,
+      url: `/files/${MINIO_BUCKET}/${path}/${transactionId}.txt`,
       headers: {
         authorization: `Bearer ${token}`
       }
@@ -81,19 +81,19 @@ describe('fileExistsHandler', () => {
 
     const [bucket, filename] = minioStatMock.mock.calls[0]
     expect(bucket).toBe(MINIO_BUCKET)
-    expect(filename).toBe(`${eventId}/${transactionId}.txt`)
+    expect(filename).toBe(`${path}/${transactionId}.txt`)
 
     expect(res.statusCode).toBe(200)
   })
 
   it('handles explicit "/" as start of of file path', async () => {
-    const eventId = 'event-12345'
+    const path = 'event-12345'
     const transactionId = 'transaction-12345'
 
     const res = await server.server.inject({
       method: 'GET',
       // double slash is handled
-      url: `/files//${MINIO_BUCKET}/${eventId}/${transactionId}.txt`,
+      url: `/files//${MINIO_BUCKET}/${path}/${transactionId}.txt`,
       headers: {
         authorization: `Bearer ${token}`
       }
@@ -101,7 +101,7 @@ describe('fileExistsHandler', () => {
 
     const [bucket, filename] = minioStatMock.mock.calls[0]
     expect(bucket).toBe(MINIO_BUCKET)
-    expect(filename).toBe(`${eventId}/${transactionId}.txt`)
+    expect(filename).toBe(`${path}/${transactionId}.txt`)
 
     expect(res.statusCode).toBe(200)
   })
@@ -144,14 +144,14 @@ describe('fileUploadHandler', () => {
     )
   }
 
-  it('adds eventId to file path when it is given', async () => {
-    const eventId = 'event-12345'
+  it('adds path to file path when it is given', async () => {
+    const path = 'event-12345'
     const transactionId = 'transaction-1'
     const body =
       `--${boundary}${CRLF}` +
       createFormProperty('transactionId', transactionId) +
       `--${boundary}${CRLF}` +
-      createFormProperty('eventId', eventId) +
+      createFormProperty('path', path) +
       `--${boundary}${CRLF}` +
       createFormProperty('file', 'test upload', 'file') +
       `--${boundary}--${CRLF}`
@@ -166,13 +166,11 @@ describe('fileUploadHandler', () => {
       }
     })
 
-    expect(res.payload).toEqual(
-      `/${MINIO_BUCKET}/${eventId}/${transactionId}.txt`
-    )
+    expect(res.payload).toEqual(`/${MINIO_BUCKET}/${path}/${transactionId}.txt`)
 
     const [bucket, filename] = minioPutMock.mock.calls[0]
     expect(bucket).toBe(MINIO_BUCKET)
-    expect(filename).toBe(`${eventId}/${transactionId}.txt`)
+    expect(filename).toBe(`${path}/${transactionId}.txt`)
 
     expect(res.statusCode).toBe(200)
   })

--- a/packages/documents/src/features/uploadDocument/handler.test.ts
+++ b/packages/documents/src/features/uploadDocument/handler.test.ts
@@ -9,13 +9,201 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 import { createServer } from '@documents/server'
+
 import { readFileSync } from 'fs'
 import * as jwt from 'jsonwebtoken'
+import { MINIO_BUCKET } from '../../minio/constants'
+
+const minioPutMock = jest.fn()
+const minioStatMock = jest.fn()
 jest.mock('../../minio/client', () => {
   return {
     __esModule: true,
-    minioClient: { putObject: () => {} }
+    minioClient: {
+      putObject: (...args: unknown[]) => minioPutMock(...args),
+      statObject: (...args: unknown[]) => {
+        minioStatMock(...args)
+        return true
+      }
+    }
   }
+})
+
+describe('fileExistsHandler', () => {
+  let server: any
+  const token = jwt.sign(
+    { scope: ['declare'] },
+    readFileSync('./test/cert.key'),
+    {
+      algorithm: 'RS256',
+      issuer: 'opencrvs:auth-service',
+      audience: 'opencrvs:documents-user',
+      subject: '123123'
+    }
+  )
+
+  beforeEach(async () => {
+    minioPutMock.mockClear()
+    minioStatMock.mockClear()
+    server = await createServer()
+  })
+
+  it('Separates bucket from file paths with multiple directories', async () => {
+    const eventId = 'event-12345'
+    const transactionId = 'transaction-12345'
+
+    const res = await server.server.inject({
+      method: 'GET',
+      url: `/files/${MINIO_BUCKET}/${eventId}/${transactionId}.txt`,
+      headers: {
+        authorization: `Bearer ${token}`
+      }
+    })
+
+    const [bucket, filename] = minioStatMock.mock.calls[0]
+    expect(bucket).toBe(MINIO_BUCKET)
+    expect(filename).toBe(`${eventId}/${transactionId}.txt`)
+
+    expect(res.statusCode).toBe(200)
+  })
+
+  it('Separates bucket from file', async () => {
+    const eventId = 'event-12345'
+    const transactionId = 'transaction-12345'
+
+    const res = await server.server.inject({
+      method: 'GET',
+      url: `/files/${MINIO_BUCKET}/${eventId}/${transactionId}.txt`,
+      headers: {
+        authorization: `Bearer ${token}`
+      }
+    })
+
+    const [bucket, filename] = minioStatMock.mock.calls[0]
+    expect(bucket).toBe(MINIO_BUCKET)
+    expect(filename).toBe(`${eventId}/${transactionId}.txt`)
+
+    expect(res.statusCode).toBe(200)
+  })
+
+  it('handles explicit "/" as start of of file path', async () => {
+    const eventId = 'event-12345'
+    const transactionId = 'transaction-12345'
+
+    const res = await server.server.inject({
+      method: 'GET',
+      // double slash is handled
+      url: `/files//${MINIO_BUCKET}/${eventId}/${transactionId}.txt`,
+      headers: {
+        authorization: `Bearer ${token}`
+      }
+    })
+
+    const [bucket, filename] = minioStatMock.mock.calls[0]
+    expect(bucket).toBe(MINIO_BUCKET)
+    expect(filename).toBe(`${eventId}/${transactionId}.txt`)
+
+    expect(res.statusCode).toBe(200)
+  })
+})
+
+describe('fileUploadHandler', () => {
+  let server: any
+  const token = jwt.sign(
+    { scope: ['declare'] },
+    readFileSync('./test/cert.key'),
+    {
+      algorithm: 'RS256',
+      issuer: 'opencrvs:auth-service',
+      audience: 'opencrvs:documents-user',
+      subject: '123123'
+    }
+  )
+
+  beforeEach(async () => {
+    minioPutMock.mockClear()
+    minioStatMock.mockClear()
+    server = await createServer()
+  })
+
+  const boundary = '--hapi-boundary'
+  const CRLF = '\r\n'
+
+  const createFormProperty = (name: string, value: string, type?: 'file') => {
+    if (type === 'file') {
+      // For file type, we need to specify the filename and content type
+      return (
+        `Content-Disposition: form-data; name="${name}"; filename="hello.txt"${CRLF}` +
+        `Content-Type: text/plain${CRLF}${CRLF}` +
+        `${value}${CRLF}`
+      )
+    }
+    return (
+      `Content-Disposition: form-data; name="${name}"${CRLF}${CRLF}` +
+      `${value}${CRLF}`
+    )
+  }
+
+  it('adds eventId to file path when it is given', async () => {
+    const eventId = 'event-12345'
+    const transactionId = 'transaction-1'
+    const body =
+      `--${boundary}${CRLF}` +
+      createFormProperty('transactionId', transactionId) +
+      `--${boundary}${CRLF}` +
+      createFormProperty('eventId', eventId) +
+      `--${boundary}${CRLF}` +
+      createFormProperty('file', 'test upload', 'file') +
+      `--${boundary}--${CRLF}`
+
+    const res = await server.server.inject({
+      method: 'POST',
+      url: '/files',
+      payload: Buffer.from(body, 'utf8'),
+      headers: {
+        'Content-Type': `multipart/form-data; boundary=${boundary}`,
+        authorization: `Bearer ${token}`
+      }
+    })
+
+    expect(res.payload).toEqual(
+      `/${MINIO_BUCKET}/${eventId}/${transactionId}.txt`
+    )
+
+    const [bucket, filename] = minioPutMock.mock.calls[0]
+    expect(bucket).toBe(MINIO_BUCKET)
+    expect(filename).toBe(`${eventId}/${transactionId}.txt`)
+
+    expect(res.statusCode).toBe(200)
+  })
+
+  it('adds bucket to file path', async () => {
+    const transactionId = 'transaction-2'
+    const body =
+      `--${boundary}${CRLF}` +
+      createFormProperty('transactionId', transactionId) +
+      `--${boundary}${CRLF}` +
+      createFormProperty('file', 'test upload', 'file') +
+      `--${boundary}--${CRLF}`
+
+    const res = await server.server.inject({
+      method: 'POST',
+      url: '/files',
+      payload: Buffer.from(body, 'utf8'),
+      headers: {
+        'Content-Type': `multipart/form-data; boundary=${boundary}`,
+        authorization: `Bearer ${token}`
+      }
+    })
+
+    expect(res.payload).toEqual(`/${MINIO_BUCKET}/${transactionId}.txt`)
+
+    const [bucket, filename] = minioPutMock.mock.calls[0]
+    expect(bucket).toBe(MINIO_BUCKET)
+    expect(filename).toBe(`${transactionId}.txt`)
+
+    expect(res.statusCode).toBe(200)
+  })
 })
 
 describe('verify document uploader handler', () => {

--- a/packages/documents/src/features/uploadDocument/handler.ts
+++ b/packages/documents/src/features/uploadDocument/handler.ts
@@ -52,7 +52,7 @@ const FileSchema = z
 const Payload = z.object({
   file: FileSchema,
   transactionId: z.string(),
-  eventId: z.string().min(1).optional()
+  path: z.string().min(1).optional()
 })
 
 /**
@@ -65,16 +65,15 @@ export async function fileUploadHandler(
   const userId = getUserId(request.headers.authorization)
   const payload = await Payload.parseAsync(request.payload).catch((error) => {
     logger.error(error)
-    console.log(error)
     throw badRequest('Invalid payload')
   })
 
-  const { file, transactionId, eventId } = payload
+  const { file, transactionId, path } = payload
 
   const extension = file.hapi.filename.split('.').pop()
   const filename = `${transactionId}.${extension}`
 
-  const filePath = joinValues([eventId, filename], '/')
+  const filePath = joinValues([path, filename], '/')
 
   await minioClient.putObject(MINIO_BUCKET, filePath, file, {
     'created-by': userId


### PR DESCRIPTION
## Description
After changing the logic where files are deleted on backend, we want to introduce a way to find possible "orphan" files. (e.g. files that were uploaded but never referenced in action payloads).
- Add event id as part of file path when possible
- Add simple test cases for parsing

![filepaths](https://github.com/user-attachments/assets/5ddb7675-32eb-4a1a-9491-1232d28bf27b)



Link this pull request to the GitHub issue (and optionally name the branch `ocrvs-<issue #>`)

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
