### PR TITLE
[OCRVS-10122] Ensure latest draft state is always shown properly in workqueues

### DIFF
--- a/packages/client/src/v2-events/features/events/Search/SearchResult.tsx
+++ b/packages/client/src/v2-events/features/events/Search/SearchResult.tsx
@@ -449,11 +449,16 @@ export const SearchResultComponent = ({
       if (!eventConfig) {
         throw new Error('Event configuration not found for event:' + event.type)
       }
+      const draft = first(drafts.filter((d) => d.eventId === event.id))
+
+      if (!draft) {
+        return event
+      }
       return deepDropNulls(
         applyDraftToEventIndex(
           event,
           // there should be only one draft per event
-          first(drafts.filter((d) => d.eventId === event.id)),
+          draft,
           eventConfig
         )
       )

--- a/packages/client/src/v2-events/features/events/useEventFormNavigation.tsx
+++ b/packages/client/src/v2-events/features/events/useEventFormNavigation.tsx
@@ -189,6 +189,7 @@ export function useEventFormNavigation() {
     modal,
     createNewDeclaration,
     deleteDeclaration,
-    closeActionView
+    closeActionView,
+    clearEphemeralFormState
   }
 }

--- a/packages/client/src/v2-events/features/workqueues/EventOverview/components/useActionMenuItems.ts
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/components/useActionMenuItems.ts
@@ -30,6 +30,7 @@ import { useAuthentication } from '@client/utils/userUtils'
 import { AssignmentStatus, getAssignmentStatus } from '@client/v2-events/utils'
 import { getScope } from '@client/profile/profileSelectors'
 import { useDrafts } from '@client/v2-events/features/drafts/useDrafts'
+import { useEventFormNavigation } from '@client/v2-events/features/events/useEventFormNavigation'
 
 const STATUSES_THAT_CAN_BE_ASSIGNED: EventStatus[] = [
   EventStatus.enum.NOTIFIED,
@@ -123,6 +124,7 @@ export function useAction(event: EventIndex) {
   const navigate = useNavigate()
   const drafts = useDrafts()
   const authentication = useAuthentication()
+  const { clearEphemeralFormState } = useEventFormNavigation()
   const { findFromCache } = useEvents().getEvent
   const isDownloaded = Boolean(findFromCache(event.id).data)
 
@@ -183,48 +185,56 @@ export function useAction(event: EventIndex) {
       },
       [ActionType.DECLARE]: {
         label: actionLabels[ActionType.DECLARE],
-        onClick: (workqueue?: string) =>
-          navigate(
+        onClick: (workqueue?: string) => {
+          clearEphemeralFormState()
+          return navigate(
             ROUTES.V2.EVENTS.DECLARE.REVIEW.buildPath(
               { eventId: event.id },
               { workqueue }
             )
-          ),
+          )
+        },
         disabled: !(eventIsAssignedToSelf || hasDeclarationDraftOpen),
         // Action menu should not show DECLARE if the user can perform VALIDATE
         shouldHide: (actions) => actions.includes(ActionType.VALIDATE)
       },
       [ActionType.VALIDATE]: {
         label: actionLabels[ActionType.VALIDATE],
-        onClick: (workqueue?: string) =>
-          navigate(
+        onClick: (workqueue?: string) => {
+          clearEphemeralFormState()
+          return navigate(
             ROUTES.V2.EVENTS.VALIDATE.REVIEW.buildPath(
               { eventId: event.id },
               { workqueue }
             )
-          ),
+          )
+        },
         disabled: !eventIsAssignedToSelf
       },
       [ActionType.REGISTER]: {
         label: actionLabels[ActionType.REGISTER],
-        onClick: (workqueue?: string) =>
-          navigate(
+        onClick: (workqueue?: string) => {
+          clearEphemeralFormState()
+          return navigate(
             ROUTES.V2.EVENTS.REGISTER.REVIEW.buildPath(
               { eventId: event.id },
               { workqueue }
             )
-          ),
+          )
+        },
         disabled: !eventIsAssignedToSelf
       },
       [ActionType.PRINT_CERTIFICATE]: {
         label: actionLabels[ActionType.PRINT_CERTIFICATE],
-        onClick: (workqueue?: string) =>
-          navigate(
+        onClick: (workqueue?: string) => {
+          clearEphemeralFormState()
+          return navigate(
             ROUTES.V2.EVENTS.PRINT_CERTIFICATE.buildPath(
               { eventId: event.id },
               { workqueue }
             )
-          ),
+          )
+        },
         disabled: !eventIsAssignedToSelf
       },
       [ActionType.DELETE]: {

--- a/packages/client/src/v2-events/layouts/EventOverview/index.tsx
+++ b/packages/client/src/v2-events/layouts/EventOverview/index.tsx
@@ -115,7 +115,13 @@ export function EventOverviewLayout({
             eventConfiguration.title,
             flattenEventIndex(
               deepDropNulls(
-                applyDraftToEventIndex(eventIndex, draft, eventConfiguration)
+                draft
+                  ? applyDraftToEventIndex(
+                      eventIndex,
+                      draft,
+                      eventConfiguration
+                    )
+                  : eventIndex
               )
             )
           )}

--- a/packages/commons/src/events/state/index.ts
+++ b/packages/commons/src/events/state/index.ts
@@ -320,23 +320,15 @@ export function applyDeclarationToEventIndex(
  */
 export function applyDraftToEventIndex(
   eventIndex: EventIndex,
-  draft: Draft | undefined,
+  draft: Draft,
   eventConfiguration: EventConfig
 ) {
-  const indexedAt = eventIndex.updatedAt
-
-  const activeDraft = draft && draft.createdAt >= indexedAt ? draft : undefined
-
-  if (!activeDraft) {
-    return eventIndex
-  }
-
   return applyDeclarationToEventIndex(
     {
       ...eventIndex,
-      updatedAt: activeDraft.createdAt
+      updatedAt: draft.createdAt
     },
-    activeDraft.action.declaration,
+    draft.action.declaration,
     eventConfiguration
   )
 }


### PR DESCRIPTION
## Description

**Problem**: sometimes when creating a draft offline, then going back online you could see record details flickering for some time

This was mostly because the draft that was created had an older creation time than the stored actions that came back from the server (CREATED) thus nullifying the draft's details


<img width="1230" height="467" alt="image" src="https://github.com/user-attachments/assets/206f4de0-01fb-4ee4-a2b4-701b94909611" />

<img width="966" height="275" alt="image" src="https://github.com/user-attachments/assets/ac0a6f00-9121-4d99-80c5-6677de7ac77b" />


## Checklist

- [x] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [x] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
