### PR TITLE
Fix/flaky event draft snapshot

### DIFF
--- a/packages/events/src/service/events/drafts.ts
+++ b/packages/events/src/service/events/drafts.ts
@@ -25,7 +25,6 @@ export const createDraft = async (
     transactionId: string
   }
 ): Promise<Draft> => {
-  const createdAt = new Date().toISOString()
   const draft = await draftsRepo.createDraft({
     eventId,
     transactionId,
@@ -46,11 +45,11 @@ export const createDraft = async (
   return {
     id: draft.id,
     transactionId: draft.transactionId,
-    createdAt,
+    createdAt: draft.createdAt,
     eventId: draft.eventId,
     action: {
       transactionId: draft.transactionId,
-      createdAt: createdAt,
+      createdAt: draft.createdAt,
       createdBy: user.id,
       createdByRole: user.role,
       createdByUserType: user.type,

--- a/packages/events/src/storage/postgres/events/drafts.ts
+++ b/packages/events/src/storage/postgres/events/drafts.ts
@@ -64,7 +64,14 @@ export async function createDraft(draft: NewEventActionDrafts) {
         createdAt: sql`NOW()`
       })
     )
-    .returning(['id', 'eventId', 'transactionId', 'declaration', 'annotation'])
+    .returning([
+      'id',
+      'eventId',
+      'transactionId',
+      'declaration',
+      'annotation',
+      'createdAt'
+    ])
     .executeTakeFirst()
 
   return result


### PR DESCRIPTION
## Description

Use database timestamp over js one when returning created draft

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
