### PR TITLE
[OCRVS-10002] Reset international address fields when country is changed

### DIFF
--- a/packages/client/src/v2-events/features/events/registered-fields/Address.interaction.stories.tsx
+++ b/packages/client/src/v2-events/features/events/registered-fields/Address.interaction.stories.tsx
@@ -11,7 +11,7 @@
 
 import type { Meta, StoryObj } from '@storybook/react'
 import { expect, fn } from '@storybook/test'
-import { userEvent, within } from '@storybook/testing-library'
+import { userEvent, waitFor, within } from '@storybook/testing-library'
 import React from 'react'
 import * as selectEvent from 'react-select-event'
 import styled from 'styled-components'
@@ -164,13 +164,17 @@ export const GenericAddressFields: StoryObj<typeof FormFieldGenerator> = {
     })
 
     await step('Expect address fields to be reset', async () => {
-      await expect(canvas.queryByTestId('text__state')).toHaveValue('')
-      await expect(canvas.queryByTestId('text__district2')).toHaveValue('')
-      await expect(canvas.queryByTestId('text__cityOrTown')).toHaveValue('')
-      await expect(canvas.queryByTestId('text__addressLine1')).toHaveValue('')
-      await expect(canvas.queryByTestId('text__addressLine2')).toHaveValue('')
-      await expect(canvas.queryByTestId('text__addressLine3')).toHaveValue('')
-      await expect(canvas.queryByTestId('text__postcodeOrZip')).toHaveValue('')
+      await waitFor(async () => {
+        await expect(canvas.queryByTestId('text__state')).toHaveValue('')
+        await expect(canvas.queryByTestId('text__district2')).toHaveValue('')
+        await expect(canvas.queryByTestId('text__cityOrTown')).toHaveValue('')
+        await expect(canvas.queryByTestId('text__addressLine1')).toHaveValue('')
+        await expect(canvas.queryByTestId('text__addressLine2')).toHaveValue('')
+        await expect(canvas.queryByTestId('text__addressLine3')).toHaveValue('')
+        await expect(canvas.queryByTestId('text__postcodeOrZip')).toHaveValue(
+          ''
+        )
+      })
     })
   },
   render: function Component(args) {

--- a/packages/client/src/v2-events/features/events/registered-fields/Address.tsx
+++ b/packages/client/src/v2-events/features/events/registered-fields/Address.tsx
@@ -27,8 +27,7 @@ import {
   AddressType,
   never,
   isFieldDisplayedOnReview,
-  AddressField,
-  field
+  AddressField
 } from '@opencrvs/commons/client'
 import { FormFieldGenerator } from '@client/v2-events/components/forms/FormFieldGenerator'
 import { Output } from '@client/v2-events/features/events/components/Output'
@@ -305,7 +304,7 @@ const GENERIC_ADDRESS_FIELDS = [
         conditional: isInternationalAddress()
       }
     ],
-    parent: field('country'),
+    parent: createFieldCondition('country'),
     required: true,
     label: {
       id: 'v2.field.address.state.label',
@@ -316,7 +315,7 @@ const GENERIC_ADDRESS_FIELDS = [
   },
   {
     id: 'district2',
-    parent: field('country'),
+    parent: createFieldCondition('country'),
     conditionals: [
       {
         type: ConditionalType.SHOW,
@@ -333,7 +332,7 @@ const GENERIC_ADDRESS_FIELDS = [
   },
   {
     id: 'cityOrTown',
-    parent: field('country'),
+    parent: createFieldCondition('country'),
     conditionals: [
       {
         type: ConditionalType.SHOW,
@@ -350,7 +349,7 @@ const GENERIC_ADDRESS_FIELDS = [
   },
   {
     id: 'addressLine1',
-    parent: field('country'),
+    parent: createFieldCondition('country'),
     conditionals: [
       {
         type: ConditionalType.SHOW,
@@ -367,7 +366,7 @@ const GENERIC_ADDRESS_FIELDS = [
   },
   {
     id: 'addressLine2',
-    parent: field('country'),
+    parent: createFieldCondition('country'),
     conditionals: [
       {
         type: ConditionalType.SHOW,
@@ -384,7 +383,7 @@ const GENERIC_ADDRESS_FIELDS = [
   },
   {
     id: 'addressLine3',
-    parent: field('country'),
+    parent: createFieldCondition('country'),
     conditionals: [
       {
         type: ConditionalType.SHOW,
@@ -401,7 +400,7 @@ const GENERIC_ADDRESS_FIELDS = [
   },
   {
     id: 'postcodeOrZip',
-    parent: field('country'),
+    parent: createFieldCondition('country'),
     conditionals: [
       {
         type: ConditionalType.SHOW,


### PR DESCRIPTION
## Description


https://github.com/user-attachments/assets/c3bab5bb-7244-4b64-b45a-bec5c019bbc4



## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [x] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
