### PR TITLE
[ocrvs-9493]: Restrict verifyPasswordById

### DIFF
--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -115,7 +115,7 @@
     ],
     "src/**/*.ts": [
       "prettier --write",
-      "eslint -c .eslintrc.js --fix"
+      "eslint --fix"
     ]
   },
   "jest": {

--- a/packages/gateway/src/features/user/root-resolvers.test.ts
+++ b/packages/gateway/src/features/user/root-resolvers.test.ts
@@ -23,7 +23,7 @@ import {
   SCOPES
 } from '@opencrvs/commons/authentication'
 import { fetchJSON } from '@opencrvs/commons'
-
+import * as userUtils from '@gateway/features/user/utils'
 let container: StartedTestContainer
 
 jest.mock('@opencrvs/commons', () => {
@@ -655,6 +655,19 @@ describe('User root resolvers', () => {
       } catch (e) {
         expect(e.message).toBe('Unauthorized to verify password')
       }
+    })
+
+    it('throws error if userId from token does not match id arg', async () => {
+      jest.spyOn(userUtils, 'getUserId').mockReturnValue('some-other-id')
+
+      await expect(
+        resolvers.Query!.verifyPasswordById(
+          {},
+          { id: '123', password: 'test' },
+          { headers: authHeaderUser },
+          { fieldName: 'verifyPasswordById' }
+        )
+      ).rejects.toThrow('Unauthorized to verify password of this user')
     })
   })
   describe('activateUser mutation', () => {

--- a/packages/gateway/src/features/user/root-resolvers.ts
+++ b/packages/gateway/src/features/user/root-resolvers.ts
@@ -288,6 +288,10 @@ export const resolvers: GQLResolver = {
     verifyPasswordById: rateLimitedResolver(
       { requestsPerMinute: 10 },
       async (_, { id, password }, { headers: authHeader }) => {
+        const userId: string = getUserId(authHeader)
+        if (userId !== id) {
+          throw new Error('Unauthorized to verify password of this user')
+        }
         const res = await fetch(`${USER_MANAGEMENT_URL}verifyPasswordById`, {
           method: 'POST',
           body: JSON.stringify({ id, password }),

--- a/packages/gateway/src/features/user/root-resolvers.ts
+++ b/packages/gateway/src/features/user/root-resolvers.ts
@@ -49,7 +49,10 @@ import {
   hasScope,
   SCOPES
 } from '@opencrvs/commons/authentication'
-import { UserInputError } from '@gateway/utils/graphql-errors'
+import {
+  AuthenticationError,
+  UserInputError
+} from '@gateway/utils/graphql-errors'
 
 export const resolvers: GQLResolver = {
   Query: {
@@ -290,7 +293,9 @@ export const resolvers: GQLResolver = {
       async (_, { id, password }, { headers: authHeader }) => {
         const userId: string = getUserId(authHeader)
         if (userId !== id) {
-          throw new Error('Unauthorized to verify password of this user')
+          throw new AuthenticationError(
+            'Unauthorized to verify password of this user'
+          )
         }
         const res = await fetch(`${USER_MANAGEMENT_URL}verifyPasswordById`, {
           method: 'POST',


### PR DESCRIPTION
## Description

Before executing the `verifyPasswordById` query, the `sub` is extracted from jwt and compared with the `id` argument. If `sub` and `id` doesn't match, an `AuthenticationError` is thrown.
Issue link [ocrvs-9493](https://github.com/opencrvs/opencrvs-core/issues/9493)

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
