### PR TITLE
Added funding json and .well-known for FLOSS fund applications

### DIFF
--- a/.well-known/funding-manifest-urls
+++ b/.well-known/funding-manifest-urls
@@ -1,0 +1,1 @@
+https://opencrvs.org/funding.json

--- a/funding.json
+++ b/funding.json
@@ -1,0 +1,88 @@
+{
+  "version": "v1.0.0",
+  "entity": {
+    "type": "organisation",
+    "role": "owner",
+    "name": "OpenCRVS Limited",
+    "email": "ed@opencrvs.org",
+    "phone": "+33749753049",
+    "description": "OpenCRVS Limited is a not-for-profit organisation based in the UK. It's mission is to make high-quality, cost-effective open-source civil registration technologies available in all low-resource countries so that the registration of life events becomes easy and valuable for everyone. The vision is that every person on the planet is recognised, protected, and provided for from birth.",
+    "webpageUrl": {
+      "url": "https://opencrvs.org"
+    }
+  },
+  "projects": [
+    {
+      "guid": "opencrvs-product-development",
+      "name": "OpenCRVS Product Development",
+      "description": "OpenCRVS is an open-source, configurable digital civil registration system designed for low- and middle-income countries. It enables efficient, secure, and reliable registration of births, deaths, marriages, and other life events. OpenCRVS supports legal identity, vital statistics, and can be adapted to meet the specific needs of different country contexts.",
+      "webpageUrl": {
+        "url": "https://opencrvs.org"
+      },
+      "repositoryUrl": {
+        "url": "https://github.com/opencrvs/opencrvs-core",
+        "wellKnown": "https://github.com/opencrvs/opencrvs-core/.well-known/funding-manifest-urls"
+      },
+      "licenses": [
+        "spdx:MPL-2.0"
+      ],
+      "tags": [
+        "ecrvs",
+        "civil-registration",
+        "digital-public-good",
+        "digital-public-goods",
+        "digital-public-infrastructure",
+        "dpg"
+      ]
+    }
+  ],
+  "funding": {
+    "channels": [
+      {
+        "guid": "opencrvs-bank",
+        "type": "bank",
+        "address": "Name: Opencrvs Limited, Account number: 8312220419, Account type: Checking, Routing number (for wire and ACH): 026073150, Swift/BIC: CMFGUS33, Bank: Community Federal Savings Bank, 89-16 Jamaica Ave, Woodhaven, NY, 11421, United States",
+        "description": "Contact ed@opencrvs.org for further payment instructions"
+      }
+    ],
+    "plans": [
+      {
+        "guid": "global-support-team-plan",
+        "status": "active",
+        "name": "Global Support Team Plan",
+        "description": "OpenCRVS Product Development involves:\n- Maintaining the OpenCRVS code base\n- Addressing bugs found in country implementations\n- Resolving technical debt and critical open source dependencies.\n- Curating GitHub issues to attract contributions from the external developer community.",
+        "amount": 100000,
+        "currency": "USD",
+        "frequency": "yearly",
+        "channels": [
+          "opencrvs-bank"
+        ]
+      },
+      {
+        "guid": "fellowship-plan",
+        "status": "active",
+        "name": "Fellowship Plan",
+        "description": "Fellowship program to support and mentor an individual contributing to OpenCRVS for 12 months.",
+        "amount": 20000,
+        "currency": "USD",
+        "frequency": "one-time",
+        "channels": [
+          "opencrvs-bank"
+        ]
+      },
+      {
+        "guid": "innovation-plan",
+        "status": "active",
+        "name": "Innovation Plan",
+        "description": "Financial prize for an innovation competition, incentivizing participation from low-income countries e.g., developing new interoperability use cases for OpenCRVS.",
+        "amount": 10000,
+        "currency": "USD",
+        "frequency": "one-time",
+        "channels": [
+          "opencrvs-bank"
+        ]
+      }
+    ],
+    "history": []
+  }
+}


### PR DESCRIPTION
We would like this funding.json to be added in order to be validated for FOSS fund applications:

https://github.com/DPGAlliance/dpg-community/discussions/38
https://fundingjson.org/

I'm going to use Cloudflare to also host the funding.json on the URL in the .well-known