### PR TITLE
Remove redundant declaration prop from DECLARE, VALIDATE, REGISTER, and CORRECTION pages to fix child field reset

### DIFF
--- a/packages/client/src/v2-events/features/events/actions/correct/request/FormFieldParentChildReset.stories.tsx
+++ b/packages/client/src/v2-events/features/events/actions/correct/request/FormFieldParentChildReset.stories.tsx
@@ -1,0 +1,400 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+import React from 'react'
+import type { Meta, StoryObj } from '@storybook/react'
+import { createTRPCMsw, httpLink } from '@vafanassieff/msw-trpc'
+import { Outlet } from 'react-router-dom'
+import superjson from 'superjson'
+import { expect, waitFor, within, userEvent } from '@storybook/test'
+import {
+  ActionType,
+  and,
+  not,
+  ConditionalType,
+  field,
+  FieldType,
+  tennisClubMembershipEvent,
+  never,
+  defineDeclarationForm,
+  generateUuid,
+  generateActionDocument
+} from '@opencrvs/commons/client'
+import { ROUTES } from '@client/v2-events/routes'
+import { AppRouter } from '@client/v2-events/trpc'
+import { testDataGenerator } from '@client/tests/test-data-generators'
+import { setEventData, addLocalEventConfig } from '../../../useEvents/api'
+import { router } from './router'
+import * as Request from './index'
+
+const meta: Meta<typeof Request.Pages> = {
+  title: 'CorrectionRequest'
+}
+
+export default meta
+
+type Story = StoryObj<typeof Request.Pages>
+const tRPCMsw = createTRPCMsw<AppRouter>({
+  links: [
+    httpLink({
+      url: '/api/events'
+    })
+  ],
+  transformer: { input: superjson, output: superjson }
+})
+
+const RecommenderType = {
+  MEMBER: 'MEMBER',
+  COACH: 'COACH',
+  FRIEND: 'FRIEND',
+  FAMILY: 'FAMILY',
+  OTHER: 'OTHER'
+} as const
+
+const recommenderOptions = [
+  {
+    label: {
+      defaultMessage: 'Club Member',
+      description: 'Label for option club member',
+      id: 'v2.form.field.label.recommender.member'
+    },
+    value: 'MEMBER'
+  },
+  {
+    label: {
+      defaultMessage: 'Coach',
+      description: 'Label for option coach',
+      id: 'v2.form.field.label.recommender.coach'
+    },
+    value: 'COACH'
+  },
+  {
+    label: {
+      defaultMessage: 'Friend',
+      description: 'Label for option friend',
+      id: 'v2.form.field.label.recommender.friend'
+    },
+    value: 'FRIEND'
+  },
+  {
+    label: {
+      defaultMessage: 'Family',
+      description: 'Label for option family',
+      id: 'v2.form.field.label.recommender.family'
+    },
+    value: 'FAMILY'
+  },
+  {
+    label: {
+      defaultMessage: 'Other',
+      description: 'Label for option other',
+      id: 'v2.form.field.label.recommender.other'
+    },
+    value: 'OTHER'
+  }
+]
+const recommenderOtherThanClubMembers = and(
+  not(
+    field('recommender.relation').inArray([
+      RecommenderType.COACH,
+      RecommenderType.MEMBER
+    ])
+  ),
+  not(field('recommender.relation').isFalsy())
+)
+
+const overridenEventConfig = {
+  ...tennisClubMembershipEvent,
+  id: 'overridenEventConfig',
+  declaration: defineDeclarationForm({
+    ...tennisClubMembershipEvent.declaration,
+    pages: [
+      {
+        id: 'recommender',
+        title: {
+          id: 'v2.event.tennis-club-membership.action.declare.form.section.recommender.title',
+          defaultMessage: 'Who is recommending the applicant?',
+          description: 'This is the title of the section'
+        },
+        fields: [
+          {
+            id: 'recommender.relation',
+            type: FieldType.SELECT,
+            required: true,
+            label: {
+              defaultMessage: 'Relationship to child',
+              description: 'This is the label for the field',
+              id: 'v2.event.birth.action.declare.form.section.recommender.field.relation.label'
+            },
+            options: recommenderOptions
+          },
+          {
+            id: 'recommender.name',
+            type: FieldType.NAME,
+            hideLabel: true,
+            required: true,
+            label: {
+              defaultMessage: "Recommender's name",
+              description: 'This is the label for the field',
+              id: 'v2.event.tennis-club-membership.action.declare.form.section.recommender.field.firstname.label'
+            },
+            parent: field('recommender.relation')
+          },
+          {
+            id: 'recommender.dob',
+            type: 'DATE',
+            required: true,
+            validation: [
+              {
+                message: {
+                  defaultMessage: 'Must be a valid Birthdate',
+                  description: 'This is the error message for invalid date',
+                  id: 'v2.event.birth.action.declare.form.section.person.field.dob.error'
+                },
+                validator: field('recommender.dob').isBefore().now()
+              },
+              {
+                message: {
+                  defaultMessage:
+                    "Birth date must be before child's birth date",
+                  description:
+                    "This is the error message for a birth date after child's birth date",
+                  id: 'v2.event.birth.action.declare.form.section.person.dob.afterChild'
+                },
+                validator: field('recommender.dob')
+                  .isBefore()
+                  .date(field('child.dob'))
+              }
+            ],
+            label: {
+              defaultMessage: 'Date of birth',
+              description: 'This is the label for the field',
+              id: 'v2.event.birth.action.declare.form.section.person.field.dob.label'
+            },
+            conditionals: [
+              {
+                type: ConditionalType.SHOW,
+                conditional: not(
+                  field('recommender.dobUnknown').isEqualTo(true)
+                )
+              }
+            ],
+            parent: field('recommender.relation')
+          },
+          {
+            id: 'recommender.dobUnknown',
+            type: FieldType.CHECKBOX,
+            label: {
+              defaultMessage: 'Exact date of birth unknown',
+              description: 'This is the label for the field',
+              id: 'v2.event.birth.action.declare.form.section.person.field.age.checkbox.label'
+            },
+            conditionals: [
+              {
+                type: ConditionalType.SHOW,
+                conditional: recommenderOtherThanClubMembers
+              },
+              {
+                type: ConditionalType.DISPLAY_ON_REVIEW,
+                conditional: never()
+              }
+            ],
+            parent: field('recommender.relation')
+          },
+          {
+            id: 'recommender.age',
+            type: FieldType.TEXT,
+            required: true,
+            label: {
+              defaultMessage: 'Age of recommender',
+              description: 'This is the label for the field',
+              id: 'v2.event.birth.action.declare.form.section.recommender.field.age.label'
+            },
+            configuration: {
+              postfix: {
+                defaultMessage: 'years',
+                description: 'This is the postfix for age field',
+                id: 'v2.event.birth.action.declare.form.section.person.field.age.postfix'
+              }
+            },
+            conditionals: [
+              {
+                type: ConditionalType.SHOW,
+                conditional: field('recommender.dobUnknown').isEqualTo(true)
+              }
+            ],
+            parent: field('recommender.relation')
+          }
+        ]
+      }
+    ]
+  })
+}
+
+const overridenActions = [
+  generateActionDocument({
+    configuration: overridenEventConfig,
+    action: ActionType.CREATE
+  }),
+  generateActionDocument({
+    configuration: overridenEventConfig,
+    action: ActionType.DECLARE,
+    defaults: {
+      declaration: {
+        'recommender.relation': 'COACH',
+        'recommender.name': { firstname: 'Mohammed', surname: 'Rahim' },
+        'recommender.dob': '1978-05-12',
+        'recommender.dobUnknown': false
+      }
+    }
+  }),
+  generateActionDocument({
+    configuration: overridenEventConfig,
+    action: ActionType.VALIDATE,
+    defaults: { declaration: {} }
+  }),
+  generateActionDocument({
+    configuration: overridenEventConfig,
+    action: ActionType.REGISTER,
+    defaults: { declaration: {} }
+  })
+]
+const overridenEvent = {
+  trackingId: generateUuid(),
+  type: overridenEventConfig.id,
+  actions: overridenActions,
+  createdAt: new Date(Date.now()).toISOString(),
+  id: generateUuid(),
+  updatedAt: new Date(Date.now()).toISOString()
+}
+const generator = testDataGenerator()
+export const FormFieldParentChildReset: Story = {
+  beforeEach: () => {
+    /*
+     * Ensure record is "downloaded offline" in the user's browser
+     */
+    addLocalEventConfig(overridenEventConfig)
+    setEventData(overridenEvent.id, overridenEvent)
+  },
+  parameters: {
+    reactRouter: {
+      router: {
+        path: '/',
+        element: <Outlet />,
+        children: [router]
+      },
+      initialPath: ROUTES.V2.EVENTS.CORRECTION.REVIEW.buildPath({
+        eventId: overridenEvent.id
+      })
+    },
+    msw: {
+      handlers: {
+        events: [
+          tRPCMsw.event.config.get.query(() => {
+            return [overridenEventConfig]
+          })
+        ],
+        event: [
+          tRPCMsw.event.get.query(() => {
+            return overridenEvent
+          })
+        ]
+      }
+    }
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+
+    await waitFor(async () => {
+      await expect(
+        canvas.getByRole('button', { name: 'Continue' })
+      ).toBeVisible()
+    })
+
+    await step('Change recommender relation', async () => {
+      await userEvent.click(
+        canvas.getByTestId('change-button-recommender.relation')
+      )
+      await expect(canvas.getByTestId('text__firstname')).toHaveValue(
+        'Mohammed'
+      )
+      await expect(canvas.getByTestId('text__surname')).toHaveValue('Rahim')
+      await expect(canvas.getByTestId('recommender____dob-dd')).toHaveValue(12)
+      await expect(canvas.getByTestId('recommender____dob-mm')).toHaveValue(5)
+      await expect(canvas.getByTestId('recommender____dob-yyyy')).toHaveValue(
+        1978
+      )
+
+      await userEvent.click(
+        canvas.getByTestId('select__recommender____relation')
+      )
+      await userEvent.click(canvas.getByText('Friend', { exact: true }))
+      await expect(canvas.getByTestId('text__firstname')).toHaveValue('')
+      await expect(canvas.getByTestId('text__surname')).toHaveValue('')
+      await expect(canvas.getByTestId('recommender____dob-dd')).toHaveValue(
+        null
+      )
+      await expect(canvas.getByTestId('recommender____dob-mm')).toHaveValue(
+        null
+      )
+      await expect(canvas.getByTestId('recommender____dob-yyyy')).toHaveValue(
+        null
+      )
+      await userEvent.type(canvas.getByTestId('text__firstname'), 'John')
+      await userEvent.type(canvas.getByTestId('text__surname'), 'Doe')
+
+      await userEvent.click(
+        await canvas.findByLabelText('Exact date of birth unknown')
+      )
+      await userEvent.type(canvas.getByTestId('text__recommender____age'), '36')
+    })
+
+    await step('Go back to review', async () => {
+      await userEvent.click(
+        canvas.getByRole('button', { name: 'Back to review' })
+      )
+
+      await expect(
+        within(canvas.getByTestId('row-value-recommender.relation')).getByText(
+          'Coach',
+          { selector: 'del' }
+        )
+      ).toHaveTextContent('Coach')
+      await expect(
+        canvas.getByTestId('row-value-recommender.relation')
+      ).toHaveTextContent('Friend')
+
+      await expect(
+        within(canvas.getByTestId('row-value-recommender.name')).getByText(
+          'Mohammed Rahim',
+          { selector: 'del' }
+        )
+      ).toHaveTextContent('Mohammed Rahim')
+      await expect(
+        canvas.getByTestId('row-value-recommender.name')
+      ).toHaveTextContent('John Doe')
+
+      await expect(
+        within(canvas.getByTestId('row-value-recommender.age')).getByText('-', {
+          selector: 'del'
+        })
+      ).toHaveTextContent('-')
+      await expect(
+        canvas.getByTestId('row-value-recommender.age')
+      ).toHaveTextContent('36')
+
+      await waitFor(async () => {
+        await expect(
+          canvas.getByRole('button', { name: 'Continue' })
+        ).toBeEnabled()
+      })
+    })
+  }
+}

--- a/packages/client/src/v2-events/features/events/actions/correct/request/FormFieldParentChildReset.stories.tsx
+++ b/packages/client/src/v2-events/features/events/actions/correct/request/FormFieldParentChildReset.stories.tsx
@@ -110,9 +110,9 @@ const recommenderOtherThanClubMembers = and(
   not(field('recommender.relation').isFalsy())
 )
 
-const overridenEventConfig = {
+const overriddenEventConfig = {
   ...tennisClubMembershipEvent,
-  id: 'overridenEventConfig',
+  id: 'overriddenEventConfig',
   declaration: defineDeclarationForm({
     ...tennisClubMembershipEvent.declaration,
     pages: [
@@ -240,11 +240,11 @@ const overridenEventConfig = {
 
 const overridenActions = [
   generateActionDocument({
-    configuration: overridenEventConfig,
+    configuration: overriddenEventConfig,
     action: ActionType.CREATE
   }),
   generateActionDocument({
-    configuration: overridenEventConfig,
+    configuration: overriddenEventConfig,
     action: ActionType.DECLARE,
     defaults: {
       declaration: {
@@ -256,19 +256,19 @@ const overridenActions = [
     }
   }),
   generateActionDocument({
-    configuration: overridenEventConfig,
+    configuration: overriddenEventConfig,
     action: ActionType.VALIDATE,
     defaults: { declaration: {} }
   }),
   generateActionDocument({
-    configuration: overridenEventConfig,
+    configuration: overriddenEventConfig,
     action: ActionType.REGISTER,
     defaults: { declaration: {} }
   })
 ]
 const overridenEvent = {
   trackingId: generateUuid(),
-  type: overridenEventConfig.id,
+  type: overriddenEventConfig.id,
   actions: overridenActions,
   createdAt: new Date(Date.now()).toISOString(),
   id: generateUuid(),
@@ -280,7 +280,7 @@ export const FormFieldParentChildReset: Story = {
     /*
      * Ensure record is "downloaded offline" in the user's browser
      */
-    addLocalEventConfig(overridenEventConfig)
+    addLocalEventConfig(overriddenEventConfig)
     setEventData(overridenEvent.id, overridenEvent)
   },
   parameters: {
@@ -298,7 +298,7 @@ export const FormFieldParentChildReset: Story = {
       handlers: {
         events: [
           tRPCMsw.event.config.get.query(() => {
-            return [overridenEventConfig]
+            return [overriddenEventConfig]
           })
         ],
         event: [

--- a/packages/client/src/v2-events/features/events/actions/correct/request/FormFieldParentChildReset.stories.tsx
+++ b/packages/client/src/v2-events/features/events/actions/correct/request/FormFieldParentChildReset.stories.tsx
@@ -25,11 +25,14 @@ import {
   never,
   defineDeclarationForm,
   generateUuid,
-  generateActionDocument
+  generateActionDocument,
+  generateTranslationConfig
 } from '@opencrvs/commons/client'
 import { ROUTES } from '@client/v2-events/routes'
 import { AppRouter } from '@client/v2-events/trpc'
 import { testDataGenerator } from '@client/tests/test-data-generators'
+import { EventOverviewLayout } from '@client/v2-events/layouts'
+import { EventOverviewIndex } from '@client/v2-events/features/workqueues/EventOverview/EventOverview'
 import { setEventData, addLocalEventConfig } from '../../../useEvents/api'
 import { router } from './router'
 import * as Request from './index'
@@ -60,43 +63,23 @@ const RecommenderType = {
 
 const recommenderOptions = [
   {
-    label: {
-      defaultMessage: 'Club Member',
-      description: 'Label for option club member',
-      id: 'v2.form.field.label.recommender.member'
-    },
+    label: generateTranslationConfig('Club Member'),
     value: 'MEMBER'
   },
   {
-    label: {
-      defaultMessage: 'Coach',
-      description: 'Label for option coach',
-      id: 'v2.form.field.label.recommender.coach'
-    },
+    label: generateTranslationConfig('Coach'),
     value: 'COACH'
   },
   {
-    label: {
-      defaultMessage: 'Friend',
-      description: 'Label for option friend',
-      id: 'v2.form.field.label.recommender.friend'
-    },
+    label: generateTranslationConfig('Friend'),
     value: 'FRIEND'
   },
   {
-    label: {
-      defaultMessage: 'Family',
-      description: 'Label for option family',
-      id: 'v2.form.field.label.recommender.family'
-    },
+    label: generateTranslationConfig('Family'),
     value: 'FAMILY'
   },
   {
-    label: {
-      defaultMessage: 'Other',
-      description: 'Label for option other',
-      id: 'v2.form.field.label.recommender.other'
-    },
+    label: generateTranslationConfig('Other'),
     value: 'OTHER'
   }
 ]
@@ -118,21 +101,13 @@ const overriddenEventConfig = {
     pages: [
       {
         id: 'recommender',
-        title: {
-          id: 'v2.event.tennis-club-membership.action.declare.form.section.recommender.title',
-          defaultMessage: 'Who is recommending the applicant?',
-          description: 'This is the title of the section'
-        },
+        title: generateTranslationConfig('Who is recommending the applicant?'),
         fields: [
           {
             id: 'recommender.relation',
             type: FieldType.SELECT,
             required: true,
-            label: {
-              defaultMessage: 'Relationship to child',
-              description: 'This is the label for the field',
-              id: 'v2.event.birth.action.declare.form.section.recommender.field.relation.label'
-            },
+            label: generateTranslationConfig('Relationship to child'),
             options: recommenderOptions
           },
           {
@@ -140,11 +115,7 @@ const overriddenEventConfig = {
             type: FieldType.NAME,
             hideLabel: true,
             required: true,
-            label: {
-              defaultMessage: "Recommender's name",
-              description: 'This is the label for the field',
-              id: 'v2.event.tennis-club-membership.action.declare.form.section.recommender.field.firstname.label'
-            },
+            label: generateTranslationConfig("Recommender's name"),
             parent: field('recommender.relation')
           },
           {
@@ -153,31 +124,19 @@ const overriddenEventConfig = {
             required: true,
             validation: [
               {
-                message: {
-                  defaultMessage: 'Must be a valid Birthdate',
-                  description: 'This is the error message for invalid date',
-                  id: 'v2.event.birth.action.declare.form.section.person.field.dob.error'
-                },
+                message: generateTranslationConfig('Must be a valid Birthdate'),
                 validator: field('recommender.dob').isBefore().now()
               },
               {
-                message: {
-                  defaultMessage:
-                    "Birth date must be before child's birth date",
-                  description:
-                    "This is the error message for a birth date after child's birth date",
-                  id: 'v2.event.birth.action.declare.form.section.person.dob.afterChild'
-                },
+                message: generateTranslationConfig(
+                  "Birth date must be before child's birth date"
+                ),
                 validator: field('recommender.dob')
                   .isBefore()
                   .date(field('child.dob'))
               }
             ],
-            label: {
-              defaultMessage: 'Date of birth',
-              description: 'This is the label for the field',
-              id: 'v2.event.birth.action.declare.form.section.person.field.dob.label'
-            },
+            label: generateTranslationConfig('Date of birth'),
             conditionals: [
               {
                 type: ConditionalType.SHOW,
@@ -191,11 +150,7 @@ const overriddenEventConfig = {
           {
             id: 'recommender.dobUnknown',
             type: FieldType.CHECKBOX,
-            label: {
-              defaultMessage: 'Exact date of birth unknown',
-              description: 'This is the label for the field',
-              id: 'v2.event.birth.action.declare.form.section.person.field.age.checkbox.label'
-            },
+            label: generateTranslationConfig('Exact date of birth unknown'),
             conditionals: [
               {
                 type: ConditionalType.SHOW,
@@ -212,17 +167,9 @@ const overriddenEventConfig = {
             id: 'recommender.age',
             type: FieldType.TEXT,
             required: true,
-            label: {
-              defaultMessage: 'Age of recommender',
-              description: 'This is the label for the field',
-              id: 'v2.event.birth.action.declare.form.section.recommender.field.age.label'
-            },
+            label: generateTranslationConfig('Age of recommender'),
             configuration: {
-              postfix: {
-                defaultMessage: 'years',
-                description: 'This is the postfix for age field',
-                id: 'v2.event.birth.action.declare.form.section.person.field.age.postfix'
-              }
+              postfix: generateTranslationConfig('years')
             },
             conditionals: [
               {
@@ -274,7 +221,6 @@ const overridenEvent = {
   id: generateUuid(),
   updatedAt: new Date(Date.now()).toISOString()
 }
-const generator = testDataGenerator()
 export const FormFieldParentChildReset: Story = {
   beforeEach: () => {
     /*
@@ -288,7 +234,17 @@ export const FormFieldParentChildReset: Story = {
       router: {
         path: '/',
         element: <Outlet />,
-        children: [router]
+        children: [
+          router,
+          {
+            path: ROUTES.V2.EVENTS.OVERVIEW.path,
+            element: (
+              <EventOverviewLayout>
+                <EventOverviewIndex />
+              </EventOverviewLayout>
+            )
+          }
+        ]
       },
       initialPath: ROUTES.V2.EVENTS.CORRECTION.REVIEW.buildPath({
         eventId: overridenEvent.id
@@ -305,6 +261,36 @@ export const FormFieldParentChildReset: Story = {
           tRPCMsw.event.get.query(() => {
             return overridenEvent
           })
+        ],
+        actions: [
+          tRPCMsw.event.actions.correction.request.request.mutation(
+            async (payload) => {
+              await expect(payload.declaration).toEqual({
+                'recommender.relation': 'FRIEND',
+                'recommender.name': {
+                  firstname: 'John',
+                  middlename: '',
+                  surname: 'Doe'
+                },
+                'recommender.dobUnknown': true,
+                'recommender.age': '36'
+              })
+              return {
+                ...overridenEvent,
+                actions: [
+                  ...overridenEvent.actions,
+                  generateActionDocument({
+                    configuration: overriddenEventConfig,
+                    action: ActionType.REQUEST_CORRECTION,
+                    defaults: {
+                      annotation: payload.annotation,
+                      declaration: payload.declaration
+                    }
+                  })
+                ]
+              }
+            }
+          )
         ]
       }
     }
@@ -395,6 +381,12 @@ export const FormFieldParentChildReset: Story = {
           canvas.getByRole('button', { name: 'Continue' })
         ).toBeEnabled()
       })
+
+      await userEvent.click(canvas.getByRole('button', { name: 'Continue' }))
+      await userEvent.click(
+        canvas.getByRole('button', { name: 'Correct record' })
+      )
+      await userEvent.click(canvas.getByRole('button', { name: 'Confirm' }))
     })
   }
 }

--- a/packages/client/src/v2-events/features/events/actions/correct/request/Pages.tsx
+++ b/packages/client/src/v2-events/features/events/actions/correct/request/Pages.tsx
@@ -16,6 +16,7 @@ import {
   useTypedSearchParams
 } from 'react-router-typesafe-routes/dom'
 import {
+  ActionType,
   getDeclarationPages,
   isNonInteractiveFieldType,
   PageConfig
@@ -84,7 +85,7 @@ export function Pages() {
     <FormLayout route={ROUTES.V2.EVENTS.CORRECTION}>
       {modal}
       <PagesComponent
-        declaration={eventIndex.declaration}
+        actionType={ActionType.REQUEST_CORRECTION}
         eventConfig={configuration}
         form={form}
         formPages={correctablePages}

--- a/packages/client/src/v2-events/features/events/actions/correct/request/Review.tsx
+++ b/packages/client/src/v2-events/features/events/actions/correct/request/Review.tsx
@@ -119,7 +119,7 @@ export function Review() {
       : form
 
   return (
-    <FormLayout route={ROUTES.V2.EVENTS.REGISTER}>
+    <FormLayout route={ROUTES.V2.EVENTS.CORRECTION}>
       <ReviewComponent.Body
         form={formWithNewValues}
         formConfig={formConfig}

--- a/packages/client/src/v2-events/features/events/actions/declare/Pages.tsx
+++ b/packages/client/src/v2-events/features/events/actions/declare/Pages.tsx
@@ -15,10 +15,7 @@ import {
   useTypedParams,
   useTypedSearchParams
 } from 'react-router-typesafe-routes/dom'
-import {
-  getCurrentEventState,
-  getDeclarationPages
-} from '@opencrvs/commons/client'
+import { ActionType, getDeclarationPages } from '@opencrvs/commons/client'
 import { Pages as PagesComponent } from '@client/v2-events/features/events/components/Pages'
 
 import { useEventFormData } from '@client/v2-events/features/events/useEventFormData'
@@ -103,7 +100,7 @@ export function Pages() {
     >
       {modal}
       <PagesComponent
-        declaration={getCurrentEventState(event, configuration).declaration}
+        actionType={ActionType.DECLARE}
         eventConfig={configuration}
         form={formValues}
         formPages={declarationPages}

--- a/packages/client/src/v2-events/features/events/actions/print-certificate/PrintCertificate.stories.tsx
+++ b/packages/client/src/v2-events/features/events/actions/print-certificate/PrintCertificate.stories.tsx
@@ -17,8 +17,7 @@ import {
   ActionType,
   generateActionDocument,
   generateEventDocument,
-  tennisClubMembershipEvent,
-  UUID
+  tennisClubMembershipEvent
 } from '@opencrvs/commons/client'
 import {
   tennisClubMembershipEventIndex,

--- a/packages/client/src/v2-events/features/events/actions/register/Pages.tsx
+++ b/packages/client/src/v2-events/features/events/actions/register/Pages.tsx
@@ -16,6 +16,7 @@ import {
   useTypedSearchParams
 } from 'react-router-typesafe-routes/dom'
 import {
+  ActionType,
   getCurrentEventState,
   getDeclarationPages
 } from '@opencrvs/commons/client'
@@ -80,7 +81,7 @@ export function Pages() {
     >
       {modal}
       <PagesComponent
-        declaration={eventIndex.declaration}
+        actionType={ActionType.REGISTER}
         eventConfig={configuration}
         form={form}
         formPages={declarationPages}

--- a/packages/client/src/v2-events/features/events/actions/validate/Pages.tsx
+++ b/packages/client/src/v2-events/features/events/actions/validate/Pages.tsx
@@ -16,6 +16,7 @@ import {
   useTypedSearchParams
 } from 'react-router-typesafe-routes/dom'
 import {
+  ActionType,
   getCurrentEventState,
   getDeclarationPages
 } from '@opencrvs/commons/client'
@@ -82,7 +83,7 @@ export function Pages() {
     >
       {modal}
       <PagesComponent
-        declaration={eventIndex.declaration}
+        actionType={ActionType.VALIDATE}
         eventConfig={configuration}
         form={form}
         formPages={formPages}

--- a/packages/client/src/v2-events/features/events/components/Pages.tsx
+++ b/packages/client/src/v2-events/features/events/components/Pages.tsx
@@ -16,7 +16,9 @@ import {
   EventConfig,
   isPageVisible,
   PageTypes,
-  PageConfig
+  PageConfig,
+  DeclarationUpdateActionType,
+  ActionType
 } from '@opencrvs/commons/client'
 import { MAIN_CONTENT_ANCHOR_ID } from '@opencrvs/components/lib/Frame/components/SkipToContent'
 import { FormFieldGenerator } from '@client/v2-events/components/forms/FormFieldGenerator'
@@ -24,6 +26,29 @@ import { makeFormFieldIdFormikCompatible } from '@client/v2-events/components/fo
 import { useEventFormData } from '../useEventFormData'
 import { VerificationWizard } from './VerificationWizard'
 import { FormWizard } from './FormWizard'
+
+interface PagesProps {
+  form: EventState
+  setFormData: (dec: EventState) => void
+  pageId: string
+  showReviewButton?: boolean
+  formPages: PageConfig[]
+  onPageChange: (nextPageId: string) => void
+  onSubmit: () => void
+  continueButtonText?: string
+  eventConfig?: EventConfig
+  validateBeforeNextPage?: boolean
+  isCorrection?: boolean
+}
+
+type DeclarationProps =
+  | {
+      actionType: DeclarationUpdateActionType
+      declaration?: undefined
+    }
+  | {
+      declaration: EventState
+    }
 /**
  *
  * Reusable component for rendering a form with pagination. Used by different action forms
@@ -42,20 +67,7 @@ export function Pages({
   validateBeforeNextPage = false,
   // When isCorrection is true, we should disabled fields with 'uncorrectable' set to true, or skip pages where all fields have 'uncorrectable' set to true
   isCorrection = false
-}: {
-  form: EventState
-  setFormData: (dec: EventState) => void
-  pageId: string
-  showReviewButton?: boolean
-  formPages: PageConfig[]
-  onPageChange: (nextPageId: string) => void
-  onSubmit: () => void
-  continueButtonText?: string
-  eventConfig?: EventConfig
-  declaration?: EventState
-  validateBeforeNextPage?: boolean
-  isCorrection?: boolean
-}) {
+}: PagesProps & DeclarationProps) {
   const intl = useIntl()
   const visiblePages = formPages.filter((page) => isPageVisible(page, form))
   const pageIdx = visiblePages.findIndex((p) => p.id === pageId)
@@ -128,8 +140,10 @@ export function Pages({
       eventConfig={eventConfig}
       fields={page.fields}
       id="locationForm"
-      // As initial values we use both the provided declaration data (previously saved to the event)
-      // and the form data (which is currently being edited).
+      // In some Action page forms, the form data itself is not the complete declaration.
+      // We still merge the optional `declaration` prop into the initial form values so that
+      // read-only declaration data is available for Data components or calculations.
+      // Example: Print Certificate action.
       initialValues={{ ...declaration, ...form }}
       isCorrection={isCorrection}
       validateAllFields={validateAllFields}

--- a/packages/commons/src/events/ActionInput.ts
+++ b/packages/commons/src/events/ActionInput.ts
@@ -82,7 +82,7 @@ export const PrintCertificateActionInput = BaseActionInput.merge(
     type: z
       .literal(ActionType.PRINT_CERTIFICATE)
       .default(ActionType.PRINT_CERTIFICATE),
-    content: PrintContent.optional(),
+    content: PrintContent.optional()
   })
 )
 

--- a/packages/commons/src/fixtures/v2-birth-event.ts
+++ b/packages/commons/src/fixtures/v2-birth-event.ts
@@ -17,15 +17,20 @@ import {
 import { PageTypes } from '../events/PageConfig'
 import { FieldType } from '../events/FieldType'
 import { BIRTH_EVENT } from '../events/Constants'
+import { ActionType } from '../events/ActionType'
+import { TranslationConfig } from 'src/events/TranslationConfig'
 
+function generateTranslationConfig(message: string): TranslationConfig {
+  return {
+    defaultMessage: message,
+    description: 'Description for ${message}',
+    id: message
+  }
+}
 const child = defineFormPage({
   id: 'child',
   type: PageTypes.enum.FORM,
-  title: {
-    defaultMessage: "Child's details",
-    description: 'Form section title for Child',
-    id: 'v2.form.birth.child.title'
-  },
+  title: generateTranslationConfig("Child's details"),
   fields: [
     {
       id: 'child.firstNames',
@@ -33,11 +38,7 @@ const child = defineFormPage({
       required: true,
       configuration: { maxLength: 32 },
       hideLabel: true,
-      label: {
-        defaultMessage: "Child's  first name",
-        description: 'This is the label for the field',
-        id: 'v2.event.birth.action.declare.form.section.child.field.name.label'
-      }
+      label: generateTranslationConfig("Child's  first name")
     },
     {
       id: 'child.familyName',
@@ -45,21 +46,13 @@ const child = defineFormPage({
       required: true,
       configuration: { maxLength: 32 },
       hideLabel: true,
-      label: {
-        defaultMessage: "Child's last name",
-        description: 'This is the label for the field',
-        id: 'v2.event.birth.action.declare.form.section.child.field.name.label'
-      }
+      label: generateTranslationConfig("Child's last name")
     },
     {
       id: 'child.DoB',
       type: 'DATE',
       required: true,
-      label: {
-        defaultMessage: 'Date of birth',
-        description: 'This is the label for the field',
-        id: 'v2.event.birth.action.declare.form.section.child.field.dob.label'
-      }
+      label: generateTranslationConfig('Date of birth')
     }
   ]
 })
@@ -67,82 +60,95 @@ const child = defineFormPage({
 const mother = defineFormPage({
   id: 'mother',
   type: PageTypes.enum.FORM,
-  title: {
-    defaultMessage: "Mother's details",
-    description: 'Form section title for mothers details',
-    id: 'v2.form.section.mother.title'
-  },
+  title: generateTranslationConfig("Mother's details"),
   fields: [
     {
       id: 'mother.firstNames',
       configuration: { maxLength: 32 },
       type: FieldType.TEXT,
       required: true,
-      label: {
-        defaultMessage: 'First name(s)',
-        description: 'This is the label for the field',
-        id: `v2.event.birth.action.declare.form.section.person.field.firstname.label`
-      }
+      label: generateTranslationConfig('First name(s)')
     },
     {
       id: `mother.familyName`,
       configuration: { maxLength: 32 },
       type: FieldType.TEXT,
       required: true,
-      label: {
-        defaultMessage: 'Last name',
-        description: 'This is the label for the field',
-        id: `v2.event.birth.action.declare.form.section.person.field.surname.label`
-      }
+      label: generateTranslationConfig('Last name')
     },
     {
       id: `mother.DoB`,
       type: 'DATE',
       required: true,
-      label: {
-        defaultMessage: 'Date of birth',
-        description: 'This is the label for the field',
-        id: `v2.event.birth.action.declare.form.section.person.field.dob.label`
-      }
+      label: generateTranslationConfig('Date of birth')
     },
     {
       id: 'mother.identifier',
       type: FieldType.ID,
       required: true,
-      label: {
-        defaultMessage: 'ID Number',
-        description: 'This is the label for the field',
-        id: `v2.event.birth.action.declare.form.section.person.field.nid.label`
-      }
+      label: generateTranslationConfig('ID Number')
     }
   ]
 })
 
+const BIRTH_DECLARATION_REVIEW = {
+  title: generateTranslationConfig(
+    '{child.name.firstname, select, __EMPTY__ {Birth declaration} other {{child.name.surname, select, __EMPTY__ {Birth declaration for {child.name.firstname}} other {Birth declaration for {child.name.firstname} {child.name.surname}}}}}'
+  ),
+  fields: [
+    {
+      id: 'review.comment',
+      type: FieldType.TEXTAREA,
+      label: generateTranslationConfig('Comment'),
+      required: true
+    },
+    {
+      type: FieldType.SIGNATURE,
+      id: 'review.signature',
+      required: true,
+      label: generateTranslationConfig('Signature of informant'),
+      signaturePromptLabel: generateTranslationConfig('Draw signature')
+    }
+  ]
+}
+
 const BIRTH_DECLARATION_FORM = defineDeclarationForm({
-  label: {
-    defaultMessage: 'Birth decalration form',
-    id: 'v2.event.birth.action.declare.form.label',
-    description: 'This is what this form is referred as in the system'
-  },
+  label: generateTranslationConfig('Birth decalration form'),
 
   pages: [child, mother]
 })
 
 export const v2BirthEvent = defineConfig({
   id: BIRTH_EVENT,
-  title: {
-    defaultMessage: '{child.name.firstname} {child.name.surname}',
-    description: 'This is the title of the summary',
-    id: 'v2.event.birth.title'
-  },
-  label: {
-    defaultMessage: 'Birth',
-    description: 'This is what this event is referred as in the system',
-    id: 'v2.event.birth.label'
-  },
+  title: generateTranslationConfig(
+    '{child.name.firstname} {child.name.surname}'
+  ),
+  label: generateTranslationConfig('Birth'),
   summary: {
     fields: []
   },
-  actions: [],
-  declaration: BIRTH_DECLARATION_FORM
+  declaration: BIRTH_DECLARATION_FORM,
+  actions: [
+    {
+      type: ActionType.READ,
+      label: generateTranslationConfig('Read'),
+      review: BIRTH_DECLARATION_REVIEW
+    },
+    {
+      type: ActionType.DECLARE,
+      label: generateTranslationConfig('Declare'),
+      review: BIRTH_DECLARATION_REVIEW
+    },
+    {
+      type: ActionType.VALIDATE,
+      label: generateTranslationConfig('Validate'),
+      review: BIRTH_DECLARATION_REVIEW
+    },
+    {
+      type: ActionType.REGISTER,
+      label: generateTranslationConfig('Register'),
+      review: BIRTH_DECLARATION_REVIEW
+    }
+  ],
+  advancedSearch: []
 })

--- a/packages/components/src/DateField/DateField.tsx
+++ b/packages/components/src/DateField/DateField.tsx
@@ -65,6 +65,13 @@ export const DateField = ({
   const { dd, mm, yyyy } = date
 
   useEffect(() => {
+    if (!initialValue) {
+      setDate({
+        yyyy: '',
+        mm: '',
+        dd: ''
+      })
+    }
     if (typeof initialValue === 'string') {
       const dateSegmentVals = initialValue?.split('-') || []
       setDate({

--- a/packages/events/src/router/event/event.actions.correction-2.test.ts
+++ b/packages/events/src/router/event/event.actions.correction-2.test.ts
@@ -1,0 +1,249 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+
+import { http, HttpResponse } from 'msw'
+import {
+  ActionType,
+  and,
+  BIRTH_EVENT,
+  ConditionalType,
+  defineConfig,
+  defineDeclarationForm,
+  defineFormPage,
+  field,
+  FieldType,
+  getCurrentEventState,
+  never,
+  not,
+  PageTypes,
+  generateTranslationConfig
+} from '@opencrvs/commons'
+import { v2BirthEvent } from '@opencrvs/commons/fixtures'
+import { createTestClient, setupTestCase } from '@events/tests/utils'
+import { mswServer } from '@events/tests/msw'
+import { env } from '@events/environment'
+
+const informantOtherThanMother = and(
+  not(field('informant.relation').inArray(['MOTHER'])),
+  not(field('informant.relation').isFalsy())
+)
+
+const informant = defineFormPage({
+  id: 'informant',
+  type: PageTypes.enum.FORM,
+  title: generateTranslationConfig("Informant's details"),
+  fields: [
+    {
+      id: 'informant.relation',
+      type: FieldType.SELECT,
+      required: true,
+      label: generateTranslationConfig('Relationship to child'),
+      options: [
+        {
+          value: 'MOTHER',
+          label: generateTranslationConfig('Mother')
+        },
+        {
+          value: 'FATHER',
+          label: generateTranslationConfig('Father')
+        },
+        {
+          value: 'BROTHER',
+          label: generateTranslationConfig('Brother')
+        }
+      ]
+    },
+    {
+      id: 'informant.name',
+      type: FieldType.NAME,
+      required: true,
+      hideLabel: true,
+      label: generateTranslationConfig("Informant's name"),
+      conditionals: [
+        {
+          type: ConditionalType.SHOW,
+          conditional: informantOtherThanMother
+        }
+      ],
+      parent: field('informant.relation')
+    },
+    {
+      id: 'informant.dob',
+      type: 'DATE',
+      required: true,
+      validation: [
+        {
+          message: generateTranslationConfig('Must be a valid Birthdate'),
+          validator: field('informant.dob').isBefore().now()
+        },
+        {
+          message: generateTranslationConfig(
+            "Birth date must be before child's birth date"
+          ),
+          validator: field('informant.dob').isBefore().date(field('child.dob'))
+        }
+      ],
+      label: generateTranslationConfig('Date of birth'),
+      conditionals: [
+        {
+          type: ConditionalType.SHOW,
+          conditional: and(
+            not(field('informant.dobUnknown').isEqualTo(true)),
+            informantOtherThanMother
+          )
+        }
+      ],
+      parent: field('informant.relation')
+    },
+    {
+      id: 'informant.dobUnknown',
+      type: FieldType.CHECKBOX,
+      label: generateTranslationConfig('Exact date of birth unknown'),
+      conditionals: [
+        {
+          type: ConditionalType.SHOW,
+          conditional: informantOtherThanMother
+        },
+        {
+          type: ConditionalType.DISPLAY_ON_REVIEW,
+          conditional: never()
+        }
+      ],
+      parent: field('informant.relation')
+    },
+    {
+      id: 'informant.age',
+      type: FieldType.TEXT,
+      required: true,
+      label: generateTranslationConfig('Age of informant'),
+      configuration: {
+        postfix: generateTranslationConfig('years')
+      },
+      conditionals: [
+        {
+          type: ConditionalType.SHOW,
+          conditional: and(
+            field('informant.dobUnknown').isEqualTo(true),
+            informantOtherThanMother
+          )
+        }
+      ],
+      parent: field('informant.relation')
+    }
+  ]
+})
+
+const modiedV2BirthEvent = defineConfig({
+  ...v2BirthEvent,
+  actions: [
+    ...v2BirthEvent.actions,
+    {
+      type: ActionType.REQUEST_CORRECTION,
+      label: generateTranslationConfig('Correct record'),
+      correctionForm: {
+        label: generateTranslationConfig('Correct record'),
+        pages: []
+      },
+      conditionals: []
+    }
+  ],
+  declaration: defineDeclarationForm({
+    ...v2BirthEvent.declaration,
+    pages: [...v2BirthEvent.declaration.pages, informant]
+  })
+})
+
+describe('Overwriting parent field', () => {
+  it('should overwrite informant.relation via REQUEST_CORRECTION action', async () => {
+    mswServer.use(
+      http.get(`${env.COUNTRY_CONFIG_URL}/events`, () => {
+        return HttpResponse.json([modiedV2BirthEvent])
+      }),
+      http.post(
+        `${env.COUNTRY_CONFIG_URL}/events/v2-birth/actions/:action`,
+        (ctx) => {
+          const payload =
+            ctx.params.action === ActionType.REGISTER
+              ? { registrationNumber: `ABC${Number(new Date())}` }
+              : {}
+
+          return HttpResponse.json(payload)
+        }
+      )
+    )
+    const output = await setupTestCase()
+    const user = output.user
+    const client = createTestClient(user)
+    const generator = output.generator
+    const declaration = {
+      'child.firstNames': 'John',
+      'child.familyName': 'Doe',
+      'child.DoB': '2020-05-15',
+      'mother.firstNames': 'Jane',
+      'mother.familyName': 'Doe',
+      'mother.DoB': '1990-03-22',
+      'mother.identifier': 'ID123456789',
+      'informant.relation': 'FATHER',
+      'informant.name': { firstname: 'Rok', surname: 'Doe' },
+      'informant.dob': '1988-06-12',
+      'informant.dobUnknown': false
+    }
+    let event = await client.event.create(
+      generator.event.create({ type: BIRTH_EVENT })
+    )
+
+    event = await client.event.actions.declare.request(
+      generator.event.actions.declare(event.id, {
+        declaration,
+        keepAssignment: true
+      })
+    )
+    await client.event.actions.validate.request(
+      generator.event.actions.validate(event.id, {
+        declaration,
+        keepAssignment: true
+      })
+    )
+    event = await client.event.actions.register.request(
+      generator.event.actions.register(event.id, {
+        declaration,
+        keepAssignment: true
+      })
+    )
+
+    let eventState = getCurrentEventState(event, modiedV2BirthEvent)
+    expect(eventState.id).toBeDefined()
+    expect(eventState.declaration['informant.dobUnknown']).toBe(false)
+    expect(eventState.declaration['informant.dob']).toBe('1988-06-12')
+    expect(eventState.declaration['informant.age']).toBeUndefined()
+
+    event = await client.event.actions.correction.request.request(
+      generator.event.actions.correction.request(event.id, {
+        declaration: {
+          'informant.relation': 'MOTHER'
+        },
+        keepAssignment: true
+      })
+    )
+
+    const requestId = event.actions[event.actions.length - 1].id
+
+    event = await client.event.actions.correction.approve.request(
+      generator.event.actions.correction.approve(event.id, requestId, {
+        keepAssignment: true
+      })
+    )
+
+    eventState = getCurrentEventState(event, modiedV2BirthEvent)
+    expect(eventState.declaration['informant.dobUnknown']).toBeFalsy()
+    expect(eventState.declaration['informant.relation']).toBe('MOTHER')
+  })
+})

--- a/packages/events/src/router/event/event.actions.correction.test.ts
+++ b/packages/events/src/router/event/event.actions.correction.test.ts
@@ -11,7 +11,6 @@
 
 import { TRPCError } from '@trpc/server'
 import { omit } from 'lodash'
-import { http, HttpResponse } from 'msw'
 import {
   ActionType,
   AddressType,
@@ -22,17 +21,12 @@ import {
   getUUID,
   SCOPES
 } from '@opencrvs/commons'
-import {
-  tennisClubMembershipEvent,
-  v2BirthEvent
-} from '@opencrvs/commons/fixtures'
+import { tennisClubMembershipEvent } from '@opencrvs/commons/fixtures'
 import {
   createEvent,
   createTestClient,
   setupTestCase
 } from '@events/tests/utils'
-import { mswServer } from '@events/tests/msw'
-import { env } from '@events/environment'
 
 test(`${ActionType.REQUEST_CORRECTION} prevents forbidden access if missing required scope`, async () => {
   const { user, generator } = await setupTestCase()
@@ -485,57 +479,4 @@ test('a correction request is not allowed if the event is already waiting for co
       message: 'Event is waiting for correction'
     })
   )
-})
-
-describe.only('overwriting hidden field deciding field with undefined', () => {
-  beforeAll(() => {
-    // Mock the events config API
-    mswServer.use(
-      http.get(`${env.COUNTRY_CONFIG_URL}/events`, () => {
-        return HttpResponse.json([v2BirthEvent])
-      })
-    )
-  })
-
-  it('should create a birth event with dobUnknown set to true and show age field', async () => {
-    const { user, generator } = await setupTestCase()
-    const client = createTestClient(user)
-
-    const originalEvent = await client.event.create(generator.event.create())
-    console.log(originalEvent)
-    const birthDeclarationInput = generator.event.actions.declare(
-      originalEvent.id,
-      {
-        declaration: {
-          'child.firstNames': 'Mihirima',
-          'child.familyName': 'Aziz',
-          'child.DoB': '2025-01-01',
-          'mother.firstNames': 'Sultana',
-          'mother.familyName': 'Aziz',
-          'mother.DoB': '1990-05-05',
-          'mother.identifier': '1234567890',
-          'informant.relation': 'GRANDFATHER',
-          'informant.dobUnknown': true,
-          'informant.age': 70
-        }
-      }
-    )
-    console.log(birthDeclarationInput)
-    const event = await client.event.actions.declare.request(
-      birthDeclarationInput
-    )
-    console.log(event)
-    await client.event.actions.validate.request(
-      generator.event.actions.validate(event.id)
-    )
-    console.log('validate')
-    const data = generator.event.actions.register(event.id, {})
-    const registeredEvent = await client.event.actions.register.request(data)
-
-    console.log(registeredEvent)
-    expect(registeredEvent.id).toBeDefined()
-    // expect(createdEvent.declaration.informant.dobUnknown).toBe(true)
-    // expect(createdEvent.declaration.informant.age).toBe(70)
-    // expect(createdEvent.declaration.informant.dob).toBeUndefined()
-  })
 })


### PR DESCRIPTION
## Description

When a parent field (e.g., informant.relation) is updated, its related child fields (such as the informant’s other details) should reset. However, because of the merge-from-declaration logic, removed fields are being repopulated from declaration, preventing the reset.

The merged declaration is still needed in the Print Certificate form for Data components, but it’s unnecessary in DECLARE, VALIDATE, REGISTER, and CORRECTION pages, where the form object already represents the full declaration.

This PR removes passing the declaration prop into those pages, allowing dependent fields to reset as expected.

[ocrvs-10207](https://github.com/opencrvs/opencrvs-core/issues/10207)

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
