### PR TITLE
Clean and filter declaration updates before mutation

### DIFF
--- a/packages/client/src/v2-events/custom-api/index.ts
+++ b/packages/client/src/v2-events/custom-api/index.ts
@@ -28,6 +28,7 @@ export interface OnDeclareParams {
   transactionId: string
   annotation?: EventState
   fullEvent?: EventDocument
+  eventConfiguration?: EventConfig
 }
 /**
  * Runs a sequence of actions from declare to register.

--- a/packages/client/src/v2-events/custom-api/index.ts
+++ b/packages/client/src/v2-events/custom-api/index.ts
@@ -28,7 +28,6 @@ export interface OnDeclareParams {
   transactionId: string
   annotation?: EventState
   fullEvent?: EventDocument
-  eventConfiguration?: EventConfig
 }
 /**
  * Runs a sequence of actions from declare to register.

--- a/packages/client/src/v2-events/features/events/actions/correct/request/CleanedUpCorrectionPayload.stories.tsx
+++ b/packages/client/src/v2-events/features/events/actions/correct/request/CleanedUpCorrectionPayload.stories.tsx
@@ -1,0 +1,328 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+import React from 'react'
+import type { Meta, StoryObj } from '@storybook/react'
+import { createTRPCMsw, httpLink } from '@vafanassieff/msw-trpc'
+import { Outlet } from 'react-router-dom'
+import superjson from 'superjson'
+import { expect, waitFor, within, userEvent } from '@storybook/test'
+import {
+  ActionType,
+  and,
+  not,
+  ConditionalType,
+  field,
+  FieldType,
+  tennisClubMembershipEvent,
+  never,
+  defineDeclarationForm,
+  generateUuid,
+  generateActionDocument,
+  generateTranslationConfig
+} from '@opencrvs/commons/client'
+import { ROUTES } from '@client/v2-events/routes'
+import { AppRouter } from '@client/v2-events/trpc'
+import { testDataGenerator } from '@client/tests/test-data-generators'
+import { EventOverviewLayout } from '@client/v2-events/layouts'
+import { EventOverviewIndex } from '@client/v2-events/features/workqueues/EventOverview/EventOverview'
+import { setEventData, addLocalEventConfig } from '../../../useEvents/api'
+import { useEventFormData } from '../../../useEventFormData'
+import { router } from './router'
+import * as Request from './index'
+
+const meta: Meta<typeof Request.Pages> = {
+  title: 'CorrectionRequest'
+}
+export default meta
+
+type Story = StoryObj<typeof Request.Pages>
+
+// --- MSW setup ---
+const tRPCMsw = createTRPCMsw<AppRouter>({
+  links: [httpLink({ url: '/api/events' })],
+  transformer: { input: superjson, output: superjson }
+})
+
+// --- Event config overrides ---
+const recommenderOptions = [
+  { label: generateTranslationConfig('Club Member'), value: 'MEMBER' },
+  { label: generateTranslationConfig('Coach'), value: 'COACH' },
+  { label: generateTranslationConfig('Friend'), value: 'FRIEND' },
+  { label: generateTranslationConfig('Family'), value: 'FAMILY' },
+  { label: generateTranslationConfig('Other'), value: 'OTHER' }
+]
+
+const recommenderOtherThanClubMembers = and(
+  not(field('recommender.relation').inArray(['MEMBER'])),
+  not(field('recommender.relation').isFalsy())
+)
+
+const overriddenEventConfig = {
+  ...tennisClubMembershipEvent,
+  id: 'overriddenEventConfig',
+  declaration: defineDeclarationForm({
+    ...tennisClubMembershipEvent.declaration,
+    pages: [
+      {
+        id: 'recommender',
+        title: generateTranslationConfig('Who is recommending the applicant?'),
+        fields: [
+          {
+            id: 'recommender.relation',
+            type: FieldType.SELECT,
+            required: true,
+            label: generateTranslationConfig('Relationship to child'),
+            options: recommenderOptions
+          },
+          {
+            id: 'recommender.name',
+            type: FieldType.NAME,
+            required: true,
+            hideLabel: true,
+            label: generateTranslationConfig("Recommender's name"),
+            conditionals: [
+              {
+                type: ConditionalType.SHOW,
+                conditional: recommenderOtherThanClubMembers
+              }
+            ],
+            parent: field('recommender.relation')
+          },
+          {
+            id: 'recommender.dob',
+            type: 'DATE',
+            required: true,
+            label: generateTranslationConfig('Date of birth'),
+            validation: [
+              {
+                message: generateTranslationConfig('Must be a valid Birthdate'),
+                validator: field('recommender.dob').isBefore().now()
+              },
+              {
+                message: generateTranslationConfig(
+                  "Birth date must be before child's birth date"
+                ),
+                validator: field('recommender.dob')
+                  .isBefore()
+                  .date(field('child.dob'))
+              }
+            ],
+            conditionals: [
+              {
+                type: ConditionalType.SHOW,
+                conditional: and(
+                  not(field('recommender.dobUnknown').isEqualTo(true)),
+                  recommenderOtherThanClubMembers
+                )
+              }
+            ],
+            parent: field('recommender.relation')
+          },
+          {
+            id: 'recommender.dobUnknown',
+            type: FieldType.CHECKBOX,
+            label: generateTranslationConfig('Exact date of birth unknown'),
+            conditionals: [
+              {
+                type: ConditionalType.SHOW,
+                conditional: recommenderOtherThanClubMembers
+              },
+              { type: ConditionalType.DISPLAY_ON_REVIEW, conditional: never() }
+            ],
+            parent: field('recommender.relation')
+          },
+          {
+            id: 'recommender.age',
+            type: FieldType.TEXT,
+            required: true,
+            label: generateTranslationConfig('Age of recommender'),
+            configuration: { postfix: generateTranslationConfig('years') },
+            conditionals: [
+              {
+                type: ConditionalType.SHOW,
+                conditional: and(
+                  field('recommender.dobUnknown').isEqualTo(true),
+                  recommenderOtherThanClubMembers
+                )
+              }
+            ],
+            parent: field('recommender.relation')
+          }
+        ]
+      }
+    ]
+  })
+}
+
+// --- Event data ---
+const overriddenEvent = {
+  trackingId: generateUuid(),
+  type: overriddenEventConfig.id,
+  id: generateUuid(),
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  actions: [
+    generateActionDocument({
+      configuration: overriddenEventConfig,
+      action: ActionType.CREATE
+    }),
+    generateActionDocument({
+      configuration: overriddenEventConfig,
+      action: ActionType.DECLARE,
+      defaults: {
+        declaration: {
+          'recommender.relation': 'COACH',
+          'recommender.name': { firstname: 'Mohammed', surname: 'Rahim' },
+          'recommender.dob': '1978-05-12'
+        }
+      }
+    }),
+    generateActionDocument({
+      configuration: overriddenEventConfig,
+      action: ActionType.VALIDATE,
+      defaults: { declaration: {} }
+    }),
+    generateActionDocument({
+      configuration: overriddenEventConfig,
+      action: ActionType.REGISTER,
+      defaults: { declaration: {} }
+    })
+  ]
+}
+
+const generator = testDataGenerator()
+const draft = generator.event.draft({
+  eventId: overriddenEvent.id,
+  actionType: ActionType.REQUEST_CORRECTION
+})
+
+// --- Story ---
+export const CleanedUpCorrectionPayload: Story = {
+  beforeEach: () => {
+    useEventFormData.setState({ formValues: {} })
+    addLocalEventConfig(overriddenEventConfig)
+    setEventData(overriddenEvent.id, overriddenEvent)
+  },
+  loaders: [
+    async () => {
+      window.localStorage.setItem(
+        'opencrvs',
+        generator.user.token.registrationAgent
+      )
+      // Avoid flaky state leakage when running stories in parallel
+      await new Promise((r) => setTimeout(r, 50))
+    }
+  ],
+  parameters: {
+    mockingDate: new Date(),
+    offline: {
+      drafts: [
+        {
+          ...draft,
+          action: {
+            ...draft.action,
+            // all of the fields in the below declaration is dependent on recommender.relation
+            // ideally, all of the valid fields below should be available in the correction request endpoint.
+            declaration: {
+              'recommender.dob': '2002-05-12',
+              'recommender.dobUnknown': true,
+              'recommender.age': '45',
+              'recommender.name': { firstname: 'Mohammed', surname: 'Karim' }
+            }
+          }
+        }
+      ]
+    },
+    reactRouter: {
+      router: {
+        path: '/',
+        element: <Outlet />,
+        children: [
+          router,
+          {
+            path: ROUTES.V2.EVENTS.OVERVIEW.path,
+            element: (
+              <EventOverviewLayout>
+                <EventOverviewIndex />
+              </EventOverviewLayout>
+            )
+          }
+        ]
+      },
+      initialPath: ROUTES.V2.EVENTS.CORRECTION.SUMMARY.buildPath({
+        eventId: overriddenEvent.id
+      })
+    },
+    msw: {
+      handlers: {
+        events: [tRPCMsw.event.config.get.query(() => [overriddenEventConfig])],
+        event: [tRPCMsw.event.get.query(() => overriddenEvent)],
+        actions: [
+          tRPCMsw.event.actions.correction.request.request.mutation(
+            async (payload) => {
+              // all the valid fields are available in the correction request endpoint
+              await expect(payload.declaration).toEqual({
+                'recommender.dobUnknown': true,
+                'recommender.age': '45',
+                'recommender.name': { firstname: 'Mohammed', surname: 'Karim' }
+              })
+              // since recommender.dobKnown is true, recommender.dob is filtered in the client
+              // before arriving to correction request endpoint
+              await expect(payload.declaration).not.toHaveProperty(
+                'recommender.dob'
+              )
+              return {
+                ...overriddenEvent,
+                actions: [
+                  ...overriddenEvent.actions,
+                  generateActionDocument({
+                    configuration: overriddenEventConfig,
+                    action: ActionType.REQUEST_CORRECTION,
+                    defaults: {
+                      annotation: payload.annotation,
+                      declaration: payload.declaration
+                    }
+                  })
+                ]
+              }
+            }
+          ),
+          tRPCMsw.event.actions.correction.approve.request.mutation(() => ({
+            ...overriddenEvent,
+            actions: [
+              ...overriddenEvent.actions,
+              generateActionDocument({
+                configuration: overriddenEventConfig,
+                action: ActionType.APPROVE_CORRECTION
+              })
+            ]
+          }))
+        ]
+      }
+    }
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+
+    await waitFor(async () =>
+      expect(
+        canvas.getByRole('button', { name: 'Submit correction request' })
+      ).toBeVisible()
+    )
+
+    await step('Submit correction request', async () => {
+      await userEvent.click(
+        canvas.getByRole('button', { name: 'Submit correction request' })
+      )
+      await userEvent.click(canvas.getByRole('button', { name: 'Confirm' }))
+    })
+  }
+}

--- a/packages/client/src/v2-events/features/events/actions/correct/request/Summary/Summary.tsx
+++ b/packages/client/src/v2-events/features/events/actions/correct/request/Summary/Summary.tsx
@@ -131,7 +131,10 @@ export function Summary() {
       fullEvent: event
     }
     if (scopes?.includes(SCOPES.RECORD_REGISTRATION_CORRECT)) {
-      events.customActions.makeCorrectionOnRequest.mutate(mutationPayload)
+      events.customActions.makeCorrectionOnRequest.mutate({
+        ...mutationPayload,
+        eventConfiguration
+      })
     } else {
       events.actions.correction.request.mutate(mutationPayload)
     }
@@ -140,6 +143,7 @@ export function Summary() {
   }, [
     form,
     fields,
+    eventConfiguration,
     event,
     scopes,
     events.customActions.makeCorrectionOnRequest,

--- a/packages/client/src/v2-events/features/events/actions/correct/request/Summary/Summary.tsx
+++ b/packages/client/src/v2-events/features/events/actions/correct/request/Summary/Summary.tsx
@@ -127,14 +127,11 @@ export function Summary() {
         ...nullifiedHiddenValues
       },
       transactionId: generateTransactionId(),
-      annotation
+      annotation,
+      fullEvent: event
     }
     if (scopes?.includes(SCOPES.RECORD_REGISTRATION_CORRECT)) {
-      events.customActions.makeCorrectionOnRequest.mutate({
-        ...mutationPayload,
-        fullEvent: event,
-        eventConfiguration
-      })
+      events.customActions.makeCorrectionOnRequest.mutate(mutationPayload)
     } else {
       events.actions.correction.request.mutate(mutationPayload)
     }
@@ -144,7 +141,6 @@ export function Summary() {
     form,
     fields,
     event,
-    eventConfiguration,
     scopes,
     events.customActions.makeCorrectionOnRequest,
     events.actions.correction.request,

--- a/packages/client/src/v2-events/features/events/useEvents/procedures/actions/action.ts
+++ b/packages/client/src/v2-events/features/events/useEvents/procedures/actions/action.ts
@@ -17,12 +17,17 @@ import type {
 import { toast } from 'react-hot-toast'
 import { TRPCClientError } from '@trpc/client'
 import { useSyncExternalStore } from 'react'
+import { isEmpty } from 'lodash'
 import {
   ActionType,
+  ActionUpdate,
   EventDocument,
   getCurrentEventState,
   omitHiddenAnnotationFields,
-  omitHiddenPaginatedFields
+  omitHiddenPaginatedFields,
+  deepMerge,
+  EventState,
+  EventConfig
 } from '@opencrvs/commons/client'
 import * as customApi from '@client/v2-events/custom-api'
 import { useEventConfigurations } from '@client/v2-events/features/events/useEventConfiguration'
@@ -65,6 +70,42 @@ function errorToastOnConflict(error: TRPCClientError<AppRouter>) {
   if (error.data?.httpStatus === 409) {
     toast.error(ToastKey.NOT_ASSIGNED_ERROR)
   }
+}
+
+function getCleanedDeclarationDiff(
+  eventConfiguration: EventConfig,
+  originalDeclaration?: EventState,
+  declarationDiff?: EventState
+): ActionUpdate | undefined {
+  if (isEmpty(declarationDiff)) {
+    return declarationDiff
+  }
+
+  // If there's no original declaration, just clean the update and return it
+  if (isEmpty(originalDeclaration)) {
+    return omitHiddenPaginatedFields(
+      eventConfiguration.declaration,
+      declarationDiff
+    )
+  }
+
+  // Merge original + updates so we get the final event state
+  // (Needed because omitHiddenPaginatedFields func requires a full snapshot, not partial)
+  const merged = deepMerge(originalDeclaration, declarationDiff)
+
+  // Remove any hidden/paginated fields from the merged declaration
+  // (Ensures we only consider fields relevant to the event configuration)
+  const cleanedDeclaration = omitHiddenPaginatedFields(
+    eventConfiguration.declaration,
+    merged
+  )
+
+  // From the update, keep only fields that are valid in the cleaned declaration
+  // (Prevents applying updates to hidden/invalid fields)
+  const cleanedDeclarationDiff: ActionUpdate = Object.fromEntries(
+    Object.entries(declarationDiff).filter(([key]) => key in cleanedDeclaration)
+  )
+  return cleanedDeclarationDiff
 }
 
 setMutationDefaults(trpcOptionsProxy.event.actions.declare.request, {
@@ -359,8 +400,9 @@ export function useEventAction<P extends DecorateMutationProcedure<any>>(
 
     return {
       ...params,
-      declaration: omitHiddenPaginatedFields(
-        eventConfiguration.declaration,
+      declaration: getCleanedDeclarationDiff(
+        eventConfiguration,
+        originalDeclaration,
         params.declaration
       ),
       annotation
@@ -394,10 +436,15 @@ export function useEventCustomAction(mutationKey: MutationKey) {
         throw new Error('Event configuration not found')
       }
 
+      const originalDeclaration = params.fullEvent
+        ? getCurrentEventState(params.fullEvent, eventConfiguration).declaration
+        : {}
+
       return mutation.mutate({
         ...params,
-        declaration: omitHiddenPaginatedFields(
-          eventConfiguration.declaration,
+        declaration: getCleanedDeclarationDiff(
+          eventConfiguration,
+          originalDeclaration,
           params.declaration
         )
       })

--- a/packages/client/src/v2-events/features/events/useEvents/procedures/actions/action.ts
+++ b/packages/client/src/v2-events/features/events/useEvents/procedures/actions/action.ts
@@ -72,6 +72,10 @@ function errorToastOnConflict(error: TRPCClientError<AppRouter>) {
   }
 }
 
+// Merge actionUpdate with the existing declaration to avoid losing dependent fields.
+// For example: if the correction payload contains only `informant.name`, but not `informant.relation`,
+// running omitHiddenPaginatedFields on the payload alone would remove `informant.name` (since its parent `informant.relation` is missing).
+// By merging first, we preserve such dependencies, and then run a diff to keep only the valid correction fields.
 function getCleanedDeclarationDiff(
   eventConfiguration: EventConfig,
   originalDeclaration?: EventState,


### PR DESCRIPTION
## Description

Issue: https://github.com/opencrvs/opencrvs-core/issues/10253

🛠️ Fix: Correction Request Field Filtering

🔍 Problem

When we directly want to correct fields like `informant.name`,
`informant.age`, the actionUpdate payload looks like this:

    {
      "informant.name": { "firstname": "Jon", "surname": "Jane" },
      "informant.age": "44",
      "informant.dobUnknown": true
    }

At one point, before the correction request procedure is called, we run
`omitHiddenPaginatedFields` validation which considers this actionType as
a standard declaration.

Since the visibility of these fields in this declaration depends on
`informant.relation`, and that field is not available here, all the fields
in this actionUpdate gets filtered, and the intended correction request is
not made.

------------------------------------------------------------------------

✅ Solution

This PR solves the issue by:

1.  Merging the actionUpdate with the existing declaration before
    running omitHiddenPaginatedFields.
2.  Ensuring valid fields stay after the merge.
3.  Running another diffing step between actionUpdate and the merged
    declaration to figure out the actual valid fields in the
    actionUpdate.

------------------------------------------------------------------------

🎯 Outcome

-   Ensures correction requests for dependent fields like
    `informant.name`, `informant.age` are properly validated.
-   Prevents unintended filtering caused by missing dependency fields
    (`informant.relation`).


## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
