### PR TITLE
fix: Branch inconsistency between core and e2e

### DIFF
--- a/.github/workflows/deploy-to-feature-environment.yml
+++ b/.github/workflows/deploy-to-feature-environment.yml
@@ -101,9 +101,9 @@ jobs:
         run: |
           e2e_repo_url="https://github.com/opencrvs/e2e.git"
 
-          if git ls-remote --heads "$e2e_repo_url" | grep -q "refs/heads/${{ github.head_ref }}"; then
+          if git ls-remote --heads "$e2e_repo_url" "refs/heads/${{ github.head_ref }}" >/dev/null; then
             e2e_branch=${{ github.head_ref }}
-          elif git ls-remote --heads "$e2e_repo_url" | grep -q "refs/heads/${{ github.base_ref }}"; then
+          elif git ls-remote --heads "$e2e_repo_url" "refs/heads/${{ github.base_ref }}" >/dev/null; then
             e2e_branch="${{ github.base_ref }}"
           else
             e2e_branch="develop"


### PR DESCRIPTION
## Description

See more context at https://opencrvsworkspace.slack.com/archives/C02LU432JGK/p1756110680357579

Github workflow should know if same branch exists in core and e2e repositories, otherwise execution will fails, e/g: https://github.com/opencrvs/e2e/actions/runs/17200959075/job/48791330985


Example of inconsistency:

- core: https://github.com/opencrvs/opencrvs-core/tree/chore/specify-postgres-minor
- e2e: https://github.com/opencrvs/e2e/tree/chore/specify-postgres-minor-e2e


## Checklist

- [ ] I have linked the correct Github issue under "Development": n/a
- [ ] I have tested the changes locally, and written appropriate tests: n/a
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths): this kind of fix will handle failure paths
- [ ] I have updated the changelog with this change (if applicable): n/a
- [ ] I have updated the GitHub issue status accordingly: n/a
