### PR TITLE
perf: give FieldConfig an explicit type

### DIFF
--- a/packages/client/src/v2-events/features/events/registered-fields/Address.tsx
+++ b/packages/client/src/v2-events/features/events/registered-fields/Address.tsx
@@ -18,7 +18,7 @@ import {
   ConditionalType,
   field as createFieldCondition,
   FieldConfig,
-  FieldProps,
+  FieldPropsWithoutReferenceValue,
   FieldType,
   not,
   GeographicalArea,
@@ -42,7 +42,7 @@ type FieldConfigWithoutAddress = Exclude<
   { type: typeof FieldType.ADDRESS }
 >
 
-type Props = FieldProps<typeof FieldType.ADDRESS> & {
+type Props = FieldPropsWithoutReferenceValue<typeof FieldType.ADDRESS> & {
   onChange: (newValue: Partial<AddressFieldValue>) => void
   value?: AddressFieldValue
   configuration?: AddressField['configuration']

--- a/packages/client/src/v2-events/features/events/registered-fields/AdministrativeArea.tsx
+++ b/packages/client/src/v2-events/features/events/registered-fields/AdministrativeArea.tsx
@@ -11,7 +11,7 @@
 import React from 'react'
 import { useSelector } from 'react-redux'
 import { Location } from '@events/service/locations/locations'
-import { FieldProps } from '@opencrvs/commons/client'
+import { FieldPropsWithoutReferenceValue } from '@opencrvs/commons/client'
 import { getAdminStructureLocations } from '@client/offline/selectors'
 import { Stringifiable } from '@client/v2-events/components/forms/utils'
 import { EMPTY_TOKEN } from '@client/v2-events/messages/utils'
@@ -42,7 +42,7 @@ function AdministrativeAreaInput({
   value,
   partOf,
   ...props
-}: FieldProps<'ADMINISTRATIVE_AREA'> & {
+}: FieldPropsWithoutReferenceValue<'ADMINISTRATIVE_AREA'> & {
   onChange: (val: string | undefined) => void
   partOf: string | null
   value?: string

--- a/packages/client/src/v2-events/features/events/registered-fields/Checkbox.tsx
+++ b/packages/client/src/v2-events/features/events/registered-fields/Checkbox.tsx
@@ -11,14 +11,14 @@
 import React from 'react'
 import { useIntl } from 'react-intl'
 import { Checkbox as CheckboxComponent } from '@opencrvs/components'
-import { FieldProps } from '@opencrvs/commons/client'
+import { FieldPropsWithoutReferenceValue } from '@opencrvs/commons/client'
 
 function CheckboxInput({
   label,
   value,
   onChange,
   ...props
-}: FieldProps<'CHECKBOX'> & {
+}: FieldPropsWithoutReferenceValue<'CHECKBOX'> & {
   value?: boolean
   onChange: (val: boolean) => void
 }) {

--- a/packages/client/src/v2-events/features/events/registered-fields/LocationSearch.tsx
+++ b/packages/client/src/v2-events/features/events/registered-fields/LocationSearch.tsx
@@ -13,7 +13,7 @@ import { useSelector } from 'react-redux'
 import { IntlShape, useIntl } from 'react-intl'
 import { Location } from '@events/service/locations/locations'
 import { LocationSearch as LocationSearchComponent } from '@opencrvs/components'
-import { FieldProps } from '@opencrvs/commons/client'
+import { FieldPropsWithoutReferenceValue } from '@opencrvs/commons/client'
 import { getOfflineData } from '@client/offline/selectors'
 import { getListOfLocations } from '@client/utils/validate'
 import { generateLocations } from '@client/utils/locationUtils'
@@ -50,7 +50,7 @@ function LocationSearchInput({
   searchableResource,
   onBlur,
   ...props
-}: FieldProps<'LOCATION' | 'OFFICE' | 'FACILITY'> & {
+}: FieldPropsWithoutReferenceValue<'LOCATION' | 'OFFICE' | 'FACILITY'> & {
   onChange: (val: string | undefined) => void
   searchableResource: ('locations' | 'facilities' | 'offices')[]
   value?: string

--- a/packages/client/src/v2-events/features/events/registered-fields/RadioGroup.tsx
+++ b/packages/client/src/v2-events/features/events/registered-fields/RadioGroup.tsx
@@ -8,11 +8,10 @@
  *
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
-import { on } from 'events'
 import React from 'react'
 import { IntlShape, useIntl } from 'react-intl'
 import {
-  FieldProps,
+  FieldPropsWithoutReferenceValue,
   RadioGroup as RadioGroupField,
   SelectOption
 } from '@opencrvs/commons/client'
@@ -28,7 +27,7 @@ function RadioGroupInput({
   options,
   configuration,
   ...props
-}: FieldProps<'RADIO_GROUP'> & {
+}: FieldPropsWithoutReferenceValue<'RADIO_GROUP'> & {
   onChange: (val: string | undefined) => void
   value?: string
 }) {

--- a/packages/client/src/v2-events/features/events/registered-fields/Select.tsx
+++ b/packages/client/src/v2-events/features/events/registered-fields/Select.tsx
@@ -11,14 +11,17 @@
 import React from 'react'
 import { IntlShape, useIntl } from 'react-intl'
 import {
-  FieldProps,
+  FieldPropsWithoutReferenceValue,
   SelectField,
   SelectOption,
   TranslationConfig
 } from '@opencrvs/commons/client'
 import { Select as SelectComponent } from '@opencrvs/components'
 
-export type SelectInputProps = Omit<FieldProps<'SELECT'>, 'label'> & {
+export type SelectInputProps = Omit<
+  FieldPropsWithoutReferenceValue<'SELECT'>,
+  'label'
+> & {
   onChange: (newValue: string) => void
   value?: string
   label?: TranslationConfig

--- a/packages/client/src/v2-events/features/events/registered-fields/SelectCountry.tsx
+++ b/packages/client/src/v2-events/features/events/registered-fields/SelectCountry.tsx
@@ -10,7 +10,10 @@
  */
 import React from 'react'
 import { IntlShape, useIntl } from 'react-intl'
-import { FieldProps, SelectOption } from '@opencrvs/commons/client'
+import {
+  FieldPropsWithoutReferenceValue,
+  SelectOption
+} from '@opencrvs/commons/client'
 import { countries } from '@client/utils/countries'
 import { Select } from './Select'
 
@@ -18,7 +21,7 @@ function SelectCountryInput({
   value,
   onChange,
   ...props
-}: FieldProps<'COUNTRY'> & {
+}: FieldPropsWithoutReferenceValue<'COUNTRY'> & {
   onChange: (val: string | undefined) => void
   value?: string
 }) {

--- a/packages/commons/src/events/FieldConfig.ts
+++ b/packages/commons/src/events/FieldConfig.ts
@@ -670,6 +670,12 @@ export type FieldConfigInput =
   | z.input<typeof DataField>
   | z.input<typeof HttpField>
 
+/*
+ *  Using explicit type for the FieldConfig schema intentionally as it's
+ *  referenced quite extensively througout various other schemas. Leaving the
+ *  type to be inferred causes typescript compiler to fail with "inferred type
+ *  exeeds max lenght"
+ */
 export const FieldConfig: z.ZodType<
   FieldConfig,
   z.ZodTypeDef,

--- a/packages/commons/src/events/FieldConfig.ts
+++ b/packages/commons/src/events/FieldConfig.ts
@@ -727,6 +727,10 @@ export type RadioField = z.infer<typeof RadioGroup>
 export type AddressField = z.infer<typeof Address>
 export type NumberField = z.infer<typeof NumberField>
 export type FieldProps<T extends FieldType> = Extract<FieldConfig, { type: T }>
+export type FieldPropsWithoutReferenceValue<T extends FieldType> = Omit<
+  Extract<FieldConfig, { type: T }>,
+  'value'
+>
 export type SelectOption = z.infer<typeof SelectOption>
 
 export type AdministrativeAreaConfiguration = z.infer<

--- a/packages/commons/src/events/FieldConfig.ts
+++ b/packages/commons/src/events/FieldConfig.ts
@@ -79,9 +79,7 @@ const BaseField = z.object({
     ),
   value: FieldReference.optional().describe(
     'Reference to a parent field. If field has a value, the value will be copied when the parent field is changed.'
-    // @TODO: When Zod is upgraded to v4, remove this any to fix error TS7056
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ) as any
+  )
 })
 
 export type BaseField = z.infer<typeof BaseField>
@@ -603,15 +601,8 @@ const HttpField = BaseField.extend({
 
 export type HttpField = z.infer<typeof HttpField>
 
-/*
- * This needs to be exported so that Typescript can refer to the type in
- * the declaration output type. If it can't do that, you might start encountering
- * "The inferred type of this node exceeds the maximum length the compiler will serialize. An explicit type annotation is needed"
- * errors when compiling
- */
-
 /** @knipignore */
-export type Inferred =
+export type FieldConfig =
   | z.infer<typeof Address>
   | z.infer<typeof TextField>
   | z.infer<typeof NumberField>
@@ -647,9 +638,12 @@ export type Inferred =
 /**
  * This is the type that should be used for the input of the FieldConfig. Useful when config uses zod defaults.
  */
-export type InferredInput =
+export type FieldConfigInput =
   | z.input<typeof Address>
   | z.input<typeof TextField>
+  | z.input<typeof TimeField>
+  | z.input<typeof SelectDateRangeField>
+  | z.input<typeof ButtonField>
   | z.input<typeof NumberField>
   | z.input<typeof TextAreaField>
   | z.input<typeof DateField>
@@ -675,7 +669,12 @@ export type InferredInput =
   | z.input<typeof EmailField>
   | z.input<typeof DataField>
   | z.input<typeof HttpField>
-export const FieldConfig = z
+
+export const FieldConfig: z.ZodType<
+  FieldConfig,
+  z.ZodTypeDef,
+  FieldConfigInput
+> = z
   .discriminatedUnion('type', [
     Address,
     TextField,
@@ -721,7 +720,6 @@ export type LocationField = z.infer<typeof Location>
 export type RadioField = z.infer<typeof RadioGroup>
 export type AddressField = z.infer<typeof Address>
 export type NumberField = z.infer<typeof NumberField>
-export type FieldConfig = Inferred
 export type FieldProps<T extends FieldType> = Extract<FieldConfig, { type: T }>
 export type SelectOption = z.infer<typeof SelectOption>
 


### PR DESCRIPTION
We were pretty close with our previous solution of exporting the inferred types, but apparently we explicitly need to set type for Zod schema for that to take proper effect. With this change, we are getting:
- ~80% reduction in number of lines in the commons build
- ~60% reduction in commons build time
