### PR TITLE
Add wait mechanism for Workbox runtime cache with controlled reloads

### DIFF
--- a/packages/client/src/components/Page.tsx
+++ b/packages/client/src/components/Page.tsx
@@ -122,7 +122,7 @@ class Component extends React.Component<IFullProps> {
     } else {
       return (
         <>
-          <LoadingBar />
+          <LoadingBar message="Loading records..." />
         </>
       )
     }

--- a/packages/client/src/components/ProtectedPage.tsx
+++ b/packages/client/src/components/ProtectedPage.tsx
@@ -173,7 +173,7 @@ class ProtectedPageComponent extends React.Component<Props, IProtectPageState> {
   }
 
   renderLoadingScreen() {
-    return <LoadingBar />
+    return <LoadingBar message="Loading records..." />
   }
 
   conditionalRenderUponSecuredState() {

--- a/packages/client/src/v2-events/features/workqueues/EventOverview/components/EventHistory/EventHistory.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/components/EventHistory/EventHistory.tsx
@@ -72,7 +72,7 @@ const messages = defineMessages({
     description: 'Role of the user in the event history'
   },
   system: {
-    id: 'v2.event.history.system',
+    id: 'event.history.system',
     defaultMessage: 'System',
     description: 'Name for system initiated actions in the event history'
   },

--- a/packages/client/src/v2-events/hooks/useWorkboxCacheReady.ts
+++ b/packages/client/src/v2-events/hooks/useWorkboxCacheReady.ts
@@ -1,0 +1,52 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+import { useEffect, useState } from 'react'
+import { CACHE_NAME } from '@client/v2-events/cache'
+
+const MAX_RETRY = 5
+
+export function useWorkboxCacheReady(cachePrefix = CACHE_NAME) {
+  const [ready, setReady] = useState<boolean | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    async function checkCache() {
+      // retry up to MAX_RETRY times with delay to check if CACHE_NAME cache key exists
+      for (let i = 0; i < MAX_RETRY; i++) {
+        const cacheKeys = await caches.keys()
+        const found = cacheKeys.find((k) => k.startsWith(cachePrefix))
+        if (found) {
+          if (!cancelled) {
+            setReady(true)
+          }
+          return
+        }
+        await new Promise((resolve) => setTimeout(resolve, 1000))
+      }
+
+      // eslint-disable-next-line no-console
+      console.warn(
+        '⚠️ Workbox runtime cache not found after retries, preparing to logout'
+      )
+      if (!cancelled) {
+        setReady(false)
+      }
+    }
+
+    void checkCache()
+
+    return () => {
+      cancelled = true
+    }
+  }, [cachePrefix])
+
+  return ready
+}

--- a/packages/client/src/v2-events/layouts/sidebar/Sidebar.tsx
+++ b/packages/client/src/v2-events/layouts/sidebar/Sidebar.tsx
@@ -22,22 +22,21 @@ import { NavigationGroup } from '@opencrvs/components/lib/SideNavigation/Navigat
 import { NavigationItem } from '@opencrvs/components/lib/SideNavigation/NavigationItem'
 import { joinValues } from '@opencrvs/commons/client'
 import { buttonMessages } from '@client/i18n/messages'
-import { storage } from '@client/storage'
 import { WORKQUEUE_TABS } from '@client/components/interface/WorkQueueTabs'
 import { useCountryConfigWorkqueueConfigurations } from '@client/v2-events/features/events/useCountryConfigWorkqueueConfigurations'
 import { ROUTES } from '@client/v2-events/routes'
-import { removeToken } from '@client/utils/authUtils'
 import * as routes from '@client/navigation/routes'
-import {
-  getIndividualNameObj,
-  removeUserDetails
-} from '@client/utils/userUtils'
+import { getIndividualNameObj } from '@client/utils/userUtils'
 import { getOfflineData } from '@client/offline/selectors'
 import { useWorkqueue } from '@client/v2-events/hooks/useWorkqueue'
 import { getScope, getUserDetails } from '@client/profile/profileSelectors'
 import { getLanguage } from '@client/i18n/selectors'
 import { Avatar } from '@client/components/Avatar'
-import { hasDraftWorkqueue, WORKQUEUE_DRAFT } from '@client/v2-events/utils'
+import {
+  hasDraftWorkqueue,
+  logout,
+  WORKQUEUE_DRAFT
+} from '@client/v2-events/utils'
 import { hasOutboxWorkqueue, WORKQUEUE_OUTBOX } from '@client/v2-events/utils'
 import { useEvents } from '@client/v2-events/features/events/useEvents/useEvents'
 import { useDrafts } from '@client/v2-events/features/drafts/useDrafts'
@@ -91,15 +90,6 @@ export const Sidebar = ({
   const avatar = <Avatar avatar={userDetails?.avatar} name={name} />
 
   const runningVer = String(localStorage.getItem('running-version'))
-
-  const logout = async () => {
-    await storage.removeItem(SCREEN_LOCK)
-    await removeToken()
-    await removeUserDetails()
-    window.location.assign(
-      `${window.config.LOGIN_URL}?lang=${await storage.getItem('language')}&redirectTo=${window.location.origin}${ROUTES.V2.buildPath({})}`
-    )
-  }
 
   return (
     <LeftNavigation

--- a/packages/client/src/v2-events/routes/CacheNotFoundError.stories.tsx
+++ b/packages/client/src/v2-events/routes/CacheNotFoundError.stories.tsx
@@ -1,0 +1,100 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+
+import React from 'react'
+import { Meta, StoryObj } from '@storybook/react'
+import { expect, waitFor, within } from '@storybook/test'
+import { Outlet } from 'react-router-dom'
+import { LoadingBar } from '@opencrvs/components'
+import { TRPCProvider } from '@client/v2-events/trpc'
+import { TRPCErrorBoundary } from '@client/v2-events/routes/TRPCErrorBoundary'
+import { NavigationHistoryProvider } from '../components/NavigationStack'
+import { tennisClubMembershipEventDocument } from '../features/events/fixtures'
+import { EventOverviewIndex } from '../features/workqueues/EventOverview/EventOverview'
+import { useWorkboxCacheReady } from '../hooks/useWorkboxCacheReady'
+import { ROUTES } from './routes'
+import { routesConfig } from './config'
+import { CacheNotFoundError } from './CacheNotFoundError'
+
+const meta: Meta<typeof CacheNotFoundError> = {
+  title: 'Components/TRPCErrorBoundary',
+  decorators: [
+    (Story) => (
+      <TRPCErrorBoundary>
+        <TRPCProvider>
+          <Story />
+        </TRPCProvider>
+      </TRPCErrorBoundary>
+    )
+  ]
+}
+
+export default meta
+
+type Story = StoryObj<typeof EventOverviewIndex>
+export const WorkboxCacheKeyCheck: Story = {
+  parameters: {
+    reactRouter: {
+      router: {
+        ...routesConfig,
+        Component: () => {
+          const cacheReady = useWorkboxCacheReady('fake-key')
+          if (cacheReady === null) {
+            return <LoadingBar message={'Loading Cache...'} />
+          }
+
+          if (!cacheReady) {
+            return <CacheNotFoundError />
+          }
+          return (
+            <NavigationHistoryProvider>
+              <Outlet />
+            </NavigationHistoryProvider>
+          )
+        }
+      },
+      initialPath: ROUTES.V2.EVENTS.VIEW.buildPath({
+        eventId: tennisClubMembershipEventDocument.id
+      })
+    }
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+
+    await step('Workbox-Runtime cache key not found error', async () => {
+      await expect(
+        await canvas.findByText('Loading Cache...')
+      ).toBeInTheDocument()
+      await waitFor(
+        async () => {
+          await expect(
+            await canvas.findByText(/Application Cache Error/i)
+          ).toBeInTheDocument()
+
+          await expect(
+            await canvas.findByText(
+              /Something went wrong with loading the app\. Reload this page, or log out and log back in to continue\./i
+            )
+          ).toBeInTheDocument()
+
+          await expect(
+            canvas.getByRole('button', { name: 'Reload' })
+          ).toBeInTheDocument()
+
+          await expect(
+            canvas.getByRole('button', { name: 'Log out' })
+          ).toBeInTheDocument()
+        },
+        { timeout: 6000 }
+      )
+    })
+  }
+}

--- a/packages/client/src/v2-events/routes/CacheNotFoundError.stories.tsx
+++ b/packages/client/src/v2-events/routes/CacheNotFoundError.stories.tsx
@@ -13,7 +13,7 @@ import React from 'react'
 import { Meta, StoryObj } from '@storybook/react'
 import { expect, waitFor, within } from '@storybook/test'
 import { Outlet } from 'react-router-dom'
-import { LoadingBar } from '@opencrvs/components'
+import { LoadingBar } from '@opencrvs/components/src/LoadingBar/LoadingBar'
 import { TRPCProvider } from '@client/v2-events/trpc'
 import { TRPCErrorBoundary } from '@client/v2-events/routes/TRPCErrorBoundary'
 import { NavigationHistoryProvider } from '../components/NavigationStack'
@@ -48,7 +48,7 @@ export const WorkboxCacheKeyCheck: Story = {
         Component: () => {
           const cacheReady = useWorkboxCacheReady('fake-key')
           if (cacheReady === null) {
-            return <LoadingBar message={'Loading Cache...'} />
+            return <LoadingBar message="Loading Cache..." />
           }
 
           if (!cacheReady) {

--- a/packages/client/src/v2-events/routes/CacheNotFoundError.tsx
+++ b/packages/client/src/v2-events/routes/CacheNotFoundError.tsx
@@ -45,24 +45,24 @@ const ButtonContainer = styled.div`
 `
 const serviceWorkerCacheMessages = {
   header: {
-    id: 'v2.serviceWorker.cacheKey.WorkBoxRuntime.error.header',
+    id: 'serviceWorker.cacheKey.WorkBoxRuntime.error.header',
     description: 'Header shown when WorkBox runtime cache key is missing',
     defaultMessage: '⚠️ Application Cache Error'
   },
   content: {
-    id: 'v2.serviceWorker.cacheKey.WorkBoxRuntime.error.content',
+    id: 'serviceWorker.cacheKey.WorkBoxRuntime.error.content',
     description: 'Content shown when WorkBox runtime cache key is missing',
     defaultMessage:
       'Something went wrong with loading the app. Reload this page, or log out and log back in to continue.'
   },
   logout: {
-    id: 'v2.serviceWorker.cacheKey.WorkBoxRuntime.error.button.logout',
+    id: 'serviceWorker.cacheKey.WorkBoxRuntime.error.button.logout',
     description:
       'Button label for logging out when WorkBox runtime cache key is missing',
     defaultMessage: 'Log out'
   },
   reload: {
-    id: 'v2.serviceWorker.cacheKey.WorkBoxRuntime.error.button.reload',
+    id: 'serviceWorker.cacheKey.WorkBoxRuntime.error.button.reload',
     description:
       'Button label for reload when WorkBox runtime cache key is missing',
     defaultMessage: 'Reload'
@@ -90,7 +90,7 @@ export const CacheNotFoundError = () => {
             <TertiaryButton onClick={() => window.location.reload()}>
               {intl.formatMessage(serviceWorkerCacheMessages.reload)}
             </TertiaryButton>
-            <TertiaryButton onClick={async () => logout()}>
+            <TertiaryButton onClick={logout}>
               {intl.formatMessage(serviceWorkerCacheMessages.logout)}
             </TertiaryButton>
           </ButtonContainer>

--- a/packages/client/src/v2-events/routes/CacheNotFoundError.tsx
+++ b/packages/client/src/v2-events/routes/CacheNotFoundError.tsx
@@ -1,0 +1,101 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+
+import React from 'react'
+import * as Sentry from '@sentry/react'
+import styled from 'styled-components'
+import { useIntl } from 'react-intl'
+import { PageWrapper } from '@opencrvs/components/lib/PageWrapper'
+import { Box } from '@opencrvs/components'
+import { TertiaryButton } from '@opencrvs/components/lib/buttons'
+import { logout } from '../utils'
+
+const ErrorContainer = styled(Box)`
+  display: flex;
+  width: 400px;
+  flex-direction: column;
+  align-items: center;
+  margin-top: -80px;
+`
+const ErrorTitle = styled.h1`
+  ${({ theme }) => theme.fonts.h1};
+  color: ${({ theme }) => theme.colors.copy};
+  margin-bottom: 16px;
+  text-align: center;
+`
+
+const ErrorMessage = styled.div`
+  ${({ theme }) => theme.fonts.reg18};
+  color: ${({ theme }) => theme.colors.copy};
+  margin-bottom: 32px;
+  text-align: center;
+`
+
+const ButtonContainer = styled.div`
+  display: flex;
+  gap: 80px;
+`
+const serviceWorkerCacheMessages = {
+  header: {
+    id: 'v2.serviceWorker.cacheKey.WorkBoxRuntime.error.header',
+    description: 'Header shown when WorkBox runtime cache key is missing',
+    defaultMessage: '⚠️ Application Cache Error'
+  },
+  content: {
+    id: 'v2.serviceWorker.cacheKey.WorkBoxRuntime.error.content',
+    description: 'Content shown when WorkBox runtime cache key is missing',
+    defaultMessage:
+      'Something went wrong with loading the app. Reload this page, or log out and log back in to continue.'
+  },
+  logout: {
+    id: 'v2.serviceWorker.cacheKey.WorkBoxRuntime.error.button.logout',
+    description:
+      'Button label for logging out when WorkBox runtime cache key is missing',
+    defaultMessage: 'Log out'
+  },
+  reload: {
+    id: 'v2.serviceWorker.cacheKey.WorkBoxRuntime.error.button.reload',
+    description:
+      'Button label for reload when WorkBox runtime cache key is missing',
+    defaultMessage: 'Reload'
+  }
+}
+
+export const CacheNotFoundError = () => {
+  const intl = useIntl()
+  return (
+    <Sentry.ErrorBoundary
+      onError={(err) => {
+        // eslint-disable-next-line no-console
+        console.log('Sentry.ErrorBoundary: ', err)
+      }}
+    >
+      <PageWrapper>
+        <ErrorContainer>
+          <ErrorTitle>
+            {intl.formatMessage(serviceWorkerCacheMessages.header)}
+          </ErrorTitle>
+          <ErrorMessage>
+            {intl.formatMessage(serviceWorkerCacheMessages.content)}
+          </ErrorMessage>
+          <ButtonContainer>
+            <TertiaryButton onClick={() => window.location.reload()}>
+              {intl.formatMessage(serviceWorkerCacheMessages.reload)}
+            </TertiaryButton>
+            <TertiaryButton onClick={async () => logout()}>
+              {intl.formatMessage(serviceWorkerCacheMessages.logout)}
+            </TertiaryButton>
+          </ButtonContainer>
+        </ErrorContainer>
+      </PageWrapper>
+    </Sentry.ErrorBoundary>
+  )
+}

--- a/packages/client/src/v2-events/routes/config.tsx
+++ b/packages/client/src/v2-events/routes/config.tsx
@@ -14,7 +14,7 @@ import { Outlet, RouteObject } from 'react-router-dom'
 
 import { useSelector } from 'react-redux'
 import { ActionType } from '@opencrvs/commons/client'
-import { LoadingBar } from '@opencrvs/components'
+import { LoadingBar } from '@opencrvs/components/src/LoadingBar/LoadingBar'
 import { Debug } from '@client/v2-events/features/debug/debug'
 import { router as correctionRequestRouter } from '@client/v2-events/features/events/actions/correct/request/router'
 import { router as correctionReviewRouter } from '@client/v2-events/features/events/actions/correct/review/router'
@@ -89,7 +89,7 @@ export const routesConfig = {
     }
 
     if (cacheReady === null) {
-      return <LoadingBar message={'Loading Cache'} />
+      return <LoadingBar message="Loading Cache" />
     }
 
     if (!cacheReady) {

--- a/packages/client/src/v2-events/routes/config.tsx
+++ b/packages/client/src/v2-events/routes/config.tsx
@@ -14,6 +14,7 @@ import { Outlet, RouteObject } from 'react-router-dom'
 
 import { useSelector } from 'react-redux'
 import { ActionType } from '@opencrvs/commons/client'
+import { LoadingBar } from '@opencrvs/components'
 import { Debug } from '@client/v2-events/features/debug/debug'
 import { router as correctionRequestRouter } from '@client/v2-events/features/events/actions/correct/request/router'
 import { router as correctionReviewRouter } from '@client/v2-events/features/events/actions/correct/review/router'
@@ -47,8 +48,10 @@ import { RedirectToWorkqueue } from '../layouts/redirectToWorkqueue'
 import { SearchLayout } from '../layouts/search'
 import { useWorkqueues } from '../hooks/useWorkqueue'
 import { ReviewDuplicateIndex } from '../features/events/actions/dedup/ReviewDuplicate'
+import { useWorkboxCacheReady } from '../hooks/useWorkboxCacheReady'
 import { ROUTES } from './routes'
 import { Toaster } from './Toaster'
+import { CacheNotFoundError } from './CacheNotFoundError'
 
 function PrefetchQueries() {
   const workqueues = useWorkqueues()
@@ -77,11 +80,20 @@ export const routesConfig = {
   path: ROUTES.V2.path,
   Component: () => {
     const currentUser = useSelector(getUserDetails)
+    const cacheReady = useWorkboxCacheReady()
 
     if (!currentUser) {
       throw new Error(
         'V2 routes cannot be initialised without user details. Make sure user details are fetched before the routes are rendered'
       )
+    }
+
+    if (cacheReady === null) {
+      return <LoadingBar message={'Loading Cache'} />
+    }
+
+    if (!cacheReady) {
+      return <CacheNotFoundError />
     }
     return (
       <NavigationHistoryProvider>

--- a/packages/client/src/v2-events/utils.ts
+++ b/packages/client/src/v2-events/utils.ts
@@ -31,6 +31,11 @@ import {
   UUID,
   SystemRole
 } from '@opencrvs/commons/client'
+import { SCREEN_LOCK } from '@client/components/ProtectedPage'
+import { storage } from '@client/storage'
+import { removeToken } from '@client/utils/authUtils'
+import { removeUserDetails } from '@client/utils/userUtils'
+import { ROUTES } from './routes'
 
 export function getUsersFullName(
   names: ResolvedUser['name'],
@@ -276,4 +281,13 @@ export function mergeWithoutNullsOrUndefined<T>(
     }
     return undefined
   })
+}
+
+export const logout = async () => {
+  await storage.removeItem(SCREEN_LOCK)
+  await removeToken()
+  await removeUserDetails()
+  window.location.assign(
+    `${window.config.LOGIN_URL}?lang=${await storage.getItem('language')}&redirectTo=${window.location.origin}${ROUTES.V2.buildPath({})}`
+  )
 }

--- a/packages/components/src/LoadingBar/LoadingBar.tsx
+++ b/packages/components/src/LoadingBar/LoadingBar.tsx
@@ -50,7 +50,7 @@ const Progress = styled.div`
   background: ${({ theme }) => theme.colors.primary};
   animation: ${ProgressAnimation} 300s ease;
 `
-export const LoadingBar = () => (
+export const LoadingBar = ({ message }: { message: string }) => (
   <ProgressBackground>
     <img
       src="/images/logo-90x90.svg"
@@ -68,7 +68,7 @@ export const LoadingBar = () => (
         <Progress id="progress" />
       </ProgressBar>
       <Text variant="reg16" element="p">
-        Loading records...
+        {message}
       </Text>
     </Stack>
   </ProgressBackground>


### PR DESCRIPTION
## ⚠️ Problem
Issue: https://github.com/opencrvs/opencrvs-core/issues/10097
country pr: https://github.com/opencrvs/opencrvs-countryconfig/pull/979
farajaland pr: https://github.com/opencrvs/opencrvs-farajaland/pull/1669

In some environments, loading records and initializing the app could fail or behave inconsistently because the service worker cache (`workbox-runtime`) may not be ready when the app routes or data fetching attempts occur. Users could experience issues such as:

- ❌ Broken Image in the drafts
- ⚠️ Errors in console about missing Workbox runtime cache

This problem is more likely in scenarios like:

- 🧹 First-time page load after clearing browser storage  
- 🕵️ Incognito/private browsing mode  
- ⏱ Service worker not fully initialised before routes are rendered  

---

## 🔍 Root Cause

- The app attempted to render `v2-events` routes and fetch records before confirming the existence of the Workbox runtime cache.  
- This could result in race conditions where `caches.keys()` does not yet include the `workbox-runtime` cache, leading to errors or incomplete loading states.

---

## 🛠 Solution

- Introduced a **`useWorkboxCacheReady`** hook to ensure routes wait until the cache is ready.  
- While the cache is being prepared:
- If the cache is missing:
  - ⚠️ Display a user-friendly `CacheNotFoundError` page indicating that the session may be impacted  
  - 🟢 Provide a logout or reload mechanism to safely restart the session  

Other improvements:

- 🔒 Consolidated logout logic (`logout()` function) to remove tokens, user data, and `SCREEN_LOCK`.  
- 🧹 Removed redundant logout code from `Sidebar` component.  
- 🧩 Prefetch queries are unaffected, but now run only after confirming the cache is ready.  

This ensures a smoother initialization and avoids race conditions with the service worker cache.

---

## ⚡ Impact

- 🛡 Prevents errors related to missing Workbox runtime cache.  
- 🌐 Improves reliability in first-time visits, incognito mode, and after storage clearances.  
- ✅ Ensures users always see a clear state (`LoadingBar` or logout prompt) rather than silent failures.

---



https://github.com/user-attachments/assets/08776215-3943-4c8a-8526-60e6e33b2270





## ✅ Checklist

- [x] Linked the relevant Github issue (if applicable)  
- [x] Tested the changes locally  
- [ ] Verified edge cases (incognito mode, first-time load)  
- [ ] Updated any necessary changelog or documentation  
