### PR TITLE
allow filtering specific fields for analytics

### DIFF
--- a/packages/commons/src/events/FieldConfig.ts
+++ b/packages/commons/src/events/FieldConfig.ts
@@ -79,7 +79,14 @@ const BaseField = z.object({
     ),
   value: FieldReference.optional().describe(
     'Reference to a parent field. If field has a value, the value will be copied when the parent field is changed.'
-  )
+  ),
+  analytics: z
+    .boolean()
+    .default(false)
+    .optional()
+    .describe(
+      'Meta field for analytics to allow filtering non-analytics fields away'
+    )
 })
 
 export type BaseField = z.infer<typeof BaseField>

--- a/packages/commons/src/fixtures/forms.ts
+++ b/packages/commons/src/fixtures/forms.ts
@@ -782,6 +782,7 @@ export const TENNIS_CLUB_DECLARATION_FORM = defineDeclarationForm({
         {
           id: 'applicant.dob',
           type: FieldType.DATE,
+          analytics: true,
           required: true,
           validation: [
             {
@@ -824,6 +825,7 @@ export const TENNIS_CLUB_DECLARATION_FORM = defineDeclarationForm({
         {
           id: 'applicant.age',
           type: FieldType.NUMBER,
+          analytics: true,
           required: true,
           label: {
             defaultMessage: 'Age of tennis-member',


### PR DESCRIPTION
## Description

Country config pull request: https://github.com/opencrvs/opencrvs-countryconfig/pull/966
Adds a meta field `analytics` that filters all other fields away from the `declaration` except the ones marked as analytics fields.

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
