### PR TITLE
Small fix to location API when updating locations

### DIFF
--- a/packages/gateway/src/config/proxies.ts
+++ b/packages/gateway/src/config/proxies.ts
@@ -17,7 +17,7 @@ import z from 'zod'
 import { ServerRoute } from '@hapi/hapi'
 
 const LegacyLocationUpdate = z.object({
-  name: z.string(),
+  name: z.string().optional(),
   alias: z.string().optional(),
   status: z.enum(['active', 'inactive']).optional(),
   statistics: z


### PR DESCRIPTION
## Description

Spotted an error when updating locations that event_actions complains if all locations are deleted.
Also the payload change of making name optional allows you to call the api just with "status": "inactive"

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
