### PR TITLE
fix: keep `ActionProcedure` as an internal type

### DIFF
--- a/packages/events/src/router/event/actions/declare.ts
+++ b/packages/events/src/router/event/actions/declare.ts
@@ -22,14 +22,13 @@ import { requiresAnyOfScopes } from '@events/router/middleware'
 import { systemProcedure } from '@events/router/trpc'
 import { addAction } from '@events/service/events/events'
 import {
-  ActionProcedure,
   defaultRequestHandler,
   getDefaultActionProcedures
 } from '@events/router/event/actions'
 import { getInMemoryEventConfigurations } from '@events/service/config/config'
 import { searchForDuplicates } from '@events/service/deduplication/deduplication'
 
-export function declareActionProcedures(): ActionProcedure {
+export function declareActionProcedures() {
   const requireScopesMiddleware = requiresAnyOfScopes(
     ACTION_ALLOWED_SCOPES[ActionType.DECLARE],
     ACTION_ALLOWED_CONFIGURABLE_SCOPES[ActionType.DECLARE]

--- a/packages/events/src/router/event/actions/index.ts
+++ b/packages/events/src/router/event/actions/index.ts
@@ -149,7 +149,7 @@ const ACTION_PROCEDURE_CONFIG = {
   }
 } satisfies Partial<Record<ActionType, ActionProcedureConfig>>
 
-export type ActionProcedure = {
+type ActionProcedure = {
   request: MutationProcedure<{
     input: ActionInput
     output: EventDocument


### PR DESCRIPTION
Typescript tries to use the `ActionProcedure` type for building the `AppRouter` one but due to how our build process works, the type is not available to be imported by default. It will instead need to be manually copied over from events/build to toolkit/build. So we opted to not expose the type altogether.

countryconfig: https://github.com/opencrvs/opencrvs-countryconfig/pull/982