### PR TITLE
feat: create get duplicates endpoint

### DIFF
--- a/packages/commons/src/events/test.utils.ts
+++ b/packages/commons/src/events/test.utils.ts
@@ -281,15 +281,18 @@ export function generateActionAnnotationInput(
   }
 }
 
-export function eventPayloadGenerator(rng: () => number) {
+export function eventPayloadGenerator(
+  rng: () => number,
+  configuration: EventConfig = tennisClubMembershipEvent
+) {
   return {
     create: (input: Partial<EventInput> = {}) => ({
       transactionId: input.transactionId ?? getUUID(),
-      type: input.type ?? TENNIS_CLUB_MEMBERSHIP
+      type: input.type ?? configuration.id
     }),
     patch: (id: string, input: Partial<EventInput> = {}) => ({
       transactionId: input.transactionId ?? getUUID(),
-      type: input.type ?? TENNIS_CLUB_MEMBERSHIP,
+      type: input.type ?? configuration.id,
       id
     }),
     draft: (
@@ -359,17 +362,13 @@ export function eventPayloadGenerator(rng: () => number) {
         declaration:
           input.declaration ??
           generateActionDeclarationInput(
-            tennisClubMembershipEvent,
+            configuration,
             ActionType.DECLARE,
             rng
           ),
         annotation:
           input.annotation ??
-          generateActionAnnotationInput(
-            tennisClubMembershipEvent,
-            ActionType.DECLARE,
-            rng
-          ),
+          generateActionAnnotationInput(configuration, ActionType.DECLARE, rng),
         eventId,
         ...input
       }),
@@ -390,7 +389,7 @@ export function eventPayloadGenerator(rng: () => number) {
           // Remove some fields to simulate incomplete data
           const partialDeclaration = omitBy(
             generateActionDeclarationInput(
-              tennisClubMembershipEvent,
+              configuration,
               ActionType.DECLARE,
               rng
             ),
@@ -423,14 +422,14 @@ export function eventPayloadGenerator(rng: () => number) {
         declaration:
           input.declaration ??
           generateActionDeclarationInput(
-            tennisClubMembershipEvent,
+            configuration,
             ActionType.VALIDATE,
             rng
           ),
         annotation:
           input.annotation ??
           generateActionAnnotationInput(
-            tennisClubMembershipEvent,
+            configuration,
             ActionType.VALIDATE,
             rng
           ),
@@ -494,11 +493,7 @@ export function eventPayloadGenerator(rng: () => number) {
         declaration: {},
         annotation:
           input.annotation ??
-          generateActionAnnotationInput(
-            tennisClubMembershipEvent,
-            ActionType.REJECT,
-            rng
-          ),
+          generateActionAnnotationInput(configuration, ActionType.REJECT, rng),
         duplicates: [],
         eventId,
         content: { reason: `${ActionType.REJECT}` },
@@ -522,14 +517,14 @@ export function eventPayloadGenerator(rng: () => number) {
         declaration:
           input.declaration ??
           generateActionDeclarationInput(
-            tennisClubMembershipEvent,
+            configuration,
             ActionType.REGISTER,
             rng
           ),
         annotation:
           input.annotation ??
           generateActionAnnotationInput(
-            tennisClubMembershipEvent,
+            configuration,
             ActionType.REGISTER,
             rng
           ),
@@ -551,7 +546,7 @@ export function eventPayloadGenerator(rng: () => number) {
         annotation:
           input.annotation ??
           generateActionAnnotationInput(
-            tennisClubMembershipEvent,
+            configuration,
             ActionType.PRINT_CERTIFICATE,
             rng
           ),
@@ -574,7 +569,7 @@ export function eventPayloadGenerator(rng: () => number) {
             input.declaration ??
             omit(
               generateActionDeclarationInput(
-                tennisClubMembershipEvent,
+                configuration,
                 ActionType.REQUEST_CORRECTION,
                 rng
               ),
@@ -583,7 +578,7 @@ export function eventPayloadGenerator(rng: () => number) {
           annotation:
             input.annotation ??
             generateActionAnnotationInput(
-              tennisClubMembershipEvent,
+              configuration,
               ActionType.REQUEST_CORRECTION,
               rng
             ),
@@ -606,7 +601,7 @@ export function eventPayloadGenerator(rng: () => number) {
           annotation:
             input.annotation ??
             generateActionAnnotationInput(
-              tennisClubMembershipEvent,
+              configuration,
               ActionType.APPROVE_CORRECTION,
               rng
             ),
@@ -630,7 +625,7 @@ export function eventPayloadGenerator(rng: () => number) {
           annotation:
             input.annotation ??
             generateActionAnnotationInput(
-              tennisClubMembershipEvent,
+              configuration,
               ActionType.REJECT_CORRECTION,
               rng
             ),

--- a/packages/events/src/router/event/event.getDuplicates.test.ts
+++ b/packages/events/src/router/event/event.getDuplicates.test.ts
@@ -10,12 +10,7 @@
  */
 import { TRPCError } from '@trpc/server'
 import { http, HttpResponse } from 'msw'
-import {
-  ActionType,
-  EventDocument,
-  generateUuid,
-  SCOPES
-} from '@opencrvs/commons'
+import { ActionType, generateUuid, SCOPES } from '@opencrvs/commons'
 import { tennisClubMembershipEventWithDedupCheck } from '@opencrvs/commons/fixtures'
 import {
   createTestClient,
@@ -70,7 +65,7 @@ test('Allows access with assignment and right scope', async () => {
   ).resolves.toEqual([])
 })
 
-test.only('Returns single duplicate when found', async () => {
+test('Returns single duplicate when found', async () => {
   const tennisClubMembershipWithDedupCheckConfig =
     tennisClubMembershipEventWithDedupCheck(ActionType.DECLARE)
 

--- a/packages/events/src/router/event/event.getDuplicates.test.ts
+++ b/packages/events/src/router/event/event.getDuplicates.test.ts
@@ -1,0 +1,186 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+import { TRPCError } from '@trpc/server'
+import { http, HttpResponse } from 'msw'
+import {
+  ActionType,
+  EventDocument,
+  generateUuid,
+  SCOPES
+} from '@opencrvs/commons'
+import { tennisClubMembershipEventWithDedupCheck } from '@opencrvs/commons/fixtures'
+import {
+  createTestClient,
+  setupTestCase,
+  TEST_USER_DEFAULT_SCOPES
+} from '@events/tests/utils'
+import { mswServer } from '../../tests/msw'
+import { env } from '../../environment'
+
+test('prevents forbidden access if missing required scope', async () => {
+  const { user } = await setupTestCase()
+  const client = createTestClient(user, [])
+
+  await expect(
+    client.event.getDuplicates({ eventId: generateUuid() })
+  ).rejects.toMatchObject(new TRPCError({ code: 'FORBIDDEN' }))
+})
+
+test('prevents forbidden access without assignment but with right scope', async () => {
+  const { generator, users } = await setupTestCase()
+  const someOtherClient = createTestClient(users[0])
+
+  const myClient = createTestClient(users[1], [SCOPES.RECORD_REVIEW_DUPLICATES])
+
+  const event = await someOtherClient.event.create(generator.event.create())
+  await someOtherClient.event.actions.declare.request(
+    generator.event.actions.declare(event.id)
+  )
+
+  await expect(
+    myClient.event.getDuplicates({ eventId: event.id })
+  ).rejects.not.toMatchObject(new TRPCError({ code: 'FORBIDDEN' }))
+})
+
+test('Allows access with assignment and right scope', async () => {
+  const { user, generator } = await setupTestCase()
+  const client = createTestClient(user, [
+    ...TEST_USER_DEFAULT_SCOPES,
+    SCOPES.RECORD_REVIEW_DUPLICATES
+  ])
+
+  const event = await client.event.create(generator.event.create())
+
+  await client.event.actions.declare.request(
+    generator.event.actions.declare(event.id, {
+      keepAssignment: true
+    })
+  )
+
+  await expect(
+    client.event.getDuplicates({ eventId: event.id })
+  ).resolves.toEqual([])
+})
+
+test.only('Returns single duplicate when found', async () => {
+  const tennisClubMembershipWithDedupCheckConfig =
+    tennisClubMembershipEventWithDedupCheck(ActionType.DECLARE)
+
+  mswServer.use(
+    http.get(`${env.COUNTRY_CONFIG_URL}/events`, () => {
+      return HttpResponse.json([tennisClubMembershipWithDedupCheckConfig])
+    })
+  )
+
+  const { user, generator } = await setupTestCase(
+    1881,
+    tennisClubMembershipWithDedupCheckConfig
+  )
+
+  const client = createTestClient(user, [
+    ...TEST_USER_DEFAULT_SCOPES,
+    SCOPES.RECORD_REVIEW_DUPLICATES
+  ])
+
+  const event1 = await client.event.create(generator.event.create())
+  const event1Payload = generator.event.actions.declare(event1.id)
+  await client.event.actions.declare.request(event1Payload)
+
+  const event2 = await client.event.create(generator.event.create())
+  await client.event.actions.declare.request(
+    generator.event.actions.declare(event2.id, {
+      declaration: event1Payload.declaration
+    })
+  )
+
+  await client.event.actions.assignment.assign({
+    eventId: event2.id,
+    assignedTo: user.id,
+    transactionId: generateUuid()
+  })
+
+  await expect(
+    client.event.getDuplicates({ eventId: event2.id })
+  ).resolves.toHaveLength(1)
+
+  await client.event.actions.assignment.assign(
+    generator.event.actions.assign(event1.id, { assignedTo: user.id })
+  )
+
+  await expect(
+    client.event.getDuplicates({ eventId: event1.id })
+  ).resolves.toHaveLength(0)
+})
+
+test('Returns multiple duplicates when found', async () => {
+  const tennisClubMembershipWithDedupCheckConfig =
+    tennisClubMembershipEventWithDedupCheck(ActionType.DECLARE)
+
+  mswServer.use(
+    http.get(`${env.COUNTRY_CONFIG_URL}/events`, () => {
+      return HttpResponse.json([tennisClubMembershipWithDedupCheckConfig])
+    })
+  )
+
+  const { user, generator } = await setupTestCase(
+    1881,
+    tennisClubMembershipWithDedupCheckConfig
+  )
+
+  const client = createTestClient(user, [
+    ...TEST_USER_DEFAULT_SCOPES,
+    SCOPES.RECORD_REVIEW_DUPLICATES
+  ])
+
+  const event1 = await client.event.create(generator.event.create())
+  const event1Payload = generator.event.actions.declare(event1.id)
+  await client.event.actions.declare.request(event1Payload)
+
+  const event2 = await client.event.create(generator.event.create())
+  await client.event.actions.declare.request(
+    generator.event.actions.declare(event2.id, {
+      declaration: event1Payload.declaration
+    })
+  )
+
+  const event3 = await client.event.create(generator.event.create())
+  await client.event.actions.declare.request(
+    generator.event.actions.declare(event3.id, {
+      declaration: event1Payload.declaration
+    })
+  )
+
+  await client.event.actions.assignment.assign(
+    generator.event.actions.assign(event3.id, { assignedTo: user.id })
+  )
+
+  // Last item knows about all the previous ones
+  await expect(
+    client.event.getDuplicates({ eventId: event3.id })
+  ).resolves.toHaveLength(2)
+
+  await client.event.actions.assignment.assign(
+    generator.event.actions.assign(event2.id, { assignedTo: user.id })
+  )
+
+  // Earlier items are not updated.
+  await expect(
+    client.event.getDuplicates({ eventId: event2.id })
+  ).resolves.toHaveLength(1)
+
+  await client.event.actions.assignment.assign(
+    generator.event.actions.assign(event1.id, { assignedTo: user.id })
+  )
+
+  await expect(
+    client.event.getDuplicates({ eventId: event1.id })
+  ).resolves.toHaveLength(0)
+})

--- a/packages/events/src/router/event/index.ts
+++ b/packages/events/src/router/event/index.ts
@@ -57,6 +57,7 @@ import {
 } from '@events/service/indexing/indexing'
 import { reindex } from '@events/service/events/reindex'
 import { UserContext } from '../../context'
+import { getDuplicateEvents } from '../../service/deduplication/deduplication'
 import { declareActionProcedures } from './actions/declare'
 import { getDefaultActionProcedures } from './actions'
 
@@ -144,6 +145,15 @@ export const eventRouter = router({
       )
 
       return updatedEvent
+    }),
+  getDuplicates: publicProcedure
+    .use(requiresAnyOfScopes([SCOPES.RECORD_REVIEW_DUPLICATES]))
+    .input(DeleteActionInput)
+    .use(middleware.requireAssignment)
+    .query(async ({ input, ctx }) => {
+      const event = await getEventById(input.eventId)
+
+      return getDuplicateEvents(event, ctx)
     }),
   delete: publicProcedure
     .use(requiresAnyOfScopes(ACTION_ALLOWED_SCOPES[ActionType.DELETE]))

--- a/packages/events/src/router/event/index.ts
+++ b/packages/events/src/router/event/index.ts
@@ -32,6 +32,7 @@ import {
   ACTION_ALLOWED_CONFIGURABLE_SCOPES
 } from '@opencrvs/commons/events'
 import * as middleware from '@events/router/middleware'
+import { EventIdParam } from '@events/router/middleware'
 import { requiresAnyOfScopes } from '@events/router/middleware/authorization'
 import { publicProcedure, router, systemProcedure } from '@events/router/trpc'
 import {
@@ -148,7 +149,7 @@ export const eventRouter = router({
     }),
   getDuplicates: publicProcedure
     .use(requiresAnyOfScopes([SCOPES.RECORD_REVIEW_DUPLICATES]))
-    .input(DeleteActionInput)
+    .input(EventIdParam)
     .use(middleware.requireAssignment)
     .query(async ({ input, ctx }) => {
       const event = await getEventById(input.eventId)

--- a/packages/events/src/router/middleware/authorization/index.ts
+++ b/packages/events/src/router/middleware/authorization/index.ts
@@ -12,6 +12,7 @@
 import { TRPCError } from '@trpc/server'
 import { MiddlewareFunction } from '@trpc/server/unstable-core-do-not-import'
 import { OpenApiMeta } from 'trpc-to-openapi'
+import z from 'zod'
 import {
   ActionDocument,
   ActionInputWithType,
@@ -186,12 +187,14 @@ export const eventTypeAuthorization: MiddlewareFunction<
   return next()
 }
 
+export const EventIdParam = z.object({ eventId: UUID })
+export type EventIdParam = z.infer<typeof EventIdParam>
 export const requireAssignment: MiddlewareFunction<
   TrpcContext,
   OpenApiMeta,
   TrpcContext,
   TrpcContext & { isDuplicateAction?: boolean; event: EventDocument },
-  ActionInputWithType | DeleteActionInput
+  ActionInputWithType | DeleteActionInput | EventIdParam
 > = async ({ input, next, ctx }) => {
   const event = await getEventById(input.eventId)
   const { user } = ctx

--- a/packages/events/src/service/deduplication/deduplication.ts
+++ b/packages/events/src/service/deduplication/deduplication.ts
@@ -22,13 +22,9 @@ import {
   FieldType,
   extractDuplicatesFromActions,
   EventDocument,
-  ActionType,
-  generateUuid,
-  UUID,
-  ActionStatus,
   getCurrentEventState
 } from '@opencrvs/commons/events'
-import { getUUID, logger } from '@opencrvs/commons'
+import { logger } from '@opencrvs/commons'
 import {
   getOrCreateClient,
   getEventIndexName
@@ -41,8 +37,7 @@ import {
   encodeFieldId,
   nameQueryKey
 } from '@events/service/indexing/utils'
-import { buildAction } from '../events/events'
-import { TrpcContext, TrpcUserContext } from '../../context'
+import { TrpcContext } from '../../context'
 import { getEventsAuditTrailed } from '../../storage/postgres/events/events'
 import { getEventConfigurationById } from '../config/config'
 

--- a/packages/events/src/service/events/events.ts
+++ b/packages/events/src/service/events/events.ts
@@ -243,7 +243,7 @@ export async function deleteUnreferencedFilesFromPreviousDrafts(
   }
 }
 
-function buildAction(
+export function buildAction(
   input: ActionInputWithType,
   status: ActionStatus,
   user: TrpcUserContext

--- a/packages/events/src/storage/postgres/events/events.ts
+++ b/packages/events/src/storage/postgres/events/events.ts
@@ -10,15 +10,23 @@
  */
 
 import { Kysely, sql } from 'kysely'
+import { DateTime } from 'luxon'
+import z from 'zod'
 import {
   ActionStatus,
   ActionType,
   EventDocument,
+  getUUID,
   UUID
 } from '@opencrvs/commons'
 import { getClient } from '@events/storage/postgres/events'
 import { dropNulls } from '../drop-nulls'
-import { EventActions, NewEventActions } from './schema/app/EventActions'
+import { buildAction } from '../../../service/events/events'
+import { TrpcUserContext } from '../../../context'
+import EventActionsTable, {
+  EventActions,
+  NewEventActions
+} from './schema/app/EventActions'
 import { Events, NewEvents } from './schema/app/Events'
 import Schema from './schema/Database'
 
@@ -290,5 +298,99 @@ export const getOrCreateEventAndAssign = async (
 
   return db.transaction().execute(async (trx) => {
     return getOrCreateEventAndAssignInTrx(input, trx)
+  })
+}
+
+/**
+ *
+ * Creates multiple actions in one query.
+ * Useful for reducing the number of database round trips (e.g. marking multiple events as read)
+ */
+async function createActionsInTrx(
+  actions: NewEventActions[],
+  trx: Kysely<Schema>
+) {
+  if (actions.length === 0) {
+    return
+  }
+
+  await trx
+    .insertInto('eventActions')
+    .values(actions)
+    .onConflict((oc) =>
+      oc.columns(['transactionId', 'actionType', 'status']).doNothing()
+    )
+    .execute()
+}
+
+/**
+ *
+ * @returns all events with the given ids in one query.
+ */
+async function getEventsByIdsInTrx(
+  trx: Kysely<Schema>,
+  eventIds: UUID[]
+): Promise<EventDocument[]> {
+  const events = (await trx
+    .selectFrom('events')
+    .selectAll('events')
+    .select(() =>
+      sql`json_agg(
+      jsonb_strip_nulls(to_jsonb(${sql.ref('eventActions')}))
+      ORDER BY
+        CASE WHEN ${sql.ref('eventActions.actionType')} = 'CREATE' THEN 0 ELSE 1 END,
+        ${sql.ref('eventActions.createdAt')}
+    )`.as('actions')
+    )
+    .leftJoin('eventActions', 'eventActions.eventId', 'events.id')
+    .where('events.id', 'in', eventIds)
+    .groupBy('events.id')
+    .orderBy('events.id')
+    // We parse on the next step so casting mistakes will be caught immediately.
+    .execute()) as (Events & { actions: EventActions[] })[]
+
+  return events.map((event) =>
+    EventDocument.parse({
+      ...event,
+      type: event.eventType,
+      actions: event.actions.map(({ actionType, createdAt, ...rest }) => {
+        return {
+          ...rest,
+          type: actionType,
+          // turns db format +00 to Z format
+          createdAt: DateTime.fromISO(createdAt).toISO()
+        }
+      })
+    })
+  )
+}
+
+/**
+ *
+ * @param eventIds array of event IDs to fetch
+ * @returns Get events while adding READ action for each of them.
+ */
+export async function getEventsAuditTrailed(
+  user: TrpcUserContext,
+  eventIds: UUID[]
+) {
+  const readActions = eventIds.map((eventId) =>
+    buildAction(
+      {
+        type: ActionType.READ,
+        declaration: {},
+        eventId,
+        transactionId: getUUID()
+      },
+      ActionStatus.Accepted,
+      user
+    )
+  )
+
+  const db = getClient()
+  return db.transaction().execute(async (trx) => {
+    await createActionsInTrx(readActions, trx)
+
+    return getEventsByIdsInTrx(trx, eventIds)
   })
 }

--- a/packages/events/src/storage/postgres/events/events.ts
+++ b/packages/events/src/storage/postgres/events/events.ts
@@ -11,7 +11,6 @@
 
 import { Kysely, sql } from 'kysely'
 import { DateTime } from 'luxon'
-import z from 'zod'
 import {
   ActionStatus,
   ActionType,
@@ -23,10 +22,7 @@ import { getClient } from '@events/storage/postgres/events'
 import { dropNulls } from '../drop-nulls'
 import { buildAction } from '../../../service/events/events'
 import { TrpcUserContext } from '../../../context'
-import EventActionsTable, {
-  EventActions,
-  NewEventActions
-} from './schema/app/EventActions'
+import { EventActions, NewEventActions } from './schema/app/EventActions'
 import { Events, NewEvents } from './schema/app/Events'
 import Schema from './schema/Database'
 

--- a/packages/events/src/tests/generators.ts
+++ b/packages/events/src/tests/generators.ts
@@ -13,7 +13,8 @@ import {
   getUUID,
   eventPayloadGenerator,
   UUID,
-  TestUserRole
+  TestUserRole,
+  EventConfig
 } from '@opencrvs/commons'
 import { Location } from '@events/service/locations/locations'
 import { addLocations } from '@events/storage/postgres/events/locations'
@@ -40,7 +41,10 @@ interface CreateUser {
 /**
  * @returns a payload generator for creating events and actions with sensible defaults.
  */
-export function payloadGenerator(rng: () => number) {
+export function payloadGenerator(
+  rng: () => number,
+  configuration?: EventConfig
+) {
   const user = {
     create: (input: CreateUser) => ({
       role: input.role ?? ('REGISTRATION_AGENT' as TestUserRole),
@@ -70,7 +74,7 @@ export function payloadGenerator(rng: () => number) {
     }
   }
 
-  return { event: eventPayloadGenerator(rng), locations, user }
+  return { event: eventPayloadGenerator(rng, configuration), locations, user }
 }
 
 /**

--- a/packages/events/src/tests/utils.ts
+++ b/packages/events/src/tests/utils.ts
@@ -14,6 +14,7 @@ import * as jwt from 'jsonwebtoken'
 import {
   ActionType,
   createPrng,
+  EventConfig,
   EventDocument,
   generateRandomSignature,
   Scope,
@@ -163,9 +164,12 @@ export function createTestClient(
 /**
  *  Setup for test cases. Creates a user and locations in the database, and provides relevant client instances and seeders.
  */
-export const setupTestCase = async (rngSeed?: number) => {
+export const setupTestCase = async (
+  rngSeed?: number,
+  configuration?: EventConfig
+) => {
   const rng = createPrng(rngSeed ?? 101)
-  const generator = payloadGenerator(rng)
+  const generator = payloadGenerator(rng, configuration)
   const eventsDb = getClient()
 
   const seed = seeder()


### PR DESCRIPTION
## Description
As a part of duplicate check, we need to be able to access those events marked as duplicate for comparison.

- Create endpoint for getting duplicates
- Create helpers for fetching full event in one call
- Allow passing in configuration for generator in tests.

Link this pull request to the GitHub issue (and optionally name the branch `ocrvs-<issue #>`)

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
