### PR TITLE
Fix: Follow ENV key=value format

### DIFF
--- a/packages/migration/Dockerfile
+++ b/packages/migration/Dockerfile
@@ -8,7 +8,7 @@ ADD --chown=node:node https://github.com/ufoscout/docker-compose-wait/releases/d
 RUN chmod +x /app/wait
 
 # Override the base log level (info).
-ENV NPM_CONFIG_LOGLEVEL warn
+ENV NPM_CONFIG_LOGLEVEL=warn
 
 WORKDIR /app/packages/migration
 


### PR DESCRIPTION
## Description

This PR updates a legacy key/value format in the Dockerfile of the packages/migration package to the modern, recommended format.

### What was changed
Replaced the legacy ENV syntax:

`ENV NPM_CONFIG_LOGLEVEL warn`

with the correct format:

`ENV NPM_CONFIG_LOGLEVEL=warn`

### Root Cause
The Dockerfile was using a legacy key/value format that is no longer recommended. According to [Docker documentation](https://docs.docker.com/reference/build-checks/legacy-key-value-format/), this format can lead to issues with build checks and might not be supported in the future.

### How it was fixed
Updated the ENV instruction to use the = sign as per Docker’s current best practices.

Confirmed the build still succeeds with the updated syntax.
🔗 Linked to issue: [opencrvs/opencrvs-core#9594](https://github.com/opencrvs/opencrvs-core/pull/9594)
Branch name: ocrvs-9594