### PR TITLE
Show fields with same label in same row in deduplication comparison

### DIFF
--- a/packages/client/src/v2-events/features/events/actions/dedup/DuplicateComparison.tsx
+++ b/packages/client/src/v2-events/features/events/actions/dedup/DuplicateComparison.tsx
@@ -170,22 +170,26 @@ export function DuplicateComparison({
           }, [])
           .map((field) => ({
             label: intl.formatMessage(field.label),
-            rightValue: Output({
-              field,
-              value: potentialDuplicateDeclaration[field.id],
-              previousForm: potentialDuplicateDeclaration,
-              formConfig: eventConfiguration.declaration,
-              displayEmptyAsDash: true,
-              showPreviouslyMissingValuesAsChanged: false
-            }),
-            leftValue: Output({
-              field,
-              value: originalDeclaration[field.id],
-              previousForm: originalDeclaration,
-              formConfig: eventConfiguration.declaration,
-              displayEmptyAsDash: true,
-              showPreviouslyMissingValuesAsChanged: false
-            })
+            rightValue: (
+              <Output
+                displayEmptyAsDash={true}
+                field={field}
+                formConfig={eventConfiguration.declaration}
+                previousForm={potentialDuplicateDeclaration}
+                showPreviouslyMissingValuesAsChanged={false}
+                value={potentialDuplicateDeclaration[field.id]}
+              />
+            ),
+            leftValue: (
+              <Output
+                displayEmptyAsDash={true}
+                field={field}
+                formConfig={eventConfiguration.declaration}
+                previousForm={originalDeclaration}
+                showPreviouslyMissingValuesAsChanged={false}
+                value={originalDeclaration[field.id]}
+              />
+            )
           }))
       }))
       .filter(({ data }) => data.length > 0)

--- a/packages/client/src/v2-events/features/events/actions/dedup/DuplicateComparison.tsx
+++ b/packages/client/src/v2-events/features/events/actions/dedup/DuplicateComparison.tsx
@@ -133,7 +133,10 @@ export function DuplicateComparison({
     FieldType.FILE,
     FieldType.FILE_WITH_OPTIONS,
     FieldType.BULLET_LIST,
-    FieldType.DIVIDER
+    FieldType.DIVIDER,
+    FieldType.PAGE_HEADER,
+    FieldType.PARAGRAPH,
+    FieldType.BULLET_LIST
   ]
 
   const comparisonData: ComparisonDeclaration[] =

--- a/packages/client/src/v2-events/features/events/actions/dedup/DuplicateComparison.tsx
+++ b/packages/client/src/v2-events/features/events/actions/dedup/DuplicateComparison.tsx
@@ -15,6 +15,7 @@ import {
   DeclarationFormConfig,
   EventIndex,
   EventState,
+  FieldConfig,
   FieldType,
   isFieldDisplayedOnReview,
   isPageVisible
@@ -33,7 +34,7 @@ import { flattenEventIndex, getUsersFullName } from '@client/v2-events/utils'
 import { useUsers } from '@client/v2-events/hooks/useUsers'
 import { noop } from '@client/v2-events'
 import { useEventConfiguration } from '../../useEventConfiguration'
-import { ValueOutput } from '../../components/Output'
+import { Output, ValueOutput } from '../../components/Output'
 import { AdministrativeArea } from '../../registered-fields'
 import { DocumentViewer } from '../../components/DocumentViewer'
 import { duplicateMessages } from './ReviewDuplicate'
@@ -154,15 +155,33 @@ export function DuplicateComparison({
             ({ type }) =>
               !hideFieldTypes.some((typeToHide) => type === typeToHide)
           )
+          // Refer to 'findPreviousValueWithSameLabel' in Output.tsx for explanation
+          .reduce<FieldConfig[]>((acc, field) => {
+            const fieldWithSameLabelDontExist = !acc.find(
+              (f) => f.label.id === field.label.id
+            )
+            if (fieldWithSameLabelDontExist) {
+              acc.push(field)
+            }
+            return acc
+          }, [])
           .map((field) => ({
             label: intl.formatMessage(field.label),
-            rightValue: ValueOutput({
-              config: field,
-              value: potentialDuplicateDeclaration[field.id]
+            rightValue: Output({
+              field,
+              value: potentialDuplicateDeclaration[field.id],
+              previousForm: potentialDuplicateDeclaration,
+              formConfig: eventConfiguration.declaration,
+              displayEmptyAsDash: true,
+              showPreviouslyMissingValuesAsChanged: false
             }),
-            leftValue: ValueOutput({
-              config: field,
-              value: originalDeclaration[field.id]
+            leftValue: Output({
+              field,
+              value: originalDeclaration[field.id],
+              previousForm: originalDeclaration,
+              formConfig: eventConfiguration.declaration,
+              displayEmptyAsDash: true,
+              showPreviouslyMissingValuesAsChanged: false
             })
           }))
       }))

--- a/packages/client/src/v2-events/features/events/actions/dedup/Review.stories.tsx
+++ b/packages/client/src/v2-events/features/events/actions/dedup/Review.stories.tsx
@@ -12,14 +12,19 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { createTRPCMsw, httpLink } from '@vafanassieff/msw-trpc'
 import superjson from 'superjson'
 import { AppRouter } from '@events/router'
-import { userEvent, within } from '@storybook/test'
+import { userEvent, within, expect } from '@storybook/test'
 import {
   ActionType,
   createPrng,
   generateActionDocument,
   generateUuid,
   tennisClubMembershipEvent,
-  generateTrackingId
+  generateTrackingId,
+  defineDeclarationForm,
+  FieldType,
+  generateTranslationConfig,
+  ConditionalType,
+  field
 } from '@opencrvs/commons/client'
 import { ROUTES, routesConfig } from '@client/v2-events/routes'
 import { ReviewDuplicateIndex } from './ReviewDuplicate'
@@ -47,13 +52,56 @@ const duplicates = [
     trackingId: generateTrackingId(prng)
   }
 ]
+const overriddenEventConfig = {
+  ...tennisClubMembershipEvent,
+  declaration: defineDeclarationForm({
+    ...tennisClubMembershipEvent.declaration,
+    pages: tennisClubMembershipEvent.declaration.pages.map((x) => {
+      x.fields = x.fields.filter((f) => f.type !== FieldType.EMAIL)
+      if (x.id === 'applicant') {
+        x.fields.push({
+          id: 'applicant.contactMethod',
+          type: FieldType.SELECT,
+          label: generateTranslationConfig('Contact Method'),
+          options: [
+            { label: generateTranslationConfig('Email'), value: 'EMAIL' },
+            { label: generateTranslationConfig('Phone'), value: 'PHONE' }
+          ]
+        })
+        x.fields.push({
+          id: 'applicant.contact',
+          type: FieldType.PHONE,
+          label: generateTranslationConfig('Contact'),
+          conditionals: [
+            {
+              type: ConditionalType.SHOW,
+              conditional: field('applicant.contactMethod').isEqualTo('PHONE')
+            }
+          ]
+        })
+        x.fields.push({
+          id: 'applicant.contact',
+          type: FieldType.EMAIL,
+          label: generateTranslationConfig('Contact'),
+          conditionals: [
+            {
+              type: ConditionalType.SHOW,
+              conditional: field('applicant.contactMethod').isEqualTo('EMAIL')
+            }
+          ]
+        })
+      }
+      return x
+    })
+  })
+}
 const actions = [
   generateActionDocument({
-    configuration: tennisClubMembershipEvent,
+    configuration: overriddenEventConfig,
     action: ActionType.CREATE
   }),
   generateActionDocument({
-    configuration: tennisClubMembershipEvent,
+    configuration: overriddenEventConfig,
     action: ActionType.DECLARE,
     defaults: {
       declaration: {
@@ -87,7 +135,7 @@ const actions = [
     }
   }),
   generateActionDocument({
-    configuration: tennisClubMembershipEvent,
+    configuration: overriddenEventConfig,
     action: ActionType.DUPLICATE_DETECTED,
     defaults: {
       content: {
@@ -99,7 +147,7 @@ const actions = [
 
 const mockOriginalEvent = {
   trackingId: generateTrackingId(prng),
-  type: tennisClubMembershipEvent.id,
+  type: overriddenEventConfig.id,
   actions,
   createdAt: new Date(Date.now()).toISOString(),
   id: generateUuid(prng),
@@ -109,7 +157,7 @@ const mockOriginalEvent = {
 
 const mockDuplicateEvent = {
   trackingId: duplicates[0].trackingId,
-  type: tennisClubMembershipEvent.id,
+  type: overriddenEventConfig.id,
   actions: actions.slice(0, 2),
   createdAt: new Date(Date.now()).toISOString(),
   id: duplicates[0].id,
@@ -148,5 +196,72 @@ export const ReviewComparison: Story = {
       name: /243D49/i
     })
     await userEvent.click(comparisonTab)
+  }
+}
+
+// Both events applicant.contactMethod is different
+// but applicant.contact has the same label "Contact"
+// This is to test that both fields are shown in the same comparison row
+// and not just one of them
+export const DuplicateWithSameLabels: Story = {
+  parameters: {
+    reactRouter: {
+      router: routesConfig,
+      initialPath: ROUTES.V2.EVENTS.REVIEW_POTENTIAL_DUPLICATE.buildPath({
+        eventId: mockOriginalEvent.id
+      })
+    },
+    offline: {
+      events: [
+        {
+          ...mockOriginalEvent,
+          actions: mockOriginalEvent.actions.map((x) => {
+            if (x.type === ActionType.DECLARE) {
+              return {
+                ...x,
+                declaration: {
+                  ...x.declaration,
+                  'applicant.contactMethod': 'EMAIL',
+                  'applicant.contact': 'abc@gmail.com'
+                }
+              }
+            }
+            return x
+          })
+        },
+        {
+          ...mockDuplicateEvent,
+          actions: mockDuplicateEvent.actions.map((x) => {
+            if (x.type === ActionType.DECLARE) {
+              return {
+                ...x,
+                declaration: {
+                  ...x.declaration,
+                  'applicant.contactMethod': 'PHONE',
+                  'applicant.contact': '0912345678'
+                }
+              }
+            }
+            return x
+          })
+        }
+      ]
+    }
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const comparisonTab = await canvas.findByRole('button', {
+      name: /243D49/i
+    })
+    await userEvent.click(comparisonTab)
+
+    const els = await canvas.findAllByText('Contact Method')
+    await expect(els).toHaveLength(1) // only appears once
+
+    await expect(canvas.getByText('Email')).toBeInTheDocument()
+    await expect(canvas.getByText('abc@gmail.com')).toBeInTheDocument()
+
+    await expect(canvas.getByText('Phone')).toBeInTheDocument()
+    await expect(canvas.getByText('0912345678')).toBeInTheDocument()
   }
 }

--- a/packages/client/src/v2-events/features/events/components/Output.tsx
+++ b/packages/client/src/v2-events/features/events/components/Output.tsx
@@ -155,12 +155,14 @@ export function ValueOutput(
   }
 
   if (isAddressFieldType(field)) {
-    return Address.Output({
-      value: field.value,
-      fields: searchMode === true ? ['country'] : undefined,
-      lineSeparator: searchMode === true ? ', ' : undefined,
-      configuration: field.config
-    })
+    return (
+      <Address.Output
+        configuration={field.config}
+        fields={searchMode === true ? ['country'] : undefined}
+        lineSeparator={searchMode === true ? ', ' : undefined}
+        value={field.value}
+      />
+    )
   }
 
   if (isRadioGroupFieldType(field)) {

--- a/packages/components/src/ComparisonListView/ComparisonListView.tsx
+++ b/packages/components/src/ComparisonListView/ComparisonListView.tsx
@@ -52,9 +52,9 @@ export const ComparisonListView = ({
     <React.Fragment>
       <Grid {...props} headingCount={headings.length + 1}>
         {[
-          <HideOnSmallScreen></HideOnSmallScreen>,
+          <HideOnSmallScreen key="spacer"></HideOnSmallScreen>,
           ...headings.map((heading, index) => (
-            <HideOnSmallScreen>
+            <HideOnSmallScreen key={`heading-${heading}-${index}`}>
               <Text
                 variant="reg16"
                 element="span"


### PR DESCRIPTION
## Summary

Issue: https://github.com/opencrvs/opencrvs-core/issues/10400

This PR updates the duplicate comparison view to handle cases where multiple fields share the same label.  
It ensures that such fields are rendered in a single comparison row rather than duplicating rows.

Additionally, a new Storybook scenario is introduced to validate this behavior with `Contact Method` and `Contact` fields.

---

## Changes

- **DuplicateComparison.tsx**
  - Replaced `ValueOutput` with `Output` for richer rendering (supports `previousForm`, `formConfig`, etc.).
  - Added deduplication step to collapse fields with the same label (`reduce` logic).

- **Review.stories.tsx**
  - Created `overriddenEventConfig` with new `contactMethod` and conditional `contact` fields.
  - Added `DuplicateWithSameLabels` story:
    - Validates that `Contact Method` appears exactly once.
    - Ensures both `Email` and `Phone` values with the same label `Contact` are shown side by side.

---

## Motivation

When two different fields share the same label (e.g., phone/email under `Contact`), the comparison UI previously rendered multiple rows.  
This caused confusion and visual duplication. The new logic ensures a cleaner and more accurate comparison.

---

## Testing

- Run Storybook and open the `DuplicateWithSameLabels` story.
- Click the comparison tab.
- Verify:
  - `Contact Method` is displayed **only once**.
  - Both `Email` and `Phone` variants of `Contact` appear correctly under the same row.

---

## Notes

- Deduplication currently relies on `label.id`.  
  ⚠️ If two unrelated fields share the same label id, they will also collapse into one row.  
  This is acceptable for now but may need refinement later.
