### PR TITLE
add errorFormatter for handling internal errors

### DIFF
--- a/packages/events/src/router/trpc.ts
+++ b/packages/events/src/router/trpc.ts
@@ -15,9 +15,26 @@ import { OpenApiMeta } from 'trpc-to-openapi'
 import { logger, TokenUserType } from '@opencrvs/commons'
 import { TrpcContext } from '@events/context'
 
-export const t = initTRPC.context<TrpcContext>().meta<OpenApiMeta>().create({
-  transformer: superjson
-})
+export const t = initTRPC
+  .context<TrpcContext>()
+  .meta<OpenApiMeta>()
+  .create({
+    transformer: superjson,
+    errorFormatter: ({ shape, error }) => {
+      // If received unhandled error, don't leak the error message or stack trace in the response.
+      // This is a security measure: the message or stack trace could contain internal technical details etc. sensitive information.
+      if (error.code === 'INTERNAL_SERVER_ERROR') {
+        return {
+          ...shape,
+          message: 'Internal server error',
+          data: { code: shape.data.code, httpStatus: shape.data.httpStatus }
+        }
+      }
+
+      // Keep all other errors as is.
+      return shape
+    }
+  })
 
 export const router = t.router
 


### PR DESCRIPTION
## Description

Resolves: https://github.com/opencrvs/opencrvs-core/issues/8796
Other matters on the issue seem to be resolved already.

Exclude message and stack trace of internal server errors from responses.

Example before:

```
{
    "message": "relation \"app.eventss\" does not exist",
    "code": "INTERNAL_SERVER_ERROR",
    "data": {
        "code": "INTERNAL_SERVER_ERROR",
        "httpStatus": 500,
        "stack": "error: relation \"app.eventss\" does not exist\n    at /Users/cihanbebek/opencrvs/opencrvs-core/node_modules/pg/lib/client.js:545:17\n    at processTicksAndRejections (node:internal/process/task_queues:105:5)\n    at PostgresConnection.executeQuery (/Users/cihanbebek/opencrvs/opencrvs-core/node_modules/kysely/dist/cjs/dialect/postgres/postgres-driver.js:93:49)\n    at /Users/cihanbebek/opencrvs/opencrvs-core/node_modules/kysely/dist/cjs/query-executor/query-executor-base.js:37:28\n    at SingleConnectionProvider.#run (/Users/cihanbebek/opencrvs/opencrvs-core/node_modules/kysely/dist/cjs/driver/single-connection-provider.js:26:16)\n    at DefaultQueryExecutor.executeQuery (/Users/cihanbebek/opencrvs/opencrvs-core/node_modules/kysely/dist/cjs/query-executor/query-executor-base.js:36:16)\n    at InsertQueryBuilder.execute (/Users/cihanbebek/opencrvs/opencrvs-core/node_modules/kysely/dist/cjs/query-builder/insert-query-builder.js:1108:24)\n    at PostgresConnection.executeQuery (/Users/cihanbebek/opencrvs/opencrvs-core/node_modules/kysely/dist/cjs/dialect/postgres/postgres-driver.js:105:69)\n    at processTicksAndRejections (node:internal/process/task_queues:105:5)\n    at /Users/cihanbebek/opencrvs/opencrvs-core/node_modules/kysely/dist/cjs/query-executor/query-executor-base.js:37:28\n    at SingleConnectionProvider.#run (/Users/cihanbebek/opencrvs/opencrvs-core/node_modules/kysely/dist/cjs/driver/single-connection-provider.js:26:16)\n    at DefaultQueryExecutor.executeQuery (/Users/cihanbebek/opencrvs/opencrvs-core/node_modules/kysely/dist/cjs/query-executor/query-executor-base.js:36:16)\n    at InsertQueryBuilder.execute (/Users/cihanbebek/opencrvs/opencrvs-core/node_modules/kysely/dist/cjs/query-builder/insert-query-builder.js:1108:24)",
        "path": "event.create"
    }
}
```

After: 

```
{
    "message": "Internal server error",
    "code": "INTERNAL_SERVER_ERROR",
    "data": {
        "code": "INTERNAL_SERVER_ERROR",
        "httpStatus": 500
    }
}
```

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
