### PR TITLE
feat: only pass event & action-specific tokens to country config

### DIFF
--- a/packages/auth/src/features/authenticate/service.ts
+++ b/packages/auth/src/features/authenticate/service.ts
@@ -137,13 +137,14 @@ export async function createToken(
 }
 
 export async function createTokenForRecordValidation(
-  userId: UUID,
-  recordId: UUID
+  { eventId, actionId }: { eventId: UUID; actionId: UUID },
+  userId: UUID
 ) {
   return sign(
     {
       scope: ['record.confirm-registration', 'record.reject-registration'],
-      recordId
+      eventId,
+      actionId
     },
     cert,
     {

--- a/packages/auth/src/features/oauthToken/token-exchange.ts
+++ b/packages/auth/src/features/oauthToken/token-exchange.ts
@@ -34,10 +34,12 @@ export async function tokenExchangeHandler(
   const subjectToken = request.query.subject_token
   const subjectTokenType = request.query.subject_token_type
   const requestedTokenType = request.query.requested_token_type
-  const recordId = request.query.record_id
+  const eventId = request.query.event_id
+  const actionId = request.query.action_id
 
   if (
-    !recordId ||
+    !eventId ||
+    !actionId ||
     !subjectToken ||
     subjectTokenType !== SUBJECT_TOKEN_TYPE ||
     requestedTokenType !== RECORD_TOKEN_TYPE
@@ -53,8 +55,8 @@ export async function tokenExchangeHandler(
 
   // @TODO: If in the future we have a fine grained access control for records, check here that the subject actually has access to the record requested
   const recordToken = await createTokenForRecordValidation(
-    sub as UUID,
-    recordId
+    { eventId, actionId },
+    sub as UUID
   )
 
   return oauthResponse.success(h, recordToken)

--- a/packages/commons/src/authentication.ts
+++ b/packages/commons/src/authentication.ts
@@ -15,6 +15,7 @@ import { Nominal } from './nominal'
 import { z } from 'zod'
 
 import { RawScopes, Scope, SCOPES } from './scopes'
+import { UUID } from './uuid'
 export * from './scopes'
 
 export const DEFAULT_ROLES_DEFINITION = [
@@ -181,6 +182,8 @@ export interface ITokenPayload {
   algorithm: string
   scope: Scope[]
   userType: TokenUserType
+  eventId?: UUID
+  actionId?: UUID
 }
 
 export function getScopes(authHeader: IAuthHeader): RawScopes[] {

--- a/packages/events/src/service/auth/index.ts
+++ b/packages/events/src/service/auth/index.ts
@@ -10,10 +10,51 @@
  */
 
 import fetch from 'node-fetch'
+import { UUID } from '@opencrvs/commons'
 import { env } from '@events/environment'
 
 export async function getAnonymousToken() {
   const res = await fetch(new URL('/anonymous-token', env.AUTH_URL).toString())
   const { token } = await res.json()
   return token as string
+}
+
+export async function getEventActionToken(
+  { eventId, actionId }: { eventId: UUID; actionId: UUID },
+  token: string
+) {
+  const grantType = 'urn:opencrvs:oauth:grant-type:token-exchange'
+  const subject_token_type = 'urn:ietf:params:oauth:token-type:access_token'
+  const requested_token_type =
+    'urn:opencrvs:oauth:token-type:single_record_token'
+
+  const params = new URLSearchParams({
+    grant_type: grantType,
+    subject_token: token,
+    subject_token_type,
+    requested_token_type,
+    event_id: eventId,
+    action_id: actionId
+  })
+
+  const res = await fetch(new URL(`token?${params}`, env.AUTH_URL), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: token
+    }
+  })
+
+  if (!res.ok) {
+    throw new Error(
+      `Error calling token exchange handler [${res.statusText} ${
+        res.status
+      }]: ${await res.text()}`
+    )
+  }
+
+  const { access_token: accessToken } = (await res.json()) as {
+    access_token: string
+  }
+  return accessToken
 }

--- a/packages/events/src/tests/msw.ts
+++ b/packages/events/src/tests/msw.ts
@@ -57,7 +57,14 @@ const handlers = [
       role: 'REGISTRATION_AGENT',
       signature: '/ocrvs/signature.png'
     })
-  })
+  }),
+  // token exchange for `event.actions.register.confirm` and `event.actions.register.reject`
+  // query params such as `subject_token`, `subject_token_type` omitted for simplicity
+  http.post(`${env.AUTH_URL}/token`, () =>
+    HttpResponse.json({
+      access_token: 'some-token'
+    })
+  )
 ]
 
 export const mswServer = setupServer(...handlers)

--- a/packages/events/src/tests/utils.ts
+++ b/packages/events/src/tests/utils.ts
@@ -128,6 +128,33 @@ export function createTestToken(
   return `Bearer ${token}`
 }
 
+function createTokenExchangeTestToken(
+  userId: string,
+  eventId: string,
+  actionId: string
+): TokenWithBearer {
+  const token = jwt.sign(
+    {
+      scope: [
+        SCOPES.RECORD_CONFIRM_REGISTRATION,
+        SCOPES.RECORD_REJECT_REGISTRATION
+      ],
+      sub: userId,
+      userType: TokenUserType.enum.user,
+      eventId,
+      actionId
+    },
+    readFileSync(join(__dirname, './cert.key')),
+    {
+      algorithm: 'RS256',
+      issuer: 'opencrvs:auth-service',
+      audience: 'opencrvs:events-user'
+    }
+  )
+
+  return `Bearer ${token}`
+}
+
 export function createSystemTestClient(
   systemId: string,
   scopes: string[] = TEST_USER_DEFAULT_SCOPES
@@ -154,6 +181,24 @@ export function createTestClient(
 ) {
   const createCaller = createCallerFactory(appRouter)
   const token = createTestToken(user.id, scopes)
+
+  const caller = createCaller({
+    user: {
+      ...user,
+      type: TokenUserType.enum.user
+    },
+    token
+  })
+  return caller
+}
+
+export function createTokenExchangeClient(
+  user: CreatedUser,
+  eventId: string,
+  actionId: string
+) {
+  const createCaller = createCallerFactory(appRouter)
+  const token = createTokenExchangeTestToken(user.id, eventId, actionId)
 
   const caller = createCaller({
     user: {


### PR DESCRIPTION
In 1.8, we passed a record-specific token to country config. This is a more narrower token that can only be used to confirm or reject an action.

## Description

Clearly describe what has been changed. Include relevant context or background.
Explain how the issue was fixed (if applicable) and the root cause.

Link this pull request to the GitHub issue (and optionally name the branch `ocrvs-<issue #>`)

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
