### PR TITLE
fix: Simplify Branch Name Detection in Workflow

### DIFF
--- a/.github/workflows/build-images-from-branch.yml
+++ b/.github/workflows/build-images-from-branch.yml
@@ -78,24 +78,15 @@ jobs:
 
       - name: Set version and branch
         id: set-version-and-branch
+        env:
+          BRANCH: ${{ inputs.branch_tag_name || github.ref_name }}
         run: |
           export VERSION=`git log -1 --pretty=format:%h`
           echo "Pushing version $VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-          # the event_name is the event that triggered the caller workflow
-          # and not "workflow_call" like how it was supposed to be when
-          # another workflow is calling this one
-
-          if [ "${{ github.event_name }}" == 'push' ]; then
-            BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
-          elif [ "${{ github.event_name }}" == 'pull_request' ]; then
-            BRANCH=${{ github.event.pull_request.head.ref }}
-          else
-            BRANCH=${{ inputs.branch_tag_name }}
-          fi
           ESCAPED_BRANCH=$(echo $BRANCH | sed 's/[^a-zA-Z0-9_.-]/-/g')
-          echo "from branch $BRANCH"
+          echo "from branch $ESCAPED_BRANCH"
           echo "branch=$ESCAPED_BRANCH" >> $GITHUB_OUTPUT
 
       - name: Set architecture label


### PR DESCRIPTION
## Description

Goal of this PR is to address issue like this one: https://github.com/opencrvs/opencrvs-core/actions/runs/17669000166

workflow was successfully build, but final image tag was `refs-tags-v1.9.0-beta.2` instead of `v1.9.0-beta.2`

Problem was is complicated logic and not taking into account edge case scenarios like tag can be supplied from workflow_dispatch (refs-tags-v1.9.0-beta.2) or workflow_call (v1.9.0-beta.2)

This PR refactors the workflow script to use built-in GitHub Actions variables for determining the branch name, instead of manually parsing and handling the branch from multiple possible sources like at https://github.com/opencrvs/opencrvs-countryconfig/blob/develop/.github/workflows/publish-to-dockerhub.yml#L92.

## Changes

- Replaces manual branch detection and variable manipulations with:
  ```yaml
  BRANCH: ${{ inputs.branch_tag_name || github.ref_name }}
  ```
- Uses GitHub-provided context (`github.ref_name`) wherever possible, simplifying logic.
- Updates output to echo the sanitized (escaped) branch name rather than the original.
- Removes now-unnecessary inline shell logic for deducing branch type and name based on `event_name`.


## Test results:

- Tag build: https://github.com/opencrvs/opencrvs-core/actions/runs/17671464524/job/50224002640
- Feature branch build: https://github.com/opencrvs/opencrvs-core/actions/runs/17671447902
- Develop branch build: https://github.com/opencrvs/opencrvs-core/actions/runs/17671477527

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
