### PR TITLE
feat: support for strict value and `not` helper

### DIFF
--- a/packages/commons/src/events/DeduplicationConfig.ts
+++ b/packages/commons/src/events/DeduplicationConfig.ts
@@ -61,7 +61,11 @@ const StrictMatcher = Matcher.extend({
   type: z.literal('strict'),
   options: z
     .object({
-      boost: z.number().optional().default(1)
+      boost: z.number().optional().default(1),
+      /**
+       * The constant value to be present in the field for both records
+       */
+      value: z.string().optional()
     })
     .optional()
     .default({
@@ -88,6 +92,16 @@ export type DateRangeMatcherOptions = z.input<
   typeof DateRangeMatcher
 >['options']
 
+export type NotInput = {
+  type: 'not'
+  clause: ClauseInput
+}
+
+export type NotOutput = {
+  type: 'not'
+  clause: ClauseOutput
+}
+
 export type AndInput = {
   type: 'and'
   clauses: ClauseInput[]
@@ -108,6 +122,12 @@ export type OrOutput = {
   clauses: ClauseOutput[]
 }
 
+const Not = z.object({
+  type: z.literal('not'),
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
+  clause: z.lazy(() => Clause)
+})
+
 const And = z.object({
   type: z.literal('and'),
   // eslint-disable-next-line @typescript-eslint/no-use-before-define
@@ -121,6 +141,7 @@ const Or = z.object({
 })
 
 export type ClauseInput =
+  | NotInput
   | AndInput
   | OrInput
   | z.input<typeof FuzzyMatcher>
@@ -128,6 +149,7 @@ export type ClauseInput =
   | z.input<typeof DateRangeMatcher>
 
 export type ClauseOutput =
+  | NotOutput
   | AndOutput
   | OrOutput
   | z.output<typeof FuzzyMatcher>
@@ -145,6 +167,7 @@ export type ClauseOutput =
 export const Clause: z.ZodType<ClauseOutput, z.ZodTypeDef, ClauseInput> = z
   .lazy(() =>
     z.discriminatedUnion('type', [
+      Not,
       And,
       Or,
       FuzzyMatcher,

--- a/packages/commons/src/events/deduplication.ts
+++ b/packages/commons/src/events/deduplication.ts
@@ -16,6 +16,13 @@ import {
   StrictMatcherOptions
 } from '.'
 
+export function not(clause: ClauseInput): ClauseInput {
+  return {
+    type: 'not',
+    clause
+  }
+}
+
 export function and(...clauses: ClauseInput[]): ClauseInput {
   return {
     type: 'and',

--- a/packages/commons/src/fixtures/v2-birth-event.ts
+++ b/packages/commons/src/fixtures/v2-birth-event.ts
@@ -18,6 +18,7 @@ import { FieldType } from '../events/FieldType'
 import { BIRTH_EVENT } from '../events/Constants'
 import { ActionType } from '../events/ActionType'
 import { TranslationConfig } from 'src/events/TranslationConfig'
+import { createFieldConditionals } from '../conditionals/conditionals'
 
 function generateTranslationConfig(message: string): TranslationConfig {
   return {
@@ -76,11 +77,51 @@ const mother = defineFormPage({
       conditionals: []
     },
     {
+      id: 'mother.idType',
+      type: FieldType.SELECT,
+      required: true,
+      label: generateTranslationConfig('Type of ID'),
+      options: [
+        {
+          value: 'NID',
+          label: generateTranslationConfig('National ID')
+        },
+        {
+          value: 'PASSPORT',
+          label: generateTranslationConfig('Passport')
+        },
+        {
+          value: 'NONE',
+          label: generateTranslationConfig('None')
+        }
+      ],
+      conditionals: []
+    },
+    {
       id: 'mother.nid',
       type: FieldType.ID,
       required: true,
-      label: generateTranslationConfig('ID Number'),
-      conditionals: [],
+      label: generateTranslationConfig('National ID'),
+      conditionals: [
+        {
+          type: 'SHOW',
+          conditional: createFieldConditionals('mother.idType').isEqualTo('NID')
+        }
+      ],
+      validation: []
+    },
+    {
+      id: 'mother.passport',
+      type: FieldType.ID,
+      required: true,
+      label: generateTranslationConfig('Passport'),
+      conditionals: [
+        {
+          type: 'SHOW',
+          conditional:
+            createFieldConditionals('mother.idType').isEqualTo('PASSPORT')
+        }
+      ],
       validation: []
     }
   ]

--- a/packages/events/src/router/event/event.actions.correction-2.test.ts
+++ b/packages/events/src/router/event/event.actions.correction-2.test.ts
@@ -188,6 +188,7 @@ describe('Overwriting parent field', () => {
       'child.dob': '2020-05-15',
       'mother.name': { firstname: 'Jane', surname: 'Doe' },
       'mother.dob': '1990-03-22',
+      'mother.idType': 'NID',
       'mother.nid': 'ID123456789',
       'informant.relation': 'FATHER',
       'informant.name': { firstname: 'Rok', surname: 'Doe' },

--- a/packages/events/src/service/deduplication/__snapshots__/deduplication.test.ts.snap
+++ b/packages/events/src/service/deduplication/__snapshots__/deduplication.test.ts.snap
@@ -34,10 +34,31 @@ exports[`deduplication query input conversion > should convert exactNamedChild t
 }
 `;
 
-exports[`deduplication query input conversion > should convert sameMotherNid to strict query 1`] = `
+exports[`deduplication query input conversion > should convert motherIdMatchesIfGiven to strict query 1`] = `
 {
-  "match_phrase": {
-    "declaration.mother____nid": "1232314352",
+  "bool": {
+    "should": [
+      {
+        "bool": {
+          "must_not": {
+            "match_phrase": {
+              "declaration.mother____idType": "NID",
+            },
+          },
+          "should": undefined,
+        },
+      },
+      {
+        "match_phrase": {
+          "declaration.mother____idType": "NONE",
+        },
+      },
+      {
+        "match_phrase": {
+          "declaration.mother____nid": "1232314352",
+        },
+      },
+    ],
   },
 }
 `;

--- a/packages/events/src/service/deduplication/deduplication.ts
+++ b/packages/events/src/service/deduplication/deduplication.ts
@@ -49,6 +49,22 @@ export function generateElasticsearchQuery(
   queryInput: ClauseOutput,
   eventConfig: EventConfig
 ): elasticsearch.estypes.QueryDslQueryContainer | null {
+  if (queryInput.type === 'not') {
+    const resolvedQuery = generateElasticsearchQuery(
+      eventIndex,
+      queryInput.clause,
+      eventConfig
+    )
+    if (resolvedQuery === null) {
+      return null
+    }
+    return {
+      bool: {
+        must_not: resolvedQuery,
+        should: undefined
+      }
+    }
+  }
   if (queryInput.type === 'and') {
     const resolvedQueries = queryInput.clauses.map((clause) => {
       return generateElasticsearchQuery(eventIndex, clause, eventConfig)
@@ -140,7 +156,7 @@ export function generateElasticsearchQuery(
 
       return {
         match_phrase: {
-          [queryKey]: queryValue.toString()
+          [queryKey]: queryInput.options.value ?? queryValue.toString()
         }
       }
     }


### PR DESCRIPTION
## Description

Introduce strict value match and `not` helper for deduplication checks.

https://github.com/opencrvs/opencrvs-countryconfig/pull/1011

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
