### PR TITLE
Add indexes for locations queries

### DIFF
--- a/packages/migration/src/migrations/events/1758176023733_locations-query-indexes.sql
+++ b/packages/migration/src/migrations/events/1758176023733_locations-query-indexes.sql
@@ -1,0 +1,9 @@
+-- Up Migration
+CREATE INDEX idx_locations_active ON app.locations(id, name, parent_id, valid_until, location_type)
+WHERE deleted_at IS NULL;
+CREATE INDEX idx_locations_valid_until ON app.locations(valid_until);
+CREATE INDEX idx_locations_parent_type ON app.locations(parent_id, location_type);
+-- Down Migration
+DROP INDEX idx_locations_deleted_at;
+DROP INDEX idx_locations_valid_until;
+DROP INDEX idx_locations_parent_type;


### PR DESCRIPTION
The first two indexes:

```
CREATE INDEX idx_locations_active ON app.locations(id, name, parent_id, valid_until, location_type)
WHERE deleted_at IS NULL;
CREATE INDEX idx_locations_valid_until ON app.locations(valid_until);
```

Target the `getLocations()` query. They are a bit unnecessary since the query is already very fast without them, but it doesn't really hurt to add them either.

The third index:

```
CREATE INDEX idx_locations_parent_type ON app.locations(parent_id, location_type);
```

Targets the `getLeafLocationIds()` query. With quick testing with >100k locations, it makes the query faster, dropping from ~170ms -> ~100ms.