### PR TITLE
Remove Performance and Vital statistics from navbar

### DIFF
--- a/packages/client/src/components/interface/Navigation.test.tsx
+++ b/packages/client/src/components/interface/Navigation.test.tsx
@@ -135,7 +135,6 @@ describe('Navigation for Registration agent related tests', () => {
       apolloClient: client
     })
     expect(component.exists('#navigation_team')).toBeTruthy()
-    expect(component.exists('#navigation_performance')).toBeTruthy()
     expect(component.exists('#navigation_config_main')).toBeFalsy()
   })
 
@@ -644,29 +643,6 @@ describe('Given a user with scopes views Navigation', () => {
     })
   })
 
-  describe('Performance', async () => {
-    const id = `#navigation_${WORKQUEUE_TABS.performance}`
-
-    const requiredScopes = [SCOPES.PERFORMANCE_READ] as Scope[]
-
-    const allOtherScopes = allScopes.filter(
-      (scope) => !requiredScopes.includes(scope)
-    )
-
-    const tests = [
-      [requiredScopes, true],
-      [allOtherScopes, false]
-    ]
-
-    tests.forEach(async ([scopes, exists]) => {
-      it(`should render when user has correct scopes ${scopes}`, async () => {
-        setScopes(scopes as Scope[], store)
-        testComponent = await build()
-        expect(testComponent.exists(id)).toBe(exists)
-      })
-    })
-  })
-
   describe('Statistics', async () => {
     const id = `#navigation_${WORKQUEUE_TABS.statistics}`
 
@@ -717,31 +693,6 @@ describe('Given a user with scopes views Navigation', () => {
     const id = `#navigation_${WORKQUEUE_TABS.leaderboards}`
 
     const requiredScopes = [SCOPES.PERFORMANCE_READ] as Scope[]
-
-    const allOtherScopes = allScopes.filter(
-      (scope) => !requiredScopes.includes(scope)
-    )
-
-    const tests = [
-      [requiredScopes, true],
-      [allOtherScopes, false]
-    ]
-
-    tests.forEach(async ([scopes, exists]) => {
-      it(`should render when user has correct scopes ${scopes}`, async () => {
-        setScopes(scopes as Scope[], store)
-        testComponent = await build()
-        expect(testComponent.exists(id)).toBe(exists)
-      })
-    })
-  })
-
-  describe('Exports', async () => {
-    const id = `#navigation_${WORKQUEUE_TABS.vsexports}`
-
-    const requiredScopes = [
-      SCOPES.PERFORMANCE_EXPORT_VITAL_STATISTICS
-    ] as Scope[]
 
     const allOtherScopes = allScopes.filter(
       (scope) => !requiredScopes.includes(scope)

--- a/packages/client/src/components/interface/Navigation.tsx
+++ b/packages/client/src/components/interface/Navigation.tsx
@@ -16,11 +16,7 @@ import {
 } from '@client/declarations'
 import { buttonMessages } from '@client/i18n/messages'
 import { navigationMessages } from '@client/i18n/messages/views/navigation'
-import {
-  formatUrl,
-  generateGoToHomeTabUrl,
-  generatePerformanceHomeUrl
-} from '@client/navigation'
+import { formatUrl, generateGoToHomeTabUrl } from '@client/navigation'
 import { ADVANCED_SEARCH_RESULT } from '@client/navigation/routes'
 import { IOfflineData } from '@client/offline/reducer'
 import { getOfflineData } from '@client/offline/selectors'
@@ -651,40 +647,8 @@ const NavigationView = (props: IFullProps) => {
                   }
                 />
               )}
-              {userDetails && hasAccess(WORKQUEUE_TABS.performance) && (
-                <NavigationItem
-                  icon={() => <Icon name="ChartBar" size="small" />}
-                  label={intl.formatMessage(navigationMessages['performance'])}
-                  onClick={() => {
-                    props.router.navigate(
-                      generatePerformanceHomeUrl({
-                        locationId: userDetails.primaryOffice.id
-                      })
-                    )
-                  }}
-                  id={`navigation_${WORKQUEUE_TABS.performance}`}
-                  isSelected={
-                    enableMenuSelection &&
-                    activeMenuItem === WORKQUEUE_TABS.performance
-                  }
-                />
-              )}
             </>
           }
-          {hasAccess(WORKQUEUE_TABS.vsexports) && (
-            <NavigationItem
-              icon={() => <Icon name="Export" size="small" />}
-              id={`navigation_${WORKQUEUE_TABS.vsexports}`}
-              label={intl.formatMessage(
-                navigationMessages[WORKQUEUE_TABS.vsexports]
-              )}
-              onClick={() => router.navigate(routes.VS_EXPORTS)}
-              isSelected={
-                enableMenuSelection &&
-                activeMenuItem === WORKQUEUE_TABS.vsexports
-              }
-            />
-          )}
         </NavigationGroup>
       )}
 
@@ -764,33 +728,29 @@ const mapStateToProps: (state: IStoreState) => IStateProps = (state) => {
     advancedSearchParams: getAdvancedSearchParamsState(state),
     activeMenuItem: window.location.href.includes(WORKQUEUE_TABS.performance)
       ? WORKQUEUE_TABS.performance
-      : window.location.href.endsWith(WORKQUEUE_TABS.vsexports)
-        ? WORKQUEUE_TABS.vsexports
-        : window.location.href.includes(WORKQUEUE_TABS.organisation)
-          ? WORKQUEUE_TABS.organisation
-          : window.location.href.includes(WORKQUEUE_TABS.team)
-            ? WORKQUEUE_TABS.team
-            : window.location.href.endsWith(WORKQUEUE_TABS.application)
-              ? WORKQUEUE_TABS.application
-              : window.location.href.endsWith(WORKQUEUE_TABS.settings)
-                ? WORKQUEUE_TABS.settings
-                : window.location.href.endsWith(WORKQUEUE_TABS.certificate)
-                  ? WORKQUEUE_TABS.certificate
-                  : window.location.href.endsWith(WORKQUEUE_TABS.systems)
-                    ? WORKQUEUE_TABS.systems
+      : window.location.href.includes(WORKQUEUE_TABS.organisation)
+        ? WORKQUEUE_TABS.organisation
+        : window.location.href.includes(WORKQUEUE_TABS.team)
+          ? WORKQUEUE_TABS.team
+          : window.location.href.endsWith(WORKQUEUE_TABS.application)
+            ? WORKQUEUE_TABS.application
+            : window.location.href.endsWith(WORKQUEUE_TABS.settings)
+              ? WORKQUEUE_TABS.settings
+              : window.location.href.endsWith(WORKQUEUE_TABS.certificate)
+                ? WORKQUEUE_TABS.certificate
+                : window.location.href.endsWith(WORKQUEUE_TABS.systems)
+                  ? WORKQUEUE_TABS.systems
+                  : window.location.href.endsWith(
+                        WORKQUEUE_TABS.informantNotification
+                      )
+                    ? WORKQUEUE_TABS.informantNotification
                     : window.location.href.endsWith(
-                          WORKQUEUE_TABS.informantNotification
+                          WORKQUEUE_TABS.emailAllUsers
                         )
-                      ? WORKQUEUE_TABS.informantNotification
-                      : window.location.href.endsWith(
-                            WORKQUEUE_TABS.emailAllUsers
-                          )
-                        ? WORKQUEUE_TABS.emailAllUsers
-                        : window.location.href.endsWith(
-                              WORKQUEUE_TABS.userRoles
-                            )
-                          ? WORKQUEUE_TABS.userRoles
-                          : ''
+                      ? WORKQUEUE_TABS.emailAllUsers
+                      : window.location.href.endsWith(WORKQUEUE_TABS.userRoles)
+                        ? WORKQUEUE_TABS.userRoles
+                        : ''
   }
 }
 


### PR DESCRIPTION
## Description

Resolves https://github.com/opencrvs/opencrvs-core/issues/10517

Agreed with Tameem that the rest of the code will be cleaned up as part of 1.10 v1 cleanup. So only remove the items from navbar for now.

After (desktop):
<img width="1276" height="727" alt="Screenshot 2025-09-22 at 13 19 14" src="https://github.com/user-attachments/assets/889097bd-9ada-4742-8734-8178a9fb34d2" />

After (mobile):
<img width="441" height="520" alt="Screenshot 2025-09-22 at 13 32 15" src="https://github.com/user-attachments/assets/bcf00a05-f152-4f0d-892b-3f810d0fa7e2" />


## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
