### PR TITLE
Introduced isGreaterThan isLessThan conditionals

### DIFF
--- a/packages/commons/src/conditionals/conditionals.test.ts
+++ b/packages/commons/src/conditionals/conditionals.test.ts
@@ -1392,3 +1392,157 @@ describe('Subfield nesting', () => {
     ).toBe(true)
   })
 })
+
+describe('isGreaterThan and isLessThan conditionals', () => {
+  // --------- isGreaterThan with another field ----------
+  it('should fail validation when numberOfChildren is not greater than numberOfDependents', () => {
+    const params = {
+      $form: {
+        'family.numberOfChildren': 2,
+        'family.numberOfDependents': 3
+      },
+      $now: formatISO(new Date(), { representation: 'date' }),
+      $locations: [],
+      $online: false
+    }
+
+    expect(
+      validate(
+        field('family.numberOfChildren').isGreaterThan({
+          $$field: 'family.numberOfDependents'
+        }),
+        params
+      )
+    ).toBe(false)
+  })
+
+  it('should pass validation when numberOfChildren is greater than numberOfDependents', () => {
+    const params = {
+      $form: {
+        'family.numberOfChildren': 5,
+        'family.numberOfDependents': 3
+      },
+      $now: formatISO(new Date(), { representation: 'date' }),
+      $locations: [],
+      $online: false
+    }
+
+    expect(
+      validate(
+        field('family.numberOfChildren').isGreaterThan({
+          $$field: 'family.numberOfDependents'
+        }),
+        params
+      )
+    ).toBe(true)
+  })
+
+  // --------- isGreaterThan with a number ----------
+  it('should fail validation when salary is not greater than 10000', () => {
+    const params = {
+      $form: { 'employee.salary': 8000 },
+      $now: formatISO(new Date(), { representation: 'date' }),
+      $locations: [],
+      $online: false
+    }
+
+    expect(
+      validate(field('employee.salary').isGreaterThan(10000), params)
+    ).toBe(false)
+  })
+
+  it('should pass validation when salary is greater than 10000', () => {
+    const params = {
+      $form: { 'employee.salary': 15000 },
+      $now: formatISO(new Date(), { representation: 'date' }),
+      $locations: [],
+      $online: false
+    }
+
+    expect(
+      validate(field('employee.salary').isGreaterThan(10000), params)
+    ).toBe(true)
+  })
+
+  // --------- isLessThan with another field ----------
+  it('should fail validation when yearsMarried is not less than yearsSinceGraduation', () => {
+    const params = {
+      $form: {
+        'person.yearsMarried': 15,
+        'person.yearsSinceGraduation': 10
+      },
+      $now: formatISO(new Date(), { representation: 'date' }),
+      $locations: [],
+      $online: false
+    }
+
+    expect(
+      validate(
+        field('person.yearsMarried').isLessThan({
+          $$field: 'person.yearsSinceGraduation'
+        }),
+        params
+      )
+    ).toBe(false)
+  })
+
+  it('should pass validation when yearsMarried is less than yearsSinceGraduation', () => {
+    const params = {
+      $form: {
+        'person.yearsMarried': 5,
+        'person.yearsSinceGraduation': 10
+      },
+      $now: formatISO(new Date(), { representation: 'date' }),
+      $locations: [],
+      $online: false
+    }
+
+    expect(
+      validate(
+        field('person.yearsMarried').isLessThan({
+          $$field: 'person.yearsSinceGraduation'
+        }),
+        params
+      )
+    ).toBe(true)
+  })
+
+  // --------- isLessThan with a number ----------
+  it('should fail validation when vacationDays is not less than 30', () => {
+    const params = {
+      $form: { 'employee.vacationDays': 45 },
+      $now: formatISO(new Date(), { representation: 'date' }),
+      $locations: [],
+      $online: false
+    }
+
+    expect(
+      validate(field('employee.vacationDays').isLessThan(30), params)
+    ).toBe(false)
+  })
+
+  it('should pass validation when vacationDays is less than 30', () => {
+    const params = {
+      $form: { 'employee.vacationDays': 15 },
+      $now: formatISO(new Date(), { representation: 'date' }),
+      $locations: [],
+      $online: false
+    }
+
+    expect(
+      validate(field('employee.vacationDays').isLessThan(30), params)
+    ).toBe(true)
+  })
+
+  it('should fail validation when salary is equal to 10000', () => {
+    const params = {
+      $form: { 'employee.salary': 10000 },
+      $now: formatISO(new Date(), { representation: 'date' }),
+      $locations: [],
+      $online: false
+    }
+    expect(
+      validate(field('employee.salary').isGreaterThan(10000), params)
+    ).toBe(false)
+  })
+})

--- a/packages/commons/src/conditionals/conditionals.ts
+++ b/packages/commons/src/conditionals/conditionals.ts
@@ -243,6 +243,40 @@ function isFieldReference(value: unknown): value is FieldReference {
   return typeof value === 'object' && value !== null && '$$field' in value
 }
 
+function defineComparison(
+  fieldId: string,
+  value: number | FieldReference,
+  keyword: 'exclusiveMinimum' | 'exclusiveMaximum'
+) {
+  if (isFieldReference(value)) {
+    const comparedFieldId = value.$$field
+    return defineFormConditional({
+      type: 'object',
+      properties: {
+        [fieldId]: {
+          type: ['number'],
+          [keyword]: { $data: `1/${comparedFieldId}` }
+        },
+        [comparedFieldId]: {
+          type: 'number'
+        }
+      },
+      required: [fieldId, comparedFieldId]
+    })
+  }
+
+  return defineFormConditional({
+    type: 'object',
+    properties: {
+      [fieldId]: {
+        type: 'number',
+        [keyword]: value
+      }
+    },
+    required: [fieldId]
+  })
+}
+
 /**
  * Generate conditional rules for a form field.
  *
@@ -342,6 +376,10 @@ export function createFieldConditionals(fieldId: string) {
       now: () =>
         defineFormConditional(getDateRange({ $data: '/$now' }, 'formatMaximum'))
     }),
+    isGreaterThan: (value: number | FieldReference) =>
+      defineComparison(fieldId, value, 'exclusiveMinimum'),
+    isLessThan: (value: number | FieldReference) =>
+      defineComparison(fieldId, value, 'exclusiveMaximum'),
     isEqualTo(value: string | boolean | FieldReference) {
       // If the value is a reference to another field, the JSON schema uses the field reference as the 'const' value we compare to
       if (isFieldReference(value)) {


### PR DESCRIPTION
https://github.com/opencrvs/opencrvs-core/issues/10393

## Overview
This PR defines `isGreaterThan` and `isLessThan` conditionals to compare numbers.

## Changes
- Added `defineComparison(fieldId, value, keyword)` utility:
  - Handles both **field reference** (`{ $$field: '...' }`) and **numeric value** comparisons.
  - Dynamically applies either `exclusiveMinimum` or `exclusiveMaximum` based on the given keyword.  
  - `isGreaterThan` → uses `exclusiveMinimum` via `defineComparison`.  
  - `isLessThan` → uses `exclusiveMaximum` via `defineComparison`.  

## Example Usage

```ts
field('employee.salary').isGreaterThan(10000)
field('person.yearsMarried').isLessThan({ $$field: 'person.yearsSinceGraduation' })
```

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
