### PR TITLE
fix: wrap inputs with suspense with `withSuspense`

### DIFF
--- a/packages/client/src/v2-events/components/forms/FormFieldGenerator/FormFieldGenerator-2.interaction.stories.tsx
+++ b/packages/client/src/v2-events/components/forms/FormFieldGenerator/FormFieldGenerator-2.interaction.stories.tsx
@@ -480,6 +480,8 @@ export const DisabledFormFields: StoryObj<typeof FormFieldGenerator> = {
     const canvas = within(canvasElement)
 
     await step('All form fields should be disabled', async () => {
+      await new Promise((resolve) => setTimeout(resolve, 5000)) // wait 5s for suspense to resolve
+
       // Find all kind of input fields and expect them to be disabled
       const formFields = [
         ...(await canvas.findAllByRole('textbox')),

--- a/packages/client/src/v2-events/features/events/registered-fields/Address.tsx
+++ b/packages/client/src/v2-events/features/events/registered-fields/Address.tsx
@@ -39,6 +39,7 @@ import { useLocations } from '@client/v2-events/hooks/useLocations'
 import { AdminStructureItem } from '@client/utils/referenceApi'
 import { getUserDetails } from '@client/profile/profileSelectors'
 import { getAdminLevelHierarchy } from '@client/v2-events/utils'
+import { withSuspense } from '@client/v2-events/components/withSuspense'
 
 // ADDRESS field may not contain another ADDRESS field
 type FieldConfigWithoutAddress = Exclude<
@@ -466,7 +467,7 @@ function toCertificateVariables(
 }
 
 export const Address = {
-  Input: AddressInput,
+  Input: withSuspense(AddressInput),
   Output: AddressOutput,
   toCertificateVariables
 }

--- a/packages/client/src/v2-events/features/events/registered-fields/AdministrativeArea.tsx
+++ b/packages/client/src/v2-events/features/events/registered-fields/AdministrativeArea.tsx
@@ -18,6 +18,7 @@ import { getAdminStructureLocations } from '@client/offline/selectors'
 import { Stringifiable } from '@client/v2-events/components/forms/utils'
 import { EMPTY_TOKEN } from '@client/v2-events/messages/utils'
 import { useLocations } from '@client/v2-events/hooks/useLocations'
+import { withSuspense } from '@client/v2-events/components/withSuspense'
 import { Select } from './Select'
 import { LocationSearch } from './LocationSearch'
 
@@ -84,7 +85,7 @@ function isAdministrativeAreaEmpty(value: Stringifiable) {
 }
 
 export const AdministrativeArea = {
-  Input: AdministrativeAreaInput,
+  Input: withSuspense(AdministrativeAreaInput),
   Output: AdministrativeAreaOutput,
   stringify,
   toCertificateVariables: LocationSearch.toCertificateVariables,

--- a/packages/client/src/v2-events/features/events/registered-fields/LocationSearch.tsx
+++ b/packages/client/src/v2-events/features/events/registered-fields/LocationSearch.tsx
@@ -23,6 +23,7 @@ import { Stringifiable } from '@client/v2-events/components/forms/utils'
 import { useLocations } from '@client/v2-events/hooks/useLocations'
 import { AdminStructureItem } from '@client/utils/referenceApi'
 import { getAdminLevelHierarchy } from '@client/v2-events/utils'
+import { withSuspense } from '@client/v2-events/components/withSuspense'
 
 interface SearchLocation {
   id: string
@@ -174,7 +175,7 @@ function isLocationEmpty(value: Stringifiable) {
 }
 
 export const LocationSearch = {
-  Input: LocationSearchInput,
+  Input: withSuspense(LocationSearchInput),
   Output: LocationSearchOutput,
   toCertificateVariables,
   isEmptyValue: isLocationEmpty


### PR DESCRIPTION
## Description

Clearly describe what has been changed. Include relevant context or background.
Explain how the issue was fixed (if applicable) and the root cause.

Link this pull request to the GitHub issue (and optionally name the branch `ocrvs-<issue #>`)

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
