### PR TITLE
Add bulk import endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - **Certificate Template Conditionals**: Certificate template conditionals allow dynamic template selection based on print history using the template conditional helpers.. [#7585](https://github.com/opencrvs/opencrvs-core/issues/7585)
 - Expose number of copies printed for a certificate template so it can be printed on the certificate. [#7586](https://github.com/opencrvs/opencrvs-core/issues/7586)
 - Add Import/Export system client and `record.export` scope to enable data migrations [#10415](https://github.com/opencrvs/opencrvs-core/issues/10415)
+- Add bulk import endpoint [#10590](https://github.com/opencrvs/opencrvs-core/pull/10590)
 
 ### Improvements
 

--- a/packages/auth/src/features/oauthToken/client-credentials.ts
+++ b/packages/auth/src/features/oauthToken/client-credentials.ts
@@ -45,6 +45,7 @@ export async function clientCredentialsHandler(
   }
 
   const isNotificationAPIUser = result.scope.includes(SCOPES.NOTIFICATION_API)
+  const isImportExportClient = result.scope.includes(SCOPES.RECORD_IMPORT)
 
   const token = await createToken(
     result.systemId,
@@ -54,9 +55,8 @@ export async function clientCredentialsHandler(
       : WEB_USER_JWT_AUDIENCES,
     JWT_ISSUER,
     undefined,
-    true,
+    !isImportExportClient,
     TokenUserType.enum.system
   )
-
   return oauthResponse.success(h, token)
 }

--- a/packages/events/src/router/event/index.ts
+++ b/packages/events/src/router/event/index.ts
@@ -357,17 +357,7 @@ export const eventRouter = router({
       }
     })
     .input(z.array(EventDocument))
-    .output(
-      z.object({
-        successful: z.array(EventDocument),
-        failed: z.array(
-          z.object({
-            event: EventDocument,
-            error: z.string()
-          })
-        )
-      })
-    )
+    .output(z.void())
     .mutation(async ({ input, ctx }) => bulkImportEvents(input, ctx.token)),
   reindex: systemProcedure
     .input(z.void())

--- a/packages/events/src/router/event/index.ts
+++ b/packages/events/src/router/event/index.ts
@@ -49,7 +49,7 @@ import {
   throwConflictIfActionNotAllowed
 } from '@events/service/events/events'
 import * as draftsRepo from '@events/storage/postgres/events/drafts'
-import { importEvent } from '@events/service/events/import'
+import { importEvent, bulkImportEvents } from '@events/service/events/import'
 import { findRecordsByQuery } from '@events/service/indexing/indexing'
 import { reindex } from '@events/service/events/reindex'
 import { markAsDuplicate } from '@events/service/events/actions/mark-as-duplicate'
@@ -346,6 +346,29 @@ export const eventRouter = router({
     .input(EventDocument)
     .output(EventDocument)
     .mutation(async ({ input, ctx }) => importEvent(input, ctx.token)),
+  bulkImport: systemProcedure
+    .use(requiresAnyOfScopes([SCOPES.RECORD_IMPORT]))
+    .meta({
+      openapi: {
+        summary: 'Import multiple full event records',
+        method: 'POST',
+        path: '/events/bulk-import',
+        tags: ['events']
+      }
+    })
+    .input(z.array(EventDocument))
+    .output(
+      z.object({
+        successful: z.array(EventDocument),
+        failed: z.array(
+          z.object({
+            event: EventDocument,
+            error: z.string()
+          })
+        )
+      })
+    )
+    .mutation(async ({ input, ctx }) => bulkImportEvents(input, ctx.token)),
   reindex: systemProcedure
     .input(z.void())
     .use(requiresAnyOfScopes([SCOPES.RECORD_REINDEX]))

--- a/packages/events/src/service/events/import.test.ts
+++ b/packages/events/src/service/events/import.test.ts
@@ -14,93 +14,205 @@ import { ActionType, generateEventDocument, SCOPES } from '@opencrvs/commons'
 import { tennisClubMembershipEvent } from '@opencrvs/commons/fixtures'
 import { createSystemTestClient, setupTestCase } from '@events/tests/utils'
 
-test(`prevents forbidden access if missing required scope`, async () => {
-  const client = createSystemTestClient('test-system', [])
+describe('import', () => {
+  test(`prevents forbidden access if missing required scope`, async () => {
+    const client = createSystemTestClient('test-system', [])
 
-  await expect(
-    client.event.import(
-      generateEventDocument({
-        configuration: tennisClubMembershipEvent,
-        actions: [ActionType.CREATE, ActionType.DECLARE]
-      })
+    await expect(
+      client.event.import(
+        generateEventDocument({
+          configuration: tennisClubMembershipEvent,
+          actions: [ActionType.CREATE, ActionType.DECLARE]
+        })
+      )
+    ).rejects.toMatchObject(new TRPCError({ code: 'FORBIDDEN' }))
+  })
+
+  test('allows access with import scope', async () => {
+    const { user } = await setupTestCase()
+    const client = createSystemTestClient('test-system', [SCOPES.RECORD_IMPORT])
+
+    await expect(
+      client.event.import(
+        generateEventDocument({
+          user,
+          configuration: tennisClubMembershipEvent,
+          actions: [ActionType.CREATE, ActionType.DECLARE]
+        })
+      )
+    ).resolves.not.toThrow()
+  })
+
+  test('importing an event indexes it into Elasticsearch', async () => {
+    const { user } = await setupTestCase()
+    const client = createSystemTestClient('test-system', [
+      SCOPES.RECORD_IMPORT,
+      SCOPES.RECORD_READ,
+      `search[event=${tennisClubMembershipEvent.id},access=all]`
+    ])
+    const event = generateEventDocument({
+      user,
+      configuration: tennisClubMembershipEvent,
+      actions: [ActionType.CREATE, ActionType.DECLARE]
+    })
+
+    await client.event.import(event)
+
+    const { results: events } = await client.event.search({
+      query: {
+        type: 'and',
+        clauses: [
+          {
+            eventType: tennisClubMembershipEvent.id
+          }
+        ]
+      }
+    })
+
+    expect(events).toHaveLength(1)
+    expect(events[0].id).toEqual(event.id)
+  })
+
+  test('importing the same event twice overwrites the previous one', async () => {
+    const { user } = await setupTestCase()
+    const client = createSystemTestClient('test-system', [
+      SCOPES.RECORD_IMPORT,
+      SCOPES.RECORD_READ,
+      `search[event=${tennisClubMembershipEvent.id},access=all]`
+    ])
+    const event = generateEventDocument({
+      user,
+      configuration: tennisClubMembershipEvent,
+      actions: [ActionType.CREATE, ActionType.DECLARE]
+    })
+
+    await client.event.import(event)
+
+    await client.event.import({ ...event, trackingId: 'ABCDEF' })
+
+    const { results: events } = await client.event.search({
+      query: {
+        type: 'and',
+        clauses: [
+          {
+            eventType: tennisClubMembershipEvent.id
+          }
+        ]
+      }
+    })
+
+    expect(events).toHaveLength(1)
+    expect(events[0].id).toEqual(event.id)
+    expect(events[0].trackingId).toEqual('ABCDEF')
+  })
+})
+
+describe('bulkImport', () => {
+  test('prevents forbidden access if missing required scope', async () => {
+    const client = createSystemTestClient('test-system', [])
+
+    await expect(
+      client.event.bulkImport([
+        generateEventDocument({
+          configuration: tennisClubMembershipEvent,
+          actions: [ActionType.CREATE, ActionType.DECLARE]
+        })
+      ])
+    ).rejects.toMatchObject(new TRPCError({ code: 'FORBIDDEN' }))
+  })
+
+  test('allows access with import scope', async () => {
+    const { user } = await setupTestCase()
+    const client = createSystemTestClient('test-system', [SCOPES.RECORD_IMPORT])
+
+    await expect(
+      client.event.bulkImport([
+        generateEventDocument({
+          user,
+          configuration: tennisClubMembershipEvent,
+          actions: [ActionType.CREATE, ActionType.DECLARE]
+        })
+      ])
+    ).resolves.not.toThrow()
+  })
+
+  test('successfully imports multiple events in bulk', async () => {
+    const { user } = await setupTestCase()
+    const client = createSystemTestClient('test-system', [
+      SCOPES.RECORD_IMPORT,
+      SCOPES.RECORD_READ,
+      `search[event=${tennisClubMembershipEvent.id},access=all]`
+    ])
+
+    const event1 = generateEventDocument({
+      user,
+      configuration: tennisClubMembershipEvent,
+      actions: [ActionType.CREATE, ActionType.DECLARE]
+    })
+    const event2 = generateEventDocument({
+      user,
+      configuration: tennisClubMembershipEvent,
+      actions: [ActionType.CREATE, ActionType.DECLARE]
+    })
+    const event3 = generateEventDocument({
+      user,
+      configuration: tennisClubMembershipEvent,
+      actions: [ActionType.CREATE, ActionType.DECLARE]
+    })
+
+    const result = await client.event.bulkImport([event1, event2, event3])
+
+    expect(result.successful).toHaveLength(3)
+    expect(result.failed).toHaveLength(0)
+    expect(result.successful.map((e) => e.id)).toEqual(
+      expect.arrayContaining([event1.id, event2.id, event3.id])
     )
-  ).rejects.toMatchObject(new TRPCError({ code: 'FORBIDDEN' }))
-})
-
-test('allows access with import scope', async () => {
-  const { user } = await setupTestCase()
-  const client = createSystemTestClient('test-system', [SCOPES.RECORD_IMPORT])
-
-  await expect(
-    client.event.import(
-      generateEventDocument({
-        user,
-        configuration: tennisClubMembershipEvent,
-        actions: [ActionType.CREATE, ActionType.DECLARE]
-      })
-    )
-  ).resolves.not.toThrow()
-})
-
-test('importing an event indexes it into Elasticsearch', async () => {
-  const { user } = await setupTestCase()
-  const client = createSystemTestClient('test-system', [
-    SCOPES.RECORD_IMPORT,
-    SCOPES.RECORD_READ,
-    `search[event=${tennisClubMembershipEvent.id},access=all]`
-  ])
-  const event = generateEventDocument({
-    user,
-    configuration: tennisClubMembershipEvent,
-    actions: [ActionType.CREATE, ActionType.DECLARE]
   })
 
-  await client.event.import(event)
+  test('importing events indexes them into Elasticsearch at the next refresh', async () => {
+    const { user } = await setupTestCase()
+    const client = createSystemTestClient('test-system', [
+      SCOPES.RECORD_IMPORT,
+      SCOPES.RECORD_READ,
+      `search[event=${tennisClubMembershipEvent.id},access=all]`
+    ])
+    const event1 = generateEventDocument({
+      user,
+      configuration: tennisClubMembershipEvent,
+      actions: [ActionType.CREATE, ActionType.DECLARE]
+    })
 
-  const { results: events } = await client.event.search({
-    query: {
-      type: 'and',
-      clauses: [
-        {
-          eventType: tennisClubMembershipEvent.id
-        }
-      ]
-    }
+    const event2 = generateEventDocument({
+      user,
+      configuration: tennisClubMembershipEvent,
+      actions: [ActionType.CREATE, ActionType.DECLARE]
+    })
+    await client.event.bulkImport([event1, event2])
+
+    // Wait 1 second before searching to allow indexing to complete
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+
+    const { results: events } = await client.event.search({
+      query: {
+        type: 'or',
+        clauses: [
+          {
+            eventType: tennisClubMembershipEvent.id
+          }
+        ]
+      }
+    })
+
+    expect(events).toHaveLength(2)
+    expect([events[0].id, events[1].id]).toEqual([event1.id, event2.id])
   })
 
-  expect(events).toHaveLength(1)
-  expect(events[0].id).toEqual(event.id)
-})
+  test('handles empty array gracefully', async () => {
+    const client = createSystemTestClient('test-system', [SCOPES.RECORD_IMPORT])
 
-test('importing the same event twice overwrites the previous one', async () => {
-  const { user } = await setupTestCase()
-  const client = createSystemTestClient('test-system', [
-    SCOPES.RECORD_IMPORT,
-    SCOPES.RECORD_READ,
-    `search[event=${tennisClubMembershipEvent.id},access=all]`
-  ])
-  const event = generateEventDocument({
-    user,
-    configuration: tennisClubMembershipEvent,
-    actions: [ActionType.CREATE, ActionType.DECLARE]
+    const result = await client.event.bulkImport([])
+
+    expect(result.successful).toHaveLength(0)
+    expect(result.failed).toHaveLength(0)
   })
-
-  await client.event.import(event)
-
-  await client.event.import({ ...event, trackingId: 'ABCDEF' })
-
-  const { results: events } = await client.event.search({
-    query: {
-      type: 'and',
-      clauses: [
-        {
-          eventType: tennisClubMembershipEvent.id
-        }
-      ]
-    }
-  })
-
-  expect(events).toHaveLength(1)
-  expect(events[0].id).toEqual(event.id)
-  expect(events[0].trackingId).toEqual('ABCDEF')
 })

--- a/packages/events/src/service/events/import.test.ts
+++ b/packages/events/src/service/events/import.test.ts
@@ -136,39 +136,6 @@ describe('bulkImport', () => {
     ).resolves.not.toThrow()
   })
 
-  test('successfully imports multiple events in bulk', async () => {
-    const { user } = await setupTestCase()
-    const client = createSystemTestClient('test-system', [
-      SCOPES.RECORD_IMPORT,
-      SCOPES.RECORD_READ,
-      `search[event=${tennisClubMembershipEvent.id},access=all]`
-    ])
-
-    const event1 = generateEventDocument({
-      user,
-      configuration: tennisClubMembershipEvent,
-      actions: [ActionType.CREATE, ActionType.DECLARE]
-    })
-    const event2 = generateEventDocument({
-      user,
-      configuration: tennisClubMembershipEvent,
-      actions: [ActionType.CREATE, ActionType.DECLARE]
-    })
-    const event3 = generateEventDocument({
-      user,
-      configuration: tennisClubMembershipEvent,
-      actions: [ActionType.CREATE, ActionType.DECLARE]
-    })
-
-    const result = await client.event.bulkImport([event1, event2, event3])
-
-    expect(result.successful).toHaveLength(3)
-    expect(result.failed).toHaveLength(0)
-    expect(result.successful.map((e) => e.id)).toEqual(
-      expect.arrayContaining([event1.id, event2.id, event3.id])
-    )
-  })
-
   test('importing events indexes them into Elasticsearch at the next refresh', async () => {
     const { user } = await setupTestCase()
     const client = createSystemTestClient('test-system', [
@@ -204,15 +171,8 @@ describe('bulkImport', () => {
     })
 
     expect(events).toHaveLength(2)
-    expect([events[0].id, events[1].id]).toEqual([event1.id, event2.id])
-  })
-
-  test('handles empty array gracefully', async () => {
-    const client = createSystemTestClient('test-system', [SCOPES.RECORD_IMPORT])
-
-    const result = await client.event.bulkImport([])
-
-    expect(result.successful).toHaveLength(0)
-    expect(result.failed).toHaveLength(0)
+    expect([events[0].id, events[1].id].sort()).toEqual(
+      [event1.id, event2.id].sort()
+    )
   })
 })

--- a/packages/events/src/service/events/import.ts
+++ b/packages/events/src/service/events/import.ts
@@ -8,14 +8,8 @@
  *
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
-import { performance } from 'node:perf_hooks'
 import { omit } from 'lodash'
-import {
-  EventDocument,
-  getUUID,
-  logger,
-  TokenWithBearer
-} from '@opencrvs/commons'
+import { EventDocument, getUUID, TokenWithBearer } from '@opencrvs/commons'
 import { upsertEventWithActions } from '@events/storage/postgres/events/import'
 import {
   getEventConfigurationById,


### PR DESCRIPTION
## Description

Add bulk import endpoint to speed up migration.
Create an exception for the import/export client so that it uses the regular 7 day default expiry, rather than the 10 minute expiry used by other system clients.

Issue: https://github.com/opencrvs/opencrvs-core/issues/10589

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [x] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
