### PR TITLE
fix: Switch to official redis image (#10173)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.8.1](https://github.com/opencrvs/opencrvs-core/compare/v1.8.1...v1.8.2)
+
+- **Switch back to default redis image** [#10173](https://github.com/opencrvs/opencrvs-core/issues/10173)
+
 ## [1.8.1](https://github.com/opencrvs/opencrvs-core/compare/v1.8.0...v1.8.1)
 
 ### Bug fixes

--- a/docker-compose.deps.yml
+++ b/docker-compose.deps.yml
@@ -14,10 +14,8 @@ services:
     restart: unless-stopped
 
   redis:
-    image: docker.io/bitnami/redis:8.0
+    image: redis:8
     restart: unless-stopped
-    environment:
-      - ALLOW_EMPTY_PASSWORD=yes
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.16.4


### PR DESCRIPTION
## Description

This PR aims to implement cherry-pick commit with switch to default Redis image, more details are at https://github.com/opencrvs/opencrvs-core/issues/10173

Changes were tested in develop branch of upcoming v1.9.0 release


## Test results

- Deployment link: https://github.com/opencrvs/opencrvs-farajaland/actions/runs/18134101869/job/51608179933
- Environment is up and running: https://register.farajaland-dev.opencrvs.dev/
- Login is working as expected (only login functionality is effected by this change)

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
