### PR TITLE
Fix request correction incorrectly omitting fields from payload `declaration`

### DIFF
--- a/packages/client/src/v2-events/features/events/actions/correct/request/Summary/Summary.tsx
+++ b/packages/client/src/v2-events/features/events/actions/correct/request/Summary/Summary.tsx
@@ -134,7 +134,8 @@ export function Summary() {
       },
       transactionId: generateTransactionId(),
       annotation,
-      event
+      event,
+      fullEvent: event
     }
 
     if (userMayCorrect) {

--- a/packages/client/src/v2-events/features/events/useEvents/procedures/actions/action.ts
+++ b/packages/client/src/v2-events/features/events/useEvents/procedures/actions/action.ts
@@ -83,8 +83,16 @@ function getCleanedDeclarationDiff(
   originalDeclaration?: EventState,
   declarationDiff?: EventState
 ): ActionUpdate | undefined {
-  if (isEmpty(declarationDiff) || isEmpty(originalDeclaration)) {
+  if (isEmpty(declarationDiff)) {
     return declarationDiff
+  }
+
+  // If there's no original declaration, just clean the update and return it
+  if (isEmpty(originalDeclaration)) {
+    return omitHiddenPaginatedFields(
+      eventConfiguration.declaration,
+      declarationDiff
+    )
   }
 
   // Merge original + updates so we get the final event state


### PR DESCRIPTION
## Description

E2e tests: https://github.com/opencrvs/opencrvs-farajaland/pull/1722

Pass `fullEvent` to correction request mutation, so that the declaration is resolved correctly in `getCleanedDeclarationDiff()`

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
