### PR TITLE
Fix issue with `packages/gateway/src/graphql/schema.d.ts` changing on development env

### DIFF
--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -5,7 +5,7 @@
   "license": "MPL-2.0",
   "scripts": {
     "postinstall": "if [ \"$NODE_ENV\" != \"production\" ]; then npx crlf --set=LF ../../node_modules/graphql-schema-typescript/**/* || npx crlf --set=LF ./node_modules/graphql-schema-typescript/**/* || true; fi",
-    "start": "yarn gen:schema && yarn gen:types && concurrently \"cross-env NODE_ENV=development NODE_OPTIONS=--dns-result-order=ipv4first nodemon --exec ts-node -r tsconfig-paths/register src/index.ts\" \"yarn gen:types:watch\" \"yarn gen:schema:watch\"",
+    "start": "yarn gen:schema && concurrently \"cross-env NODE_ENV=development NODE_OPTIONS=--dns-result-order=ipv4first nodemon --exec ts-node -r tsconfig-paths/register src/index.ts\" \"yarn gen:types:watch\" \"yarn gen:schema:watch\"",
     "start:prod": "TS_NODE_BASEURL=./build/dist/src node -r tsconfig-paths/register build/dist/src/index.js",
     "test": "yarn test:compilation && jest",
     "test:watch": "jest --watch",


### PR DESCRIPTION
## Description

Since the command already has `yarn gen:types:watch` the first one is unnecessary and caused unnecessary file changes on development env

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
