### PR TITLE
fix: restart event service on changes to commons

### DIFF
--- a/packages/events/nodemon.json
+++ b/packages/events/nodemon.json
@@ -1,0 +1,5 @@
+{
+  "watch": ["src/**", "../commons/build/dist/common/**"],
+  "delay": 2000,
+  "ext": "js,ts"
+}


### PR DESCRIPTION
## Description

Event service will now hot reload when any changes to commons are made.
- Added debounce of 2 sec so that there's less churning when commons is built
