### PR TITLE
Add exception for the export client so it is not considered "External"

### DIFF
--- a/packages/search/src/features/search/handler.ts
+++ b/packages/search/src/features/search/handler.ts
@@ -216,7 +216,10 @@ export async function advancedRecordSearch(
   try {
     let isExternalSearch = false
     const tokenPayload = getTokenPayload(request.headers.authorization)
-    if (tokenPayload.scope.includes(SCOPES.RECORDSEARCH)) {
+    if (
+      tokenPayload.scope.includes(SCOPES.RECORDSEARCH) &&
+      !tokenPayload.scope.includes(SCOPES.RECORD_EXPORT)
+    ) {
       isExternalSearch = true
     }
     const result = await advancedSearch(


### PR DESCRIPTION
## Description

External clients can only access registered records and the migration client needs everything.

This fix adds an exception for the scope only used by the migration client so it is not considered external.

It's not an ideal solution, ideally we would configure system client scope in the same way we configure user roles. 
But this is the quickest way to achieve this without causing a regression.

Fixes: https://github.com/opencrvs/opencrvs-core/issues/10680

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
