### PR TITLE
Disable printing button if printing is already in progress

### DIFF
--- a/packages/client/src/v2-events/features/events/actions/print-certificate/Review.tsx
+++ b/packages/client/src/v2-events/features/events/actions/print-certificate/Review.tsx
@@ -182,7 +182,7 @@ export function Review() {
   const formConfig = getPrintForm(eventConfiguration)
   const { isActionAllowed } = useUserAllowedActions(fullEvent.type)
   const userDetails = useSelector(getUserDetails)
-  const [isPrinting, setIsPrinting] = useState(false)
+  const { isPending } = onlineActions.printCertificate
 
   if (!userDetails) {
     throw new Error('User details are not available')
@@ -272,7 +272,7 @@ export function Review() {
           </Button>,
           <Button
             key="print-certificate"
-            disabled={!isOnline || isPrinting}
+            disabled={!isOnline || isPending}
             id="print-certificate"
             type="primary"
             onClick={() => close(true)}
@@ -296,7 +296,6 @@ export function Review() {
     if (confirmed) {
       try {
         const printCertificate = await preparePdfCertificate(fullEvent)
-        setIsPrinting(true)
 
         await onlineActions.printCertificate.mutateAsync({
           fullEvent,
@@ -309,7 +308,6 @@ export function Review() {
         })
 
         printCertificate()
-        setIsPrinting(false)
 
         toast.custom(
           <Toast
@@ -382,7 +380,7 @@ export function Review() {
               >
                 <Button
                   fullWidth
-                  disabled={!isOnline || isPrinting}
+                  disabled={!isOnline || isPending}
                   id="confirm-print"
                   size="large"
                   type="positive"

--- a/packages/client/src/v2-events/features/events/useEvents/procedures/actions/action.ts
+++ b/packages/client/src/v2-events/features/events/useEvents/procedures/actions/action.ts
@@ -465,7 +465,8 @@ export function useEventAction<P extends DecorateMutationProcedure<any>>(
     mutate: (params: ActionMutationInput) =>
       mutation.mutate(getMutationPayload(params)),
     mutateAsync: async (params: ActionMutationInput) =>
-      mutation.mutateAsync(getMutationPayload(params))
+      mutation.mutateAsync(getMutationPayload(params)),
+    isPending: mutation.isPending
   }
 }
 


### PR DESCRIPTION
## Description

Resolves: https://github.com/opencrvs/opencrvs-core/issues/10671
E2e tests: https://github.com/opencrvs/opencrvs-farajaland/pull/1743

Use react-query `isPending` to disable printing button if printing is already in progress.

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
