### PR TITLE
Preserve workqueue context across correction and review navigation flows

### DIFF
--- a/packages/client/src/v2-events/features/events/Search/SearchResult.tsx
+++ b/packages/client/src/v2-events/features/events/Search/SearchResult.tsx
@@ -344,9 +344,12 @@ export const SearchResultComponent = ({
             type={type}
             onClick={() => {
               return navigate(
-                ROUTES.V2.EVENTS.OVERVIEW.buildPath({
-                  eventId: event.id
-                })
+                ROUTES.V2.EVENTS.OVERVIEW.buildPath(
+                  {
+                    eventId: event.id
+                  },
+                  { workqueue: slug }
+                )
               )
             }}
           />

--- a/packages/client/src/v2-events/features/events/actions/correct/request/Onboarding/Onboarding.tsx
+++ b/packages/client/src/v2-events/features/events/actions/correct/request/Onboarding/Onboarding.tsx
@@ -11,7 +11,10 @@
 import * as React from 'react'
 import { defineMessages, useIntl } from 'react-intl'
 import { useNavigate } from 'react-router-dom'
-import { useTypedParams } from 'react-router-typesafe-routes/dom'
+import {
+  useTypedParams,
+  useTypedSearchParams
+} from 'react-router-typesafe-routes/dom'
 import { ActionType, getCurrentEventState } from '@opencrvs/commons/client'
 import { ActionPageLight } from '@opencrvs/components/lib/ActionPageLight'
 import { buttonMessages } from '@client/i18n/messages'
@@ -33,6 +36,9 @@ const messages = defineMessages({
 
 export function Onboarding() {
   const { eventId, pageId } = useTypedParams(
+    ROUTES.V2.EVENTS.REQUEST_CORRECTION.ONBOARDING
+  )
+  const [{ workqueue }] = useTypedSearchParams(
     ROUTES.V2.EVENTS.REQUEST_CORRECTION.ONBOARDING
   )
   const validatorContext = useValidatorContext()
@@ -68,12 +74,15 @@ export function Onboarding() {
   React.useEffect(() => {
     if (!currentPageId) {
       navigate(
-        ROUTES.V2.EVENTS.REQUEST_CORRECTION.REVIEW.buildPath({
-          eventId: event.id
-        })
+        ROUTES.V2.EVENTS.REQUEST_CORRECTION.REVIEW.buildPath(
+          {
+            eventId: event.id
+          },
+          { workqueue }
+        )
       )
     }
-  }, [currentPageId, navigate, event.id])
+  }, [currentPageId, navigate, event.id, workqueue])
 
   if (!currentPageId) {
     return null
@@ -100,15 +109,21 @@ export function Onboarding() {
         validatorContext={validatorContext}
         onPageChange={(nextPageId: string) => {
           return navigate(
-            ROUTES.V2.EVENTS.REQUEST_CORRECTION.ONBOARDING.buildPath({
-              eventId,
-              pageId: nextPageId
-            })
+            ROUTES.V2.EVENTS.REQUEST_CORRECTION.ONBOARDING.buildPath(
+              {
+                eventId,
+                pageId: nextPageId
+              },
+              { workqueue }
+            )
           )
         }}
         onSubmit={() => {
           return navigate(
-            ROUTES.V2.EVENTS.REQUEST_CORRECTION.REVIEW.buildPath({ eventId })
+            ROUTES.V2.EVENTS.REQUEST_CORRECTION.REVIEW.buildPath(
+              { eventId },
+              { workqueue }
+            )
           )
         }}
       />

--- a/packages/client/src/v2-events/features/events/actions/correct/request/Summary/Summary.tsx
+++ b/packages/client/src/v2-events/features/events/actions/correct/request/Summary/Summary.tsx
@@ -152,7 +152,11 @@ export function Summary() {
       events.actions.correction.request.mutate(mutationPayload)
     }
 
-    navigate(ROUTES.V2.EVENTS.OVERVIEW.buildPath({ eventId }))
+    if (workqueue) {
+      navigate(ROUTES.V2.WORKQUEUES.WORKQUEUE.buildPath({ slug: workqueue }))
+    } else {
+      navigate(ROUTES.V2.EVENTS.OVERVIEW.buildPath({ eventId }))
+    }
   }, [
     form,
     fields,
@@ -165,7 +169,8 @@ export function Summary() {
     navigate,
     userMayCorrect,
     validatorContext,
-    eventConfiguration
+    eventConfiguration,
+    workqueue
   ])
 
   return (
@@ -201,9 +206,12 @@ export function Summary() {
               id="back-to-review"
               onClick={() =>
                 navigate(
-                  ROUTES.V2.EVENTS.REQUEST_CORRECTION.REVIEW.buildPath({
-                    eventId
-                  })
+                  ROUTES.V2.EVENTS.REQUEST_CORRECTION.REVIEW.buildPath(
+                    {
+                      eventId
+                    },
+                    { workqueue }
+                  )
                 )
               }
             >

--- a/packages/client/src/v2-events/features/events/actions/correct/review/ReviewCorrection.tsx
+++ b/packages/client/src/v2-events/features/events/actions/correct/review/ReviewCorrection.tsx
@@ -252,12 +252,15 @@ export function ReviewCorrection({
             requestId: correctionRequestAction.id,
             annotation
           })
-          return navigate(
-            ROUTES.V2.EVENTS.OVERVIEW.buildPath(
-              { eventId },
-              { workqueue: searchParams.workqueue }
+          if (searchParams.workqueue) {
+            return navigate(
+              ROUTES.V2.WORKQUEUES.WORKQUEUE.buildPath({
+                slug: searchParams.workqueue
+              })
             )
-          )
+          } else {
+            return navigate(ROUTES.V2.EVENTS.OVERVIEW.buildPath({ eventId }))
+          }
         }}
       />
     ))
@@ -275,12 +278,20 @@ export function ReviewCorrection({
             annotation,
             content: { reason }
           })
-          return navigate(
-            ROUTES.V2.EVENTS.OVERVIEW.buildPath(
-              { eventId },
-              { workqueue: searchParams.workqueue }
+          if (searchParams.workqueue) {
+            return navigate(
+              ROUTES.V2.WORKQUEUES.WORKQUEUE.buildPath({
+                slug: searchParams.workqueue
+              })
             )
-          )
+          } else {
+            return navigate(
+              ROUTES.V2.EVENTS.OVERVIEW.buildPath(
+                { eventId },
+                { workqueue: searchParams.workqueue }
+              )
+            )
+          }
         }}
       />
     ))

--- a/packages/client/src/v2-events/features/workqueues/EventOverview/components/ActionMenu.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/components/ActionMenu.tsx
@@ -12,6 +12,7 @@
 import React from 'react'
 import { useIntl } from 'react-intl'
 
+import { useTypedSearchParams } from 'react-router-typesafe-routes/dom'
 import { Icon } from '@opencrvs/components/lib/Icon'
 import { CaretDown } from '@opencrvs/components/lib/Icon/all-icons'
 import { PrimaryButton } from '@opencrvs/components/lib/buttons'
@@ -23,6 +24,7 @@ import { useAuthentication } from '@client/utils/userUtils'
 import { useUsers } from '@client/v2-events/hooks/useUsers'
 import { getUsersFullName } from '@client/v2-events/utils'
 import { useLocations } from '@client/v2-events/hooks/useLocations'
+import { ROUTES } from '@client/v2-events/routes'
 import { useAllowedActionConfigurations } from './useAllowedActionConfigurations'
 
 export function ActionMenu({
@@ -33,7 +35,7 @@ export function ActionMenu({
   onAction?: () => void
 }) {
   const intl = useIntl()
-
+  const [{ workqueue }] = useTypedSearchParams(ROUTES.V2.EVENTS.OVERVIEW)
   const { getUser } = useUsers()
   const { getLocations } = useLocations()
   const [locations] = getLocations.useSuspenseQuery()
@@ -101,7 +103,7 @@ export function ActionMenu({
                 key={action.type}
                 disabled={'disabled' in action ? action.disabled : false}
                 onClick={async () => {
-                  await action.onClick()
+                  await action.onClick(workqueue)
                   onAction?.()
                 }}
               >

--- a/packages/client/src/v2-events/features/workqueues/EventOverview/components/useAllowedActionConfigurations.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/components/useAllowedActionConfigurations.tsx
@@ -424,7 +424,7 @@ function useViewableActionConfigurations(
       [ActionType.REQUEST_CORRECTION]: {
         label: actionLabels[ActionType.REQUEST_CORRECTION],
         icon: 'NotePencil' as const,
-        onClick: () => {
+        onClick: (workqueue?: string) => {
           const correctionPages = eventConfiguration.actions.find(
             (action) => action.type === ActionType.REQUEST_CORRECTION
           )?.correctionForm.pages
@@ -438,17 +438,23 @@ function useViewableActionConfigurations(
           // If no pages are configured, skip directly to review page
           if (correctionPages.length === 0) {
             navigate(
-              ROUTES.V2.EVENTS.REQUEST_CORRECTION.REVIEW.buildPath({ eventId })
+              ROUTES.V2.EVENTS.REQUEST_CORRECTION.REVIEW.buildPath(
+                { eventId },
+                { workqueue }
+              )
             )
             return
           }
 
           // If pages are configured, navigate to first page
           navigate(
-            ROUTES.V2.EVENTS.REQUEST_CORRECTION.ONBOARDING.buildPath({
-              eventId,
-              pageId: correctionPages[0].id
-            })
+            ROUTES.V2.EVENTS.REQUEST_CORRECTION.ONBOARDING.buildPath(
+              {
+                eventId,
+                pageId: correctionPages[0].id
+              },
+              { workqueue }
+            )
           )
         },
         disabled: !isDownloadedAndAssignedToUser || eventIsWaitingForCorrection,
@@ -457,12 +463,15 @@ function useViewableActionConfigurations(
       [ClientSpecificAction.REVIEW_CORRECTION_REQUEST]: {
         label: actionLabels[ClientSpecificAction.REVIEW_CORRECTION_REQUEST],
         icon: 'NotePencil' as const,
-        onClick: () => {
+        onClick: (workqueue?: string) => {
           clearEphemeralFormState()
           navigate(
-            ROUTES.V2.EVENTS.REVIEW_CORRECTION.REVIEW.buildPath({
-              eventId
-            })
+            ROUTES.V2.EVENTS.REVIEW_CORRECTION.REVIEW.buildPath(
+              {
+                eventId
+              },
+              { workqueue }
+            )
           )
         },
         disabled: !isDownloadedAndAssignedToUser,


### PR DESCRIPTION
## Description

issue: https://github.com/opencrvs/opencrvs-core/issues/10688
related: https://github.com/opencrvs/opencrvs-core/issues/10691
farajaland pr: https://github.com/opencrvs/opencrvs-farajaland/pull/1770

Workqueue context persist through navigation for correction and review actions.
Before this change, navigating from mobile views or certain action menus would lose the workqueue query param, causing users to land in the wrong queue (typically assigned-to-you).

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
