### PR TITLE
Fix issue with `parent` functionality not using default values

### DIFF
--- a/packages/client/src/v2-events/components/forms/FormFieldGenerator/FormSectionComponent.tsx
+++ b/packages/client/src/v2-events/components/forms/FormFieldGenerator/FormSectionComponent.tsx
@@ -23,7 +23,6 @@ import {
   IndexMap,
   joinValues,
   isNonInteractiveFieldType,
-  SystemVariables,
   InteractiveFieldType,
   FieldReference,
   getAllUniqueFields,
@@ -125,30 +124,6 @@ function resolveFieldReferenceValue(
   return $$subfield && $$subfield.length > 0
     ? get(fieldValues[referenceKeyInFormikFormat], $$subfield)
     : fieldValues[referenceKeyInFormikFormat]
-}
-
-function getUpdatedChildValueOnChange({
-  childField,
-  fieldReference,
-  fieldValues,
-  systemVariables
-}: {
-  childField: InteractiveFieldType
-  fieldReference: FieldReference | undefined
-  fieldValues: Record<string, FieldValue>
-  systemVariables: SystemVariables
-}) {
-  if (!fieldReference) {
-    // If there is no reference, we reset the value to the default value.
-    return (
-      handleDefaultValue({
-        field: childField,
-        systemVariables
-      }) ?? null
-    )
-  }
-
-  return resolveFieldReferenceValue(fieldReference, fieldValues)
 }
 
 /**


### PR DESCRIPTION
## Description

Resolves comment: https://github.com/opencrvs/opencrvs-core/issues/10578#issuecomment-3441404625

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
