### PR TITLE
chore: direct user back in stack if event is not found

### DIFF
--- a/packages/client/src/v2-events/features/events/useToastAndRedirect.tsx
+++ b/packages/client/src/v2-events/features/events/useToastAndRedirect.tsx
@@ -57,7 +57,9 @@ export function useToastAndRedirect() {
     eventId: UUID
   }) {
     showWarningToast({ message, toastType: 'warning', toastId })
-    return navigate(ROUTES.V2.EVENTS.OVERVIEW.buildPath({ eventId }))
+    return navigate(ROUTES.V2.EVENTS.OVERVIEW.buildPath({ eventId }), {
+      replace: true
+    })
   }
 
   return { redirectToEventOverviewPage }


### PR DESCRIPTION
## Description
When navigating back on browser level, user is redirected to overview page when previous page was under `<DeclarationAction>`. DeclarationAction does not render `NavigationStack` when event is missing.

This works in most cases. When action is "started" from workqueue, user should end up there, after pressing the back button.

Changes:
- When event is missing, check whether react-router has items in history and direct there.
- Keep the overview as fallback


![back-button](https://github.com/user-attachments/assets/ac1c8365-1550-4806-9848-075749ead69d)



## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
