### PR TITLE
refactor: migrate PerformanceDashboard to v2 routes with typesafe navigation

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -396,14 +396,6 @@ export const routesConfig = turnOffV2Events
             element: <RegistrationList />
           },
           {
-            path: routes.DASHBOARD,
-            element: (
-              <ProtectedRoute scopes={[SCOPES.PERFORMANCE_READ_DASHBOARDS]}>
-                <PerformanceDashboard />
-              </ProtectedRoute>
-            )
-          },
-          {
             path: routes.PERFORMANCE_FIELD_AGENT_LIST,
             element: <FieldAgentList />
           },

--- a/packages/client/src/v2-events/components/NavigationStack.tsx
+++ b/packages/client/src/v2-events/components/NavigationStack.tsx
@@ -36,7 +36,7 @@ export const NavigationHistoryProvider = ({ children }: PropsWithChildren) => {
   )
 }
 
-function useNavigationHistory() {
+export function useNavigationHistory() {
   return useContext(NavigationContext)
 }
 

--- a/packages/client/src/v2-events/features/performance/Dashboard.tsx
+++ b/packages/client/src/v2-events/features/performance/Dashboard.tsx
@@ -1,0 +1,114 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+
+import React from 'react'
+import IframeResizer from 'iframe-resizer-react'
+import { useIntl } from 'react-intl'
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom'
+import styled from 'styled-components'
+import { Icon } from '@opencrvs/components/lib/Icon'
+import { Button } from '@opencrvs/components/lib/Button'
+import { AppBar, Frame } from '@opencrvs/components'
+import { constantsMessages } from '@client/i18n/messages'
+import { ROUTES } from '@client/v2-events/routes'
+import {
+  NavigationStack,
+  useNavigationHistory
+} from '@client/v2-events/components/NavigationStack'
+
+const StyledIFrame = styled(IframeResizer)`
+  width: 100%;
+  height: 100%;
+  border: none;
+`
+interface IdashboardView {
+  title: string
+  url?: string
+  icon?: JSX.Element
+}
+
+function DashboardEmbedView({ title, url, icon }: IdashboardView) {
+  const intl = useIntl()
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const { eventId, slug, eventType, workqueue, ...rest } = Object.fromEntries(
+    searchParams.entries()
+  )
+  const history = useNavigationHistory()
+
+  const handleCrossBar = () => {
+    if (history.length > 1) {
+      const previousLocation = history[history.length - 2]
+      navigate(previousLocation.pathname + previousLocation.search)
+    } else {
+      // Fallback to home if no previous location
+      navigate(ROUTES.V2.path)
+    }
+  }
+
+  return (
+    <>
+      <Frame
+        header={
+          <AppBar
+            desktopLeft={icon}
+            desktopRight={
+              <Button
+                size="medium"
+                type="icon"
+                onClick={() => handleCrossBar()}
+              >
+                <Icon color="primary" name="X" />
+              </Button>
+            }
+            desktopTitle={title}
+            mobileLeft={icon}
+            mobileRight={
+              <Button
+                size="medium"
+                type="icon"
+                onClick={() => handleCrossBar()}
+              >
+                <Icon color="primary" name="X" />
+              </Button>
+            }
+            mobileTitle={title}
+          />
+        }
+        skipToContentText={intl.formatMessage(
+          constantsMessages.skipToMainContent
+        )}
+      >
+        <StyledIFrame allowFullScreen id={title} src={url} />
+      </Frame>
+    </>
+  )
+}
+
+export const PerformanceDashboard = () => {
+  const intl = useIntl()
+  const params = useParams()
+  const id = params.id
+  const config = window.config.DASHBOARDS.find((d) => d.id === id)
+  if (!config) {
+    // If no dashboard config found for the given id, render nothing
+    return null
+  }
+  return (
+    <NavigationStack>
+      <DashboardEmbedView
+        icon={<Icon name="Activity" size="medium" />}
+        title={intl.formatMessage(config.title)}
+        url={config.url}
+      />
+    </NavigationStack>
+  )
+}

--- a/packages/client/src/v2-events/layouts/sidebar/PerformanceNavigationGroup.tsx
+++ b/packages/client/src/v2-events/layouts/sidebar/PerformanceNavigationGroup.tsx
@@ -17,8 +17,7 @@ import { Icon } from '@opencrvs/components/lib/Icon'
 import { NavigationGroup } from '@opencrvs/components/lib/SideNavigation/NavigationGroup'
 import { NavigationItem } from '@opencrvs/components/lib/SideNavigation/NavigationItem'
 import { usePermissions } from '@client/hooks/useAuthorization'
-import { formatUrl } from '@client/navigation'
-import * as routes from '@client/navigation/routes'
+import { ROUTES } from '@client/v2-events/routes'
 
 /**
  * Based on packages/client/src/components/interface/Navigation.tsx
@@ -47,16 +46,11 @@ export function PerformanceNavigationGroup({
                     id={`navigation_dashboard_${config.id}`}
                     isSelected={currentWorkqueueSlug === 'dashboard'}
                     label={intl.formatMessage(config.title)}
-                    onClick={() =>
+                    onClick={() => {
                       navigate(
-                        formatUrl(routes.DASHBOARD, {
-                          id: config.id
-                        }),
-                        {
-                          state: { isNavigatedInsideApp: true }
-                        }
+                        `${ROUTES.V2.DASHBOARD.buildPath({ id: config.id })}`
                       )
-                    }
+                    }}
                   />
                 )
               })}

--- a/packages/client/src/v2-events/routes/config.tsx
+++ b/packages/client/src/v2-events/routes/config.tsx
@@ -54,6 +54,7 @@ import { ProtectedRoute } from '../../components/ProtectedRoute'
 import { UserAudit } from '../../views/UserAudit/UserAudit'
 import { SystemList } from '../../views/SysAdmin/Config/Systems/Systems'
 import AllUserEmail from '../../views/SysAdmin/Communications/AllUserEmail/AllUserEmail'
+import { PerformanceDashboard } from '../features/performance/Dashboard'
 import { ROUTES } from './routes'
 import { Toaster } from './Toaster'
 
@@ -253,6 +254,14 @@ export const routesConfig = {
     {
       path: ROUTES.V2.SETTINGS.path,
       element: <SettingsPage />
+    },
+    {
+      path: ROUTES.V2.DASHBOARD.path,
+      element: (
+        <ProtectedRoute scopes={[SCOPES.PERFORMANCE_READ_DASHBOARDS]}>
+          <PerformanceDashboard />
+        </ProtectedRoute>
+      )
     },
     /** LEGACY ROUTES
      * During regression testing QA discovered that we were still using old workqueues on some components.

--- a/packages/client/src/v2-events/routes/routes.ts
+++ b/packages/client/src/v2-events/routes/routes.ts
@@ -12,7 +12,6 @@
 import { hashValues, route, string } from 'react-router-typesafe-routes/dom'
 import { zod } from 'react-router-typesafe-routes/zod'
 import * as z from 'zod'
-import { config } from '@client/config'
 import {
   requestRoutes as correctionRequestRoutes,
   reviewRoutes as correctionReviewRoutes
@@ -158,6 +157,9 @@ export const ROUTES = {
           REVIEW_CORRECTION: correctionReviewRoutes
         }
       ),
+      DASHBOARD: route('performance/dashboard/:id', {
+        params: { id: string().defined() }
+      }),
       WORKQUEUES: workqueueRoutes,
       ADVANCED_SEARCH: route('advanced-search'),
       SEARCH_RESULT: route('search-result/:eventType', {


### PR DESCRIPTION
Issue: [Cross button in Dashboards act like a back button before finally closing](https://github.com/opencrvs/opencrvs-core/issues/10903)

e2e pr: https://github.com/opencrvs/opencrvs-farajaland/pull/1815

## Overview
This PR refactors the **PerformanceDashboard** route to use the new **v2 routing system**. The old route in `App.tsx` has been removed, and the dashboard is now fully integrated with `ROUTES.V2`. Navigation has been updated to be **type-safe** using `react-router-typesafe-routes`.

## Changes
- Removed the legacy `DASHBOARD` route from `App.tsx`.
- Added `DASHBOARD` route to `v2-events/routes/config.tsx` with proper `ProtectedRoute` and permissions (`SCOPES.PERFORMANCE_READ_DASHBOARDS`).
- Updated `PerformanceNavigationGroup.tsx` to navigate using `ROUTES.V2.DASHBOARD.buildPath` and properly serialize search params.
- Cleaned up unused imports (`formatUrl`, `config`) and unnecessary `zod` usage in workqueue routes.

## Benefits
- Consistent with the new v2 routing system.
- Type-safe navigation reduces runtime errors.
- Preserves query params during navigation.
- Easier to maintain and extend in the future.

## Notes
- Path params are handled separately; only query/search params are serialized.
- Navigation state can be preserved if needed (`isNavigatedInsideApp`).

## Testing
- Click the dashboard link from the sidebar and verify navigation.
- Confirm query parameters are preserved when navigating from other pages.
- Ensure permission checks still work for users without `PERFORMANCE_READ_DASHBOARDS` scope.



## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migrates PerformanceDashboard to v2 routing with a new embedded view and type-safe navigation, removing the legacy route and preserving query params.
> 
> - **V2 Routing / Performance Dashboards**:
>   - Add `ROUTES.V2.DASHBOARD` (`performance/dashboard/:id`) and mount it in `v2-events/routes/config.tsx` behind `SCOPES.PERFORMANCE_READ_DASHBOARDS`.
>   - New `v2-events/features/performance/Dashboard.tsx` with `DashboardEmbedView` (iframe embed, context-aware close behavior) and `PerformanceDashboard` (loads config by `:id`).
>   - Update sidebar `PerformanceNavigationGroup` to navigate via `ROUTES.V2.DASHBOARD.buildPath` and serialize/preserve route/search params.
> - **Cleanup**:
>   - Remove legacy `routes.DASHBOARD` route from `App.tsx`.
>   - Simplify workqueue route param typing (`slug: string()` in `features/workqueues/routes.ts`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49d0d9979cb14d5343048e9f47e28954097226dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->