### PR TITLE
feat: Add branch name validation

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+branch=$(git rev-parse --abbrev-ref HEAD)
+pattern='^[a-z][a-z0-9\/\-]{1,29}$'
+
+if [[ ! "$branch" =~ $pattern ]]; then
+  echo """
+  ❌ Invalid branch name: '$branch'
+  ➡️  Branch names must match regex: $pattern
+      - Start with a lowercase letter
+      - Can contain lowercase letters, numbers, and hyphens
+      - Length between 2 and 30 characters
+      - Slashes '/' are allowed for hierarchical branch names
+    Example: ocrvs-12345, feature-login, fix-bug123, refactor-api
+    """
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
# Description

Goal of this PR is to implement restriction on git branch names: https://github.com/opencrvs/opencrvs-core/issues/9816

Branch name is limited to 30 characters due to helm release name limitations 53 characters.

NOTE: 30 characters length is the restriction increased a while ago for docker (https://github.com/moby/moby/pull/11118)


Related PR: https://github.com/opencrvs/infrastructure/pull/187

# Testing


https://github.com/user-attachments/assets/8f90b24e-3f21-489e-be54-2f9246a54e25



## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
