### PR TITLE
Fix workqueue time-based sorting and add unit test bug Issue#10534

### DIFF
--- a/packages/client/src/v2-events/features/events/Search/SearchResult.tsx
+++ b/packages/client/src/v2-events/features/events/Search/SearchResult.tsx
@@ -66,6 +66,36 @@ const COLUMNS = {
   NONE: 'none'
 } as const
 
+const TIME_COLUMNS: Array<(typeof COLUMNS)[keyof typeof COLUMNS]> = [
+  COLUMNS.LAST_UPDATED,
+  COLUMNS.SENT_FOR_REVIEW,
+  COLUMNS.SENT_FOR_APPROVAL,
+  COLUMNS.REGISTERED,
+  COLUMNS.SENT_FOR_VALIDATION
+]
+
+export function sortEventsForWorkqueue(
+  data: any[],
+  sortedCol: (typeof COLUMNS)[keyof typeof COLUMNS],
+  sortOrder: (typeof SORT_ORDER)[keyof typeof SORT_ORDER]
+) {
+  if (TIME_COLUMNS.includes(sortedCol)) {
+    return [...data].sort((a, b) => {
+      const aValue = a[sortedCol]
+      const bValue = b[sortedCol]
+
+      const aTime = aValue ? new Date(aValue as string).getTime() : 0
+      const bTime = bValue ? new Date(bValue as string).getTime() : 0
+
+      return sortOrder === SORT_ORDER.ASCENDING
+        ? aTime - bTime // earliest to latest
+        : bTime - aTime // latest to earliest
+    })
+  }
+
+  return orderBy(data, sortedCol, sortOrder)
+}
+
 interface Column {
   label?: string
   width: number
@@ -435,7 +465,10 @@ export const SearchResultComponent = ({
     return { ...event, title, useFallbackTitle }
   })
 
-  const sortedResult = orderBy(dataWithTitle, sortedCol, sortOrder)
+  
+
+  const sortedResult = sortEventsForWorkqueue(dataWithTitle, sortedCol, sortOrder)
+
 
   const rows = mapEventsToResultRows(sortedResult)
 
@@ -508,3 +541,4 @@ export const SearchResultComponent = ({
     </WithTestId>
   )
 }
+

--- a/packages/client/src/v2-events/features/events/Search/SearchResultComponent.sort.test.ts
+++ b/packages/client/src/v2-events/features/events/Search/SearchResultComponent.sort.test.ts
@@ -1,0 +1,36 @@
+import { sortEventsForWorkqueue } from './SearchResultComponent'
+import { SORT_ORDER } from '@opencrvs/components/lib/Workqueue'
+
+// Rebuild the same COLUMNS object shape used in SearchResultComponent
+// (or export COLUMNS from there and import it instead, if allowed)
+const COLUMNS = {
+  LAST_UPDATED: 'updatedAt'
+} as const
+
+describe('sortEventsForWorkqueue - time columns', () => {
+  const data = [
+    { id: 'a', updatedAt: '2023-01-03T10:00:00Z' }, // latest
+    { id: 'b', updatedAt: '2023-01-01T10:00:00Z' }, // earliest
+    { id: 'c', updatedAt: '2023-01-02T10:00:00Z' }  // middle
+  ]
+
+  it('sorts LAST_UPDATED ascending from earliest to latest', () => {
+    const result = sortEventsForWorkqueue(
+      data,
+      COLUMNS.LAST_UPDATED,
+      SORT_ORDER.ASCENDING
+    )
+
+    expect(result.map((r) => r.id)).toEqual(['b', 'c', 'a'])
+  })
+
+  it('sorts LAST_UPDATED descending from latest to earliest', () => {
+    const result = sortEventsForWorkqueue(
+      data,
+      COLUMNS.LAST_UPDATED,
+      SORT_ORDER.DESCENDING
+    )
+
+    expect(result.map((r) => r.id)).toEqual(['a', 'c', 'b'])
+  })
+})


### PR DESCRIPTION
Bug description:
When records are sorted by the 'Last updated' column, sorting is applied based on the actual timestamp of the update. However, the UI displays the value in a relative format (e.g., "x hours ago"). This creates confusion, as an ascending sort (earliest update first) can appear to users as descending order due to the way the relative time is shown.