### PR TITLE
fix: Hide health check transactions from APM data

### DIFF
--- a/packages/commons/src/monitoring.ts
+++ b/packages/commons/src/monitoring.ts
@@ -30,7 +30,9 @@ function init() {
       containerId: process.env.HOSTNAME,
       hostname: process.env.APN_NODE_NAME || require('os').hostname(),
       environment:
-        process.env.APN_ENVIRONMENT || process.env.NODE_ENV || 'development'
+        process.env.APN_ENVIRONMENT || process.env.NODE_ENV || 'development',
+      transactionIgnoreUrls: ['/health/ready', '/ping'],
+      ignoreUrls: ['/health/ready', '/ping']
     })
   }
 }


### PR DESCRIPTION
## Description

Related issue: https://github.com/opencrvs/opencrvs-core/issues/6405

This PR aims to improve collected data by filtering health-check endpoints

Collected APM traces have a lot of data from health check endpoints:
<img width="1898" height="907" alt="image" src="https://github.com/user-attachments/assets/0cf98510-2a65-4672-b208-d2d1b95aa2b7" />

## Testing

Environment: https://hide-health-check.e2e-k8s.opencrvs.dev/

<img width="1636" height="806" alt="image" src="https://github.com/user-attachments/assets/3a7da1e2-f824-424e-874e-fc55c4792914" />


## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
