### PR TITLE
display 'No actions available' text in action menu, if no actions are available

### DIFF
--- a/packages/client/src/i18n/messages/views/action.ts
+++ b/packages/client/src/i18n/messages/views/action.ts
@@ -21,6 +21,11 @@ const messagesToDefine = {
     description: 'Label for assignee',
     id: 'action.assignee'
   },
+  noActionsAvailable: {
+    defaultMessage: 'No actions available',
+    description: 'No actions available message',
+    id: 'action.noActionsAvailable'
+  },
   view: {
     defaultMessage: 'View {recordOrDeclaration}',
     description: 'Label for view button in dropdown menu',

--- a/packages/client/src/v2-events/features/workqueues/EventOverview/components/ActionMenu.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/components/ActionMenu.tsx
@@ -11,7 +11,6 @@
 
 import React from 'react'
 import { useIntl } from 'react-intl'
-
 import { useTypedSearchParams } from 'react-router-typesafe-routes/dom'
 import { Icon } from '@opencrvs/components/lib/Icon'
 import { CaretDown } from '@opencrvs/components/lib/Icon/all-icons'
@@ -97,6 +96,11 @@ export function ActionMenu({
               </DropdownMenu.Label>
               <DropdownMenu.Separator />
             </>
+          )}
+          {!actionMenuItems.length && (
+            <DropdownMenu.Label>
+              <i>{intl.formatMessage(messages.noActionsAvailable)}</i>
+            </DropdownMenu.Label>
           )}
           {actionMenuItems.map((action) => {
             return (


### PR DESCRIPTION
## Description

CC PR: https://github.com/opencrvs/opencrvs-countryconfig/pull/1170

Resolves: https://github.com/opencrvs/opencrvs-core/issues/11221

Title says it all

<img width="338" height="147" alt="Screenshot 2025-12-04 at 13 51 52" src="https://github.com/user-attachments/assets/4b800b67-9382-4676-a99c-3ea45b73b8ef" />
<img width="325" height="185" alt="Screenshot 2025-12-04 at 13 51 54" src="https://github.com/user-attachments/assets/7d693c40-e6cd-4a5c-b4c5-c6eea6e8f739" />


## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
