### PR TITLE
Add missing phosphor-react icons

### DIFF
--- a/packages/commons/src/icons.ts
+++ b/packages/commons/src/icons.ts
@@ -104,7 +104,6 @@ export const AvailableIcons = z.enum([
   'FileArrowUp',
   'FileDotted',
   'Files',
-  'FileEdit',
   'PencilLine',
   'PencilCircle',
   'UserCircle',

--- a/packages/components/src/Icon/all-icons.ts
+++ b/packages/components/src/Icon/all-icons.ts
@@ -50,7 +50,6 @@ export {
   FileSearch,
   FileText,
   FileX,
-  FileEdit,
   Fingerprint,
   FloppyDisk,
   Gear,


### PR DESCRIPTION
## Description

Add two icons which are required by new custom actions config

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
