### PR TITLE
feat: add showParentFieldError config to suppress subfield errors while showing composite field errors

### DIFF
--- a/packages/client/src/v2-events/components/forms/FormFieldGenerator/FormSectionComponent.tsx
+++ b/packages/client/src/v2-events/components/forms/FormFieldGenerator/FormSectionComponent.tsx
@@ -462,6 +462,7 @@ export function FormSectionComponent({
                   allKnownFields={allFieldsWithDotSeparator}
                   disabled={isDisabled}
                   error={isDisabled ? '' : error}
+                  eventConfig={eventConfig}
                   fieldDefinition={field}
                   form={completeForm}
                   readonlyMode={readonlyMode}

--- a/packages/client/src/v2-events/components/forms/FormFieldGenerator/GeneratedInputField.tsx
+++ b/packages/client/src/v2-events/components/forms/FormFieldGenerator/GeneratedInputField.tsx
@@ -63,7 +63,9 @@ import {
   isQrReaderFieldType,
   isLoaderFieldType,
   isAgeFieldType,
-  isNumberWithUnitFieldType
+  isNumberWithUnitFieldType,
+  NameField,
+  EventConfig
 } from '@opencrvs/commons/client'
 import { TextArea } from '@opencrvs/components/lib/TextArea'
 import { InputField } from '@client/components/form/InputField'
@@ -114,6 +116,7 @@ import {
 
 interface GeneratedInputFieldProps<T extends FieldConfig> {
   fieldDefinition: T
+  eventConfig?: EventConfig
   /** non-native onChange. Updates Formik state by updating the value and its dependencies */
   onFieldValueChange: (name: string, value: FieldValue | undefined) => void
   /** Optional callback that is called whenever any field value changes.
@@ -143,6 +146,7 @@ interface GeneratedInputFieldProps<T extends FieldConfig> {
 export const GeneratedInputField = React.memo(
   <T extends FieldConfig>({
     fieldDefinition,
+    eventConfig,
     validatorContext,
     onBlur,
     onFieldValueChange,
@@ -221,10 +225,15 @@ export const GeneratedInputField = React.memo(
 
       return (
         // We are showing errors to underlying text input, so we need to ignore them here
-        <InputField {...omit(field.inputFieldProps, 'error')}>
+        <InputField
+          {...(field.config.configuration?.showParentFieldError
+            ? field.inputFieldProps
+            : omit(field.inputFieldProps, 'error'))}
+        >
           <Name.Input
             configuration={field.config.configuration}
             disabled={disabled}
+            eventConfig={eventConfig}
             id={fieldDefinition.id}
             validation={validation}
             validatorContext={validatorContext}

--- a/packages/client/src/v2-events/features/events/registered-fields/Name.tsx
+++ b/packages/client/src/v2-events/features/events/registered-fields/Name.tsx
@@ -13,6 +13,7 @@ import { useLocation } from 'react-router-dom'
 import {
   alwaysTrue,
   ConditionalType,
+  EventConfig,
   FieldConfig,
   FieldType,
   getValidatorsForField,
@@ -28,6 +29,7 @@ import { FormFieldGenerator } from '@client/v2-events/components/forms/FormField
 
 interface Props {
   id: string
+  eventConfig?: EventConfig
   onChange: (newValue: NameFieldValue) => void
   configuration?: NameField['configuration']
   validation: FieldConfig['validation']
@@ -121,6 +123,7 @@ function NameInput(props: Props) {
     onChange,
     disabled,
     value = {},
+    eventConfig,
     configuration,
     validatorContext
   } = props
@@ -160,7 +163,9 @@ function NameInput(props: Props) {
             description: 'This is the label for the firstname field',
             id: 'field.name.firstname.label'
           },
-          validation: getValidatorsForField('firstname', validators)
+          validation: configuration?.showParentFieldError
+            ? undefined
+            : getValidatorsForField('firstname', validators)
         } satisfies TextField
       case 'middlename':
         return {
@@ -179,7 +184,9 @@ function NameInput(props: Props) {
             description: 'This is the label for the middlename field',
             id: 'field.name.middlename.label'
           },
-          validation: getValidatorsForField('middlename', validators)
+          validation: configuration?.showParentFieldError
+            ? undefined
+            : getValidatorsForField('middlename', validators)
         }
       case 'surname':
         return {
@@ -198,7 +205,9 @@ function NameInput(props: Props) {
             description: 'This is the label for the surname field',
             id: 'field.name.surname.label'
           },
-          validation: getValidatorsForField('surname', validators)
+          validation: configuration?.showParentFieldError
+            ? undefined
+            : getValidatorsForField('surname', validators)
         }
       default:
         throw new Error(`Unknown field type: ${field}`)
@@ -208,6 +217,7 @@ function NameInput(props: Props) {
   return (
     <>
       <FormFieldGenerator
+        eventConfig={eventConfig}
         fields={fields}
         id={id}
         initialValues={{ ...value }}

--- a/packages/commons/src/events/FieldConfig.ts
+++ b/packages/commons/src/events/FieldConfig.ts
@@ -530,7 +530,14 @@ const NameField = BaseField.extend({
       order: z.array(z.enum(['firstname', 'middlename', 'surname'])).optional(),
       maxLength: z.number().optional().describe('Maximum length of the text'),
       prefix: TranslationConfig.optional(),
-      postfix: TranslationConfig.optional()
+      postfix: TranslationConfig.optional(),
+      showParentFieldError: z
+        .boolean()
+        .default(false)
+        .optional()
+        .describe(
+          `If true, shows the parent field error and hides the subfield error`
+        )
     })
     .default({
       name: {


### PR DESCRIPTION
…ile showing sub-field errors

https://github.com/opencrvs/opencrvs-core/issues/11604

countryconfig pr: https://github.com/opencrvs/opencrvs-countryconfig/pull/1260
farajaland pr: https://github.com/opencrvs/opencrvs-farajaland/pull/1957

## Description

Clearly describe what has been changed. Include relevant context or background.
Explain how the issue was fixed (if applicable) and the root cause.

Link this pull request to the GitHub issue (and optionally name the branch `ocrvs-<issue #>`)

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
