### PR TITLE
use `<Summary>` component in FieldType.Data

### DIFF
--- a/packages/client/src/v2-events/features/events/registered-fields/Data.tsx
+++ b/packages/client/src/v2-events/features/events/registered-fields/Data.tsx
@@ -110,7 +110,7 @@ const Container = styled.div`
 const Subtitle = styled.div`
   ${({ theme }) => theme.fonts.reg16};
   color: ${({ theme }) => theme.colors.grey500};
-  margin: 0 0 2rem;
+  margin: 0 0 1rem;
 `
 
 /**


### PR DESCRIPTION
## Description

Fixes `FieldType.DATA`, as it has never been aligned with design. @opencrvs/design asserted [in Slack](https://opencrvsworkspace.slack.com/archives/C02UN28EJ9M/p1769762075917319) that the Data field type is intended to use Summary, and not be fully vertical in desktop.

❌ Old
<img width="248" height="451" alt="image" src="https://github.com/user-attachments/assets/9f5a3ac8-ad8e-441c-a86f-825af0159177" />


💚 New
<img width="510" height="344" alt="image" src="https://github.com/user-attachments/assets/c8bb7e60-6516-4a5e-b1ef-416c27269177" />

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
