### PR TITLE
fix: Disable image attestations

### DIFF
--- a/.github/workflows/build-images-from-branch.yml
+++ b/.github/workflows/build-images-from-branch.yml
@@ -116,6 +116,7 @@ jobs:
           action: docker/build-push-action@v6
           with: |
             file: packages/Dockerfile.base
+            provenance: false
             push: true
             context: .
             tags: |
@@ -202,6 +203,7 @@ jobs:
             build-args: |
               VERSION=${{ needs.base.outputs.version }}
               BRANCH=${{ needs.base.outputs.branch }}
+            provenance: false
             push: true
             context: .
             tags: |


### PR DESCRIPTION
## Description

By default docker image build action creates multiple image manifest:
```
docker manifest inspect opencrvs/ocrvs-farajaland:4a1f4b3-amd64 | jq .manifests
```

output:
- first image is archive with binaries
- second image is attastation image, see [1]
```json
[
  {
    "mediaType": "application/vnd.oci.image.manifest.v1+json",
    "size": 2760,
    "digest": "sha256:5257e81f5379f7b35e13e072a6785bd3c841fe897b12e9de0aef31c7aeab4a56",
    "platform": {
      "architecture": "amd64",
      "os": "linux"
    }
  },
  {
    "mediaType": "application/vnd.oci.image.manifest.v1+json",
    "size": 566,
    "digest": "sha256:e5dd45d4652e031730a56cd78cb6f8eab0f4f22f274be996d0a50bd95b2ae855",
    "platform": {
      "architecture": "unknown",
      "os": "unknown"
    }
  }
]
```

Adding attestations to OpenCRVS as public and open source product is optional, but not required. By this PR we temporary disable attestations.

Alternative ways to keep attestations:
- Build GitHub actions as explained on Docker documentation https://docs.docker.com/build/ci/github-actions/multi-platform/

## Links

[1] https://docs.docker.com/build/metadata/attestations/slsa-provenance/
[2] https://github.com/docker/build-push-action?tab=readme-ov-file#inputs

## Checklist

- [ ] I have linked the correct Github issue under "Development": No issue
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable): Not relevant
- [ ] I have updated the GitHub issue status accordingly: No issue
