### PR TITLE
adds html role="dialog" to Dialog

### DIFF
--- a/packages/components/src/Dialog/Dialog.tsx
+++ b/packages/components/src/Dialog/Dialog.tsx
@@ -139,6 +139,7 @@ export function Dialog({
             width={width}
             variant={variant}
             ref={dialogRef}
+            role="dialog"
           >
             <DialogHeader>
               <DialogTitle>


### PR DESCRIPTION
## Description

Adds `role="dialog"` to Dialog, so that E2E tests can properly getByRole.

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
