### PR TITLE
fix: if user administrative area is null, scope administrative area should be treated as all

### DIFF
--- a/packages/events/src/router/middleware/authorization/utils.ts
+++ b/packages/events/src/router/middleware/authorization/utils.ts
@@ -64,8 +64,9 @@ function canAccessEventWithScope(
   if (opts?.declaredIn === JurisdictionFilter.enum.administrativeArea) {
     const locationIds = event.legalStatuses?.DECLARED?.createdAtLocation
     if (
-      !locationIds ||
-      !locationIds.some((id) => id === user.administrativeAreaId)
+      (!locationIds ||
+        !locationIds.some((id) => id === user.administrativeAreaId)) &&
+      user.administrativeAreaId !== null
     ) {
       return false
     }
@@ -85,7 +86,8 @@ function canAccessEventWithScope(
     const locationIds = event.legalStatuses?.REGISTERED?.createdAtLocation
     if (
       !locationIds ||
-      !locationIds.some((id) => id === user.administrativeAreaId)
+      (!locationIds.some((id) => id === user.administrativeAreaId) &&
+        user.administrativeAreaId !== null)
     ) {
       return false
     }


### PR DESCRIPTION
Test failed intermittently but for right reasons. Fix bug where administrative area = null was not handled correctly.

I have WIP pr open that will refactor the code around this change but rather fix it first on develop, since it will take some time to complete.


## Description

Clearly describe what has been changed. Include relevant context or background.
Explain how the issue was fixed (if applicable) and the root cause.

Link this pull request to the GitHub issue (and optionally name the branch `ocrvs-<issue #>`)

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
