### PR TITLE
[OCRVS 11955] fix: use date-fns to parse ISO date in DateOutput component

### DIFF
--- a/packages/client/src/v2-events/features/events/registered-fields/DateField.tsx
+++ b/packages/client/src/v2-events/features/events/registered-fields/DateField.tsx
@@ -25,6 +25,7 @@ import {
 } from '@opencrvs/components/lib/DateField'
 import { useResolveDefaultValue } from '../useResolveDefaultValue'
 import { StringifierContext } from './RegisteredField'
+import { parseISO } from 'date-fns'
 
 const messages = defineMessages({
   dateFormat: {
@@ -116,7 +117,7 @@ function DateOutput({ value }: { value?: string }) {
 
   if (parsed.success) {
     return format(
-      new Date(parsed.data),
+      parseISO(parsed.data),
       intl.formatMessage(messages.dateFormat)
     )
   }


### PR DESCRIPTION
## Description
Clearly describe what has been changed. Include relevant context or background.
Explain how the issue was fixed (if applicable) and the root cause.

## Checklist
 I have linked the correct Github issue under "Development"
 I have tested the changes locally, and written appropriate tests
 I have tested beyond the happy path (e.g. edge cases, failure paths)
 I have updated the changelog with this change (if applicable)
 I have updated the GitHub issue status accordingly
