### PR TITLE
fix: resolve correction submitter name for system/integration clients

### DIFF
--- a/packages/client/src/v2-events/features/events/actions/correct/request/Summary/CorrectionDetails.tsx
+++ b/packages/client/src/v2-events/features/events/actions/correct/request/Summary/CorrectionDetails.tsx
@@ -27,7 +27,6 @@ import {
   PageTypes,
   RequestedCorrectionAction,
   TranslationConfig,
-  User,
   UUID,
   ValidatorContext
 } from '@opencrvs/commons/client'
@@ -40,8 +39,7 @@ import {
   Output
 } from '@client/v2-events/features/events/components/Output'
 import { ROUTES } from '@client/v2-events/routes'
-import { useUsers } from '@client/v2-events/hooks/useUsers'
-import { getUsersFullName } from '@client/v2-events/utils'
+import { useUserDetails } from '@client/v2-events/hooks/useUserDetails'
 import { useLocations } from '@client/v2-events/hooks/useLocations'
 import { DeclarationComparisonTable } from './DeclarationComparisonTable'
 
@@ -80,11 +78,9 @@ const Label = styled.label`
  */
 function getRequestActionDetails(
   correctionRequestAction: Action,
-  users: User[],
-  locations: Map<UUID, Location>,
-  intl: IntlShape
+  submitterName: string,
+  locations: Map<UUID, Location>
 ): CorrectionDetail[] {
-  const user = users.find((u) => u.id === correctionRequestAction.createdBy)
   const location =
     correctionRequestAction.createdAtLocation &&
     locations.get(correctionRequestAction.createdAtLocation)
@@ -92,7 +88,7 @@ function getRequestActionDetails(
     {
       label: messages.correctionSubmittedBy,
       id: 'correction.submitter',
-      valueDisplay: user ? getUsersFullName(user.name, intl.locale) : ''
+      valueDisplay: submitterName
     },
     {
       label: messages.correctionRequesterOffice,
@@ -115,7 +111,7 @@ function buildCorrectionDetails(
   annotation: EventState,
   form: EventState,
   intl: IntlShape,
-  users: User[],
+  submitterName: string,
   locations: Map<UUID, Location>,
   validatorContext: ValidatorContext,
   correctionRequestAction?: Action
@@ -155,9 +151,8 @@ function buildCorrectionDetails(
     details.unshift(
       ...getRequestActionDetails(
         correctionRequestAction,
-        users,
-        locations,
-        intl
+        submitterName,
+        locations
       )
     )
   }
@@ -209,8 +204,7 @@ export function CorrectionDetails({
   const { eventConfiguration } = useEventConfiguration(event.type)
 
   const navigate = useNavigate()
-  const { getUser } = useUsers()
-  const users = getUser.getAllCached()
+  const { getUserDetails } = useUserDetails()
 
   const { getLocations } = useLocations()
   const locations = getLocations.useSuspenseQuery()
@@ -220,12 +214,21 @@ export function CorrectionDetails({
       (action) => action.type === ActionType.REQUEST_CORRECTION
     )?.correctionForm.pages || []
 
+  const submitterName = correctionRequestAction
+    ? getUserDetails({
+        createdByUserType: correctionRequestAction.createdByUserType,
+        createdBy: correctionRequestAction.createdBy,
+        type: correctionRequestAction.type,
+        createdByRole: correctionRequestAction.createdByRole
+      }).name
+    : ''
+
   const correctionDetails = buildCorrectionDetails(
     correctionFormPages,
     annotation,
     form,
     intl,
-    users,
+    submitterName,
     locations,
     validatorContext,
     correctionRequestAction


### PR DESCRIPTION
## Description

https://github.com/opencrvs/opencrvs-core/issues/12122

<img width="730" height="696" alt="Screenshot 2026-03-24 at 9 00 22 PM" src="https://github.com/user-attachments/assets/8bc7b119-6672-4b87-bf79-0370b5270c10" />

When a correction request was created by a system/integration client, the submitter name showed blank. Switched from manual user lookup to useUserDetails which already handles the user → system fallback, so both human users and integration clients are now resolved correctly.

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
