### PR TITLE
Translations 2.0

### DIFF
--- a/.github/workflows/check-missing-translation.yml
+++ b/.github/workflows/check-missing-translation.yml
@@ -19,10 +19,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Create directory for core and countryconfig
-        run: |
-          mkdir -m 777 -p $HOME/core
-          mkdir -m 777 -p $HOME/countryconfig
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Create directory for countryconfig
+        run: mkdir -m 777 -p $HOME/countryconfig
 
       - name: Clone countryconfig and check if there any branch exists with the same name like current branch
         id: set_branch
@@ -61,30 +62,26 @@ jobs:
           fi
           echo "countryconfig_path=$HOME/countryconfig/opencrvs-countryconfig" >> $GITHUB_OUTPUT
 
-      - name: Checkout core repository
-        uses: actions/checkout@v6
-        with:
-          repository: opencrvs/opencrvs-core
-          ref: ${{ github.head_ref }}
-
       - name: Setup Node.js from core nvmrc
         uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
 
-      - name: Install dependencies and check for missing translations
+      - name: Install countryconfig dependencies
+        working-directory: ${{ steps.set_branch.outputs.countryconfig_path }}
+        run: yarn install
+
+      - name: Check core-en.json is in sync
         run: |
-          export COUNTRY_CONFIG_PATH=${{steps.set_branch.outputs.countryconfig_path}}
-          yarn install
-          cd ./packages/client
-          CI=true yarn extract:translations 2>&1 | tee output.txt
-          if grep -q "Missing translations" output.txt; then
-             awk '/You are missing the following content keys from your country configuration package:/ {flag=1; next} /Add them to this file and run again:/ {flag=0} flag' output.txt > missing_translations.txt
-             sed -i '/^$/d' missing_translations.txt
-             echo "### Summary Of Missing Translation" >> $GITHUB_STEP_SUMMARY
-             echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-             cat missing_translations.txt >> $GITHUB_STEP_SUMMARY
-             echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-             echo "Create a pull request to the \`opencrvs/countryconfig\` repository with a branch name ${{ github.head_ref }} and add the translations to \`src/translations/client.csv\`. After pushing the changes, you can run this pipeline again." >> $GITHUB_STEP_SUMMARY
-             exit 1
+          core_file="$GITHUB_WORKSPACE/packages/toolkit/dist/core-en.json"
+          cc_file="${{ steps.set_branch.outputs.countryconfig_path }}/node_modules/@opencrvs/toolkit/dist/core-en.json"
+          if ! diff -q "$core_file" "$cc_file" > /dev/null 2>&1; then
+            echo "### Translation sync error" >> $GITHUB_STEP_SUMMARY
+            echo "core-en.json in this core PR differs from the version installed in countryconfig." >> $GITHUB_STEP_SUMMARY
+            echo "The countryconfig branch must install a version of \`@opencrvs/toolkit\` built from the same core changes before translations can be validated." >> $GITHUB_STEP_SUMMARY
+            exit 1
           fi
+
+      - name: Validate translations
+        working-directory: ${{ steps.set_branch.outputs.countryconfig_path }}
+        run: yarn validate:translations:ci

--- a/generate-core-translations.ts
+++ b/generate-core-translations.ts
@@ -1,0 +1,139 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+
+/**
+ * Extracts all MessageDescriptor objects from the client and login packages
+ * and writes them to a single core-en.json file.
+ *
+ * This file is consumed by the @opencrvs/toolkit package and published with it,
+ * so country configurations can validate their translations against a known core version.
+ *
+ * Usage (run from repo root):
+ *   yarn generate:core-translations
+ */
+
+/* eslint-disable no-console */
+import * as fs from 'fs'
+import * as path from 'path'
+import ts from 'typescript'
+import { MessageDescriptor } from 'react-intl'
+
+const PACKAGES_DIR = path.resolve(__dirname, 'packages')
+const PACKAGES_TO_SCAN = ['client', 'login']
+const OUTPUT_PATH = path.resolve(PACKAGES_DIR, 'toolkit/dist/core-en.json')
+
+function findSourceFiles(dir: string): string[] {
+  if (!fs.existsSync(dir)) return []
+  const results: string[] = []
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (['node_modules', 'tests', '__tests__'].includes(entry.name)) continue
+      results.push(...findSourceFiles(path.join(dir, entry.name)))
+    } else if (
+      /\.(ts|tsx)$/.test(entry.name) &&
+      !/\.(test|spec|stories)\.(ts|tsx)$/.test(entry.name)
+    ) {
+      results.push(path.join(dir, entry.name))
+    }
+  }
+  return results
+}
+
+function extractMessageDescriptors(
+  _filePath: string,
+  sourceCode: string
+): MessageDescriptor[] {
+  const sourceFile = ts.createSourceFile(
+    'temp.ts',
+    sourceCode,
+    ts.ScriptTarget.Latest,
+    true
+  )
+  const matches: MessageDescriptor[] = []
+
+  function visit(node: ts.Node) {
+    if (!ts.isObjectLiteralExpression(node)) {
+      ts.forEachChild(node, visit)
+      return
+    }
+
+    const idProp = node.properties.find(
+      (p) => ts.isPropertyAssignment(p) && p.name.getText() === 'id'
+    )
+    const defaultMessageProp = node.properties.find(
+      (p) =>
+        ts.isPropertyAssignment(p) && p.name.getText() === 'defaultMessage'
+    )
+
+    if (!(idProp && defaultMessageProp)) {
+      ts.forEachChild(node, visit)
+      return
+    }
+
+    const objectText = node.getText(sourceFile)
+    try {
+      // eslint-disable-next-line no-new-func
+      matches.push(new Function(`return (${objectText});`)())
+    } catch {
+      // Dynamic message identifier – skip
+    }
+
+    ts.forEachChild(node, visit)
+  }
+
+  visit(sourceFile)
+  return matches
+}
+
+type MessageEntry = { defaultMessage: string; description: string }
+
+function extractFromDirectory(dir: string): Record<string, MessageEntry> {
+  const messages: Record<string, MessageEntry> = {}
+  for (const file of findSourceFiles(dir)) {
+    const contents = fs.readFileSync(file, 'utf8')
+    for (const { id, defaultMessage, description } of extractMessageDescriptors(
+      file,
+      contents
+    )) {
+      if (id)
+        messages[id as string] = {
+          defaultMessage: defaultMessage?.toString() ?? '',
+          description: description?.toString() ?? ''
+        }
+    }
+  }
+  return messages
+}
+
+async function main() {
+  const allMessages: Record<string, MessageEntry> = {}
+
+  for (const pkg of PACKAGES_TO_SCAN) {
+    const srcDir = path.join(PACKAGES_DIR, pkg, 'src')
+    console.log(`Scanning ${srcDir}...`)
+    Object.assign(allMessages, extractFromDirectory(srcDir))
+  }
+
+  const sorted = Object.fromEntries(
+    Object.entries(allMessages).sort(([a], [b]) => a.localeCompare(b))
+  )
+
+  fs.mkdirSync(path.dirname(OUTPUT_PATH), { recursive: true })
+  await fs.promises.writeFile(OUTPUT_PATH, JSON.stringify(sorted, null, 2))
+  console.log(
+    `Written ${Object.keys(sorted).length} keys → ${OUTPUT_PATH}`
+  )
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "check:license": "license-check-and-add check -f license-config.json",
     "seed:dev": "NODE_ENV=development lerna run seed --stream --scope @opencrvs/data-seeder",
     "seed:prod": "NODE_ENV=production lerna run seed --stream --scope @opencrvs/data-seeder",
+    "generate:core-translations": "ts-node --compiler-options='{\"module\": \"commonjs\", \"moduleResolution\": \"node\", \"esModuleInterop\": true}' generate-core-translations.ts",
     "add:license": "license-check-and-add add -f license-config.json",
     "build:components": "lerna run build --scope @opencrvs/components",
     "debug": "bash debug-service-in-chrome.sh"

--- a/packages/toolkit/build.sh
+++ b/packages/toolkit/build.sh
@@ -58,4 +58,7 @@ else
   find dist -type f -exec sed -i 's|@opencrvs/commons|../commons|g' {} +
 fi
 
+# Generate core-en.json from client + login source and place it in dist
+(cd ../.. && yarn generate:core-translations)
+
 echo "Build completed successfully."

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -11,7 +11,8 @@
     "./scopes": "./dist/scopes/index.js",
     "./events/deduplication": "./dist/events/deduplication.js",
     "./conditionals": "./dist/conditionals/index.js",
-    "./notification": "./dist/notification/index.js"
+    "./notification": "./dist/notification/index.js",
+    "./translations": "./dist/core-en.json"
   },
   "scripts": {
     "build": "./build.sh",


### PR DESCRIPTION
## Description

Change core to export all current translation keys as part of the toolkit.
This allows the country config to always have an up-to-date version of the keys in use.

Change the missing translation github action to:
- check that the country config branch has the same set of translations
- validate translations from the country config side, rather than from core

Country config PR: https://github.com/opencrvs/opencrvs-countryconfig/pull/1352

Fixes: https://github.com/opencrvs/opencrvs-core/issues/12192

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
