### PR TITLE
Translations 2.0

### DIFF
--- a/.github/workflows/check-missing-translation.yml
+++ b/.github/workflows/check-missing-translation.yml
@@ -19,10 +19,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Create directory for core and countryconfig
-        run: |
-          mkdir -m 777 -p $HOME/core
-          mkdir -m 777 -p $HOME/countryconfig
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Create directory for countryconfig
+        run: mkdir -m 777 -p $HOME/countryconfig
 
       - name: Clone countryconfig and check if there any branch exists with the same name like current branch
         id: set_branch
@@ -61,30 +62,39 @@ jobs:
           fi
           echo "countryconfig_path=$HOME/countryconfig/opencrvs-countryconfig" >> $GITHUB_OUTPUT
 
-      - name: Checkout core repository
-        uses: actions/checkout@v6
-        with:
-          repository: opencrvs/opencrvs-core
-          ref: ${{ github.head_ref }}
-
       - name: Setup Node.js from core nvmrc
         uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
 
-      - name: Install dependencies and check for missing translations
+      - name: Install core dependencies
+        run: yarn install
+
+      - name: Generate core translations
+        run: yarn generate:core-translations
+
+      - name: Install countryconfig dependencies
+        working-directory: ${{ steps.set_branch.outputs.countryconfig_path }}
+        run: yarn install
+
+      - name: Check core-en.json is in sync
         run: |
-          export COUNTRY_CONFIG_PATH=${{steps.set_branch.outputs.countryconfig_path}}
-          yarn install
-          cd ./packages/client
-          CI=true yarn extract:translations 2>&1 | tee output.txt
-          if grep -q "Missing translations" output.txt; then
-             awk '/You are missing the following content keys from your country configuration package:/ {flag=1; next} /Add them to this file and run again:/ {flag=0} flag' output.txt > missing_translations.txt
-             sed -i '/^$/d' missing_translations.txt
-             echo "### Summary Of Missing Translation" >> $GITHUB_STEP_SUMMARY
-             echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-             cat missing_translations.txt >> $GITHUB_STEP_SUMMARY
-             echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-             echo "Create a pull request to the \`opencrvs/countryconfig\` repository with a branch name ${{ github.head_ref }} and add the translations to \`src/translations/client.csv\`. After pushing the changes, you can run this pipeline again." >> $GITHUB_STEP_SUMMARY
-             exit 1
+          core_file="$GITHUB_WORKSPACE/packages/toolkit/dist/core-en.json"
+          cc_file="${{ steps.set_branch.outputs.countryconfig_path }}/node_modules/@opencrvs/toolkit/dist/core-en.json"
+          echo "core file exists: $(test -f "$core_file" && echo yes || echo NO)"
+          echo "cc file exists:   $(test -f "$cc_file" && echo yes || echo NO)"
+          diff_output=$(diff "$core_file" "$cc_file" 2>&1 || true)
+          if [ -n "$diff_output" ]; then
+            echo "### Translation sync error" >> $GITHUB_STEP_SUMMARY
+            echo "core-en.json in this core PR differs from the version installed in countryconfig." >> $GITHUB_STEP_SUMMARY
+            echo "The countryconfig branch must install a version of \`@opencrvs/toolkit\` built from the same core changes before translations can be validated." >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "\`\`\`diff" >> $GITHUB_STEP_SUMMARY
+            echo "$diff_output" >> $GITHUB_STEP_SUMMARY
+            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+            exit 1
           fi
+
+      - name: Validate translations
+        working-directory: ${{ steps.set_branch.outputs.countryconfig_path }}
+        run: yarn validate:translations:ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ HTTP input now accepts `field('..')` references in the HTTP body definition.
 - Added OAuth2 support for `application/x-www-form-urlencoded` content type in auth-service access token endpoints, maintaining backwards compatibility with query parameters. [#11590](https://github.com/opencrvs/opencrvs-core/pull/11590)
 - Change reindex call to make operation non-destructive. Create endpoint to track progress of reindex. [#11877](https://github.com/opencrvs/opencrvs-core/issues/11877)
 - Fixed vulnerabilities on CSP HTTP Header for login page [#12094](https://github.com/opencrvs/opencrvs-core/issues/12094)
+- Export core translation key as part of the toolkit [#12192](https://github.com/opencrvs/opencrvs-core/issues/12192)
 
 ## 1.9.12
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -50,6 +50,21 @@ module.exports = defineConfig([
       'arrow-parens': 'off',
       'no-return-assign': 'off',
       'no-restricted-imports': 'error',
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            "Property[key.name='defaultMessage'] > TemplateLiteral[expressions.length=0]",
+          message:
+            'Use a plain string literal for defaultMessage. Template literals are silently dropped by the translation extractor.'
+        },
+        {
+          selector:
+            "ObjectExpression:has(> Property[key.name='defaultMessage']) > Property[key.name='id'] > TemplateLiteral[expressions.length=0]",
+          message:
+            'Use a plain string literal for message id. Template literals are silently dropped by the translation extractor.'
+        }
+      ],
       'no-unreachable': 2,
       'import/no-unassigned-import': 'error',
       'import/no-extraneous-dependencies': 'off',

--- a/generate-core-translations.ts
+++ b/generate-core-translations.ts
@@ -146,9 +146,14 @@ async function main() {
 
   fs.mkdirSync(path.dirname(OUTPUT_PATH), { recursive: true })
   await fs.promises.writeFile(OUTPUT_PATH, JSON.stringify(sorted, null, 2))
-  console.log(
-    `Written ${Object.keys(sorted).length} keys → ${OUTPUT_PATH}`
+
+  const translationsDefinition = `declare const translations: Record<string, { defaultMessage: string; description: string }>
+  export default translations`
+  fs.writeFileSync(
+    OUTPUT_PATH.replace('.json', '.json.d.ts'),
+    translationsDefinition
   )
+  console.log(`Written ${Object.keys(sorted).length} keys → ${OUTPUT_PATH}`)
 }
 
 main().catch((err) => {

--- a/generate-core-translations.ts
+++ b/generate-core-translations.ts
@@ -8,6 +8,7 @@
  *
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
+/// <reference types="node" />
 
 /**
  * Extracts all MessageDescriptor objects from the client and login packages
@@ -47,10 +48,7 @@ function findSourceFiles(dir: string): string[] {
   return results
 }
 
-function extractMessageDescriptors(
-  _filePath: string,
-  sourceCode: string
-): MessageDescriptor[] {
+function extractMessageDescriptors(sourceCode: string): MessageDescriptor[] {
   const sourceFile = ts.createSourceFile(
     'temp.ts',
     sourceCode,
@@ -69,8 +67,11 @@ function extractMessageDescriptors(
       (p) => ts.isPropertyAssignment(p) && p.name.getText() === 'id'
     )
     const defaultMessageProp = node.properties.find(
-      (p) =>
-        ts.isPropertyAssignment(p) && p.name.getText() === 'defaultMessage'
+      (p) => ts.isPropertyAssignment(p) && p.name.getText() === 'defaultMessage'
+    )
+
+    const descriptionProp = node.properties.find(
+      (p) => ts.isPropertyAssignment(p) && p.name.getText() === 'description'
     )
 
     if (!(idProp && defaultMessageProp)) {
@@ -78,12 +79,30 @@ function extractMessageDescriptors(
       return
     }
 
-    const objectText = node.getText(sourceFile)
     try {
-      // eslint-disable-next-line no-new-func
-      matches.push(new Function(`return (${objectText});`)())
+      const idNode = (idProp as ts.PropertyAssignment).initializer
+      const msgNode = (defaultMessageProp as ts.PropertyAssignment).initializer
+      const descriptionNode = (descriptionProp as ts.PropertyAssignment)
+        ?.initializer
+
+      const description =
+        descriptionNode && ts.isStringLiteral(descriptionNode)
+          ? descriptionNode.text
+          : undefined
+
+      if (ts.isStringLiteral(idNode) && ts.isStringLiteral(msgNode)) {
+        matches.push({
+          id: idNode.text,
+          defaultMessage: msgNode.text,
+          description: description
+        })
+      } else {
+        console.warn(
+          `Skipping non-literal descriptor : ${node.getText(sourceFile)}`
+        )
+      }
     } catch {
-      // Dynamic message identifier – skip
+      console.warn(`Skipping dynamic descriptor : ${node.getText(sourceFile)}`)
     }
 
     ts.forEachChild(node, visit)
@@ -100,7 +119,6 @@ function extractFromDirectory(dir: string): Record<string, MessageEntry> {
   for (const file of findSourceFiles(dir)) {
     const contents = fs.readFileSync(file, 'utf8')
     for (const { id, defaultMessage, description } of extractMessageDescriptors(
-      file,
       contents
     )) {
       if (id)

--- a/generate-core-translations.ts
+++ b/generate-core-translations.ts
@@ -1,0 +1,139 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+
+/**
+ * Extracts all MessageDescriptor objects from the client and login packages
+ * and writes them to a single core-en.json file.
+ *
+ * This file is consumed by the @opencrvs/toolkit package and published with it,
+ * so country configurations can validate their translations against a known core version.
+ *
+ * Usage (run from repo root):
+ *   yarn generate:core-translations
+ */
+
+/* eslint-disable no-console */
+import * as fs from 'fs'
+import * as path from 'path'
+import ts from 'typescript'
+import { MessageDescriptor } from 'react-intl'
+
+const PACKAGES_DIR = path.resolve(__dirname, 'packages')
+const PACKAGES_TO_SCAN = ['client', 'login']
+const OUTPUT_PATH = path.resolve(PACKAGES_DIR, 'toolkit/dist/core-en.json')
+
+function findSourceFiles(dir: string): string[] {
+  if (!fs.existsSync(dir)) return []
+  const results: string[] = []
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (['node_modules', 'tests', '__tests__'].includes(entry.name)) continue
+      results.push(...findSourceFiles(path.join(dir, entry.name)))
+    } else if (
+      /\.(ts|tsx)$/.test(entry.name) &&
+      !/\.(test|spec|stories)\.(ts|tsx)$/.test(entry.name)
+    ) {
+      results.push(path.join(dir, entry.name))
+    }
+  }
+  return results
+}
+
+function extractMessageDescriptors(
+  _filePath: string,
+  sourceCode: string
+): MessageDescriptor[] {
+  const sourceFile = ts.createSourceFile(
+    'temp.ts',
+    sourceCode,
+    ts.ScriptTarget.Latest,
+    true
+  )
+  const matches: MessageDescriptor[] = []
+
+  function visit(node: ts.Node) {
+    if (!ts.isObjectLiteralExpression(node)) {
+      ts.forEachChild(node, visit)
+      return
+    }
+
+    const idProp = node.properties.find(
+      (p) => ts.isPropertyAssignment(p) && p.name.getText() === 'id'
+    )
+    const defaultMessageProp = node.properties.find(
+      (p) =>
+        ts.isPropertyAssignment(p) && p.name.getText() === 'defaultMessage'
+    )
+
+    if (!(idProp && defaultMessageProp)) {
+      ts.forEachChild(node, visit)
+      return
+    }
+
+    const objectText = node.getText(sourceFile)
+    try {
+      // eslint-disable-next-line no-new-func
+      matches.push(new Function(`return (${objectText});`)())
+    } catch {
+      // Dynamic message identifier – skip
+    }
+
+    ts.forEachChild(node, visit)
+  }
+
+  visit(sourceFile)
+  return matches
+}
+
+type MessageEntry = { defaultMessage: string; description: string }
+
+function extractFromDirectory(dir: string): Record<string, MessageEntry> {
+  const messages: Record<string, MessageEntry> = {}
+  for (const file of findSourceFiles(dir)) {
+    const contents = fs.readFileSync(file, 'utf8')
+    for (const { id, defaultMessage, description } of extractMessageDescriptors(
+      file,
+      contents
+    )) {
+      if (id)
+        messages[id as string] = {
+          defaultMessage: defaultMessage?.toString() ?? '',
+          description: description?.toString() ?? ''
+        }
+    }
+  }
+  return messages
+}
+
+async function main() {
+  const allMessages: Record<string, MessageEntry> = {}
+
+  for (const pkg of PACKAGES_TO_SCAN) {
+    const srcDir = path.join(PACKAGES_DIR, pkg, 'src')
+    console.log(`Scanning ${srcDir}...`)
+    Object.assign(allMessages, extractFromDirectory(srcDir))
+  }
+
+  const sorted = Object.fromEntries(
+    Object.entries(allMessages).sort(([a], [b]) => a.localeCompare(b))
+  )
+
+  fs.mkdirSync(path.dirname(OUTPUT_PATH), { recursive: true })
+  await fs.promises.writeFile(OUTPUT_PATH, JSON.stringify(sorted, null, 2))
+  console.log(
+    `Written ${Object.keys(sorted).length} keys → ${OUTPUT_PATH}`
+  )
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/generate-core-translations.ts
+++ b/generate-core-translations.ts
@@ -48,6 +48,12 @@ function findSourceFiles(dir: string): string[] {
   return results
 }
 
+function getStringValue(node: ts.Expression): string | undefined {
+  if (ts.isStringLiteral(node)) return node.text
+  if (ts.isNoSubstitutionTemplateLiteral(node)) return node.text
+  return undefined
+}
+
 function extractMessageDescriptors(sourceCode: string): MessageDescriptor[] {
   const sourceFile = ts.createSourceFile(
     'temp.ts',
@@ -90,19 +96,24 @@ function extractMessageDescriptors(sourceCode: string): MessageDescriptor[] {
           ? descriptionNode.text
           : undefined
 
-      if (ts.isStringLiteral(idNode) && ts.isStringLiteral(msgNode)) {
+      const idVal = getStringValue(idNode)
+      const msgVal = getStringValue(msgNode)
+
+      if (idVal !== undefined && msgVal !== undefined) {
         matches.push({
-          id: idNode.text,
-          defaultMessage: msgNode.text,
+          id: idVal,
+          defaultMessage: msgVal,
           description: description
         })
       } else {
         console.warn(
-          `Skipping non-literal descriptor : ${node.getText(sourceFile)}`
+          `Skipping non-literal descriptor : ${node.getText(sourceFile).slice(0, 80)}`
         )
       }
     } catch {
-      console.warn(`Skipping dynamic descriptor : ${node.getText(sourceFile)}`)
+      console.warn(
+        `Skipping dynamic descriptor : ${node.getText(sourceFile).slice(0, 80)}`
+      )
     }
 
     ts.forEachChild(node, visit)
@@ -137,7 +148,18 @@ async function main() {
   for (const pkg of PACKAGES_TO_SCAN) {
     const srcDir = path.join(PACKAGES_DIR, pkg, 'src')
     console.log(`Scanning ${srcDir}...`)
-    Object.assign(allMessages, extractFromDirectory(srcDir))
+    const extracted = extractFromDirectory(srcDir)
+    for (const [id, entry] of Object.entries(extracted)) {
+      if (
+        allMessages[id] &&
+        allMessages[id].defaultMessage !== entry.defaultMessage
+      ) {
+        console.warn(
+          `Key "${id}" already defined with a different defaultMessage, overwriting with ${pkg} version`
+        )
+      }
+    }
+    Object.assign(allMessages, extracted)
   }
 
   const sorted = Object.fromEntries(

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "check:license": "license-check-and-add check -f license-config.json",
     "seed:dev": "NODE_ENV=development lerna run seed --stream --scope @opencrvs/data-seeder",
     "seed:prod": "NODE_ENV=production lerna run seed --stream --scope @opencrvs/data-seeder",
+    "generate:core-translations": "ts-node --compiler-options='{\"module\": \"commonjs\", \"moduleResolution\": \"node\", \"esModuleInterop\": true}' generate-core-translations.ts",
     "add:license": "license-check-and-add add -f license-config.json",
     "build:components": "lerna run build --scope @opencrvs/components",
     "debug": "bash debug-service-in-chrome.sh"

--- a/packages/client/eslint.legacy.config.js
+++ b/packages/client/eslint.legacy.config.js
@@ -19,6 +19,21 @@ module.exports = defineConfig([
   {
     rules: {
       'no-eval': 'error',
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            "Property[key.name='defaultMessage'] > TemplateLiteral[expressions.length=0]",
+          message:
+            'Use a plain string literal for defaultMessage. Template literals are silently dropped by the translation extractor.'
+        },
+        {
+          selector:
+            "ObjectExpression:has(> Property[key.name='defaultMessage']) > Property[key.name='id'] > TemplateLiteral[expressions.length=0]",
+          message:
+            'Use a plain string literal for message id. Template literals are silently dropped by the translation extractor.'
+        }
+      ],
       'no-console': 'warn',
       'import/prefer-default-export': 'off',
       'import/no-duplicates': 'off',

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -30,8 +30,7 @@
     "src/**/*.{ts,tsx}": [
       "prettier --write",
       "eslint --fix",
-      "stylelint",
-      "yarn extract:translations"
+      "stylelint"
     ],
     "src/**/*.json": "prettier --write"
   },

--- a/packages/client/src/i18n/messages/constants.ts
+++ b/packages/client/src/i18n/messages/constants.ts
@@ -432,8 +432,10 @@ const messagesToDefine: IConstantsMessages = {
     id: 'constants.estimatedNumberOfRegistartion'
   },
   estimatedTargetDaysRegistrationTitle: {
-    defaultMessage: `Estimated vs total registered in {registrationTargetDays} days`,
-    description: `A label for estimated vs total registered in {registrationTargetDays} days`,
+    defaultMessage:
+      'Estimated vs total registered in {registrationTargetDays} days',
+    description:
+      'A label for estimated vs total registered in {registrationTargetDays} days',
     id: 'constants.estimatedTargetDaysRegistrationTitle'
   },
   event: {
@@ -713,8 +715,8 @@ const messagesToDefine: IConstantsMessages = {
     id: 'constants.registeredBy'
   },
   registeredInTargetd: {
-    defaultMessage: `Registered in {registrationTargetDays} days`,
-    description: `A label for Registered in {registrationTargetDays} days`,
+    defaultMessage: 'Registered in {registrationTargetDays} days',
+    description: 'A label for Registered in {registrationTargetDays} days',
     id: 'constants.registeredInTargetd'
   },
   registeredStatus: {
@@ -723,8 +725,9 @@ const messagesToDefine: IConstantsMessages = {
     id: 'constants.registered.status'
   },
   registeredWithinTargetd: {
-    defaultMessage: `Registered within\n{registrationTargetDays} days of event`,
-    description: `A label for Registered {registrationTargetDays} within  days of event`,
+    defaultMessage: 'Registered within\n{registrationTargetDays} days of event',
+    description:
+      'A label for Registered {registrationTargetDays} within  days of event',
     id: 'constants.registeredWithinTargetd'
   },
   rejected: {
@@ -906,8 +909,9 @@ const messagesToDefine: IConstantsMessages = {
     id: 'constants.totalRegistered'
   },
   totalRegisteredInTargetDays: {
-    defaultMessage: `Total registered in {registrationTargetDays} days`,
-    description: `A label for total registered in {registrationTargetDays} days`,
+    defaultMessage: 'Total registered in {registrationTargetDays} days',
+    description:
+      'A label for total registered in {registrationTargetDays} days',
     id: 'constants.totalRegisteredInTargetDays'
   },
   trackingId: {
@@ -971,17 +975,18 @@ const messagesToDefine: IConstantsMessages = {
     id: 'constants.within1YearTo5Years'
   },
   withinTargetDays: {
-    defaultMessage: `Within {registrationTargetDays} days`,
-    description: `Label for registrations within {registrationTargetDays} days`,
+    defaultMessage: 'Within {registrationTargetDays} days',
+    description: 'Label for registrations within {registrationTargetDays} days',
     id: 'constants.withinTargetDays'
   },
   withinTargetDaysTo1Year: {
-    defaultMessage: `{registrationTargetDays} days - 1 year`,
-    description: `Label for registrations within {registrationTargetDays} days to 1 year`,
+    defaultMessage: '{registrationTargetDays} days - 1 year',
+    description:
+      'Label for registrations within {registrationTargetDays} days to 1 year',
     id: 'constants.withinTargetDaysTo1Year'
   },
   humanName: {
-    defaultMessage: `{firstName} {middleName} {lastName}`,
+    defaultMessage: '{firstName} {middleName} {lastName}',
     description: 'A localized order of the full name',
     id: 'constants.humanName'
   }

--- a/packages/client/src/i18n/messages/user.ts
+++ b/packages/client/src/i18n/messages/user.ts
@@ -339,7 +339,8 @@ const messagesToDefine: IUserMessages = {
     id: 'settings.changePassword'
   },
   changePasswordMessage: {
-    defaultMessage: `Create a unique password - one that you don't use for other websites or applications. A secure and easy to remember passphrase could include three random words, while avoiding the use of personal info.`,
+    defaultMessage:
+      "Create a unique password - one that you don't use for other websites or applications. A secure and easy to remember passphrase could include three random words, while avoiding the use of personal info.",
     description: 'Password change message',
     id: 'misc.newPass.instruction'
   },

--- a/packages/client/src/i18n/messages/views/integrations.ts
+++ b/packages/client/src/i18n/messages/views/integrations.ts
@@ -104,43 +104,43 @@ const messagesToDefine = {
 
   childDetails: {
     id: 'integrations.childDetails',
-    defaultMessage: `Child's details`,
+    defaultMessage: "Child's details",
     description: 'Label for child details'
   },
 
   motherDetails: {
     id: 'integrations.motherDetails',
-    defaultMessage: `Mother's details`,
+    defaultMessage: "Mother's details",
     description: 'Label for mothers details'
   },
 
   fatherDetails: {
     id: 'integrations.fatherDetails',
-    defaultMessage: `Father's details`,
+    defaultMessage: "Father's details",
     description: 'Label for fathers details'
   },
 
   informantDetails: {
     id: 'integrations.informantDetails',
-    defaultMessage: `Informant's details`,
+    defaultMessage: "Informant's details",
     description: 'Label for informant details'
   },
 
   documentDetails: {
     id: 'integrations.documentDetails',
-    defaultMessage: `Document details`,
+    defaultMessage: 'Document details',
     description: 'Label for document details'
   },
 
   deathEventDetails: {
     id: 'integrations.deathEventDetails',
-    defaultMessage: `Event details`,
+    defaultMessage: 'Event details',
     description: 'Label for death event details'
   },
 
   deceasedDetails: {
     id: 'integrations.deceasedDetails',
-    defaultMessage: `Deceased's details`,
+    defaultMessage: "Deceased's details",
     description: 'Label for Deceased details'
   },
 

--- a/packages/client/src/i18n/messages/views/register.ts
+++ b/packages/client/src/i18n/messages/views/register.ts
@@ -85,7 +85,8 @@ const messagesToDefine: IRegisterMessages = {
   },
   deleteDeclarationConfirmModalDescription: {
     id: 'register.form.modal.desc.deleteDeclarationConfirm',
-    defaultMessage: `Are you certain you want to delete this draft declaration form? Please note, this action can't be undone.`,
+    defaultMessage:
+      "Are you certain you want to delete this draft declaration form? Please note, this action can't be undone.",
     description: 'Description for delete declaration confirmation modal'
   },
   exitWithoutSavingModalForCorrectionRecordTitle: {

--- a/packages/client/src/i18n/messages/views/userSetup.ts
+++ b/packages/client/src/i18n/messages/views/userSetup.ts
@@ -109,7 +109,8 @@ const messagesToDefine: IUserSetupMessages = {
     id: 'misc.newPass.header'
   },
   instruction: {
-    defaultMessage: `Create a unique password - one that you don't use for other websites or applications. A secure and easy to remember passphrase could include three random words, while avoiding the use of personal info.`,
+    defaultMessage:
+      "Create a unique password - one that you don't use for other websites or applications. A secure and easy to remember passphrase could include three random words, while avoiding the use of personal info.",
     description: 'New Password instruction',
     id: 'misc.newPass.instruction'
   },

--- a/packages/client/src/v2-events/features/events/components/TranslationTextWithFormatModifier.interaction.stories.tsx
+++ b/packages/client/src/v2-events/features/events/components/TranslationTextWithFormatModifier.interaction.stories.tsx
@@ -117,7 +117,8 @@ export const CodeAndQuotation: Story = {
   args: {
     message: {
       id: 'test.code',
-      defaultMessage: `Run <code>npm install</code>, press <kbd>Enter</kbd>, then <q>confirm</q>`
+      defaultMessage:
+        'Run <code>npm install</code>, press <kbd>Enter</kbd>, then <q>confirm</q>'
     },
     element: 'span'
   },

--- a/packages/client/src/v2-events/features/events/registered-fields/Autocomplete.stories.tsx
+++ b/packages/client/src/v2-events/features/events/registered-fields/Autocomplete.stories.tsx
@@ -12,11 +12,7 @@
 import type { Meta, StoryFn, StoryObj } from '@storybook/react'
 import React from 'react'
 import styled from 'styled-components'
-import {
-  field,
-  FieldType,
-  ConditionalType
-} from '@opencrvs/commons/client'
+import { field, FieldType, ConditionalType } from '@opencrvs/commons/client'
 import {
   FormFieldGenerator,
   FormFieldGeneratorPropsWithoutRef
@@ -86,7 +82,7 @@ export const ICD: Story = {
               defaultMessage:
                 'Enter the diagnosis or condition not found in the list above',
               description: 'This is the label for the field',
-              id: `symptom.icd10.other.label`
+              id: 'symptom.icd10.other.label'
             },
             conditionals: [
               {

--- a/packages/client/src/v2-events/features/events/registered-fields/Data.stories.tsx
+++ b/packages/client/src/v2-events/features/events/registered-fields/Data.stories.tsx
@@ -86,7 +86,7 @@ export const DataDisplay: Story = {
                     id: 'event.tennis-club-membership.action.print.verify.id.label'
                   },
                   value: {
-                    defaultMessage: `National ID | {applicant.id}`,
+                    defaultMessage: 'National ID | {applicant.id}',
                     description: 'This is the label for the field',
                     id: 'event.tennis-club-membership.action.print.verify.id.label'
                   }

--- a/packages/client/src/v2-events/features/events/useEventFormNavigation.tsx
+++ b/packages/client/src/v2-events/features/events/useEventFormNavigation.tsx
@@ -45,7 +45,8 @@ const modalMessages = defineMessages({
   },
   deleteDeclarationDescription: {
     id: 'register.form.modal.description.deleteDeclarationConfirm',
-    defaultMessage: `Are you certain you want to delete this draft declaration form? Please note, this action can't be undone.`,
+    defaultMessage:
+      "Are you certain you want to delete this draft declaration form? Please note, this action can't be undone.",
     description: 'Description for delete declaration confirmation modal'
   }
 })

--- a/packages/login/src/i18n/messages/views/resetCredentialsForm.ts
+++ b/packages/login/src/i18n/messages/views/resetCredentialsForm.ts
@@ -84,7 +84,8 @@ const messagesToDefine = {
   },
   passwordUpdateFormBodySubheader: {
     id: 'misc.newPass.instruction',
-    defaultMessage: `Create a unique password - one that you don't use for other websites or applications. A secure and easy to remember passphrase could include three random words, while avoiding the use of personal info.`,
+    defaultMessage:
+      "Create a unique password - one that you don't use for other websites or applications. A secure and easy to remember passphrase could include three random words, while avoiding the use of personal info.",
     description: 'New Password instruction'
   },
   passwordLengthCharacteristicsForPasswordUpdateForm: {

--- a/packages/toolkit/build.sh
+++ b/packages/toolkit/build.sh
@@ -66,4 +66,7 @@ fi
 npx esbuild src/cli.ts --bundle --format=cjs --outdir=./dist --allow-overwrite --packages=external --banner:js="#!/usr/bin/env node"
 chmod +x ./dist/cli.js
 
+# Generate core-en.json from client + login source and place it in dist
+(cd ../.. && yarn generate:core-translations)
+
 echo "Build completed successfully."

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -15,7 +15,10 @@
     "./events/deduplication": "./dist/events/deduplication.js",
     "./conditionals": "./dist/conditionals/index.js",
     "./notification": "./dist/notification/index.js",
-    "./translations": "./dist/core-en.json"
+    "./translations": {
+      "types": "./dist/core-en.json.d.ts",
+      "default": "./dist/core-en.json"
+    }
   },
   "scripts": {
     "build": "./build.sh",

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -14,7 +14,8 @@
     "./scopes": "./dist/scopes/index.js",
     "./events/deduplication": "./dist/events/deduplication.js",
     "./conditionals": "./dist/conditionals/index.js",
-    "./notification": "./dist/notification/index.js"
+    "./notification": "./dist/notification/index.js",
+    "./translations": "./dist/core-en.json"
   },
   "scripts": {
     "build": "./build.sh",


### PR DESCRIPTION
## Description

Change core to export all current translation keys as part of the toolkit.
This allows the country config to always have an up-to-date version of the keys in use.

Change the missing translation github action to:
- check that the country config branch has the same set of translations
- validate translations from the country config side, rather than from core

Country config PR: https://github.com/opencrvs/opencrvs-countryconfig/pull/1353

Fixes: https://github.com/opencrvs/opencrvs-core/issues/12192

### Possible further improvements

Instead of using a custom script to look for all IMessageDescriptors, use FormatJS CLI.
This will require a significant refactor as it requires using the constructor:
`const messages = defineMessages({...`
everywhere or FormatJS won't pick up the keys.  

I may submit that as a separate PR.


## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
