### PR TITLE
[OCRVS-12055] Poll probing `api/ping` until all services are up

### DIFF
--- a/packages/client/src/v2-events/components/LoadingIndicator.tsx
+++ b/packages/client/src/v2-events/components/LoadingIndicator.tsx
@@ -20,14 +20,6 @@ import { Spinner } from '@opencrvs/components/lib/Spinner'
 import { errorMessages } from '@client/v2-events/messages'
 import { useOnlineStatus } from '@client/utils'
 
-const messages = defineMessages({
-  noConnection: {
-    defaultMessage: 'No connection',
-    description: 'No Connection hover text',
-    id: 'constants.noConnection'
-  }
-})
-
 const ErrorText = styled.div`
   color: ${({ theme }) => theme.colors.negative};
   ${({ theme }) => theme.fonts.reg16};
@@ -35,15 +27,6 @@ const ErrorText = styled.div`
   margin-top: 100px;
 `
 
-const ConnectivityContainer = styled.div`
-  width: 100%;
-  display: flex;
-  justify-content: center;
-`
-const NoConnectivity = styled(ConnectionError)`
-  width: 24px;
-  margin-right: 8px;
-`
 const Wrapper = styled.div`
   display: flex;
   align-items: center;
@@ -60,10 +43,6 @@ const LoadingContainer = styled.div`
     align-items: center;
     justify-content: center;
   }
-`
-const Text = styled.div`
-  ${({ theme }) => theme.fonts.reg16};
-  text-align: center;
 `
 
 const MobileViewContainer = styled.div<{ noDeclaration?: boolean }>`
@@ -104,14 +83,6 @@ function LoadingIndicatorComp({
           <ErrorText id="search-result-error-text-count">
             {intl.formatMessage(errorMessages.queryError)}
           </ErrorText>
-        )}
-        {!isOnline && (
-          <ConnectivityContainer>
-            <NoConnectivity />
-            <Text id="wait-connection-text">
-              {intl.formatMessage(messages.noConnection)}
-            </Text>
-          </ConnectivityContainer>
         )}
       </MobileViewContainer>
     </Wrapper>

--- a/packages/client/src/v2-events/layouts/sidebar/Sidebar.tsx
+++ b/packages/client/src/v2-events/layouts/sidebar/Sidebar.tsx
@@ -52,6 +52,14 @@ import { PerformanceNavigationGroup } from './PerformanceNavigationGroup'
 
 const SCREEN_LOCK = 'screenLock'
 
+function subscribeOnlineStatus(cb: () => void) {
+  return onlineManager.subscribe(cb)
+}
+
+function getOnlineSnapshot() {
+  return onlineManager.isOnline()
+}
+
 function Workqueues({
   workqueues,
   currentWorkqueueSlug,
@@ -111,12 +119,11 @@ export const SidebarComponent = ({
   const offlineCountryConfig = useSelector(getOfflineData)
   const userDetails = useSelector(getUserDetails)
   const language = useSelector(getLanguage)
-  const [isOnline, setIsOnline] = React.useState(onlineManager.isOnline())
-  React.useEffect(() => {
-    return onlineManager.subscribe(() => {
-      setIsOnline(onlineManager.isOnline())
-    })
-  }, [])
+  const isOnline = React.useSyncExternalStore(
+    subscribeOnlineStatus,
+    getOnlineSnapshot,
+    () => true
+  )
 
   let name = ''
   if (userDetails?.name) {

--- a/packages/client/src/v2-events/layouts/sidebar/Sidebar.tsx
+++ b/packages/client/src/v2-events/layouts/sidebar/Sidebar.tsx
@@ -14,6 +14,7 @@ import { useNavigate } from 'react-router-dom'
 import { useTypedParams } from 'react-router-typesafe-routes/dom'
 import { useIntl } from 'react-intl'
 import { useSelector } from 'react-redux'
+import { onlineManager } from '@tanstack/react-query'
 import { Icon } from '@opencrvs/components/lib/Icon'
 import { LogoutNavigation } from '@opencrvs/components/lib/icons/LogoutNavigation'
 import { SettingsNavigation } from '@opencrvs/components/lib/icons/SettingsNavigation'
@@ -110,6 +111,12 @@ export const SidebarComponent = ({
   const offlineCountryConfig = useSelector(getOfflineData)
   const userDetails = useSelector(getUserDetails)
   const language = useSelector(getLanguage)
+  const [isOnline, setIsOnline] = React.useState(onlineManager.isOnline())
+  React.useEffect(() => {
+    return onlineManager.subscribe(() => {
+      setIsOnline(onlineManager.isOnline())
+    })
+  }, [])
 
   let name = ''
   if (userDetails?.name) {
@@ -141,6 +148,7 @@ export const SidebarComponent = ({
       applicationName={offlineCountryConfig.config.APPLICATION_NAME}
       applicationVersion={runningVer}
       avatar={() => avatar}
+      isOnline={isOnline}
       name={name}
       navigationWidth={navigationWidth}
       role={role}

--- a/packages/client/src/v2-events/routes/config.test.ts
+++ b/packages/client/src/v2-events/routes/config.test.ts
@@ -1,0 +1,163 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+import { renderHook, act } from '@testing-library/react'
+import { onlineManager } from '@tanstack/react-query'
+import createFetchMock from 'vitest-fetch-mock'
+import { useNetworkProbe } from './config'
+
+const fetchMock = createFetchMock(vi)
+fetchMock.enableMocks()
+
+const ALL_SERVICES_HEALTHY = {
+  auth: true,
+  search: true,
+  'user-mgnt': true,
+  metrics: true,
+  notification: true,
+  countryconfig: true,
+  workflow: true
+}
+
+// fetch-mock resolves as microtasks; act() flushes them without advancing fake timers
+async function flushFetch() {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  await act(async () => {})
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  onlineManager.setOnline(true)
+  fetchMock.resetMocks()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('useNetworkProbe', () => {
+  it('sets offline immediately on mount, then online when all services are healthy', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify(ALL_SERVICES_HEALTHY))
+
+    const { unmount } = renderHook(() => useNetworkProbe())
+
+    expect(onlineManager.isOnline()).toBe(false)
+
+    await flushFetch()
+
+    expect(onlineManager.isOnline()).toBe(true)
+    unmount()
+  })
+
+  it('remains offline when a service is not ready', async () => {
+    fetchMock.mockResponseOnce(
+      JSON.stringify({ ...ALL_SERVICES_HEALTHY, metrics: false })
+    )
+
+    const { unmount } = renderHook(() => useNetworkProbe())
+
+    await flushFetch()
+
+    expect(onlineManager.isOnline()).toBe(false)
+    unmount()
+  })
+
+  it('remains offline when fetch throws a network error', async () => {
+    fetchMock.mockRejectOnce(new Error('Network error'))
+
+    const { unmount } = renderHook(() => useNetworkProbe())
+
+    await flushFetch()
+
+    expect(onlineManager.isOnline()).toBe(false)
+    unmount()
+  })
+
+  it('retries the probe every 5 seconds while offline', async () => {
+    fetchMock.mockRejectOnce(new Error('Network error'))
+    fetchMock.mockResponseOnce(JSON.stringify(ALL_SERVICES_HEALTHY))
+
+    const { unmount } = renderHook(() => useNetworkProbe())
+
+    await flushFetch()
+    expect(onlineManager.isOnline()).toBe(false)
+
+    await act(async () => {
+      vi.advanceTimersByTime(5000)
+    })
+    await flushFetch()
+
+    expect(onlineManager.isOnline()).toBe(true)
+    unmount()
+  })
+
+  it('does not run concurrent probes', async () => {
+    let resolveFirst!: (value: Response) => void
+    const slowFetch = new Promise<Response>((resolve) => {
+      resolveFirst = resolve
+    })
+    fetchMock.mockImplementationOnce(() => slowFetch)
+    fetchMock.mockResponseOnce(JSON.stringify(ALL_SERVICES_HEALTHY))
+
+    const { unmount } = renderHook(() => useNetworkProbe())
+
+    await act(async () => {
+      vi.advanceTimersByTime(5000)
+    })
+
+    expect(fetch).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      resolveFirst(
+        new Response(JSON.stringify(ALL_SERVICES_HEALTHY), { status: 200 })
+      )
+    })
+    await flushFetch()
+    unmount()
+  })
+
+  it('clears the retry interval once online', async () => {
+    fetchMock.mockResponse(JSON.stringify(ALL_SERVICES_HEALTHY))
+
+    const { unmount } = renderHook(() => useNetworkProbe())
+
+    await flushFetch()
+    expect(onlineManager.isOnline()).toBe(true)
+
+    const callsAfterOnline = fetchMock.mock.calls.length
+
+    await act(async () => {
+      vi.advanceTimersByTime(20000)
+    })
+    await flushFetch()
+
+    expect(fetchMock.mock.calls.length).toBe(callsAfterOnline)
+    unmount()
+  })
+
+  it('aborts the in-flight fetch and clears the interval on unmount', async () => {
+    const abortSpy = vi.fn()
+    const controller = { abort: abortSpy, signal: new AbortController().signal }
+    const OriginalAbortController = global.AbortController
+    global.AbortController = vi.fn(
+      () => controller
+    ) as unknown as typeof AbortController
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    fetchMock.mockImplementationOnce(() => new Promise<Response>(() => {}))
+
+    const { unmount } = renderHook(() => useNetworkProbe())
+
+    unmount()
+
+    expect(abortSpy).toHaveBeenCalled()
+    global.AbortController = OriginalAbortController
+  })
+})

--- a/packages/client/src/v2-events/routes/config.test.ts
+++ b/packages/client/src/v2-events/routes/config.test.ts
@@ -89,7 +89,7 @@ describe('useNetworkProbe', () => {
     await flushFetch()
     expect(onlineManager.isOnline()).toBe(false)
 
-    await act(async () => {
+    act(() => {
       vi.advanceTimersByTime(5000)
     })
     await flushFetch()
@@ -103,18 +103,18 @@ describe('useNetworkProbe', () => {
     const slowFetch = new Promise<Response>((resolve) => {
       resolveFirst = resolve
     })
-    fetchMock.mockImplementationOnce(() => slowFetch)
+    fetchMock.mockImplementationOnce(async () => slowFetch)
     fetchMock.mockResponseOnce(JSON.stringify(ALL_SERVICES_HEALTHY))
 
     const { unmount } = renderHook(() => useNetworkProbe())
 
-    await act(async () => {
+    act(() => {
       vi.advanceTimersByTime(5000)
     })
 
-    expect(fetch).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
 
-    await act(async () => {
+    act(() => {
       resolveFirst(
         new Response(JSON.stringify(ALL_SERVICES_HEALTHY), { status: 200 })
       )
@@ -133,7 +133,7 @@ describe('useNetworkProbe', () => {
 
     const callsAfterOnline = fetchMock.mock.calls.length
 
-    await act(async () => {
+    act(() => {
       vi.advanceTimersByTime(20000)
     })
     await flushFetch()
@@ -142,7 +142,7 @@ describe('useNetworkProbe', () => {
     unmount()
   })
 
-  it('aborts the in-flight fetch and clears the interval on unmount', async () => {
+  it('aborts the in-flight fetch and clears the interval on unmount', () => {
     const abortSpy = vi.fn()
     const controller = { abort: abortSpy, signal: new AbortController().signal }
     const OriginalAbortController = global.AbortController

--- a/packages/client/src/v2-events/routes/config.test.ts
+++ b/packages/client/src/v2-events/routes/config.test.ts
@@ -16,16 +16,6 @@ import { useNetworkProbe } from './config'
 const fetchMock = createFetchMock(vi)
 fetchMock.enableMocks()
 
-const ALL_SERVICES_HEALTHY = {
-  auth: true,
-  search: true,
-  'user-mgnt': true,
-  metrics: true,
-  notification: true,
-  countryconfig: true,
-  workflow: true
-}
-
 // fetch-mock resolves as microtasks; act() flushes them without advancing fake timers
 async function flushFetch() {
   // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -43,8 +33,8 @@ afterEach(() => {
 })
 
 describe('useNetworkProbe', () => {
-  it('sets offline immediately on mount, then online when all services are healthy', async () => {
-    fetchMock.mockResponseOnce(JSON.stringify(ALL_SERVICES_HEALTHY))
+  it('sets offline immediately on mount, then online when ping succeeds', async () => {
+    fetchMock.mockResponseOnce('', { status: 200 })
 
     const { unmount } = renderHook(() => useNetworkProbe())
 
@@ -56,10 +46,8 @@ describe('useNetworkProbe', () => {
     unmount()
   })
 
-  it('remains offline when a service is not ready', async () => {
-    fetchMock.mockResponseOnce(
-      JSON.stringify({ ...ALL_SERVICES_HEALTHY, metrics: false })
-    )
+  it('remains offline when ping returns a non-ok status', async () => {
+    fetchMock.mockResponseOnce('', { status: 503 })
 
     const { unmount } = renderHook(() => useNetworkProbe())
 
@@ -82,7 +70,7 @@ describe('useNetworkProbe', () => {
 
   it('retries the probe every 5 seconds while offline', async () => {
     fetchMock.mockRejectOnce(new Error('Network error'))
-    fetchMock.mockResponseOnce(JSON.stringify(ALL_SERVICES_HEALTHY))
+    fetchMock.mockResponseOnce('', { status: 200 })
 
     const { unmount } = renderHook(() => useNetworkProbe())
 
@@ -104,7 +92,7 @@ describe('useNetworkProbe', () => {
       resolveFirst = resolve
     })
     fetchMock.mockImplementationOnce(async () => slowFetch)
-    fetchMock.mockResponseOnce(JSON.stringify(ALL_SERVICES_HEALTHY))
+    fetchMock.mockResponseOnce('', { status: 200 })
 
     const { unmount } = renderHook(() => useNetworkProbe())
 
@@ -115,16 +103,14 @@ describe('useNetworkProbe', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
 
     act(() => {
-      resolveFirst(
-        new Response(JSON.stringify(ALL_SERVICES_HEALTHY), { status: 200 })
-      )
+      resolveFirst(new Response('', { status: 200 }))
     })
     await flushFetch()
     unmount()
   })
 
   it('clears the retry interval once online', async () => {
-    fetchMock.mockResponse(JSON.stringify(ALL_SERVICES_HEALTHY))
+    fetchMock.mockResponse('', { status: 200 })
 
     const { unmount } = renderHook(() => useNetworkProbe())
 
@@ -150,7 +136,7 @@ describe('useNetworkProbe', () => {
       () => controller
     ) as unknown as typeof AbortController
 
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    // eslint-disable-next-line @typescript-eslint/no-empty-function, @typescript-eslint/promise-function-async
     fetchMock.mockImplementationOnce(() => new Promise<Response>(() => {}))
 
     const { unmount } = renderHook(() => useNetworkProbe())

--- a/packages/client/src/v2-events/routes/config.tsx
+++ b/packages/client/src/v2-events/routes/config.tsx
@@ -90,30 +90,38 @@ export const routesConfig = {
   Component: () => {
     useEffect(() => {
       let cancelled = false
+      let intervalId: ReturnType<typeof setInterval> | null = null
+      let probeInProgress = false
+      let currentController: AbortController | null = null
 
       onlineManager.setOnline(false)
 
+      const services = [
+        'auth',
+        'search',
+        'user-mgnt',
+        'metrics',
+        'notification',
+        'countryconfig',
+        'workflow'
+      ]
+
       async function probeNetwork() {
+        if (probeInProgress) {
+          return
+        }
+        probeInProgress = true
         try {
-          const controller = new AbortController()
-          setTimeout(() => controller.abort(), 3000)
+          currentController = new AbortController()
+          setTimeout(() => currentController?.abort(), 3000)
 
           const res = await fetch('/api/ping', {
             method: 'GET',
             cache: 'no-store',
-            signal: controller.signal
+            signal: currentController.signal
           })
 
           const status = await res.json()
-          const services = [
-            'auth',
-            'search',
-            'user-mgnt',
-            'metrics',
-            'notification',
-            'countryconfig',
-            'workflow'
-          ]
 
           const allServicesReady =
             res.ok &&
@@ -123,18 +131,35 @@ export const routesConfig = {
 
           if (!cancelled) {
             onlineManager.setOnline(allServicesReady)
+            if (allServicesReady && intervalId !== null) {
+              clearInterval(intervalId)
+              intervalId = null
+            }
           }
         } catch {
           if (!cancelled) {
             onlineManager.setOnline(false)
           }
+        } finally {
+          probeInProgress = false
+          currentController = null
         }
       }
 
       void probeNetwork()
 
+      intervalId = setInterval(() => {
+        if (!onlineManager.isOnline()) {
+          void probeNetwork()
+        }
+      }, 5000)
+
       return () => {
         cancelled = true
+        currentController?.abort()
+        if (intervalId !== null) {
+          clearInterval(intervalId)
+        }
       }
     }, [])
 

--- a/packages/client/src/v2-events/routes/config.tsx
+++ b/packages/client/src/v2-events/routes/config.tsx
@@ -85,83 +85,95 @@ function PrefetchQueries() {
  * Each route is defined as a child of the `ROUTES.V2` route.
  */
 
+const PING_SERVICES = [
+  'auth',
+  'search',
+  'user-mgnt',
+  'metrics',
+  'notification',
+  'countryconfig',
+  'workflow'
+] as const
+
+export function useNetworkProbe() {
+  useEffect(() => {
+    let cancelled = false
+    let intervalId: ReturnType<typeof setInterval> | null = null
+    let probeInProgress = false
+    let currentController: AbortController | null = null
+    let abortTimeoutId: ReturnType<typeof setTimeout> | null = null
+
+    onlineManager.setOnline(false)
+
+    async function probeNetwork() {
+      if (probeInProgress) {
+        return
+      }
+      probeInProgress = true
+      try {
+        currentController = new AbortController()
+        abortTimeoutId = setTimeout(() => currentController?.abort(), 3000)
+
+        const res = await fetch('/api/ping', {
+          method: 'GET',
+          cache: 'no-store',
+          signal: currentController.signal
+        })
+
+        const status = await res.json()
+
+        const allServicesReady =
+          res.ok &&
+          PING_SERVICES.every((service) => {
+            return status[service] === true
+          })
+
+        if (!cancelled) {
+          onlineManager.setOnline(allServicesReady)
+          if (allServicesReady && intervalId !== null) {
+            clearInterval(intervalId)
+            intervalId = null
+          }
+        }
+      } catch {
+        if (!cancelled) {
+          onlineManager.setOnline(false)
+        }
+      } finally {
+        if (abortTimeoutId !== null) {
+          clearTimeout(abortTimeoutId)
+          abortTimeoutId = null
+        }
+        probeInProgress = false
+        currentController = null
+      }
+    }
+
+    void probeNetwork()
+
+    intervalId = setInterval(() => {
+      if (!onlineManager.isOnline()) {
+        void probeNetwork()
+      }
+    }, 5000)
+
+    return () => {
+      cancelled = true
+      currentController?.abort()
+      if (abortTimeoutId !== null) {
+        clearTimeout(abortTimeoutId)
+      }
+      if (intervalId !== null) {
+        clearInterval(intervalId)
+      }
+    }
+  }, [])
+}
+
 export const routesConfig = {
   path: ROUTES.V2.path,
   Component: () => {
-    useEffect(() => {
-      let cancelled = false
-      let intervalId: ReturnType<typeof setInterval> | null = null
-      let probeInProgress = false
-      let currentController: AbortController | null = null
-
-      onlineManager.setOnline(false)
-
-      const services = [
-        'auth',
-        'search',
-        'user-mgnt',
-        'metrics',
-        'notification',
-        'countryconfig',
-        'workflow'
-      ]
-
-      async function probeNetwork() {
-        if (probeInProgress) {
-          return
-        }
-        probeInProgress = true
-        try {
-          currentController = new AbortController()
-          setTimeout(() => currentController?.abort(), 3000)
-
-          const res = await fetch('/api/ping', {
-            method: 'GET',
-            cache: 'no-store',
-            signal: currentController.signal
-          })
-
-          const status = await res.json()
-
-          const allServicesReady =
-            res.ok &&
-            services.every((service) => {
-              return status[service] === true
-            })
-
-          if (!cancelled) {
-            onlineManager.setOnline(allServicesReady)
-            if (allServicesReady && intervalId !== null) {
-              clearInterval(intervalId)
-              intervalId = null
-            }
-          }
-        } catch {
-          if (!cancelled) {
-            onlineManager.setOnline(false)
-          }
-        } finally {
-          probeInProgress = false
-          currentController = null
-        }
-      }
-
-      void probeNetwork()
-
-      intervalId = setInterval(() => {
-        if (!onlineManager.isOnline()) {
-          void probeNetwork()
-        }
-      }, 5000)
-
-      return () => {
-        cancelled = true
-        currentController?.abort()
-        if (intervalId !== null) {
-          clearInterval(intervalId)
-        }
-      }
-    }, [])
+    useNetworkProbe()
 
     const currentUser = useSelector(getUserDetails)
 

--- a/packages/client/src/v2-events/routes/config.tsx
+++ b/packages/client/src/v2-events/routes/config.tsx
@@ -85,16 +85,6 @@ function PrefetchQueries() {
  * Each route is defined as a child of the `ROUTES.V2` route.
  */
 
-const PING_SERVICES = [
-  'auth',
-  'search',
-  'user-mgnt',
-  'metrics',
-  'notification',
-  'countryconfig',
-  'workflow'
-] as const
-
 export function useNetworkProbe() {
   useEffect(() => {
     let cancelled = false
@@ -120,17 +110,9 @@ export function useNetworkProbe() {
           signal: currentController.signal
         })
 
-        const status = await res.json()
-
-        const allServicesReady =
-          res.ok &&
-          PING_SERVICES.every((service) => {
-            return status[service] === true
-          })
-
         if (!cancelled) {
-          onlineManager.setOnline(allServicesReady)
-          if (allServicesReady && intervalId !== null) {
+          onlineManager.setOnline(res.ok)
+          if (res.ok && intervalId !== null) {
             clearInterval(intervalId)
             intervalId = null
           }

--- a/packages/components/src/SideNavigation/ConnectionStatus.tsx
+++ b/packages/components/src/SideNavigation/ConnectionStatus.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 
 interface ConnectionStatusProps {
   isOnline?: boolean
+  className?: string
 }
 
 const Dot = styled.span<{ isOnline: boolean }>`
@@ -23,14 +24,14 @@ const Label = styled.span`
 const Container = styled.div`
   display: flex;
   align-items: center;
-  padding: 8px 0;
 `
 
 export const ConnectionStatus: React.FC<ConnectionStatusProps> = ({
-  isOnline = false
+  isOnline = false,
+  className
 }) => {
   return (
-    <Container>
+    <Container className={className}>
       <Dot isOnline={isOnline} />
       <Label>{isOnline ? 'Online' : 'Offline'}</Label>
     </Container>

--- a/packages/components/src/SideNavigation/ConnectionStatus.tsx
+++ b/packages/components/src/SideNavigation/ConnectionStatus.tsx
@@ -17,17 +17,16 @@ interface ConnectionStatusProps {
 }
 
 const Dot = styled.span<{ isOnline: boolean }>`
-  width: 10px;
-  height: 10px;
+  width: 8px;
+  height: 8px;
   border-radius: 50%;
   background-color: ${({ isOnline, theme }) =>
     isOnline ? theme.colors.green : theme.colors.red};
-  display: inline-block;
-  margin-right: 8px;
+  margin-right: 4px;
 `
 
 const Label = styled.span`
-  ${({ theme }) => theme.fonts.reg14};
+  ${({ theme }) => theme.fonts.reg12};
   color: ${({ theme }) => theme.colors.grey500};
 `
 

--- a/packages/components/src/SideNavigation/ConnectionStatus.tsx
+++ b/packages/components/src/SideNavigation/ConnectionStatus.tsx
@@ -1,3 +1,13 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
 import React from 'react'
 import styled from 'styled-components'
 

--- a/packages/components/src/SideNavigation/ConnectionStatus.tsx
+++ b/packages/components/src/SideNavigation/ConnectionStatus.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import styled from 'styled-components'
+
+interface ConnectionStatusProps {
+  isOnline?: boolean
+}
+
+const Dot = styled.span<{ isOnline: boolean }>`
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background-color: ${({ isOnline, theme }) =>
+    isOnline ? theme.colors.green : theme.colors.red};
+  display: inline-block;
+  margin-right: 8px;
+`
+
+const Label = styled.span`
+  ${({ theme }) => theme.fonts.reg14};
+  color: ${({ theme }) => theme.colors.grey500};
+`
+
+const Container = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 8px 0;
+`
+
+export const ConnectionStatus: React.FC<ConnectionStatusProps> = ({
+  isOnline = false
+}) => {
+  return (
+    <Container>
+      <Dot isOnline={isOnline} />
+      <Label>{isOnline ? 'Online' : 'Offline'}</Label>
+    </Container>
+  )
+}

--- a/packages/components/src/SideNavigation/LeftNavigation.tsx
+++ b/packages/components/src/SideNavigation/LeftNavigation.tsx
@@ -80,7 +80,6 @@ const ApplicationName = styled.div`
 
 const VersionCard = styled.div`
   color: ${({ theme }) => theme.colors.grey400};
-  ${({ theme }) => theme.fonts.reg14};
   height: auto;
   padding: 16px;
   background-color: ${({ theme }) => theme.colors.grey50};
@@ -89,12 +88,8 @@ const VersionCard = styled.div`
 `
 
 const VersionText = styled.span`
-  ${({ theme }) => theme.fonts.bold14};
+  ${({ theme }) => theme.fonts.bold10};
   text-transform: uppercase;
-`
-
-const StyledConnectionStatus = styled(ConnectionStatus)`
-  margin-bottom: 8px;
 `
 
 const Container = styled.div`
@@ -127,7 +122,7 @@ export const LeftNavigation = (props: ILeftNavigationProps) => {
       <MenuItem>{props.children && props.children}</MenuItem>
       <Container>
         <VersionCard>
-          <StyledConnectionStatus isOnline={props.isOnline} />
+          <ConnectionStatus isOnline={props.isOnline} />
           {props.warning}
           <VersionText>OpenCRVS v{props.applicationVersion}</VersionText>
         </VersionCard>

--- a/packages/components/src/SideNavigation/LeftNavigation.tsx
+++ b/packages/components/src/SideNavigation/LeftNavigation.tsx
@@ -89,7 +89,7 @@ const VersionCard = styled.div`
 `
 
 const VersionText = styled.span`
-  font-weight: 600;
+  ${({ theme }) => theme.fonts.bold14};
   text-transform: uppercase;
 `
 

--- a/packages/components/src/SideNavigation/LeftNavigation.tsx
+++ b/packages/components/src/SideNavigation/LeftNavigation.tsx
@@ -93,6 +93,10 @@ const VersionText = styled.span`
   text-transform: uppercase;
 `
 
+const StyledConnectionStatus = styled(ConnectionStatus)`
+  margin-bottom: 8px;
+`
+
 const Container = styled.div`
   flex: 0 0 auto;
 `
@@ -123,7 +127,7 @@ export const LeftNavigation = (props: ILeftNavigationProps) => {
       <MenuItem>{props.children && props.children}</MenuItem>
       <Container>
         <VersionCard>
-          <ConnectionStatus isOnline={props.isOnline} />
+          <StyledConnectionStatus isOnline={props.isOnline} />
           {props.warning}
           <VersionText>OpenCRVS v{props.applicationVersion}</VersionText>
         </VersionCard>

--- a/packages/components/src/SideNavigation/LeftNavigation.tsx
+++ b/packages/components/src/SideNavigation/LeftNavigation.tsx
@@ -11,6 +11,7 @@
 
 import * as React from 'react'
 import styled from 'styled-components'
+import { ConnectionStatus } from './ConnectionStatus'
 
 export interface ILeftNavigationProps {
   applicationName: string
@@ -22,6 +23,7 @@ export interface ILeftNavigationProps {
   warning?: JSX.Element | null
   className?: string
   applicationVersion: string
+  isOnline?: boolean
 }
 
 const LeftNavigationContainer = styled.div<{
@@ -76,11 +78,19 @@ const ApplicationName = styled.div`
   text-overflow: ellipsis;
 `
 
-const Version = styled.div`
+const VersionCard = styled.div`
   color: ${({ theme }) => theme.colors.grey400};
   ${({ theme }) => theme.fonts.reg14};
   height: auto;
   padding: 16px;
+  background-color: ${({ theme }) => theme.colors.grey50};
+  margin: 16px;
+  border-radius: 8px;
+`
+
+const VersionText = styled.span`
+  font-weight: 600;
+  text-transform: uppercase;
 `
 
 const Container = styled.div`
@@ -112,10 +122,11 @@ export const LeftNavigation = (props: ILeftNavigationProps) => {
       </Container>
       <MenuItem>{props.children && props.children}</MenuItem>
       <Container>
-        <Version>
+        <VersionCard>
+          <ConnectionStatus isOnline={props.isOnline} />
           {props.warning}
-          <span>OpenCRVS v{props.applicationVersion}</span>
-        </Version>
+          <VersionText>OpenCRVS v{props.applicationVersion}</VersionText>
+        </VersionCard>
       </Container>
     </LeftNavigationContainer>
   )

--- a/packages/components/src/fonts.ts
+++ b/packages/components/src/fonts.ts
@@ -118,6 +118,14 @@ const bold12 = `
   margin: 0;
 `
 
+const bold10 = `
+  font-family: ${family};
+  font-weight: 600;
+  font-size: 10px;
+  line-height: 140%;
+  margin: 0;
+`
+
 export const fonts = {
   hero,
   h1,
@@ -128,6 +136,7 @@ export const fonts = {
   bold16,
   bold14,
   bold12,
+  bold10,
   reg19,
   reg18,
   reg16,

--- a/packages/gateway/src/constants.ts
+++ b/packages/gateway/src/constants.ts
@@ -45,6 +45,7 @@ export const NOTIFICATION_URL = env.NOTIFICATION_URL
 export const WORKFLOW_URL = env.WORKFLOW_URL
 export const COUNTRY_CONFIG_URL = env.COUNTRY_CONFIG_URL
 export const DOCUMENTS_URL = env.DOCUMENTS_URL
+export const EVENTS_URL = env.EVENTS_URL
 export const DISABLE_RATE_LIMIT = env.DISABLE_RATE_LIMIT
 export const SENTRY_DSN = env.SENTRY_DSN
 export const PRODUCTION = env.isProd

--- a/packages/gateway/src/features/healthCheck/handler.ts
+++ b/packages/gateway/src/features/healthCheck/handler.ts
@@ -13,7 +13,7 @@ import { EVENTS_URL } from '@gateway/constants'
 import fetch from '@gateway/fetch'
 
 export default async function healthCheckHandler(
-  request: Hapi.Request,
+  _request: Hapi.Request,
   h: Hapi.ResponseToolkit
 ) {
   try {

--- a/packages/gateway/src/features/healthCheck/handler.ts
+++ b/packages/gateway/src/features/healthCheck/handler.ts
@@ -9,83 +9,20 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 import * as Hapi from '@hapi/hapi'
-import * as Joi from 'joi'
-import {
-  AUTH_URL,
-  SEARCH_URL,
-  USER_MANAGEMENT_URL,
-  METRICS_URL,
-  NOTIFICATION_URL,
-  COUNTRY_CONFIG_URL,
-  WORKFLOW_URL
-} from '@gateway/constants'
+import { EVENTS_URL } from '@gateway/constants'
 import fetch from '@gateway/fetch'
-
-export async function checkServiceHealth(url: string) {
-  const res = await fetch(url, {
-    method: 'GET'
-  })
-
-  const body = await res.json()
-
-  if (body.success === true) {
-    return true
-  }
-
-  return false
-}
-
-enum Services {
-  AUTH = 'auth',
-  USER_MGNT = 'user-mgnt',
-  METRICS = 'metrics',
-  NOTIFICATION = 'notification',
-  COUNTRY_CONFIG = 'countryconfig',
-  SEARCH = 'search',
-  WORKFLOW = 'workflow',
-  GATEWAY = 'gateway'
-}
-
-const SERVICES = {
-  [Services.AUTH]: `${AUTH_URL}/ping`,
-  [Services.SEARCH]: `${SEARCH_URL}ping`,
-  [Services.USER_MGNT]: `${USER_MANAGEMENT_URL}ping`,
-  [Services.METRICS]: `${METRICS_URL}/ping`,
-  [Services.NOTIFICATION]: `${NOTIFICATION_URL}ping`,
-  [Services.COUNTRY_CONFIG]: `${COUNTRY_CONFIG_URL}/ping`,
-  [Services.WORKFLOW]: `${WORKFLOW_URL}ping`
-}
 
 export default async function healthCheckHandler(
   request: Hapi.Request,
   h: Hapi.ResponseToolkit
 ) {
-  const responses = {} as Record<keyof typeof SERVICES, boolean>
-
-  for (const [key, value] of Object.entries(SERVICES)) {
-    try {
-      const res = await checkServiceHealth(value)
-      responses[key as keyof typeof SERVICES] = res
-    } catch (err) {
-      responses[key as keyof typeof SERVICES] = false
+  try {
+    const res = await fetch(`${EVENTS_URL}health/ready`, { method: 'GET' })
+    if (!res.ok) {
+      return h.response({ success: false }).code(503)
     }
+    return { success: true }
+  } catch {
+    return h.response({ success: false }).code(503)
   }
-  return responses
 }
-
-export const querySchema = Joi.object({
-  service: Joi.array()
-    .items(
-      Joi.string().valid(
-        Services.AUTH,
-        Services.USER_MGNT,
-        Services.METRICS,
-        Services.NOTIFICATION,
-        Services.COUNTRY_CONFIG,
-        Services.SEARCH,
-        Services.WORKFLOW,
-        Services.GATEWAY
-      )
-    )
-    .single()
-})

--- a/packages/gateway/src/index.test.ts
+++ b/packages/gateway/src/index.test.ts
@@ -144,19 +144,23 @@ describe('Route authorization', () => {
 
     expect(res.statusCode).toBe(401)
   })
-  it('Tests the health check for all the service', async () => {
+  it('returns success: false when events service is unhealthy', async () => {
+    fetch.mockResponseOnce('', { status: 503 })
     const res = await server.app.inject({
       method: 'GET',
       url: '/ping'
     })
-    expect(res.result).toEqual({
-      auth: false,
-      search: false,
-      'user-mgnt': false,
-      metrics: false,
-      notification: false,
-      countryconfig: false,
-      workflow: false
+    expect(res.statusCode).toBe(503)
+    expect(res.result).toEqual({ success: false })
+  })
+
+  it('returns success: true when events service is healthy', async () => {
+    fetch.mockResponseOnce('', { status: 200 })
+    const res = await server.app.inject({
+      method: 'GET',
+      url: '/ping'
     })
+    expect(res.statusCode).toBe(200)
+    expect(res.result).toEqual({ success: true })
   })
 })


### PR DESCRIPTION
 ---
  Why                                                                                                                                                                                   
                                                                                                                                                                                        
  The previous implementation performed a one-shot check against individual service /ping endpoints (auth, search, user-mgnt, metrics, notification, countryconfig, workflow) when the  
  v2 routes loaded. If any service was still starting up at that moment, the client would incorrectly remain offline with no retry mechanism.                                           
                                                                                                                                                                                        
  This PR replaces the one-shot probe with a polling loop that retries every 5 seconds until the gateway confirms all services are ready, and surfaces the connection state visually in 
  the sidebar.                                                                                                                                                                          
                                                                                                                                                                                        
  What changed                                                                                                                                                                          
                                                                                                                                                                                        
  - packages/client/src/v2-events/routes/config.tsx — Extracted a useNetworkProbe hook. Instead of a single fetch, it now polls /api/ping on a 5-second interval while offline, prevents
   concurrent probes, and stops polling once the gateway responds with ok.                                                                                                              
  - packages/gateway/src/features/healthCheck/handler.ts — Simplified the /api/ping handler to proxy a single request to the events service health/ready endpoint, removing the         
  per-service health checks and Joi query schema (72 lines removed).                                                                                                                    
  - packages/components/src/SideNavigation/ConnectionStatus.tsx — New component: a coloured dot (green = online, red = offline) with an "Online" / "Offline" label.                     
  - packages/components/src/SideNavigation/LeftNavigation.tsx — Integrates ConnectionStatus into the sidebar version card; adds isOnline prop.                                          
  - packages/client/src/v2-events/layouts/sidebar/Sidebar.tsx — Uses React.useSyncExternalStore with TanStack Query's onlineManager to subscribe to real-time connectivity changes and  
  pass isOnline down to LeftNavigation.                                                                                                                                                 
  - packages/client/src/v2-events/components/LoadingIndicator.tsx — Removes the inline "No connection" message from workqueues since connection status is now shown persistently in the 
  sidebar.                                                                                                                                                                              
                                                                                                                                                                                      
  How to test                                                                                                                                                                           
                                                                                                                                                                                      
  1. Start OpenCRVS with the backend services still booting.
  2. Open the app — the sidebar should show a red dot / "Offline" status.
  3. Wait for services to become ready — within ≤5 seconds the sidebar should switch to a green dot / "Online" status without a page reload.
  4. Stop a backend service while logged in — the sidebar should revert to "Offline".                                                                                                   
  5. Confirm the old "No connection" message no longer appears at the bottom of workqueue lists.
