### PR TITLE
fix: provide form values when validating review fields

### DIFF
--- a/.github/workflows/deploy-to-feature-environment.yml
+++ b/.github/workflows/deploy-to-feature-environment.yml
@@ -70,6 +70,7 @@ jobs:
       author: ${{ steps.get_author.outputs.AUTHOR }}
       slugified_branch: ${{ steps.slugify_bname.outputs.stack }}
       e2e_branch: ${{ steps.get_e2e_branch.outputs.branch }}
+      chart_branch: ${{ steps.get_chart_branch.outputs.branch }}
     steps:
       - uses: actions/checkout@v5
 
@@ -141,6 +142,20 @@ jobs:
           fi
           echo "e2e branch name=${e2e_branch}"
           echo "branch=$e2e_branch" >> $GITHUB_OUTPUT
+      - name: Get chart branch
+        id: get_chart_branch
+        # ls-remote should provide list of branches. When none are found, it should be empty string.
+        run: |
+          chart_repo_url="https://github.com/opencrvs/opencrvs-helm-charts.git"
+          if [ -n "$(git ls-remote --heads "$chart_repo_url" "refs/heads/${{ github.head_ref }}")" ]; then
+            branch=${{ github.head_ref }}
+          elif [ -n "$(git ls-remote --heads "$chart_repo_url" "refs/heads/${{ github.base_ref }}")" ]; then
+            branch="${{ github.base_ref }}"
+          else
+            branch="develop"
+          fi
+          echo "chart branch name=${branch}"
+          echo "branch=$branch" >> $GITHUB_OUTPUT
       - name: Get PR Author
         id: get_author
         env:
@@ -266,7 +281,7 @@ jobs:
                 stack: '${{  steps.generate_stack.outputs.stack  }}',
                 'keep-e2e': '${{ needs.generate_stack_name_and_branch.outputs.keep_e2e }}',
                 'branch': '${{ needs.generate_stack_name_and_branch.outputs.e2e_branch }}',
-                'runtime': '${{ needs.generate_stack_name_and_branch.outputs.runtime }}'
+                'chart-branch': '${{ needs.generate_stack_name_and_branch.outputs.chart_branch }}'
               }
             });
 

--- a/packages/client/src/v2-events/components/forms/validation.ts
+++ b/packages/client/src/v2-events/components/forms/validation.ts
@@ -114,7 +114,11 @@ export function validationErrorsInActionFormExist({
     })
 
   const hasAnnotationValidationErrors = Object.values(
-    getValidationErrorsForForm(reviewFields, visibleAnnotationFields, context)
+    getValidationErrorsForForm(
+      reviewFields,
+      { ...formWithoutHiddenFields, ...visibleAnnotationFields },
+      context
+    )
   ).some((fieldErrors) => flattenFormState(fieldErrors ?? []).length > 0)
 
   return hasValidationErrors || hasAnnotationValidationErrors

--- a/packages/events/src/router/event/event.actions.declare.test.ts
+++ b/packages/events/src/router/event/event.actions.declare.test.ts
@@ -24,7 +24,10 @@ import {
   TENNIS_CLUB_MEMBERSHIP,
   ActionUpdate,
   EventState,
-  EventDocument
+  EventDocument,
+  ConditionalType,
+  field as conditionalField,
+  not
 } from '@opencrvs/commons'
 import {
   tennisClubMembershipEvent,
@@ -180,6 +183,72 @@ describe('Declare action', () => {
     if (savedAction?.status === ActionStatus.Requested) {
       expect(savedAction.declaration).toEqual(form)
     }
+  })
+
+  test('Skips required review field validation when review field is conditionally hidden', async () => {
+    // Build a modified event where review.signature is required but only shown when applicant.dobUnknown is truthy
+    const modifiedEvent = {
+      ...tennisClubMembershipEvent,
+      actions: tennisClubMembershipEvent.actions.map((action) => {
+        if (action.type !== ActionType.DECLARE) {
+          return action
+        }
+        return {
+          ...action,
+          review: {
+            ...action.review,
+            fields: action.review.fields.map((f) =>
+              f.id !== 'review.signature'
+                ? f
+                : {
+                    ...f,
+                    required: true,
+                    conditionals: [
+                      {
+                        type: ConditionalType.SHOW,
+                        conditional: not(
+                          conditionalField('applicant.dobUnknown').isFalsy()
+                        )
+                      }
+                    ]
+                  }
+            )
+          }
+        }
+      })
+    }
+
+    mswServer.use(
+      http.get(`${env.COUNTRY_CONFIG_URL}/events`, () => {
+        return HttpResponse.json([modifiedEvent])
+      })
+    )
+
+    const client = createTestClient(user)
+    const event = await client.event.create(generator.event.create())
+
+    // applicant.dobUnknown is false → SHOW conditional not met → review.signature is hidden
+    const declaration = {
+      'applicant.dob': '2024-02-01',
+      'applicant.dobUnknown': false,
+      'applicant.name': { firstname: 'John', surname: 'Doe' },
+      'recommender.none': true,
+      'applicant.address': {
+        country: 'FAR',
+        addressType: AddressType.DOMESTIC,
+        administrativeArea: '27160bbd-32d1-4625-812f-860226bfb92a',
+        streetLevelDetails: { state: 'state', district2: 'district2' }
+      }
+    } satisfies ActionUpdate
+
+    const data = generator.event.actions.declare(event.id, {
+      declaration,
+      annotation: {} // no signature provided – required check must be skipped for hidden field
+    })
+
+    await expect(
+      client.event.actions.declare.request(data)
+    ).resolves.not.toThrow()
   })
 
   test('gives validation error when a conditional page, which is visible, has a required field', async () => {

--- a/packages/events/src/router/middleware/validate/index.ts
+++ b/packages/events/src/router/middleware/validate/index.ts
@@ -212,7 +212,7 @@ function validateDeclarationUpdateAction({
 
   const annotationErrors = getFieldErrors(
     reviewFields,
-    visibleAnnotationFields,
+    { ...cleanedDeclaration, ...visibleAnnotationFields },
     context,
     {}
   )


### PR DESCRIPTION
## Description

When validating the review page fields, provide the full form values to use in the validations.

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [x] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
