### PR TITLE
Use `EncodedScope` brand type everywhere

### DIFF
--- a/packages/auth/src/features/authenticate/handler.ts
+++ b/packages/auth/src/features/authenticate/handler.ts
@@ -24,7 +24,13 @@ import { forbidden, unauthorized } from '@hapi/boom'
 import * as Hapi from '@hapi/hapi'
 import * as Joi from 'joi'
 import { env } from '@auth/environment'
-import { fetchJSON, joinUrl, logger, Roles } from '@opencrvs/commons'
+import {
+  EncodedScope,
+  fetchJSON,
+  joinUrl,
+  logger,
+  Roles
+} from '@opencrvs/commons'
 
 interface IAuthPayload {
   username: string
@@ -48,7 +54,7 @@ async function getUserRoleScopeMapping() {
     'Country config implements the new /roles response format. Custom scopes apply'
   )
 
-  return roles.reduce<Record<string, string[]>>((acc, { id, scopes }) => {
+  return roles.reduce<Record<string, EncodedScope[]>>((acc, { id, scopes }) => {
     acc[id] = scopes
     return acc
   }, {})

--- a/packages/auth/src/features/authenticate/service.ts
+++ b/packages/auth/src/features/authenticate/service.ts
@@ -27,7 +27,11 @@ import {
 import { logger, UUID, IUserName } from '@opencrvs/commons'
 import { UserAuditLog } from '@opencrvs/commons/events'
 import * as F from 'fp-ts'
-import { encodeScope, TokenUserType } from '@opencrvs/commons/authentication'
+import {
+  EncodedScope,
+  encodeScope,
+  TokenUserType
+} from '@opencrvs/commons/authentication'
 const { chainW, tryCatch } = F.either
 const { pipe } = F.function
 import { env } from '@auth/environment'
@@ -64,7 +68,7 @@ export interface IAuthentication {
 export interface ISystemAuthentication {
   systemId: string
   status: string
-  scope: string[]
+  scope: EncodedScope[]
 }
 
 export class UserInfoNotFoundError extends Error {}
@@ -118,7 +122,7 @@ export async function authenticateSystem(
 
 export async function createToken(
   userId: string,
-  scope: string[],
+  scope: EncodedScope[],
   audience: string[],
   issuer: string,
   role?: string | number | undefined,

--- a/packages/auth/src/features/authenticate/service.ts
+++ b/packages/auth/src/features/authenticate/service.ts
@@ -256,7 +256,9 @@ const tokenPayload = t.type({
   userType: t.string
 })
 
-export type ITokenPayload = t.TypeOf<typeof tokenPayload>
+export type ITokenPayload = t.TypeOf<typeof tokenPayload> & {
+  scope: EncodedScope[]
+}
 
 function safeVerifyJwt(token: string) {
   return tryCatch(

--- a/packages/auth/src/features/oauthToken/client-credentials.ts
+++ b/packages/auth/src/features/oauthToken/client-credentials.ts
@@ -50,7 +50,7 @@ export async function clientCredentialsHandler(
   const v2Scopes = result.scope.map((s) => {
     // Intentionally verbose for clarity.
     if (s === 'record.notify') {
-      return 'type=record.notify'
+      return encodeScope({ type: 'record.notify' })
     }
 
     if (s === 'record.search') {
@@ -69,7 +69,7 @@ export async function clientCredentialsHandler(
       return encodeScope({ type: 'record.import' })
     }
 
-    return
+    return s
   })
 
   const token = await createToken(

--- a/packages/auth/src/features/oauthToken/client-credentials.ts
+++ b/packages/auth/src/features/oauthToken/client-credentials.ts
@@ -20,7 +20,12 @@ import {
   NOTIFICATION_API_USER_AUDIENCE
 } from '@auth/constants'
 import * as oauthResponse from './responses'
-import { TokenUserType, hasScope, encodeScope } from '@opencrvs/commons'
+import {
+  TokenUserType,
+  hasScope,
+  encodeScope,
+  EncodedScope
+} from '@opencrvs/commons'
 import { getParam } from './utils'
 
 export async function clientCredentialsHandler(
@@ -73,7 +78,7 @@ export async function clientCredentialsHandler(
       return encodeScope({ type: 'record.import' })
     }
 
-    return s
+    return s as EncodedScope
   })
 
   const isNotificationAPIUser = hasScope(v2Scopes, 'notification-api')

--- a/packages/auth/src/features/oauthToken/token-exchange.ts
+++ b/packages/auth/src/features/oauthToken/token-exchange.ts
@@ -15,7 +15,7 @@ import {
   verifyToken
 } from '@auth/features/authenticate/service'
 import { pipe } from 'fp-ts/lib/function'
-import { decodeScope, UUID } from '@opencrvs/commons'
+import { decodeScope, EncodedScope, UUID } from '@opencrvs/commons'
 import { getParam } from './utils'
 
 export const SUBJECT_TOKEN_TYPE =
@@ -57,13 +57,15 @@ export async function tokenExchangeHandler(
 
   const { sub, userType } = decodedOrError.right
 
-  const rejectScopeOfUserAssignedRole = decodedOrError.right.scope.find((s) => {
-    const v2Scope = decodeScope(s)
+  const rejectScopeOfUserAssignedRole = decodedOrError.right.scope.find(
+    (s: EncodedScope) => {
+      const v2Scope = decodeScope(s)
 
-    const isV2RejectScope = v2Scope?.type === 'record.reject'
+      const isV2RejectScope = v2Scope?.type === 'record.reject'
 
-    return s.startsWith('record.declared.reject') || isV2RejectScope
-  })
+      return s.startsWith('record.declared.reject') || isV2RejectScope
+    }
+  )
 
   // @TODO: If in the future we have a fine grained access control for records, check here that the subject actually has access to the record requested
   const recordToken = await createTokenForActionConfirmation(

--- a/packages/auth/src/features/refresh/handler.ts
+++ b/packages/auth/src/features/refresh/handler.ts
@@ -11,7 +11,7 @@
 import * as Hapi from '@hapi/hapi'
 import * as Joi from 'joi'
 import { unauthorized } from '@hapi/boom'
-import { verifyToken } from '@auth/features/authenticate/service'
+import { verifyToken, ITokenPayload } from '@auth/features/authenticate/service'
 import { refreshToken } from '@auth/features/refresh/service'
 
 interface IRefreshPayload {
@@ -29,7 +29,7 @@ export default async function refreshHandler(request: Hapi.Request) {
 
   const decoded = decodedOrError.right
 
-  const newToken = await refreshToken(decoded)
+  const newToken = await refreshToken(decoded as ITokenPayload)
   return { token: newToken }
 }
 

--- a/packages/auth/src/features/refresh/service.ts
+++ b/packages/auth/src/features/refresh/service.ts
@@ -11,7 +11,7 @@
 import { createToken, ITokenPayload } from '@auth/features/authenticate/service'
 import { WEB_USER_JWT_AUDIENCES, JWT_ISSUER } from '@auth/constants'
 
-export async function refreshToken(payload: ITokenPayload): Promise<string> {
+export async function refreshToken(payload: ITokenPayload) {
   return createToken(
     payload.sub,
     payload.scope,

--- a/packages/auth/src/features/verifyCode/service.ts
+++ b/packages/auth/src/features/verifyCode/service.ts
@@ -90,7 +90,7 @@ export async function sendVerificationCode(
     authHeader: {
       Authorization: `Bearer ${await createToken(
         'auth',
-        ['service'],
+        [],
         ['opencrvs:notification-user', 'opencrvs:countryconfig-user'],
         JWT_ISSUER,
         undefined,

--- a/packages/client/src/hooks/useAuthorization.ts
+++ b/packages/client/src/hooks/useAuthorization.ts
@@ -19,11 +19,9 @@ import {
   ScopeType,
   getAcceptedScopesByType,
   getScopeOptionValue,
-  JurisdictionFilter,
-  EncodedScope
+  JurisdictionFilter
 } from '@opencrvs/commons/client'
 import { isLocationUnderJurisdiction } from '@client/utils/locationUtils'
-import { IStoreState } from '@client/store'
 import { useLocations } from '@client/v2-events/hooks/useLocations'
 import { useAdministrativeAreas } from '../v2-events/hooks/useAdministrativeAreas'
 
@@ -37,11 +35,6 @@ export function usePermissions() {
   const locations = getLocations.useSuspenseQuery()
   const { getAdministrativeAreas } = useAdministrativeAreas()
   const administrativeAreas = getAdministrativeAreas.useSuspenseQuery()
-
-  const roles = useSelector((store: IStoreState) => store.userForm.userRoles)
-
-  const roleScopes = (role: string) =>
-    (roles.find(({ id }) => id === role)?.scopes as EncodedScope[]) ?? []
 
   const hasAnyScope = (neededScopes: ScopeType[]) =>
     hasAnyScopeFromCommons(userScopes, neededScopes)
@@ -123,10 +116,6 @@ export function usePermissions() {
     }
 
     if (accessLevels.includes(JurisdictionFilter.enum.administrativeArea)) {
-      if (hasScopeFromCommons(roleScopes(user.role), 'user.edit')) {
-        return false
-      }
-
       return isLocationUnderJurisdiction({
         locationId: userPrimaryOfficeId,
         otherLocationId: user.primaryOfficeId,

--- a/packages/client/src/hooks/useAuthorization.ts
+++ b/packages/client/src/hooks/useAuthorization.ts
@@ -19,7 +19,8 @@ import {
   ScopeType,
   getAcceptedScopesByType,
   getScopeOptionValue,
-  JurisdictionFilter
+  JurisdictionFilter,
+  EncodedScope
 } from '@opencrvs/commons/client'
 import { isLocationUnderJurisdiction } from '@client/utils/locationUtils'
 import { IStoreState } from '@client/store'
@@ -40,7 +41,7 @@ export function usePermissions() {
   const roles = useSelector((store: IStoreState) => store.userForm.userRoles)
 
   const roleScopes = (role: string) =>
-    roles.find(({ id }) => id === role)?.scopes ?? []
+    (roles.find(({ id }) => id === role)?.scopes as EncodedScope[]) ?? []
 
   const hasAnyScope = (neededScopes: ScopeType[]) =>
     hasAnyScopeFromCommons(userScopes, neededScopes)

--- a/packages/client/src/profile/profileSelectors.ts
+++ b/packages/client/src/profile/profileSelectors.ts
@@ -10,6 +10,7 @@
  */
 import { ProfileState } from '@client/profile/profileReducer'
 import { IStoreState } from '@client/store'
+import { EncodedScope } from '@opencrvs/commons/client'
 
 const getPartialState = (store: IStoreState): ProfileState => store.profile
 
@@ -24,7 +25,7 @@ export const getAuthenticated = (
 const getTokenPayload = (store: IStoreState): ProfileState['tokenPayload'] =>
   getKey(store, 'tokenPayload')
 
-export const getScope = (store: IStoreState): string[] | null => {
+export const getScope = (store: IStoreState): EncodedScope[] | null => {
   const tokenPayload = getTokenPayload(store)
   return tokenPayload && tokenPayload.scope
 }
@@ -32,4 +33,3 @@ export const getScope = (store: IStoreState): string[] | null => {
 export const getUserDetails = (
   store: IStoreState
 ): ProfileState['userDetails'] => getKey(store, 'userDetails')
-

--- a/packages/client/src/user/userReducer.ts
+++ b/packages/client/src/user/userReducer.ts
@@ -17,7 +17,6 @@ import {
 import * as offlineActions from '@client/offline/actions'
 import * as profileActions from '@client/profile/profileActions'
 import { IUserAuditForm, userAuditForm } from '@client/user/user-audit'
-import { UserRole } from '@client/utils/gateway'
 import { trpcClient } from '@client/v2-events/trpc'
 import { User } from '@opencrvs/commons/client'
 
@@ -41,7 +40,6 @@ export enum TOAST_MESSAGES {
 const initialState: IUserFormState = {
   userDetailsStored: false,
   submitting: false,
-  userRoles: [],
   submissionError: false,
   userAuditForm
 }
@@ -131,7 +129,6 @@ export interface IUserFormState {
   userDetailsStored: boolean
   submitting: boolean
   submissionError: boolean
-  userRoles: UserRole[]
   userAuditForm: IUserAuditForm
 }
 

--- a/packages/client/src/v2-events/utils.ts
+++ b/packages/client/src/v2-events/utils.ts
@@ -35,7 +35,8 @@ import {
   EventMetadataDateFieldId,
   getAcceptedScopesByType,
   decodeScope,
-  RecordScopeTypeV2
+  RecordScopeTypeV2,
+  EncodedScope
 } from '@opencrvs/commons/client'
 
 export function getUsersFullName(name: UserOrSystem['name'], language: string) {
@@ -276,7 +277,7 @@ export enum CoreWorkqueues {
   DRAFT = 'draft'
 }
 
-export function hasOutboxWorkqueue(scopes: string[]) {
+export function hasOutboxWorkqueue(scopes: EncodedScope[]) {
   const hasRecordScope = scopes.some((s) => {
     const scope = decodeScope(s)
     return (
@@ -288,7 +289,7 @@ export function hasOutboxWorkqueue(scopes: string[]) {
   return hasRecordScope
 }
 
-export function hasDraftWorkqueue(scopes: string[]) {
+export function hasDraftWorkqueue(scopes: EncodedScope[]) {
   return (
     getAcceptedScopesByType({
       acceptedScopes: ['record.create'],

--- a/packages/client/src/views/SysAdmin/Team/user/userEditor/UserEditor.tsx
+++ b/packages/client/src/views/SysAdmin/Team/user/userEditor/UserEditor.tsx
@@ -29,7 +29,8 @@ import {
   TokenUserType,
   EventConfigToDeclarationFormType,
   UserInput,
-  hasScope
+  hasScope,
+  EncodedScope
 } from '@opencrvs/commons/client'
 import { AppBar, Frame, Spinner } from '@opencrvs/components'
 import { Button } from '@opencrvs/components/lib/Button'
@@ -73,7 +74,7 @@ const SpinnerWrapper = styled.div`
   padding: 20px;
 `
 
-function getUserEditConfig(selectedRole?: { scopes: string[] }) {
+function getUserEditConfig(selectedRole?: { scopes: EncodedScope[] }) {
   return {
     id: '__user__',
     summary: {

--- a/packages/commons/src/authentication.ts
+++ b/packages/commons/src/authentication.ts
@@ -11,7 +11,7 @@
 import decode from 'jwt-decode'
 import { Nominal } from './nominal'
 import * as z from 'zod/v4'
-import { ScopeType, decodeScope, Scope } from './scopes'
+import { ScopeType, decodeScope, Scope, EncodedScope } from './scopes'
 import { UUID } from './uuid'
 export * from './scopes'
 
@@ -53,7 +53,7 @@ export interface ITokenPayload {
   sub: string
   exp: string
   algorithm: string
-  scope: string[]
+  scope: EncodedScope[]
   role?: string
   userType: TokenUserType
   eventId?: UUID
@@ -69,7 +69,7 @@ export function setBearerForToken(token: string) {
   return token.startsWith(bearer) ? token : `${bearer} ${token}`
 }
 
-export function getScopes(token: string): string[] {
+export function getScopes(token: string): EncodedScope[] {
   const authHeader = { Authorization: setBearerForToken(token) }
   const tokenPayload = getTokenPayload(authHeader.Authorization.split(' ')[1])
 

--- a/packages/commons/src/conditionals/conditionals.test.ts
+++ b/packages/commons/src/conditionals/conditionals.test.ts
@@ -28,7 +28,7 @@ import { ActionType } from '../events/ActionType'
 import { ActionStatus, EventState } from '../events/ActionDocument'
 import { field } from '../events/field'
 import { event } from '../events/event'
-import { TokenUserType } from '../authentication'
+import { EncodedScope, TokenUserType } from '../authentication'
 import { UUID } from '../uuid'
 import { EventStatus, InherentFlags } from '../client'
 
@@ -1010,7 +1010,7 @@ describe('"field" conditionals', () => {
 describe('"user" conditionals', () => {
   const userParams = {
     $user: {
-      scope: ['record.register', 'record.registration-correct'],
+      scope: ['type=test-scope-1', 'type=test-scope-2'] as EncodedScope[],
       role: 'LOCAL_REGISTRAR',
       exp: '1739881718',
       algorithm: 'RS256',
@@ -1027,8 +1027,8 @@ describe('"user" conditionals', () => {
   }
 
   it('validates "user.hasScope" conditional', () => {
-    expect(validate(user.hasScope('bypassratelimit'), userParams)).toBe(false)
-    expect(validate(user.hasScope('record.register'), userParams)).toBe(true)
+    expect(validate(user.hasScope('type=test-scope-0'), userParams)).toBe(false)
+    expect(validate(user.hasScope('type=test-scope-1'), userParams)).toBe(true)
   })
 
   it('validates "user.isOnline" conditional', () => {

--- a/packages/commons/src/events/scopes.test.ts
+++ b/packages/commons/src/events/scopes.test.ts
@@ -63,76 +63,6 @@ describe('isActionInScope()', () => {
     })
   })
 
-  describe('actions with empty scope map (never allowed)', () => {
-    it('should return false for DUPLICATE_DETECTED even with scopes', () => {
-      expect(
-        isActionInScope({
-          scopes: ['record.read[event=birth]'],
-          action: ActionType.DUPLICATE_DETECTED,
-          event: makeEvent('birth'),
-          currentUser: testUser
-        })
-      ).toBe(false)
-    })
-
-    it('should return false for CUSTOM even with scopes', () => {
-      expect(
-        isActionInScope({
-          scopes: ['record.read[event=birth]'],
-          action: ActionType.CUSTOM,
-          event: makeEvent('birth'),
-          currentUser: testUser
-        })
-      ).toBe(false)
-    })
-  })
-
-  describe('non-encoded scopes', () => {
-    it('should prevent READ when legacy scope includes the event type', () => {
-      expect(
-        isActionInScope({
-          scopes: ['record.read[event=birth]'],
-          action: ActionType.READ,
-          event: makeEvent('birth'),
-          currentUser: testUser
-        })
-      ).toBe(false)
-    })
-
-    it('should deny READ when legacy scope does not include the event type', () => {
-      expect(
-        isActionInScope({
-          scopes: ['record.read[event=birth]'],
-          action: ActionType.READ,
-          event: makeEvent('death'),
-          currentUser: testUser
-        })
-      ).toBe(false)
-    })
-
-    it('should deny DECLARE when user has legacy record.declare scope for the event', () => {
-      expect(
-        isActionInScope({
-          scopes: ['record.declare[event=birth|death]'],
-          action: ActionType.DECLARE,
-          event: makeEvent('birth'),
-          currentUser: testUser
-        })
-      ).toBe(false)
-    })
-
-    it('should deny DECLARE when user has legacy record.register scope for the event', () => {
-      expect(
-        isActionInScope({
-          scopes: ['record.register[event=birth]'],
-          action: ActionType.DECLARE,
-          event: makeEvent('birth'),
-          currentUser: testUser
-        })
-      ).toBe(false)
-    })
-  })
-
   describe('encoded scopes', () => {
     it('should allow READ when V2 scope includes the event type', () => {
       const encodedScope = encodeScope({
@@ -223,59 +153,6 @@ describe('isActionInScope()', () => {
         isActionInScope({
           scopes: [encodedScope],
           action: ActionType.REGISTER,
-          event: makeEvent('tennis-club-membership'),
-          currentUser: testUser
-        })
-      ).toBe(false)
-    })
-  })
-
-  describe('encoded and non-encoded scope interaction (OR logic)', () => {
-    it('should allow when V1 denies but V2 allows', () => {
-      const nonEncodedScope = 'record.read[event=birth]'
-      const encodedScope = encodeScope({
-        type: 'record.read',
-        options: { event: ['death'] }
-      })
-
-      expect(
-        isActionInScope({
-          scopes: [encodedScope, nonEncodedScope],
-          action: ActionType.READ,
-          event: makeEvent('death'),
-          currentUser: testUser
-        })
-      ).toBe(true)
-    })
-
-    it('should deny when V1 allows but V2 denies', () => {
-      const nonEncodedScope = 'record.read[event=birth]'
-      const encodedScope = encodeScope({
-        type: 'record.read',
-        options: { event: ['death'] }
-      })
-
-      expect(
-        isActionInScope({
-          scopes: [nonEncodedScope, encodedScope],
-          action: ActionType.READ,
-          event: makeEvent('birth'),
-          currentUser: testUser
-        })
-      ).toBe(false)
-    })
-
-    it('should deny when both V1 and V2 deny', () => {
-      const nonEncodedScope = 'record.read[event=birth]'
-      const encodedScope = encodeScope({
-        type: 'record.read',
-        options: { event: ['death'] }
-      })
-
-      expect(
-        isActionInScope({
-          scopes: [nonEncodedScope, encodedScope],
-          action: ActionType.READ,
           event: makeEvent('tennis-club-membership'),
           currentUser: testUser
         })

--- a/packages/commons/src/events/scopes.ts
+++ b/packages/commons/src/events/scopes.ts
@@ -16,6 +16,7 @@ import {
   DisplayableAction
 } from './ActionType'
 import {
+  EncodedScope,
   getAcceptedScopesByType,
   RecordScopeTypeV2,
   RecordScopeV2
@@ -90,7 +91,7 @@ export function getAssignmentStatus(
  * (hardcoded, non-configurable) and V2 scopes, which validate event type, jurisdiction,
  * and user context via {@link userCanAccessEventWithScopes}.
  *
- * @param {string[]} scopes - The raw encoded scope strings the user possesses (from JWT).
+ * @param {EncodedScope[]} scopes - The raw encoded scope strings the user possesses (from JWT).
  * @param {DisplayableAction} action - The action to check authorization for.
  * @param {EventIndexWithAdministrativeHierarchy} event - The event with resolved administrative hierarchy.
  * @param {UserContext} currentUser - The current user's context used for V2 scope validation.
@@ -102,7 +103,7 @@ export function isActionInScope({
   event,
   currentUser
 }: {
-  scopes: string[]
+  scopes: EncodedScope[]
   action: DisplayableAction
   event: EventIndexWithAdministrativeHierarchy
   currentUser: UserContext

--- a/packages/commons/src/roles.ts
+++ b/packages/commons/src/roles.ts
@@ -9,10 +9,11 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 import { z } from 'zod'
+import { EncodedScope } from './scopes'
 
 export const Role = z.object({
   id: z.string(),
-  scopes: z.array(z.string())
+  scopes: z.array(EncodedScope)
 })
 
 export type Role = z.infer<typeof Role>
@@ -21,5 +22,5 @@ export type Roles = Array<{
   id: string
   /** @deprecated */
   labels: Array<{ language: string; label: string }>
-  scopes: string[]
+  scopes: EncodedScope[]
 }>

--- a/packages/commons/src/scopes.test.ts
+++ b/packages/commons/src/scopes.test.ts
@@ -11,6 +11,7 @@
 
 import {
   decodeScope,
+  EncodedScope,
   encodeScope,
   getScopeOptionValue,
   JurisdictionFilter,
@@ -284,7 +285,8 @@ describe('2.0 scopes', () => {
 
   it('Should decode scope with single event & template', () => {
     const scope =
-      'type=record.print-certified-copies&event=tennis-club-membership&templates=v2.tennis-club-membership-certificate-alpha'
+      'type=record.print-certified-copies&event=tennis-club-membership&templates=v2.tennis-club-membership-certificate-alpha' as EncodedScope
+
     const decodedScope = decodeScope(scope)
     expect(decodedScope).toEqual({
       type: 'record.print-certified-copies',

--- a/packages/commons/src/scopes.ts
+++ b/packages/commons/src/scopes.ts
@@ -336,7 +336,6 @@ export type EncodedScope = z.infer<typeof EncodedScope>
 export const encodeScope = (scope: Scope): EncodedScope => {
   const flattened = flattenScope(scope)
 
-  // Cast to the branded type
   return qs.stringify(flattened, {
     arrayFormat: 'comma',
     allowDots: true,
@@ -354,7 +353,7 @@ export const encodeScope = (scope: Scope): EncodedScope => {
  * @returns The encoded scope as a branded string (`EncodedScope`).
  */
 
-export const decodeScope = (query: string) => {
+export const decodeScope = (query: EncodedScope) => {
   const scope = qs.parse(query, {
     ignoreQueryPrefix: true,
     comma: true,
@@ -400,7 +399,7 @@ export function getAcceptedScopesByType({
   scopes
 }: {
   acceptedScopes: ScopeType[]
-  scopes: string[]
+  scopes: EncodedScope[]
 }): Scope[] {
   return scopes
     .map((scope) => {
@@ -434,11 +433,14 @@ export function hasAnyScope(token: string, scopes: ScopeType[]): boolean
 /**
  * Checks if the provided array of scopes contains any of the accepted scopes.
  *
- * @param {string[]} userScopes - Array of scopes to check.
+ * @param {EncodedScope[]} userScopes - Array of scopes to check.
  * @param {ScopeType[]} scopes - An array of scope types to check for.
  * @returns {boolean} True if the scope list contains at least one of the accepted scopes.
  */
-export function hasAnyScope(userScopes: string[], scopes: ScopeType[]): boolean
+export function hasAnyScope(
+  userScopes: EncodedScope[],
+  scopes: ScopeType[]
+): boolean
 /**
  * Implementation handling both overloads.
  *
@@ -447,7 +449,7 @@ export function hasAnyScope(userScopes: string[], scopes: ScopeType[]): boolean
  * @returns True if any of the scopes is present.
  */
 export function hasAnyScope(
-  tokenOrScopes: string | string[],
+  tokenOrScopes: string | EncodedScope[],
   scopes: ScopeType[]
 ): boolean {
   const userScopes = Array.isArray(tokenOrScopes)
@@ -486,7 +488,7 @@ export function hasScope(token: string, scope: ScopeType): boolean
  * @param scope - The scope type to check for.
  * @returns True if the scope list contains the specified scope.
  */
-export function hasScope(scopes: string[], scope: ScopeType): boolean
+export function hasScope(scopes: EncodedScope[], scope: ScopeType): boolean
 /**
  * Implementation handling both overloads.
  *
@@ -495,7 +497,7 @@ export function hasScope(scopes: string[], scope: ScopeType): boolean
  * @returns True if the scope is present.
  */
 export function hasScope(
-  tokenOrScopes: string | string[],
+  tokenOrScopes: string | EncodedScope[],
   scope: ScopeType
 ): boolean {
   if (Array.isArray(tokenOrScopes)) {
@@ -517,7 +519,10 @@ export function hasScope(
  * @param {string} eventType - The event type to check for permission.
  * @returns {boolean} Returns true if the event type is allowed by the scope.
  */
-export function canUserCreateEvent(userScopes: string[], eventType: string) {
+export function canUserCreateEvent(
+  userScopes: EncodedScope[],
+  eventType: string
+) {
   const scopes = getAcceptedScopesByType({
     acceptedScopes: ['record.create'],
     scopes: userScopes
@@ -534,4 +539,14 @@ export function canUserCreateEvent(userScopes: string[], eventType: string) {
 
     return scope.options?.event?.includes(eventType)
   })
+}
+
+/**
+ * Helper for defining scopes for user roles. Should be used in country config.
+ * @param scopes Array of scopes in object format.
+ *
+ * @returns Array of scopes in string format, encoded for use in JWT tokens.
+ */
+export function defineScopes(scopes: RecordScopeV2[]) {
+  return scopes.map((scope) => RecordScopeV2.parse(scope)).map(encodeScope)
 }

--- a/packages/commons/src/scopes.ts
+++ b/packages/commons/src/scopes.ts
@@ -543,10 +543,10 @@ export function canUserCreateEvent(
 
 /**
  * Helper for defining scopes for user roles. Should be used in country config.
- * @param scopes Array of scopes in object format.
  *
+ * @param scopes Array of scopes in object format.
  * @returns Array of scopes in string format, encoded for use in JWT tokens.
  */
-export function defineScopes(scopes: RecordScopeV2[]) {
-  return scopes.map((scope) => RecordScopeV2.parse(scope)).map(encodeScope)
+export function defineScopes(scopes: Scope[]) {
+  return scopes.map((scope) => Scope.parse(scope)).map(encodeScope)
 }

--- a/packages/data-seeder/src/users.ts
+++ b/packages/data-seeder/src/users.ts
@@ -17,7 +17,8 @@ import {
   EventConfig,
   hasScope,
   joinUrl,
-  parseConfigurableScope
+  parseConfigurableScope,
+  EncodedScope
 } from '@opencrvs/commons'
 import { fromZodError } from 'zod-validation-error'
 import { createClient } from '@opencrvs/toolkit/api'
@@ -32,7 +33,7 @@ const RoleSchema = (eventIds: string[]) =>
         id: z.string()
       }),
       scopes: z.array(
-        z.string().superRefine((scope, ctx) => {
+        EncodedScope.superRefine((scope, ctx) => {
           const parsedConfigurableScope = parseConfigurableScope(scope)
           const parsedV2Scopes = decodeScope(scope)
 

--- a/packages/events/src/router/integrations/index.ts
+++ b/packages/events/src/router/integrations/index.ts
@@ -12,7 +12,7 @@
 import { randomUUID } from 'crypto'
 import * as z from 'zod/v4'
 import { TRPCError } from '@trpc/server'
-import { UUID } from '@opencrvs/commons'
+import { EncodedScope, UUID } from '@opencrvs/commons'
 import {
   publicProcedure,
   router,
@@ -66,7 +66,7 @@ const AuthenticateSystemInput = z.object({
 const AuthenticateSystemOutput = z.object({
   id: UUID,
   status: z.string(),
-  scope: z.array(z.string())
+  scope: z.array(EncodedScope)
 })
 
 const IntegrationIdInput = z.object({

--- a/packages/user-mgnt/src/features/updateUser/handler.ts
+++ b/packages/user-mgnt/src/features/updateUser/handler.ts
@@ -16,7 +16,8 @@ import {
   personNameFromV1ToV2,
   findScope,
   getScopes,
-  hasScope
+  hasScope,
+  EncodedScope
 } from '@opencrvs/commons'
 import { recordUserAuditEvent } from '@user-mgnt/utils/userAudit'
 import {
@@ -58,7 +59,12 @@ export default async function updateUser(
   existingUser.role = user.role
 
   if (existingUser.primaryOfficeId !== user.primaryOfficeId) {
-    if (hasScope(request.auth.credentials?.scope ?? [], 'config.update-all')) {
+    if (
+      hasScope(
+        (request.auth.credentials?.scope as EncodedScope[]) ?? [],
+        'config.update-all'
+      )
+    ) {
       existingUser.primaryOfficeId = user.primaryOfficeId
     } else {
       throw new Error('Location can not be changed by this user')


### PR DESCRIPTION
## Description

* Refactor scopes from string -> EncodedScope
* Add `defineScopes()` back in

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
