### PR TITLE
fix: disable country field base on permission

### DIFF
--- a/packages/client/src/v2-events/features/events/registered-fields/Address.stories.tsx
+++ b/packages/client/src/v2-events/features/events/registered-fields/Address.stories.tsx
@@ -19,7 +19,9 @@ import {
   AddressField,
   AddressType,
   getDeclaration,
-  UUID
+  UUID,
+  TestUserRole,
+  user
 } from '@opencrvs/commons/client'
 import { FormFieldGenerator } from '@client/v2-events/components/forms/FormFieldGenerator'
 import { Review } from '@client/v2-events/features/events/components/Review'
@@ -214,6 +216,33 @@ export const AddressFieldWithUserPrimaryOfficeAddress: FormStory = {
               type: FieldType.TEXT
             }
           ]
+        }
+      }
+    ]
+  }
+}
+
+export const AddressFieldWithLockedCountry: FormStory = {
+  name: 'Country field disabled for jurisdiction-restricted user',
+  parameters: {
+    userRole: TestUserRole.enum.COMMUNITY_LEADER
+  },
+  args: {
+    eventConfig: tennisClubMembershipEvent,
+    formValues: {
+      'storybook.address': {
+        country: 'FAR',
+        addressType: AddressType.DOMESTIC,
+        administrativeArea: ''
+      }
+    },
+    fields: [
+      {
+        ...addressField,
+        configuration: {
+          allowedLocations: user.jurisdiction(
+            user.scope('record.create').attribute('placeOfEvent')
+          )
         }
       }
     ]

--- a/packages/client/src/v2-events/features/events/registered-fields/Address.tsx
+++ b/packages/client/src/v2-events/features/events/registered-fields/Address.tsx
@@ -34,12 +34,15 @@ import {
   FormState,
   FieldConfig,
   EventConfig,
-  UUID
+  UUID,
+  JurisdictionFilter,
+  resolveJurisdictionReference
 } from '@opencrvs/commons/client'
 import { FormFieldGenerator } from '@client/v2-events/components/forms/FormFieldGenerator'
 import { Output } from '@client/v2-events/features/events/components/Output'
 import { getFormDataStringifier } from '@client/v2-events/hooks/useFormDataStringifier'
 import { getOfflineData } from '@client/offline/selectors'
+import { getToken } from '@client/utils/authUtils'
 import { useAdministrativeAreas } from '@client/v2-events/hooks/useAdministrativeAreas'
 import { AdminStructureItem } from '@client/utils/referenceApi'
 import { getAdminLevelHierarchy } from '@client/v2-events/utils'
@@ -551,11 +554,21 @@ function AddressInput(props: Props) {
     touched = {},
     ...otherProps
   } = props
+  const token = useSelector(getToken)
   const { config } = useSelector(getOfflineData)
   const { getAdministrativeAreas } = useAdministrativeAreas()
   const administrativeAreas = getAdministrativeAreas.useSuspenseQuery()
   const appConfigAdminLevels = config.ADMIN_STRUCTURE
   const adminLevelIds = appConfigAdminLevels.map((level) => level.id)
+
+  const jurisdictionFilter = resolveJurisdictionReference(
+    addressConfig.configuration?.allowedLocations,
+    token,
+    eventConfig?.id
+  )
+  const isCountryLocked =
+    jurisdictionFilter !== undefined &&
+    jurisdictionFilter !== JurisdictionFilter.enum.all
 
   const { countryField, domesticFields, streetAddressFields } =
     generateAddressFields(addressConfig, appConfigAdminLevels, disabled)
@@ -573,7 +586,11 @@ function AddressInput(props: Props) {
     streetAddressFieldIds
   )
 
-  const fields = [countryField, ...domesticFields, ...streetAddressFields]
+  const fields = [
+    isCountryLocked ? withDisabledConditional(countryField) : countryField,
+    ...domesticFields,
+    ...streetAddressFields
+  ]
 
   return (
     <FormFieldGenerator


### PR DESCRIPTION
## Description

Province/district/village users with a `placeOfEvent` jurisdiction scope could still change the Country dropdown inside an Address field, allowing out-of-country submissions.

**Root cause:** The admin-area dropdowns in an Address field already filter options via `allowedLocations` (using `resolveJurisdictionReference`) and auto-disable when restricted to a single choice. The Country picker had no equivalent — it ignored `allowedLocations` entirely and was always rendered enabled.

**Fix:** In `AddressInput`, `allowedLocations` is now resolved via `resolveJurisdictionReference`. When the result is non-`all`, `withDisabledConditional` is applied to the country field, locking it to the default country. A Storybook story is added to snapshot this state.

Note: this is client-side enforcement only. Backend validation for `allowedLocations` on `ADDRESS` fields is tracked in #11961.

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly