### PR TITLE
fix: 'Assigned office' is blank on the 'Confirm your details' page while new user onboarding.

### DIFF
--- a/packages/client/src/v2-events/hooks/useLocations.ts
+++ b/packages/client/src/v2-events/hooks/useLocations.ts
@@ -28,6 +28,25 @@ setQueryDefaults(trpcOptionsProxy.locations.list, {
   staleTime: 1000 * 60 * 60 * 24 // keep it in cache 1 day
 })
 
+setQueryDefaults(trpcOptionsProxy.locations.get, {
+  queryFn: async (...params) => {
+    const {
+      queryKey: [, input]
+    } = params[0]
+
+    const queryOptions = trpcOptionsProxy.locations.get.queryOptions(
+      input.input
+    )
+
+    if (typeof queryOptions.queryFn !== 'function') {
+      throw new Error('queryFn is not a function')
+    }
+
+    return await queryOptions.queryFn(...params)
+  },
+  staleTime: 1000 * 60 * 60 * 24
+})
+
 export function useLocations() {
   const trpc = useTRPC()
   return {
@@ -65,7 +84,8 @@ export function useLocations() {
     },
     getLocation: {
       useQuery: (id: string) => {
-        const { queryFn, ...options } = trpc.locations.get.queryOptions({ id })
+        const { queryFn, ...options } =
+          trpcOptionsProxy.locations.get.queryOptions({ id })
         return useQuery({
           ...options,
           queryKey: trpc.locations.get.queryKey({ id })

--- a/packages/client/src/views/UserSetup/SetupReviewPage.stories.tsx
+++ b/packages/client/src/views/UserSetup/SetupReviewPage.stories.tsx
@@ -1,0 +1,56 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+
+import type { Meta, StoryObj } from '@storybook/react'
+import { fn } from '@storybook/test'
+import { createTRPCMsw, httpLink } from '@vafanassieff/msw-trpc'
+import superjson from 'superjson'
+import { AppRouter } from '@client/v2-events/trpc'
+import { V2_DEFAULT_MOCK_LOCATIONS } from '@client/tests/v2-events/administrative-hierarchy-mock'
+import { UserSetupReview } from './SetupReviewPage'
+
+const tRPCMsw = createTRPCMsw<AppRouter>({
+  links: [httpLink({ url: '/api/events' })],
+  transformer: { input: superjson, output: superjson }
+})
+
+const meta: Meta<typeof UserSetupReview> = {
+  title: 'UserSetup/SetupReviewPage',
+  component: UserSetupReview,
+  parameters: {
+    msw: {
+      handlers: {
+        locationGet: [
+          tRPCMsw.locations.get.query((input) => {
+            return (
+              V2_DEFAULT_MOCK_LOCATIONS.find((l) => l.id === input.id) ??
+              V2_DEFAULT_MOCK_LOCATIONS[0]
+            )
+          })
+        ],
+        userActivate: [tRPCMsw.user.activate.mutation(() => {})]
+      }
+    }
+  },
+  args: {
+    setupData: {
+      userId: 'test-user-id',
+      password: 'test-password',
+      securityQuestionAnswers: [{ questionKey: 'BIRTH_TOWN', answer: 'Lusaka' }]
+    },
+    goToStep: fn()
+  }
+}
+
+export default meta
+type Story = StoryObj<typeof UserSetupReview>
+
+export const Default: Story = {}


### PR DESCRIPTION
## Description

Before:
<img width="1881" height="879" alt="image" src="https://github.com/user-attachments/assets/a3df154c-7f8d-4eb9-a7b6-35d112a60ee0" />


After:
<img width="1249" height="956" alt="Screenshot from 2026-04-24 12-43-42" src="https://github.com/user-attachments/assets/94967c60-c0e6-4d06-a8c1-449367138d92" />


## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
