### PR TITLE
fix: show all locations in user form

### DIFF
--- a/packages/client/src/v2-events/components/forms/FormFieldGenerator/GeneratedInputField.tsx
+++ b/packages/client/src/v2-events/components/forms/FormFieldGenerator/GeneratedInputField.tsx
@@ -743,7 +743,7 @@ export const GeneratedInputField = <T extends FieldConfig>(
           {...field.config}
           disabled={disabled}
           eventType={eventConfig?.id}
-          locationTypes={field.config.configuration.locationTypes}
+          locationTypes={field.config.configuration?.locationTypes}
           value={field.value}
           onBlur={handleBlur}
           onChange={(val) => onFieldValueChange(name, val)}
@@ -1010,20 +1010,14 @@ export const GeneratedInputField = <T extends FieldConfig>(
 
   if (isHiddenFieldType(field)) {
     return (
-      <Hidden.Input
-        {...inputProps}
-        value={field.value as string | undefined}
-      />
+      <Hidden.Input {...inputProps} value={field.value as string | undefined} />
     )
   }
 
   if (isUserRoleFieldType(field)) {
     return (
       <InputField {...inputFieldProps}>
-        <UserRole.Input
-          {...inputProps}
-          value={field.value}
-        />
+        <UserRole.Input {...inputProps} value={field.value} />
       </InputField>
     )
   }

--- a/packages/client/src/v2-events/features/events/registered-fields/LocationSearch.test.ts
+++ b/packages/client/src/v2-events/features/events/registered-fields/LocationSearch.test.ts
@@ -193,5 +193,23 @@ describe('filterLocationsByJurisdiction', () => {
 
       expect(result).toHaveLength(V2_DEFAULT_MOCK_LOCATIONS.length)
     })
+
+    it('returns both CRVS offices and health facilities when both types are specified', () => {
+      // Regression for: hospital offices not appearing in the registration office
+      // dropdown during user create/edit. The fix adds HEALTH_FACILITY alongside
+      // CRVS_OFFICE in getUserEditConfig so that hospital staff can be assigned
+      // to a hospital as their primary office.
+      const result = filterLocationsByJurisdiction({
+        locations,
+        administrativeAreas,
+        userLocationId: undefined,
+        locationTypes: ['CRVS_OFFICE', 'HEALTH_FACILITY'],
+        jurisdictionFilter: undefined
+      })
+
+      expect(result.some((l) => l.locationType === 'CRVS_OFFICE')).toBe(true)
+      expect(result.some((l) => l.locationType === 'HEALTH_FACILITY')).toBe(true)
+      expect(result).toHaveLength(V2_DEFAULT_MOCK_LOCATIONS.length)
+    })
   })
 })

--- a/packages/client/src/v2-events/features/events/registered-fields/LocationSearch.test.ts
+++ b/packages/client/src/v2-events/features/events/registered-fields/LocationSearch.test.ts
@@ -195,10 +195,9 @@ describe('filterLocationsByJurisdiction', () => {
     })
 
     it('returns both CRVS offices and health facilities when both types are specified', () => {
-      // Regression for: hospital offices not appearing in the registration office
-      // dropdown during user create/edit. The fix adds HEALTH_FACILITY alongside
-      // CRVS_OFFICE in getUserEditConfig so that hospital staff can be assigned
-      // to a hospital as their primary office.
+      // Verifies that the filter correctly handles multiple location types in one call.
+      // Related: the registration office dropdown in user create/edit was fixed by
+      // removing the locationTypes restriction entirely (so all location types are shown).
       const result = filterLocationsByJurisdiction({
         locations,
         administrativeAreas,

--- a/packages/client/src/views/SysAdmin/Team/user/userEditor/UserEditor.interaction.stories.tsx
+++ b/packages/client/src/views/SysAdmin/Team/user/userEditor/UserEditor.interaction.stories.tsx
@@ -1,0 +1,87 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+import type { Meta, StoryObj } from '@storybook/react'
+import { within, expect } from '@storybook/test'
+import { userEvent } from '@storybook/testing-library'
+import { createTRPCMsw, httpLink } from '@vafanassieff/msw-trpc'
+import superjson from 'superjson'
+import { TestUserRole } from '@opencrvs/commons/client'
+import { AppRouter } from '@client/v2-events/trpc'
+import { ROUTES, routesConfig } from '@client/v2-events/routes'
+import { EditUser, useUserFormState } from './UserEditor'
+
+const tRPCMsw = createTRPCMsw<AppRouter>({
+  links: [httpLink({ url: '/api/events' })],
+  transformer: { input: superjson, output: superjson }
+})
+
+const mockRoles = [
+  { id: TestUserRole.enum.REGISTRATION_AGENT, scopes: [] },
+  { id: TestUserRole.enum.LOCAL_REGISTRAR, scopes: [] }
+]
+
+const meta: Meta<typeof EditUser> = {
+  title: 'SysAdmin/UserEditor/Interaction',
+  parameters: {
+    userRole: TestUserRole.enum.NATIONAL_SYSTEM_ADMIN,
+    msw: {
+      handlers: {
+        userRoles: [tRPCMsw.user.roles.list.query(() => mockRoles)]
+      }
+    }
+  }
+}
+
+export default meta
+
+/**
+ * Regression test for: hospital offices not appearing as Registration Office options.
+ *
+ * The registration office field must include both CRVS_OFFICE and HEALTH_FACILITY
+ * locations so that hospital clerks can be assigned to a hospital as their office.
+ */
+export const RegistrationOfficeIncludesHospitals: StoryObj<typeof EditUser> = {
+  parameters: {
+    reactRouter: {
+      router: routesConfig,
+      initialPath: ROUTES.V2.SETTINGS.USER.EDIT.buildPath({
+        userId: '__NEW__',
+        pageId: 'user.office'
+      })
+    }
+  },
+  loaders: [
+    async () => {
+      window.config.ADDITIONAL_USER_FIELDS = []
+      useUserFormState.getState().clear()
+    }
+  ],
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+
+    await step(
+      'Registration office dropdown shows both CRVS offices and hospital facilities',
+      async () => {
+        const input = await canvas.findByRole('combobox')
+
+        await userEvent.type(input, 'Ibombo')
+
+        await expect(
+          canvas.findByText('Ibombo District Office')
+        ).resolves.toBeInTheDocument()
+
+        await expect(
+          canvas.findByText('Ibombo Rural Health Centre')
+        ).resolves.toBeInTheDocument()
+      }
+    )
+  }
+}

--- a/packages/client/src/views/SysAdmin/Team/user/userEditor/UserEditor.tsx
+++ b/packages/client/src/views/SysAdmin/Team/user/userEditor/UserEditor.tsx
@@ -103,9 +103,6 @@ function getUserEditConfig(
               id: 'primaryOfficeId',
               type: FieldType.LOCATION,
               required: true,
-              configuration: {
-                locationTypes: ['CRVS_OFFICE', 'HEALTH_FACILITY']
-              },
               label: messages.registrationOffice
             }
           ]

--- a/packages/client/src/views/SysAdmin/Team/user/userEditor/UserEditor.tsx
+++ b/packages/client/src/views/SysAdmin/Team/user/userEditor/UserEditor.tsx
@@ -104,7 +104,7 @@ function getUserEditConfig(
               type: FieldType.LOCATION,
               required: true,
               configuration: {
-                locationTypes: ['CRVS_OFFICE']
+                locationTypes: ['CRVS_OFFICE', 'HEALTH_FACILITY']
               },
               label: messages.registrationOffice
             }

--- a/packages/commons/src/events/FieldConfig.ts
+++ b/packages/commons/src/events/FieldConfig.ts
@@ -658,13 +658,15 @@ export type AdministrativeAreaField = z.infer<typeof AdministrativeAreaField>
 const LocationInput = BaseField.extend({
   type: z.literal(FieldType.LOCATION),
   defaultValue: z.union([NonEmptyTextValue, SerializedUserField]).optional(),
-  configuration: z.object({
-    locationTypes: z
-      .array(z.string())
-      .optional()
-      .describe('Types of the locations that are available for selection.'),
-    allowedLocations: AllowedLocations
-  })
+  configuration: z
+    .object({
+      locationTypes: z
+        .array(z.string())
+        .optional()
+        .describe('Types of the locations that are available for selection.'),
+      allowedLocations: AllowedLocations
+    })
+    .optional()
 }).describe('Input field for a location')
 
 export type LocationInput = z.infer<typeof LocationInput>
@@ -1180,10 +1182,7 @@ export type FieldConfigInput =
  *  type to be inferred causes typescript compiler to fail with "inferred type
  *  exeeds max length"
  */
-export const FieldConfig: z.ZodType<
-  FieldConfig,
-  FieldConfigInput
-> = z
+export const FieldConfig: z.ZodType<FieldConfig, FieldConfigInput> = z
   .discriminatedUnion('type', [
     FieldGroup,
     Address,


### PR DESCRIPTION
## Description

The registration office dropdown in user create/edit hardcoded locationTypes: ['CRVS_OFFICE'], silently excluding all other location types including hospitals. `CRVS_OFFICE` and `HEALTH_FACILITY` are now deprecated as hardcoded strings — location types are arbitrary and defined by country config.                                                                       
                              
Fix: Removed the `locationTypes` restriction from `primaryOfficeId` in `getUserEditConfig()` so all locations are available regardless of type. Also made configuration optional on `LocationInput` in the field schema, with a safe ?. access in `GeneratedInputField`.    

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
