### PR TITLE
Add migration for user id references in event actions table

### DIFF
--- a/packages/migration/src/migrations/migrate-legacy-data/1777535353629_migrate-user-id-references-on-events.sql
+++ b/packages/migration/src/migrations/migrate-legacy-data/1777535353629_migrate-user-id-references-on-events.sql
@@ -1,0 +1,20 @@
+-- Up Migration
+UPDATE event_actions
+SET created_by = users.id::text
+FROM users
+WHERE event_actions.created_by = users.legacy_id;
+
+ALTER TABLE event_actions
+ALTER COLUMN created_by TYPE uuid
+USING created_by::uuid;
+
+
+-- Down Migration
+ALTER TABLE event_actions
+ALTER COLUMN created_by TYPE text
+USING created_by::text;
+
+UPDATE event_actions
+SET created_by = users.legacy_id
+FROM users
+WHERE event_actions.created_by = users.id::text;


### PR DESCRIPTION
## Description

Decided to leave out changing `z.string()` to `UUID` in EventAction schema for now.

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [x] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
