### PR TITLE
Fix `event_actions` table user id reference migration

### DIFF
--- a/packages/migration/src/migrations/migrate-legacy-data/1777535353629_migrate-user-id-references-on-events.sql
+++ b/packages/migration/src/migrations/migrate-legacy-data/1777535353629_migrate-user-id-references-on-events.sql
@@ -9,8 +9,33 @@ SET created_by = system_clients.id::text
 FROM system_clients
 WHERE event_actions.created_by = system_clients.legacy_id;
 
+UPDATE event_actions
+SET created_by = users.id::text
+FROM event_actions accepted_declare_actions, users
+WHERE event_actions.created_by = ''
+  AND accepted_declare_actions.event_id = event_actions.event_id
+  AND accepted_declare_actions.action_type = 'DECLARE'
+  AND accepted_declare_actions.status = 'Accepted'
+  AND users.legacy_id = accepted_declare_actions.created_by;
+
+UPDATE event_actions
+SET created_by = system_clients.id::text
+FROM event_actions accepted_declare_actions, system_clients
+WHERE event_actions.created_by = ''
+  AND accepted_declare_actions.event_id = event_actions.event_id
+  AND accepted_declare_actions.action_type = 'DECLARE'
+  AND accepted_declare_actions.status = 'Accepted'
+  AND system_clients.legacy_id = accepted_declare_actions.created_by;
+
+ALTER TABLE event_actions
+ALTER COLUMN created_by TYPE uuid
+USING created_by::uuid;
 
 -- Down Migration
+ALTER TABLE event_actions
+ALTER COLUMN created_by TYPE text
+USING created_by::text;
+
 UPDATE event_actions
 SET created_by = users.legacy_id
 FROM users

--- a/packages/migration/src/migrations/migrate-legacy-data/1777535353629_migrate-user-id-references-on-events.sql
+++ b/packages/migration/src/migrations/migrate-legacy-data/1777535353629_migrate-user-id-references-on-events.sql
@@ -10,8 +10,11 @@ FROM system_clients
 WHERE event_actions.created_by = system_clients.legacy_id;
 
 ALTER TABLE event_actions
+ALTER COLUMN created_by DROP NOT NULL;
+
+ALTER TABLE event_actions
 ALTER COLUMN created_by TYPE uuid
-USING created_by::uuid;
+USING NULLIF(created_by, '')::uuid;
 
 
 -- Down Migration
@@ -28,3 +31,10 @@ UPDATE event_actions
 SET created_by = system_clients.legacy_id
 FROM system_clients
 WHERE event_actions.created_by = system_clients.id::text;
+
+UPDATE event_actions
+SET created_by = ''
+WHERE created_by IS NULL;
+
+ALTER TABLE event_actions
+ALTER COLUMN created_by SET NOT NULL;

--- a/packages/migration/src/migrations/migrate-legacy-data/1777535353629_migrate-user-id-references-on-events.sql
+++ b/packages/migration/src/migrations/migrate-legacy-data/1777535353629_migrate-user-id-references-on-events.sql
@@ -10,6 +10,16 @@ FROM system_clients
 WHERE event_actions.created_by = system_clients.legacy_id;
 
 UPDATE event_actions
+SET assigned_to = users.id::text
+FROM users
+WHERE event_actions.assigned_to = users.legacy_id;
+
+UPDATE event_actions
+SET assigned_to = system_clients.id::text
+FROM system_clients
+WHERE event_actions.assigned_to = system_clients.legacy_id;
+
+UPDATE event_actions
 SET created_by = users.id::text
 FROM event_actions accepted_declare_actions, users
 WHERE event_actions.created_by = ''
@@ -27,14 +37,40 @@ WHERE event_actions.created_by = ''
   AND accepted_declare_actions.status = 'Accepted'
   AND system_clients.legacy_id = accepted_declare_actions.created_by;
 
+UPDATE event_actions
+SET assigned_to = users.id::text
+FROM event_actions accepted_declare_actions, users
+WHERE event_actions.assigned_to = ''
+  AND accepted_declare_actions.event_id = event_actions.event_id
+  AND accepted_declare_actions.action_type = 'DECLARE'
+  AND accepted_declare_actions.status = 'Accepted'
+  AND users.legacy_id = accepted_declare_actions.assigned_to;
+
+UPDATE event_actions
+SET assigned_to = system_clients.id::text
+FROM event_actions accepted_declare_actions, system_clients
+WHERE event_actions.assigned_to = ''
+  AND accepted_declare_actions.event_id = event_actions.event_id
+  AND accepted_declare_actions.action_type = 'DECLARE'
+  AND accepted_declare_actions.status = 'Accepted'
+  AND system_clients.legacy_id = accepted_declare_actions.assigned_to;
+
 ALTER TABLE event_actions
 ALTER COLUMN created_by TYPE uuid
 USING created_by::uuid;
+
+ALTER TABLE event_actions
+ALTER COLUMN assigned_to TYPE uuid
+USING NULLIF(assigned_to, '')::uuid;
 
 -- Down Migration
 ALTER TABLE event_actions
 ALTER COLUMN created_by TYPE text
 USING created_by::text;
+
+ALTER TABLE event_actions
+ALTER COLUMN assigned_to TYPE text
+USING assigned_to::text;
 
 UPDATE event_actions
 SET created_by = users.legacy_id
@@ -45,3 +81,13 @@ UPDATE event_actions
 SET created_by = system_clients.legacy_id
 FROM system_clients
 WHERE event_actions.created_by = system_clients.id::text;
+
+UPDATE event_actions
+SET assigned_to = users.legacy_id
+FROM users
+WHERE event_actions.assigned_to = users.id::text;
+
+UPDATE event_actions
+SET assigned_to = system_clients.legacy_id
+FROM system_clients
+WHERE event_actions.assigned_to = system_clients.id::text;

--- a/packages/migration/src/migrations/migrate-legacy-data/1777535353629_migrate-user-id-references-on-events.sql
+++ b/packages/migration/src/migrations/migrate-legacy-data/1777535353629_migrate-user-id-references-on-events.sql
@@ -9,19 +9,8 @@ SET created_by = system_clients.id::text
 FROM system_clients
 WHERE event_actions.created_by = system_clients.legacy_id;
 
-ALTER TABLE event_actions
-ALTER COLUMN created_by DROP NOT NULL;
-
-ALTER TABLE event_actions
-ALTER COLUMN created_by TYPE uuid
-USING NULLIF(created_by, '')::uuid;
-
 
 -- Down Migration
-ALTER TABLE event_actions
-ALTER COLUMN created_by TYPE text
-USING created_by::text;
-
 UPDATE event_actions
 SET created_by = users.legacy_id
 FROM users
@@ -31,10 +20,3 @@ UPDATE event_actions
 SET created_by = system_clients.legacy_id
 FROM system_clients
 WHERE event_actions.created_by = system_clients.id::text;
-
-UPDATE event_actions
-SET created_by = ''
-WHERE created_by IS NULL;
-
-ALTER TABLE event_actions
-ALTER COLUMN created_by SET NOT NULL;

--- a/packages/migration/src/migrations/migrate-legacy-data/1777535353629_migrate-user-id-references-on-events.sql
+++ b/packages/migration/src/migrations/migrate-legacy-data/1777535353629_migrate-user-id-references-on-events.sql
@@ -37,24 +37,6 @@ WHERE event_actions.created_by = ''
   AND accepted_declare_actions.status = 'Accepted'
   AND system_clients.legacy_id = accepted_declare_actions.created_by;
 
-UPDATE event_actions
-SET assigned_to = users.id::text
-FROM event_actions accepted_declare_actions, users
-WHERE event_actions.assigned_to = ''
-  AND accepted_declare_actions.event_id = event_actions.event_id
-  AND accepted_declare_actions.action_type = 'DECLARE'
-  AND accepted_declare_actions.status = 'Accepted'
-  AND users.legacy_id = accepted_declare_actions.assigned_to;
-
-UPDATE event_actions
-SET assigned_to = system_clients.id::text
-FROM event_actions accepted_declare_actions, system_clients
-WHERE event_actions.assigned_to = ''
-  AND accepted_declare_actions.event_id = event_actions.event_id
-  AND accepted_declare_actions.action_type = 'DECLARE'
-  AND accepted_declare_actions.status = 'Accepted'
-  AND system_clients.legacy_id = accepted_declare_actions.assigned_to;
-
 ALTER TABLE event_actions
 ALTER COLUMN created_by TYPE uuid
 USING created_by::uuid;


### PR DESCRIPTION
## Description

* For actions which have empty string as created_by, lets use the DECLARE action created_by as user.
* Also migrate assigned_to column to new user id

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
