### PR TITLE
fix: exclude non admin area location from hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug fixes
 
+- Health facilities and other non-administrative locations are no longer included in the administrative area hierarchy when resolving location ancestry. [#12485](https://github.com/opencrvs/opencrvs-core/issues/12485)
 - The work queue list now automatically refreshes after a new event is created, without requiring a manual page reload. Previously the sidebar count updated immediately but the list itself stayed stale. [#12103](https://github.com/opencrvs/opencrvs-core/issues/12103)
 
 ### Improvements

--- a/packages/client/.storybook/default-request-handlers.ts
+++ b/packages/client/.storybook/default-request-handlers.ts
@@ -199,6 +199,13 @@ export const V2_DEFAULT_MOCK_LOCATIONS = [
     validUntil: null
   },
   {
+    id: 'b1c2d3e4-f5a6-7890-bcde-f12345678901' as UUID,
+    name: 'Central Health Post',
+    locationType: LocationType.enum.HEALTH_FACILITY,
+    parentId: 'a45b982a-5c7b-4bd9-8fd8-a42d0994054c' as UUID,
+    validUntil: null
+  },
+  {
     id: '028d2c85-ca31-426d-b5d1-2cef545a4902' as UUID,
     name: 'Ibombo District Office',
     locationType: LocationType.enum.CRVS_OFFICE,

--- a/packages/client/src/v2-events/features/events/registered-fields/LocationSearch.stories.tsx
+++ b/packages/client/src/v2-events/features/events/registered-fields/LocationSearch.stories.tsx
@@ -141,3 +141,15 @@ export const LocationSearchOutputResolvedPualula: StoryObj<
     value: '7ef2b9c7-5e6d-49f6-ae05-656207d0fc64' // Pualula
   }
 }
+
+// Central Health Post is a HEALTH_FACILITY directly under "Central" (province).
+// Output must be: Central Health Post, Central, Farajaland
+export const LocationSearchOutputResolvedCentralHealthPost: StoryObj<
+  typeof LocationSearch.Output
+> = {
+  name: 'LocationSearch output for facility under intermediate admin level',
+  render: (props) => <LocationSearch.Output {...props} />,
+  args: {
+    value: 'b1c2d3e4-f5a6-7890-bcde-f12345678901' // Central Health Post
+  }
+}

--- a/packages/client/src/v2-events/utils.ts
+++ b/packages/client/src/v2-events/utils.ts
@@ -320,8 +320,16 @@ export function getAdminLevelHierarchy(
   // Collect location objects from leaf to root
   const collectedLocations: Location[] = []
 
-  let current = locationId
+  const srcLocation = locationId
     ? locations.find((l) => l.id === locationId.toString())
+    : null
+
+  if (srcLocation?.locationType === 'ADMIN_STRUCTURE') {
+    collectedLocations.push(srcLocation)
+  }
+
+  let current = srcLocation
+    ? locations.find((l) => l.id === srcLocation.parentId)
     : null
 
   while (current) {


### PR DESCRIPTION
## Description

Exclude non admin area location when calculating hierarchy which ensures that a health facility/office's name does not appear twice if it's not under the lowest admin level.

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
