### PR TITLE
feat!: unassign by default when rejected from cc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking changes
 
 - Redundant `defaultValue` removed from BULLET_LIST, FORM_HEADER and PARAGRAPH field types.
+- `action.reject(...)` now by default unassigns the event from the last assigned user. To keep assignment, `keepAssignment: true` option must be explicitly passed when rejecting an action.
 
 ### New features
 
@@ -13,22 +14,20 @@
 
 ### Bug fixes
 
-<<<<<<< ocrvs-12350
 - Two mutually exclusive form pages can now share field IDs. Previously a field that appeared on a hidden page was always stripped from the event data, even if an identically-named field on a different visible page had a value. The system now only omits a field when it is hidden on every page it appears on. [#12350](https://github.com/opencrvs/opencrvs-core/issues/12350)
 - Navigating to the next form page now uses the values the user just entered, not the previous render's state. This prevented correct page routing when the next page's visibility depended on a field filled on the current page. [#12350](https://github.com/opencrvs/opencrvs-core/issues/12350)
 - Switching between form pages no longer briefly flashes stale values from the previous page. The Formik instance is now remounted on page change instead of being reset via a `useEffect`. [#12350](https://github.com/opencrvs/opencrvs-core/issues/12350)
 - `CHECKBOX` and `BUTTON` field default values (booleans, numbers) are no longer silently dropped during form initialisation. [#12350](https://github.com/opencrvs/opencrvs-core/issues/12350)
 - The `DATA` field now uses the first visible field config when multiple fields share the same ID, ensuring the correct field is displayed when fields are mutually exclusive. [#12350](https://github.com/opencrvs/opencrvs-core/issues/12350)
 - Address field defaults no longer set `administrativeArea` to an empty string when the user reference cannot be resolved. This prevents empty address submission errors and correctly enables optional address sub-fields. [#12350](https://github.com/opencrvs/opencrvs-core/issues/12350)
-=======
 - Health facilities and other non-administrative locations are no longer included in the administrative area hierarchy when resolving location ancestry. [#12485](https://github.com/opencrvs/opencrvs-core/issues/12485)
->>>>>>> release-v1.9.13
 - The work queue list now automatically refreshes after a new event is created, without requiring a manual page reload. Previously the sidebar count updated immediately but the list itself stayed stale. [#12103](https://github.com/opencrvs/opencrvs-core/issues/12103)
 
 ### Improvements
 
 - The sidebar navigation footer now displays the user's assigned office alongside their name and role. [#11421](https://github.com/opencrvs/opencrvs-core/issues/11421)
 - The client now periodically polls `api/ping` every 5 seconds until all services are reachable, so users automatically recover from offline to online without a page reload. A `ConnectionStatus` indicator in the sidebar reflects real-time connectivity state. [#12055](https://github.com/opencrvs/opencrvs-core/issues/12055)
+- Allow assignment to be controlled when rejecting an action both synchronously and asynchronously by passing an optional `keepAssignment` parameter to response body (during synchronous rejection) or to the `action.reject` function (during asynchronous rejection). [#12347](https://github.com/opencrvs/opencrvs-core/issues/12347)
 
 ## 1.9.12
 

--- a/packages/client/src/v2-events/custom-api/index.ts
+++ b/packages/client/src/v2-events/custom-api/index.ts
@@ -52,6 +52,13 @@ function hasPotentialDuplicates(
   return eventIndex.potentialDuplicates.length > 0
 }
 
+function wasRejected(event: EventDocument, actionType: ActionType): boolean {
+  return (
+    event.actions.filter((a) => a.type === actionType).at(-1)?.status ===
+    ActionStatus.Rejected
+  )
+}
+
 /**
  * Runs a sequence of actions from declare to register.
  *
@@ -70,10 +77,13 @@ export async function registerOnDeclare({
     annotation,
     eventId,
     transactionId,
-    keepAssignment: true
+    keepAssignmentIfAccepted: true
   })
 
-  if (hasPotentialDuplicates(declaredEvent, eventConfiguration)) {
+  if (
+    hasPotentialDuplicates(declaredEvent, eventConfiguration) ||
+    wasRejected(declaredEvent, ActionType.DECLARE)
+  ) {
     return declaredEvent
   }
 
@@ -84,11 +94,14 @@ export async function registerOnDeclare({
       annotation,
       eventId,
       transactionId,
-      keepAssignment: true
+      keepAssignmentIfAccepted: true
     }
   )
 
-  if (hasPotentialDuplicates(validatedEvent, eventConfiguration)) {
+  if (
+    hasPotentialDuplicates(validatedEvent, eventConfiguration) ||
+    wasRejected(validatedEvent, ActionType.VALIDATE)
+  ) {
     return validatedEvent
   }
 
@@ -122,10 +135,13 @@ export async function validateOnDeclare({
     annotation,
     eventId,
     transactionId,
-    keepAssignment: true
+    keepAssignmentIfAccepted: true
   })
 
-  if (hasPotentialDuplicates(declaredEvent, eventConfiguration)) {
+  if (
+    hasPotentialDuplicates(declaredEvent, eventConfiguration) ||
+    wasRejected(declaredEvent, ActionType.DECLARE)
+  ) {
     return declaredEvent
   }
 
@@ -155,17 +171,21 @@ export async function registerOnValidate({
   declaration,
   annotation
 }: CustomMutationParams) {
-  const maybeDuplicateEvent =
-    await trpcClient.event.actions.validate.request.mutate({
+  const validatedEvent = await trpcClient.event.actions.validate.request.mutate(
+    {
       declaration,
       annotation,
       eventId,
       transactionId,
-      keepAssignment: true
-    })
+      keepAssignmentIfAccepted: true
+    }
+  )
 
-  if (hasPotentialDuplicates(maybeDuplicateEvent, eventConfiguration)) {
-    return maybeDuplicateEvent
+  if (
+    hasPotentialDuplicates(validatedEvent, eventConfiguration) ||
+    wasRejected(validatedEvent, ActionType.VALIDATE)
+  ) {
+    return validatedEvent
   }
 
   const latestResponse = await trpcClient.event.actions.register.request.mutate(
@@ -252,8 +272,12 @@ export async function makeCorrectionOnRequest({
       declaration,
       transactionId,
       annotation,
-      keepAssignment: true
+      keepAssignmentIfAccepted: true
     })
+
+  if (wasRejected(response, ActionType.REQUEST_CORRECTION)) {
+    return response
+  }
 
   const requestId = response.actions.find(
     (a) =>

--- a/packages/commons/src/events/ActionInput.ts
+++ b/packages/commons/src/events/ActionInput.ts
@@ -29,6 +29,8 @@ export const BaseActionInput = z.object({
   annotation: ActionUpdate.optional(),
   originalActionId: UUID.optional(), // should not be part of base action.
   keepAssignment: z.boolean().optional(),
+  keepAssignmentIfAccepted: z.boolean().optional(),
+  keepAssignmentIfRejected: z.boolean().optional(),
   // For normal users, the createdAtLocation is resolved on the backend from the user's primaryOfficeId.
   createdAtLocation: CreatedAtLocation.describe(
     'A valid office location ID. This is required for system users performing actions. The provided location must be a leaf-location, i.e. it must not have any children locations.'

--- a/packages/events/src/router/event/actions/declare.ts
+++ b/packages/events/src/router/event/actions/declare.ts
@@ -74,8 +74,7 @@ export function declareActionProcedures() {
           user,
           token,
           event,
-          config,
-          DeclareActionInput
+          config
         )
 
         const dedupConfig = config.actions.find(

--- a/packages/events/src/router/event/actions/index.ts
+++ b/packages/events/src/router/event/actions/index.ts
@@ -184,10 +184,8 @@ export async function defaultRequestHandler(
   event: EventDocument,
   configuration: EventConfig,
   // @TODO: Could this be typed with the actual input schema, or could these actually be anything?
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  inputSchema: z.ZodObject<any>,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  actionConfirmationResponseSchema?: z.ZodObject<any>
+  inputSchema: z.ZodObject<z.ZodRawShape>,
+  actionConfirmationResponseSchema?: z.ZodObject<z.ZodRawShape>
 ) {
   await throwConflictIfActionNotAllowed(input.eventId, input.type, token)
 
@@ -204,13 +202,12 @@ export async function defaultRequestHandler(
     { eventId: input.eventId, actionId: requestedAction.id },
     token
   )
-  const { responseStatus, responseBody: confirmationResponse } =
-    await requestActionConfirmation(
-      input.type,
-      input.transactionId,
-      eventWithRequestedAction,
-      setBearerForToken(eventActionToken)
-    )
+  const { responseStatus, responseBody } = await requestActionConfirmation(
+    input.type,
+    input.transactionId,
+    eventWithRequestedAction,
+    setBearerForToken(eventActionToken)
+  )
 
   // If we get an unexpected failure response, we just return HTTP 500 without saving the
   if (responseStatus === ActionConfirmationResponse.UnexpectedFailure) {
@@ -218,62 +215,54 @@ export async function defaultRequestHandler(
       code: 'INTERNAL_SERVER_ERROR',
       message: 'Unexpected failure from country config action confirmation API'
     })
-    // For Async flow, we just return the event with the requested action and ensure it is indexed
-  } else if (responseStatus === ActionConfirmationResponse.RequiresProcessing) {
+  }
+
+  // For Async flow, we just return the event with the requested action and ensure it is indexed
+  if (responseStatus === ActionConfirmationResponse.RequiresProcessing) {
     await ensureEventIndexed(eventWithRequestedAction, configuration)
     return eventWithRequestedAction
   }
 
-  let status: ActionStatus = ActionStatus.Requested
-  let parsedBody
+  // For Sync flow, we parse the result and merge it with the action input
+  // before storing the accepted/rejected action
+  const status =
+    responseStatus === ActionConfirmationResponse.Success
+      ? ActionStatus.Accepted
+      : ActionStatus.Rejected
 
-  // If we immediately get a rejected response, we can mark the action as rejected
-  if (responseStatus === ActionConfirmationResponse.Rejected) {
-    status = ActionStatus.Rejected
+  const schema =
+    responseStatus === ActionConfirmationResponse.Success
+      ? (actionConfirmationResponseSchema ??
+        z.object({}).merge(inputSchema.partial()))
+      : inputSchema.partial()
 
-    logger.debug(
-      {
-        transactionId: input.transactionId,
-        actionType: input.type,
-        eventId: event.id
-      },
-      `Action immediately rejected (status: "${responseStatus}")`
-    )
+  const maybeParsed = schema.safeParse(responseBody ?? {})
+
+  if (!maybeParsed.success) {
+    logger.error(maybeParsed.error)
+    throw new TRPCError({
+      code: 'INTERNAL_SERVER_ERROR',
+      message:
+        'Invalid payload received from country config action confirmation API'
+    })
   }
 
-  // If we immediately get a success response, we mark the action as succeeded
-  // and also validate the payload received from the notify API
-  if (responseStatus === ActionConfirmationResponse.Success) {
-    status = ActionStatus.Accepted
+  const parsedBody = maybeParsed.data
 
-    try {
-      parsedBody = (actionConfirmationResponseSchema ?? z.object({}))
-        .merge(inputSchema.partial())
-        .parse(confirmationResponse ?? {})
-    } catch (error) {
-      logger.error(error)
+  logger.debug(
+    {
+      transactionId: input.transactionId,
+      eventType: event.type,
+      actionType: input.type,
+      eventId: event.id
+    },
+    `Action immediately ${status === ActionStatus.Accepted ? 'accepted' : 'rejected'} (status: "${responseStatus}")`
+  )
 
-      throw new TRPCError({
-        code: 'INTERNAL_SERVER_ERROR',
-        message:
-          'Invalid payload received from country config action confirmation API'
-      })
-    }
-
-    logger.debug(
-      {
-        transactionId: input.transactionId,
-        eventType: event.type,
-        actionType: input.type,
-        eventId: event.id
-      },
-      `Action immediately accepted (status: "${responseStatus}")`
-    )
-  }
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { declaration, annotation, ...strippedInput } = input
 
-  const updatedEvent = await processAction(
+  return processAction(
     {
       ...strippedInput,
       declaration: {},
@@ -282,8 +271,6 @@ export async function defaultRequestHandler(
     },
     { event, user, token, status, configuration }
   )
-
-  return updatedEvent
 }
 
 /**

--- a/packages/events/src/router/event/actions/index.ts
+++ b/packages/events/src/router/event/actions/index.ts
@@ -33,10 +33,7 @@ import {
   ActionInputWithType,
   EventConfig
 } from '@opencrvs/commons/events'
-import {
-  TokenUserType,
-  TokenWithBearer
-} from '@opencrvs/commons/authentication'
+import { TokenWithBearer } from '@opencrvs/commons/authentication'
 import * as middleware from '@events/router/middleware'
 import {
   requiresAnyOfScopes,
@@ -426,7 +423,11 @@ export function getDefaultActionProcedures(
       }),
 
     reject: systemProcedure
-      .input(AsyncActionConfirmationResponseSchema)
+      .input(
+        AsyncActionConfirmationResponseSchema.extend({
+          keepAssignment: z.boolean().default(false)
+        })
+      )
       .use(middleware.requireActionConfirmationAuthorization)
       .mutation(async ({ input, ctx }) => {
         const { eventId, actionId } = input
@@ -451,17 +452,19 @@ export function getDefaultActionProcedures(
           return getEventById(input.eventId)
         }
 
-        return addAsyncRejectAction({
-          ...input,
-          originalActionId: actionId,
-          type: actionType,
-          createdBy: ctx.user.id,
-          createdByUserType: TokenUserType.Enum.user,
-          createdByRole: ctx.user.role,
-          createdAtLocation: ctx.user.primaryOfficeId ?? undefined,
+        const configuration = await getEventConfigurationById({
           token: ctx.token,
           eventType: event.type
         })
+
+        return addAsyncRejectAction(
+          { ...input, type: actionType, originalActionId: actionId },
+          {
+            event,
+            user: ctx.user,
+            configuration
+          }
+        )
       })
   }
 }

--- a/packages/events/src/router/event/actions/index.ts
+++ b/packages/events/src/router/event/actions/index.ts
@@ -159,6 +159,21 @@ const ACTION_PROCEDURE_CONFIG = {
 
 type DistributiveOmit<T, K extends keyof T> = T extends T ? Omit<T, K> : never
 
+const AsyncActionInput = BaseActionInput.pick({
+  eventId: true,
+  transactionId: true,
+  keepAssignment: true
+}).extend({
+  actionId: UUID
+})
+
+export type AsyncActionInput = z.infer<typeof AsyncActionInput>
+
+const SyncActionConfirmationSchema = BaseActionInput.pick({
+  declaration: true,
+  annotation: true
+})
+
 type ActionProcedure = {
   request: MutationProcedure<{
     input: ActionInput
@@ -174,26 +189,11 @@ type ActionProcedure = {
     meta: OpenApiMeta
   }>
   reject: MutationProcedure<{
-    input: { eventId: string; actionId: string; transactionId: string }
+    input: z.input<typeof AsyncActionInput>
     output: EventDocument
     meta: OpenApiMeta
   }>
 }
-
-const AsyncActionInput = BaseActionInput.pick({
-  eventId: true,
-  transactionId: true,
-  keepAssignment: true
-}).extend({
-  actionId: UUID
-})
-
-export type AsyncActionInput = z.infer<typeof AsyncActionInput>
-
-const SyncActionConfirmationSchema = BaseActionInput.pick({
-  declaration: true,
-  annotation: true
-})
 
 export async function defaultRequestHandler(
   input: ActionInputWithType,

--- a/packages/events/src/router/event/actions/index.ts
+++ b/packages/events/src/router/event/actions/index.ts
@@ -31,7 +31,8 @@ import {
   RejectCorrectionActionInput,
   getPendingAction,
   ActionInputWithType,
-  EventConfig
+  EventConfig,
+  BaseActionInput
 } from '@opencrvs/commons/events'
 import { TokenWithBearer } from '@opencrvs/commons/authentication'
 import * as middleware from '@events/router/middleware'
@@ -65,8 +66,8 @@ import {
  * @property {OpenApiMeta} [meta] - Meta information, incl. OpenAPI definition
  */
 interface ActionProcedureConfig {
-  inputSchema: z.ZodType
-  actionConfirmationResponseSchema: z.ZodType | undefined
+  inputSchema: z.ZodObject<z.ZodRawShape>
+  actionConfirmationResponseSchema: z.ZodObject<z.ZodRawShape> | undefined
   meta?: OpenApiMeta
 }
 
@@ -156,6 +157,8 @@ const ACTION_PROCEDURE_CONFIG = {
   }
 } satisfies Partial<Record<ActionType, ActionProcedureConfig>>
 
+type DistributiveOmit<T, K extends keyof T> = T extends T ? Omit<T, K> : never
+
 type ActionProcedure = {
   request: MutationProcedure<{
     input: ActionInput
@@ -163,7 +166,10 @@ type ActionProcedure = {
     meta: OpenApiMeta
   }>
   accept: MutationProcedure<{
-    input: ActionInput & { actionId: string }
+    input: DistributiveOmit<
+      ActionInput,
+      'keepAssignmentIfAccepted' | 'keepAssignmentIfRejected'
+    > & { actionId: string }
     output: EventDocument
     meta: OpenApiMeta
   }>
@@ -174,6 +180,26 @@ type ActionProcedure = {
   }>
 }
 
+const AsyncActionInput = BaseActionInput.pick({
+  eventId: true,
+  transactionId: true,
+  keepAssignment: true
+}).extend({
+  actionId: UUID
+})
+
+export type AsyncActionInput = z.infer<typeof AsyncActionInput>
+
+const SyncActionConfirmationSchema = BaseActionInput.pick({
+  keepAssignment: true,
+  declaration: true,
+  annotation: true
+})
+
+const SyncActionRejectionSchema = BaseActionInput.pick({
+  keepAssignment: true
+})
+
 export async function defaultRequestHandler(
   input: ActionInputWithType,
   user: TrpcUserContext,
@@ -181,7 +207,6 @@ export async function defaultRequestHandler(
   event: EventDocument,
   configuration: EventConfig,
   // @TODO: Could this be typed with the actual input schema, or could these actually be anything?
-  inputSchema: z.ZodObject<z.ZodRawShape>,
   actionConfirmationResponseSchema?: z.ZodObject<z.ZodRawShape>
 ) {
   await throwConflictIfActionNotAllowed(input.eventId, input.type, token)
@@ -230,8 +255,8 @@ export async function defaultRequestHandler(
   const schema =
     responseStatus === ActionConfirmationResponse.Success
       ? (actionConfirmationResponseSchema ??
-        z.object({}).merge(inputSchema.partial()))
-      : inputSchema.partial()
+        z.object({}).merge(SyncActionConfirmationSchema))
+      : SyncActionRejectionSchema
 
   const maybeParsed = schema.safeParse(responseBody ?? {})
 
@@ -256,12 +281,26 @@ export async function defaultRequestHandler(
     `Action immediately ${status === ActionStatus.Accepted ? 'accepted' : 'rejected'} (status: "${responseStatus}")`
   )
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { declaration, annotation, ...strippedInput } = input
+  const {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    declaration,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    annotation,
+    keepAssignment,
+    keepAssignmentIfAccepted,
+    keepAssignmentIfRejected,
+    ...strippedInput
+  } = input
+
+  const effectiveKeepAssignment =
+    status === ActionStatus.Accepted
+      ? (keepAssignmentIfAccepted ?? keepAssignment ?? false)
+      : (keepAssignmentIfRejected ?? keepAssignment ?? false)
 
   return processAction(
     {
       ...strippedInput,
+      keepAssignment: effectiveKeepAssignment,
       declaration: {},
       originalActionId: requestedAction.id,
       ...parsedBody
@@ -269,19 +308,6 @@ export async function defaultRequestHandler(
     { event, user, token, status, configuration }
   )
 }
-
-/**
- * These fields aren't required in the synchronous flow as the action is processed immediately and we still have access to them.
- */
-const AsyncActionConfirmationResponseSchema = z.object({
-  eventId: UUID,
-  actionId: UUID,
-  transactionId: z.string()
-})
-
-export type AsyncActionConfirmationResponseSchema = z.infer<
-  typeof AsyncActionConfirmationResponseSchema
->
 
 /**
  * Most actions share a similar model, where the action is first requested, and then either synchronously or asynchronously
@@ -298,14 +324,6 @@ export function getDefaultActionProcedures(
   actionType: keyof typeof ACTION_PROCEDURE_CONFIG
 ): ActionProcedure {
   const actionConfig = ACTION_PROCEDURE_CONFIG[actionType]
-
-  let asyncAcceptInputFields = AsyncActionConfirmationResponseSchema
-
-  if (actionConfig.actionConfirmationResponseSchema) {
-    asyncAcceptInputFields = asyncAcceptInputFields.merge(
-      actionConfig.actionConfirmationResponseSchema
-    )
-  }
 
   const requireScopesForRequestMiddleware = requiresAnyOfScopes(
     [],
@@ -348,13 +366,16 @@ export function getDefaultActionProcedures(
           token,
           event,
           eventConfiguration,
-          actionConfig.inputSchema,
           actionConfig.actionConfirmationResponseSchema
         )
       }),
 
     accept: systemProcedure
-      .input(actionConfig.inputSchema.merge(asyncAcceptInputFields))
+      .input(
+        actionConfig.inputSchema
+          .merge(actionConfig.actionConfirmationResponseSchema ?? z.object({}))
+          .merge(AsyncActionInput)
+      )
       .use(middleware.requireActionConfirmationAuthorization)
       .mutation(async ({ ctx, input }) => {
         const { token, user } = ctx
@@ -411,7 +432,10 @@ export function getDefaultActionProcedures(
         }
 
         return processAction(
-          { ...input, originalActionId: actionId },
+          {
+            ...input,
+            originalActionId: actionId
+          },
           {
             event,
             user,
@@ -423,11 +447,7 @@ export function getDefaultActionProcedures(
       }),
 
     reject: systemProcedure
-      .input(
-        AsyncActionConfirmationResponseSchema.extend({
-          keepAssignment: z.boolean().default(false)
-        })
-      )
+      .input(AsyncActionInput)
       .use(middleware.requireActionConfirmationAuthorization)
       .mutation(async ({ input, ctx }) => {
         const { eventId, actionId } = input
@@ -458,7 +478,12 @@ export function getDefaultActionProcedures(
         })
 
         return addAsyncRejectAction(
-          { ...input, type: actionType, originalActionId: actionId },
+          {
+            ...input,
+            type: actionType,
+            originalActionId: actionId,
+            keepAssignment: input.keepAssignment ?? false
+          },
           {
             event,
             user: ctx.user,

--- a/packages/events/src/router/event/actions/index.ts
+++ b/packages/events/src/router/event/actions/index.ts
@@ -191,13 +191,8 @@ const AsyncActionInput = BaseActionInput.pick({
 export type AsyncActionInput = z.infer<typeof AsyncActionInput>
 
 const SyncActionConfirmationSchema = BaseActionInput.pick({
-  keepAssignment: true,
   declaration: true,
   annotation: true
-})
-
-const SyncActionRejectionSchema = BaseActionInput.pick({
-  keepAssignment: true
 })
 
 export async function defaultRequestHandler(
@@ -254,9 +249,10 @@ export async function defaultRequestHandler(
 
   const schema =
     responseStatus === ActionConfirmationResponse.Success
-      ? (actionConfirmationResponseSchema ??
-        z.object({}).merge(SyncActionConfirmationSchema))
-      : SyncActionRejectionSchema
+      ? SyncActionConfirmationSchema.merge(
+          actionConfirmationResponseSchema ?? z.object({})
+        )
+      : z.object({})
 
   const maybeParsed = schema.safeParse(responseBody ?? {})
 

--- a/packages/events/src/router/event/event.actions.async-confirmation.test.ts
+++ b/packages/events/src/router/event/event.actions.async-confirmation.test.ts
@@ -1,0 +1,140 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+
+import { HttpResponse, http } from 'msw'
+import { ActionType, ActionStatus, getUUID } from '@opencrvs/commons'
+import {
+  createTestClient,
+  createCountryConfigClient,
+  setupTestCase
+} from '@events/tests/utils'
+import { mswServer } from '@events/tests/msw'
+import { env } from '@events/environment'
+
+function mockDeclareApi(status: number) {
+  return mswServer.use(
+    http.post(
+      `${env.COUNTRY_CONFIG_URL}/trigger/events/tennis-club-membership/actions/DECLARE`,
+      () =>
+        HttpResponse.json(
+          {},
+          // @ts-expect-error - msw types complain about numeric status
+          { status }
+        )
+    )
+  )
+}
+
+function getDeclareActionId(
+  actions: { type: ActionType; status: ActionStatus; id: string }[]
+) {
+  const id = actions.find(
+    (a) => a.type === ActionType.DECLARE && a.status === ActionStatus.Requested
+  )?.id
+  if (!id) {
+    throw new Error('Declare action not found in actions list')
+  }
+  return id
+}
+
+describe('Async confirmation - keepAssignment flags on reject', () => {
+  test('default: assignment dropped after async reject', async () => {
+    const { user, generator } = await setupTestCase()
+    const client = createTestClient(user)
+    const event = await client.event.create(generator.event.create())
+
+    mockDeclareApi(202)
+
+    const data = generator.event.actions.declare(event.id)
+    const requestResponse = await client.event.actions.declare.request(data)
+
+    const actionId = getDeclareActionId(requestResponse.actions)
+    const ccClient = createCountryConfigClient(user, event.id, actionId)
+
+    const response = await ccClient.event.actions.declare.reject({
+      eventId: event.id,
+      actionId,
+      transactionId: getUUID()
+    })
+
+    expect(response.actions.at(-1)?.type).toEqual(ActionType.UNASSIGN)
+  })
+
+  test('keepAssignment=true: assignment kept after async reject', async () => {
+    const { user, generator } = await setupTestCase()
+    const client = createTestClient(user)
+    const event = await client.event.create(generator.event.create())
+
+    mockDeclareApi(202)
+
+    const data = generator.event.actions.declare(event.id)
+    const requestResponse = await client.event.actions.declare.request(data)
+
+    const actionId = getDeclareActionId(requestResponse.actions)
+    const ccClient = createCountryConfigClient(user, event.id, actionId)
+
+    const response = await ccClient.event.actions.declare.reject({
+      eventId: event.id,
+      actionId,
+      transactionId: getUUID(),
+      keepAssignment: true
+    })
+
+    expect(response.actions.at(-1)?.type).not.toEqual(ActionType.UNASSIGN)
+  })
+})
+
+describe('Async confirmation - keepAssignment flags on accept', () => {
+  test('default: assignment dropped after async accept', async () => {
+    const { user, generator } = await setupTestCase()
+    const client = createTestClient(user)
+    const event = await client.event.create(generator.event.create())
+
+    mockDeclareApi(202)
+
+    const data = generator.event.actions.declare(event.id)
+    const requestResponse = await client.event.actions.declare.request(data)
+
+    const actionId = getDeclareActionId(requestResponse.actions)
+    const ccClient = createCountryConfigClient(user, event.id, actionId)
+
+    const response = await ccClient.event.actions.declare.accept({
+      ...data,
+      actionId,
+      transactionId: getUUID()
+    })
+
+    expect(response.actions.at(-1)?.type).toEqual(ActionType.UNASSIGN)
+  })
+
+  test('keepAssignment=true: assignment kept after async accept', async () => {
+    const { user, generator } = await setupTestCase()
+    const client = createTestClient(user)
+    const event = await client.event.create(generator.event.create())
+
+    mockDeclareApi(202)
+
+    const data = generator.event.actions.declare(event.id)
+    const requestResponse = await client.event.actions.declare.request(data)
+
+    const actionId = getDeclareActionId(requestResponse.actions)
+    const ccClient = createCountryConfigClient(user, event.id, actionId)
+
+    const response = await ccClient.event.actions.declare.accept({
+      ...data,
+      actionId,
+      transactionId: getUUID(),
+      keepAssignment: true
+    })
+
+    expect(response.actions.at(-1)?.type).not.toEqual(ActionType.UNASSIGN)
+  })
+})

--- a/packages/events/src/router/event/event.actions.sync-confirmation.test.ts
+++ b/packages/events/src/router/event/event.actions.sync-confirmation.test.ts
@@ -1,0 +1,231 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+
+import { HttpResponse, http } from 'msw'
+import { TRPCError } from '@trpc/server'
+import { ActionDocument, ActionStatus, ActionType } from '@opencrvs/commons'
+import { createTestClient, setupTestCase } from '@events/tests/utils'
+import { mswServer } from '@events/tests/msw'
+import { env } from '@events/environment'
+
+function mockDeclareApi(status: number, body: Record<string, unknown> = {}) {
+  return mswServer.use(
+    http.post(
+      `${env.COUNTRY_CONFIG_URL}/trigger/events/tennis-club-membership/actions/DECLARE`,
+      () =>
+        HttpResponse.json(
+          body,
+          // @ts-expect-error - msw types complain about numeric status
+          { status }
+        )
+    )
+  )
+}
+
+function findDeclareAction(
+  actions: { type: ActionType; status: ActionStatus }[],
+  status: ActionStatus
+) {
+  return actions.find(
+    (a): a is Extract<ActionDocument, { type: 'DECLARE' }> =>
+      a.type === ActionType.DECLARE && a.status === status
+  )
+}
+
+describe('Synchronous confirmation - keepAssignment flags', () => {
+  test('keepAssignmentIfAccepted=true: assignment kept after sync accept', async () => {
+    const { user, generator } = await setupTestCase()
+    const client = createTestClient(user)
+    const event = await client.event.create(generator.event.create())
+
+    mockDeclareApi(200)
+
+    const response = await client.event.actions.declare.request({
+      ...generator.event.actions.declare(event.id),
+      keepAssignmentIfAccepted: true
+    })
+
+    expect(response.actions.at(-1)?.type).not.toEqual(ActionType.UNASSIGN)
+  })
+
+  test('keepAssignmentIfAccepted=false: assignment dropped after sync accept', async () => {
+    const { user, generator } = await setupTestCase()
+    const client = createTestClient(user)
+    const event = await client.event.create(generator.event.create())
+
+    mockDeclareApi(200)
+
+    const response = await client.event.actions.declare.request({
+      ...generator.event.actions.declare(event.id),
+      keepAssignmentIfAccepted: false
+    })
+
+    expect(response.actions.at(-1)?.type).toEqual(ActionType.UNASSIGN)
+  })
+
+  test('keepAssignmentIfRejected=true: assignment kept after sync reject', async () => {
+    const { user, generator } = await setupTestCase()
+    const client = createTestClient(user)
+    const event = await client.event.create(generator.event.create())
+
+    mockDeclareApi(400)
+
+    const response = await client.event.actions.declare.request({
+      ...generator.event.actions.declare(event.id),
+      keepAssignmentIfRejected: true
+    })
+
+    expect(response.actions.at(-1)?.type).not.toEqual(ActionType.UNASSIGN)
+  })
+
+  test('keepAssignmentIfRejected=false: assignment dropped after sync reject', async () => {
+    const { user, generator } = await setupTestCase()
+    const client = createTestClient(user)
+    const event = await client.event.create(generator.event.create())
+
+    mockDeclareApi(400)
+
+    const response = await client.event.actions.declare.request({
+      ...generator.event.actions.declare(event.id),
+      keepAssignmentIfRejected: false
+    })
+
+    expect(response.actions.at(-1)?.type).toEqual(ActionType.UNASSIGN)
+  })
+
+  test('keepAssignment=true fallback: assignment kept when keepAssignmentIfAccepted not set', async () => {
+    const { user, generator } = await setupTestCase()
+    const client = createTestClient(user)
+    const event = await client.event.create(generator.event.create())
+
+    mockDeclareApi(200)
+
+    const response = await client.event.actions.declare.request(
+      generator.event.actions.declare(event.id, { keepAssignment: true })
+    )
+
+    expect(response.actions.at(-1)?.type).not.toEqual(ActionType.UNASSIGN)
+  })
+
+  test('no flags: assignment dropped by default after sync accept', async () => {
+    const { user, generator } = await setupTestCase()
+    const client = createTestClient(user)
+    const event = await client.event.create(generator.event.create())
+
+    mockDeclareApi(200)
+
+    const response = await client.event.actions.declare.request(
+      generator.event.actions.declare(event.id)
+    )
+
+    expect(response.actions.at(-1)?.type).toEqual(ActionType.UNASSIGN)
+  })
+
+  test('keepAssignmentIfAccepted overrides keepAssignment on sync accept', async () => {
+    const { user, generator } = await setupTestCase()
+    const client = createTestClient(user)
+    const event = await client.event.create(generator.event.create())
+
+    mockDeclareApi(200)
+
+    const response = await client.event.actions.declare.request({
+      ...generator.event.actions.declare(event.id, { keepAssignment: true }),
+      keepAssignmentIfAccepted: false
+    })
+
+    expect(response.actions.at(-1)?.type).toEqual(ActionType.UNASSIGN)
+  })
+})
+
+describe('Synchronous confirmation - CC response payload', () => {
+  test('CC sends declaration in sync accept: saved on accepted action', async () => {
+    const { user, generator } = await setupTestCase()
+    const client = createTestClient(user)
+    const event = await client.event.create(generator.event.create())
+
+    const ccDeclaration = {
+      'applicant.name': { firstname: 'CC', surname: 'Sent' }
+    }
+    mockDeclareApi(200, { declaration: ccDeclaration })
+
+    const response = await client.event.actions.declare.request(
+      generator.event.actions.declare(event.id)
+    )
+
+    const acceptedAction = findDeclareAction(
+      response.actions,
+      ActionStatus.Accepted
+    )
+
+    expect(acceptedAction?.declaration).toEqual(ccDeclaration)
+  })
+
+  test('CC sends annotation in sync accept: saved on accepted action', async () => {
+    const { user, generator } = await setupTestCase()
+    const client = createTestClient(user)
+    const event = await client.event.create(generator.event.create())
+
+    const ccAnnotation = { 'review.comment': 'Approved by CC' }
+    mockDeclareApi(200, { annotation: ccAnnotation })
+
+    const response = await client.event.actions.declare.request(
+      generator.event.actions.declare(event.id)
+    )
+
+    const acceptedAction = findDeclareAction(
+      response.actions,
+      ActionStatus.Accepted
+    )
+
+    expect(acceptedAction?.annotation).toEqual(ccAnnotation)
+  })
+
+  test('CC sends unknown field in sync accept: returns 500', async () => {
+    const { user, generator } = await setupTestCase()
+    const client = createTestClient(user)
+    const event = await client.event.create(generator.event.create())
+
+    mockDeclareApi(200, { unknownField: 'not-in-schema' })
+
+    await expect(
+      client.event.actions.declare.request(
+        generator.event.actions.declare(event.id)
+      )
+    ).rejects.toThrow(
+      new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        message:
+          'Invalid payload received from country config action confirmation API'
+      })
+    )
+  })
+
+  test('CC sends body on sync reject: body ignored, action saved with empty declaration', async () => {
+    const { user, generator } = await setupTestCase()
+    const client = createTestClient(user)
+    const event = await client.event.create(generator.event.create())
+
+    mockDeclareApi(400, { someField: 'should-be-ignored' })
+
+    const response = await client.event.actions.declare.request({
+      ...generator.event.actions.declare(event.id),
+      keepAssignmentIfRejected: true
+    })
+
+    const rejectedAction = findDeclareAction(
+      response.actions,
+      ActionStatus.Rejected
+    )
+
+    expect(rejectedAction?.status).toEqual(ActionStatus.Rejected)
+    expect(rejectedAction?.declaration).toEqual({})
+  })
+})

--- a/packages/events/src/router/middleware/authorization/index.ts
+++ b/packages/events/src/router/middleware/authorization/index.ts
@@ -38,7 +38,7 @@ import {
 } from '@opencrvs/commons'
 import { EventNotFoundError, getEventById } from '@events/service/events/events'
 import { TrpcContext } from '@events/context'
-import { AsyncActionConfirmationResponseSchema } from '@events/router/event/actions'
+import { AsyncActionInput } from '@events/router/event/actions'
 import { getUserOrSystem } from '../../../service/users/api'
 import { isLocationUnderJurisdiction } from '../../../storage/postgres/events/locations'
 
@@ -274,7 +274,7 @@ export const requireActionConfirmationAuthorization: MiddlewareFunction<
   OpenApiMeta,
   TrpcContext,
   TrpcContext,
-  AsyncActionConfirmationResponseSchema
+  AsyncActionInput
 > = async ({ next, ctx, input }) => {
   const {
     eventId: grantedEventId,

--- a/packages/events/src/service/events/events.ts
+++ b/packages/events/src/service/events/events.ts
@@ -423,47 +423,58 @@ export async function processAction(
   return updatedEvent
 }
 
-type AsyncRejectActionInput = Omit<
+type AsyncRejectActionInput = Pick<
   z.infer<typeof AsyncRejectActionDocument>,
-  'createdAt' | 'id' | 'status'
+  'transactionId' | 'originalActionId' | 'type'
 > & {
-  transactionId: string
-  eventId: UUID
-  originalActionId: UUID
-  createdAtLocation?: UUID
-  createdByUserType: TokenUserType
-  token: TokenWithBearer
-  eventType: string
+  keepAssignment: boolean
 }
 
-export async function addAsyncRejectAction({
-  transactionId,
-  eventId,
-  type,
-  originalActionId,
-  createdBy,
-  createdByRole,
-  createdByUserType,
-  createdAtLocation,
-  eventType,
-  token
-}: AsyncRejectActionInput) {
-  const configuration = await getEventConfigurationById({
-    eventType,
-    token
-  })
-
+export async function addAsyncRejectAction(
+  {
+    transactionId,
+    originalActionId,
+    type,
+    keepAssignment
+  }: AsyncRejectActionInput,
+  {
+    user,
+    event,
+    configuration
+  }: {
+    user: TrpcUserContext
+    event: EventDocument
+    configuration: EventConfig
+  }
+) {
+  const eventId = event.id
   await eventsRepo.createAction({
     eventId,
     transactionId,
     actionType: type,
     status: ActionStatus.Rejected,
     originalActionId,
-    createdBy,
-    createdByRole,
-    createdByUserType,
-    createdAtLocation
+    createdBy: user.id,
+    createdByRole: user.role,
+    createdByUserType: user.type,
+    createdAtLocation: user.primaryOfficeId
   })
+
+  if (!keepAssignment) {
+    await eventsRepo.createAction(
+      buildAction(
+        {
+          eventId,
+          transactionId,
+          type: ActionType.UNASSIGN,
+          declaration: {},
+          assignedTo: null
+        },
+        ActionStatus.Accepted,
+        user
+      )
+    )
+  }
 
   const updatedEvent = await getEventById(eventId)
   await indexEvent(updatedEvent, configuration)


### PR DESCRIPTION
## Description

- Allow assignment to be explicitly controlled when requesting an action with `keepAssignmentIfAccepted` and `keepAssignmentIfRejected`.  It is entirely controlled by the caller and cannot be overridden by cc. 
- `action.reject(...)` now by default unassigns the event from the last assigned user. To keep assignment, `keepAssignment: true` option must be explicitly passed when rejecting an action.

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [x] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
