### PR TITLE
fix: enforce min/max validation on NUMBER fields and add maxLength support 

### DIFF
--- a/packages/client/src/v2-events/components/forms/FormFieldGenerator/GeneratedInputField.tsx
+++ b/packages/client/src/v2-events/components/forms/FormFieldGenerator/GeneratedInputField.tsx
@@ -531,6 +531,7 @@ export const GeneratedInputField = <T extends FieldConfig>(
           {...inputProps}
           max={field.config.configuration?.max}
           min={field.config.configuration?.min}
+          maxLength={field.config.configuration?.maxLength}
           value={field.value}
         />
       </InputField>

--- a/packages/client/src/v2-events/features/events/registered-fields/Number.test.tsx
+++ b/packages/client/src/v2-events/features/events/registered-fields/Number.test.tsx
@@ -1,0 +1,86 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ThemeProvider } from 'styled-components'
+import { getTheme } from '@opencrvs/components/lib/theme'
+import { Number } from './Number'
+
+function renderNumberInput(props: {
+  min?: number
+  max?: number
+  maxLength?: number
+  value?: number
+  onChange?: (val: number | undefined) => void
+}) {
+  const { min, max, maxLength, value, onChange } = props
+  return render(
+    <ThemeProvider theme={getTheme()}>
+      <Number.Input
+        id="test-number"
+        name="test-number"
+        label="Test Number"
+        min={min}
+        max={max}
+        maxLength={maxLength}
+        value={value}
+        onChange={onChange ?? vi.fn()}
+        onBlur={vi.fn()}
+        touched={false}
+      />
+    </ThemeProvider>
+  )
+}
+
+describe('Number.Input', () => {
+  it('renders an input with type number', () => {
+    renderNumberInput({})
+    const input = screen.getByTestId('number__test-number')
+    expect(input.getAttribute('type')).toBe('number')
+  })
+
+  it('passes min attribute to the input', () => {
+    renderNumberInput({ min: 0 })
+    const input = screen.getByTestId('number__test-number')
+    expect(input.getAttribute('min')).toBe('0')
+  })
+
+  it('passes max attribute to the input', () => {
+    renderNumberInput({ max: 100 })
+    const input = screen.getByTestId('number__test-number')
+    expect(input.getAttribute('max')).toBe('100')
+  })
+
+  it('passes maxLength attribute to the input', () => {
+    renderNumberInput({ maxLength: 3 })
+    const input = screen.getByTestId('number__test-number')
+    expect(input.getAttribute('maxlength')).toBe('3')
+  })
+
+  it('passes min, max and maxLength together', () => {
+    renderNumberInput({ min: 18, max: 100, maxLength: 3 })
+    const input = screen.getByTestId('number__test-number')
+    expect(input.getAttribute('min')).toBe('18')
+    expect(input.getAttribute('max')).toBe('100')
+    expect(input.getAttribute('maxlength')).toBe('3')
+  })
+
+  it('calls onChange with the entered value on blur', async () => {
+    const onChange = vi.fn()
+    renderNumberInput({ onChange })
+    const input = screen.getByTestId('number__test-number')
+    await userEvent.type(input, '42')
+    await userEvent.tab()
+    expect(onChange).toHaveBeenCalledWith(42)
+  })
+})

--- a/packages/client/src/v2-events/features/events/registered-fields/Number.tsx
+++ b/packages/client/src/v2-events/features/events/registered-fields/Number.tsx
@@ -18,18 +18,27 @@ import {
 import { NumberField } from '@opencrvs/commons/client'
 
 interface NumberInputProps
-  extends Omit<TextInputProps, 'type' | 'maxLength' | 'onChange'> {
+  extends Omit<TextInputProps, 'type' | 'onChange'> {
   onChange(val: number | undefined): void
   value: number | undefined
   min?: number
+  max?: number
+  maxLength?: number
 }
 
-function NumberInput({ value, disabled, ...props }: NumberInputProps) {
+function NumberInput({
+  value,
+  disabled,
+  min,
+  max,
+  maxLength,
+  ...props
+}: NumberInputProps) {
   const [inputValue, setInputValue] = React.useState(
     value && isNaN(value) ? undefined : value
   )
 
-  const allowOnlyPositive = props.min !== undefined && props.min >= 0
+  const allowOnlyPositive = min !== undefined && min >= 0
 
   React.useEffect(() => {
     setInputValue(value ?? undefined)
@@ -41,6 +50,9 @@ function NumberInput({ value, disabled, ...props }: NumberInputProps) {
       data-testid={`number__${props.id}`}
       isDisabled={disabled}
       value={inputValue}
+      min={min}
+      max={max}
+      maxLength={maxLength}
       onBlur={(e) => {
         props.onChange(inputValue)
         props.onBlur?.(e)

--- a/packages/commons/src/events/FieldConfig.ts
+++ b/packages/commons/src/events/FieldConfig.ts
@@ -181,6 +181,7 @@ const NumberField = BaseField.extend({
     .object({
       min: z.number().optional().describe('Minimum value'),
       max: z.number().optional().describe('Maximum value'),
+      maxLength: z.number().optional().describe('Maximum length of the input'),
       prefix: TranslationConfig.optional(),
       postfix: TranslationConfig.optional()
     })

--- a/packages/commons/src/events/FieldTypeMapping.ts
+++ b/packages/commons/src/events/FieldTypeMapping.ts
@@ -181,9 +181,19 @@ export function mapFieldTypeToZod(field: FieldConfig, actionType?: ActionType) {
     case FieldType.USER_ROLE:
       schema = field.required ? NonEmptyTextValue : TextValue
       break
-    case FieldType.NUMBER:
+    case FieldType.NUMBER: {
       schema = NumberFieldValue
+      if (field.type === FieldType.NUMBER) {
+        const config = field.configuration
+        if (config?.min !== undefined) {
+          schema = schema.min(config.min)
+        }
+        if (config?.max !== undefined) {
+          schema = schema.max(config.max)
+        }
+      }
       break
+    }
     case FieldType.NUMBER_WITH_UNIT:
       schema = field.required
         ? NumberWithUnitFieldValue


### PR DESCRIPTION
## Description

NUMBER fields had min/max in their config but they weren't being forwarded to the HTML input or enforced by Zod validation. Country configs had to work around this with custom `isBetween` validators.                            
                                                            
This forwards `min`, `max`, and `maxLength` as HTML attributes to the Number input and generates Zod `.min()`/`.max()` constraints from the field config so validation enforces the range automatically.

Closes #10959 

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
