### PR TITLE
Add rich text highlighting support to action modal supporting copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,20 @@ V1 are deprecated. 2.0.0 onwards, locations are fetched from `events` service.
 
 ### New features
 
+#### Rich text support in MessageDescriptor.defaultMessage
+
+`TranslationTextWithFormatModifier` — use inline HTML-like tags directly in a `MessageDescriptor.defaultMessage` and render rich text via this component instead of wiring `intl.formatMessage` handlers manually. Supported tags: `<strong>`, `<b>`, `<em>`, `<i>`, `<u>`, `<mark>`, `<small>`, `<sub>`, `<sup>`, `<del>`, `<ins>`, `<code>`, `<kbd>`, `<q>`, `<br></br>`, `<tab></tab>`. Example message:
+
+```
+{
+  id: 'id',
+  description: 'Rich text example in translation',
+  defaultMessage: '<strong>WARNING!</strong>: Record will be <strong>legally registered</strong> via the outbox.<br></br>Further amends require a legal correction process.'
+}
+```
+
+Currently used to render `supportingCopy` in the action confirmation dialog (`useQuickActionModal`). [#12441](https://github.com/opencrvs/opencrvs-core/issues/12441)
+
 #### Autocomplete Input
 
 A select component enhanced with suggestions based on user search input. Works in conjunction with a countryconfig endpoint that returns suggestions based on user input. The list of suggestions are fetched from a table in the reference_data schema in events database.

--- a/packages/client/src/v2-events/features/events/actions/quick-actions/useQuickActionModal.tsx
+++ b/packages/client/src/v2-events/features/events/actions/quick-actions/useQuickActionModal.tsx
@@ -12,7 +12,7 @@ import React from 'react'
 import { MessageDescriptor, useIntl } from 'react-intl'
 import { useNavigate } from 'react-router-dom'
 import { v4 as uuid } from 'uuid'
-import { Dialog, Text } from '@opencrvs/components'
+import { Dialog } from '@opencrvs/components'
 import {
   DangerButton,
   PrimaryButton,
@@ -41,6 +41,7 @@ import { ROUTES } from '@client/v2-events/routes'
 import { FormFieldGenerator } from '@client/v2-events/components/forms/FormFieldGenerator'
 import { useValidatorContext } from '@client/v2-events/hooks/useValidatorContext'
 import { useUserAllowedActions } from '@client/v2-events/features/workqueues/Actions/useUserAllowedActions'
+import { TranslationTextWithFormatModifier } from '../../components/TranslationTextWithFormatModifier'
 import { useModal } from '../../../../hooks/useModal'
 import { actionLabels } from '../../../workqueues/Actions/utils'
 import { register } from './register'
@@ -180,11 +181,14 @@ function QuickActionModal({
       onClose={() => close({ result: false })}
     >
       <Stack alignItems="left" direction="column" gap={16}>
-        <Text color="grey500" element="p" variant="reg16">
-          {config.supportingCopy
-            ? intl.formatMessage(config.supportingCopy)
-            : null}
-        </Text>
+        {config.supportingCopy && (
+          <TranslationTextWithFormatModifier
+            color="supportingCopy"
+            element="p"
+            message={config.supportingCopy}
+            variant="reg16"
+          />
+        )}
         <FormFieldGenerator
           eventConfig={eventConfiguration}
           fields={config.fields ?? []}

--- a/packages/client/src/v2-events/features/events/components/Review.tsx
+++ b/packages/client/src/v2-events/features/events/components/Review.tsx
@@ -140,6 +140,14 @@ const ReviewContainter = styled.div`
     padding: 0;
   }
 `
+
+const Highlighted = styled.strong`
+  color: ${({ theme }) => theme.colors.grey600};
+`
+
+const SupportingCopy = styled(Text)`
+  color: ${({ theme }) => theme.colors.supportingCopy};
+`
 const DeclarationDataContainer = styled.div``
 
 const reviewMessages = defineMessages({
@@ -692,9 +700,15 @@ function AcceptActionModal({
       width={600}
     >
       <Stack>
-        <Text color="grey500" element="p" variant="reg16">
-          {copy.supportingCopy ? intl.formatMessage(copy.supportingCopy) : null}
-        </Text>
+        <SupportingCopy color="grey500" element="p" variant="reg16">
+          {copy.supportingCopy
+            ? intl.formatMessage(copy.supportingCopy, {
+                strong: (chunks: React.ReactNode[]) => (
+                  <Highlighted>{chunks}</Highlighted>
+                )
+              })
+            : null}
+        </SupportingCopy>
       </Stack>
     </ResponsiveModal>
   )

--- a/packages/client/src/v2-events/features/events/components/Review.tsx
+++ b/packages/client/src/v2-events/features/events/components/Review.tsx
@@ -46,6 +46,7 @@ import { withSuspense } from '@client/v2-events/components/withSuspense'
 import { buttonMessages } from '@client/i18n/messages'
 import { Output } from './Output'
 import { DocumentViewer } from './DocumentViewer'
+import { TranslationTextWithFormatModifier } from './TranslationTextWithFormatModifier'
 
 const ValidationError = styled.span`
   color: ${({ theme }) => theme.colors.negative};
@@ -141,13 +142,6 @@ const ReviewContainter = styled.div`
   }
 `
 
-const Highlighted = styled.strong`
-  color: ${({ theme }) => theme.colors.grey600};
-`
-
-const SupportingCopy = styled(Text)`
-  color: ${({ theme }) => theme.colors.supportingCopy};
-`
 const DeclarationDataContainer = styled.div``
 
 const reviewMessages = defineMessages({
@@ -700,15 +694,14 @@ function AcceptActionModal({
       width={600}
     >
       <Stack>
-        <SupportingCopy color="grey500" element="p" variant="reg16">
-          {copy.supportingCopy
-            ? intl.formatMessage(copy.supportingCopy, {
-                strong: (chunks: React.ReactNode[]) => (
-                  <Highlighted>{chunks}</Highlighted>
-                )
-              })
-            : null}
-        </SupportingCopy>
+        {copy.supportingCopy && (
+          <TranslationTextWithFormatModifier
+            color="supportingCopy"
+            element="p"
+            message={copy.supportingCopy}
+            variant="reg16"
+          />
+        )}
       </Stack>
     </ResponsiveModal>
   )

--- a/packages/client/src/v2-events/features/events/components/TranslationTextWithFormatModifier.interaction.stories.tsx
+++ b/packages/client/src/v2-events/features/events/components/TranslationTextWithFormatModifier.interaction.stories.tsx
@@ -8,7 +8,6 @@
  *
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
-import React from 'react'
 import type { Meta, StoryObj } from '@storybook/react'
 import { expect, within } from '@storybook/test'
 import { TranslationTextWithFormatModifier } from './TranslationTextWithFormatModifier'
@@ -39,7 +38,7 @@ async function checkTag(
   expectedText: string
 ) {
   const el = await within(canvasElement).findByText(expectedText)
-  expect(
+  await expect(
     el.tagName.toLowerCase(),
     `"${expectedText}" should be wrapped in <${tag}>`
   ).toBe(tag)
@@ -144,12 +143,12 @@ export const LineBreakAndTab: Story = {
     // Wait for the component to render before doing querySelector checks
     await within(canvasElement).findByText(/line one/, { exact: false })
 
-    expect(
+    await expect(
       canvasElement.querySelector('br'),
       '<br> element should be rendered for line breaks'
     ).not.toBeNull()
 
-    expect(
+    await expect(
       canvasElement.querySelector('span[style*="2em"]'),
       '<tab> should render a span with 2em width'
     ).not.toBeNull()

--- a/packages/client/src/v2-events/features/events/components/TranslationTextWithFormatModifier.interaction.stories.tsx
+++ b/packages/client/src/v2-events/features/events/components/TranslationTextWithFormatModifier.interaction.stories.tsx
@@ -1,0 +1,157 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+import React from 'react'
+import type { Meta, StoryObj } from '@storybook/react'
+import { expect, within } from '@storybook/test'
+import { TranslationTextWithFormatModifier } from './TranslationTextWithFormatModifier'
+
+const meta: Meta<typeof TranslationTextWithFormatModifier> = {
+  title: 'Components/TranslationTextWithFormatModifier',
+  component: TranslationTextWithFormatModifier,
+  parameters: {
+    chromatic: { disableSnapshot: true }
+  },
+  args: {
+    element: 'p',
+    variant: 'reg16'
+  }
+}
+
+export default meta
+type Story = StoryObj<typeof TranslationTextWithFormatModifier>
+
+/**
+ * Waits for the element containing expectedText to appear, then asserts its
+ * tag name. Uses findByText (async, retrying) so assertions are safe against
+ * the WaitForUserDetails render delay in the global storybook decorator.
+ */
+async function checkTag(
+  canvasElement: HTMLElement,
+  tag: string,
+  expectedText: string
+) {
+  const el = await within(canvasElement).findByText(expectedText)
+  expect(
+    el.tagName.toLowerCase(),
+    `"${expectedText}" should be wrapped in <${tag}>`
+  ).toBe(tag)
+}
+
+/**
+ * <strong> bold with semantic importance
+ * <b>      bold without semantic meaning
+ * <em>     italic with semantic emphasis
+ * <i>      italic without semantic meaning
+ */
+export const BoldAndEmphasis: Story = {
+  args: {
+    message: {
+      id: 'test.bold-emphasis',
+      defaultMessage:
+        '<strong>important</strong> <b>bold</b> <em>emphasis</em> <i>italic</i>'
+    }
+  },
+  play: async ({ canvasElement }) => {
+    await checkTag(canvasElement, 'strong', 'important')
+    await checkTag(canvasElement, 'b', 'bold')
+    await checkTag(canvasElement, 'em', 'emphasis')
+    await checkTag(canvasElement, 'i', 'italic')
+  }
+}
+
+/**
+ * <u>    underline
+ * <mark> highlight (yellow background by default)
+ * <del>  strikethrough — deleted / removed content
+ * <ins>  underline — inserted / added content
+ */
+export const TextDecoration: Story = {
+  args: {
+    message: {
+      id: 'test.decoration',
+      defaultMessage:
+        '<u>underline</u> <mark>highlight</mark> <del>deleted</del> <ins>inserted</ins>'
+    }
+  },
+  play: async ({ canvasElement }) => {
+    await checkTag(canvasElement, 'u', 'underline')
+    await checkTag(canvasElement, 'mark', 'highlight')
+    await checkTag(canvasElement, 'del', 'deleted')
+    await checkTag(canvasElement, 'ins', 'inserted')
+  }
+}
+
+/**
+ * <small> fine print / reduced font size
+ * <sub>   subscript  e.g. H<sub>subscript</sub>
+ * <sup>   superscript e.g. x<sup>superscript</sup>
+ */
+export const SizeModifiers: Story = {
+  args: {
+    message: {
+      id: 'test.size',
+      defaultMessage:
+        '<small>small/fine print</small> <sub>subscript</sub> <sup>superscript</sup>'
+    }
+  },
+  play: async ({ canvasElement }) => {
+    await checkTag(canvasElement, 'small', 'small/fine print')
+    await checkTag(canvasElement, 'sub', 'subscript')
+    await checkTag(canvasElement, 'sup', 'superscript')
+  }
+}
+
+/**
+ * <code> inline monospace code
+ * <kbd>  keyboard input  e.g. press <kbd>Ctrl+S</kbd>
+ * <q>    inline quotation — browser adds locale-aware quote marks via CSS
+ */
+export const CodeAndQuotation: Story = {
+  args: {
+    message: {
+      id: 'test.code',
+      defaultMessage: `Run <code>npm install</code>, press <kbd>Enter</kbd>, then <q>confirm</q>`
+    },
+    element: 'span'
+  },
+  play: async ({ canvasElement }) => {
+    await checkTag(canvasElement, 'code', 'npm install')
+    await checkTag(canvasElement, 'kbd', 'Enter')
+    await checkTag(canvasElement, 'q', 'confirm')
+  }
+}
+
+/**
+ * <br></br>   line break — note: react-intl ignores self-closing <br/>
+ * <tab></tab> 2em inline indent spacer (custom tag, not a standard HTML element)
+ */
+export const LineBreakAndTab: Story = {
+  args: {
+    message: {
+      id: 'test.layout',
+      defaultMessage: 'line one<br></br>line two<tab></tab>indented'
+    }
+  },
+  play: async ({ canvasElement }) => {
+    // Wait for the component to render before doing querySelector checks
+    await within(canvasElement).findByText(/line one/, { exact: false })
+
+    expect(
+      canvasElement.querySelector('br'),
+      '<br> element should be rendered for line breaks'
+    ).not.toBeNull()
+
+    expect(
+      canvasElement.querySelector('span[style*="2em"]'),
+      '<tab> should render a span with 2em width'
+    ).not.toBeNull()
+  }
+}

--- a/packages/client/src/v2-events/features/events/components/TranslationTextWithFormatModifier.tsx
+++ b/packages/client/src/v2-events/features/events/components/TranslationTextWithFormatModifier.tsx
@@ -1,0 +1,87 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+import React, { ComponentProps } from 'react'
+import { MessageDescriptor, useIntl } from 'react-intl'
+import styled from 'styled-components'
+import { Text } from '@opencrvs/components'
+
+const StyledKbd = styled.kbd`
+  /* stylelint-disable-next-line opencrvs/no-font-styles */
+  font-family: monospace;
+  /* stylelint-disable-next-line opencrvs/no-font-styles */
+  font-size: 0.9em;
+  padding: 1px 5px;
+  border: 1px solid ${({ theme }) => theme.colors.grey400};
+  border-bottom-width: 2px;
+  border-radius: 3px;
+  background: ${({ theme }) => theme.colors.grey100};
+`
+
+const StyledCode = styled.code`
+  /* stylelint-disable-next-line opencrvs/no-font-styles */
+  font-family: monospace;
+  /* stylelint-disable-next-line opencrvs/no-font-styles */
+  font-size: 0.9em;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: ${({ theme }) => theme.colors.grey100};
+`
+
+export interface TranslationTextWithFormatModifierProps
+  extends Omit<ComponentProps<typeof Text>, 'children'> {
+  message: MessageDescriptor
+}
+
+/**
+ * Renders a translated message as a Text component with automatic support for
+ * inline tags in the translation string:
+ *   <strong>, <b>, <em>, <i>, <u>, <mark>, <small>, <sub>, <sup>,
+ *   <del>, <ins>, <code>, <kbd>, <q>
+ * For line breaks use <br></br> — react-intl ignores self-closing <br/>.
+ * For indentation use <tab></tab> (custom tag, renders a 2em inline spacer).
+ *
+ * Example translation:
+ *   '<strong>WARNING!</strong>: Record will be <strong>legally registered</strong>.'
+ */
+export function TranslationTextWithFormatModifier({
+  message,
+  ...textProps
+}: TranslationTextWithFormatModifierProps) {
+  const intl = useIntl()
+
+  return (
+    <Text {...textProps}>
+      {
+        intl.formatMessage(message, {
+          strong: (chunks: React.ReactNode[]) => <strong>{chunks}</strong>, // bold + semantic importance
+          b: (chunks: React.ReactNode[]) => <b>{chunks}</b>, // bold, no semantic meaning
+          em: (chunks: React.ReactNode[]) => <em>{chunks}</em>, // italic + semantic emphasis
+          i: (chunks: React.ReactNode[]) => <i>{chunks}</i>, // italic, no semantic meaning
+          u: (chunks: React.ReactNode[]) => <u>{chunks}</u>, // underline
+          mark: (chunks: React.ReactNode[]) => <mark>{chunks}</mark>, // highlight
+          small: (chunks: React.ReactNode[]) => <small>{chunks}</small>, // fine print / smaller text
+          sub: (chunks: React.ReactNode[]) => <sub>{chunks}</sub>, // subscript e.g. H<sub>2</sub>O
+          sup: (chunks: React.ReactNode[]) => <sup>{chunks}</sup>, // superscript e.g. x<sup>2</sup>
+          del: (chunks: React.ReactNode[]) => <del>{chunks}</del>, // strikethrough / deleted text
+          ins: (chunks: React.ReactNode[]) => <ins>{chunks}</ins>, // underline / inserted text
+          code: (chunks: React.ReactNode[]) => (
+            <StyledCode>{chunks}</StyledCode>
+          ), // inline monospace code
+          kbd: (chunks: React.ReactNode[]) => <StyledKbd>{chunks}</StyledKbd>, // keyboard input e.g. <kbd>Ctrl+S</kbd>
+          q: (chunks: React.ReactNode[]) => <q>{chunks}</q>, // inline quotation with browser quote marks
+          br: () => <br />, // line break — use <br></br> not <br/> (react-intl ignores self-closing)
+           
+          tab: () => <span style={{ display: 'inline-block', width: '2em' }} /> // indent — use <tab></tab>
+        }) as React.ReactNode
+      }
+    </Text>
+  )
+}


### PR DESCRIPTION
## Description
https://github.com/opencrvs/opencrvs-core/issues/12441
country pr: https://github.com/opencrvs/opencrvs-countryconfig/pull/1412

<img width="1033" height="693" alt="Screenshot 2026-05-04 at 9 33 39 PM" src="https://github.com/user-attachments/assets/df47bc10-f961-47cd-8077-cf10e8358bc6" />

`TranslationTextWithFormatModifier` — use inline HTML-like tags directly in a `MessageDescriptor.defaultMessage` and render rich text via this component instead of wiring `intl.formatMessage` handlers manually. Supported tags: `<strong>`, `<b>`, `<em>`, `<i>`, `<u>`, `<mark>`, `<small>`, `<sub>`, `<sup>`, `<del>`, `<ins>`, `<code>`, `<kbd>`, `<q>`, `<br></br>`, `<tab></tab>`. Example message:

```
{
  id: 'id',
  description: 'Rich text example in translation',
  defaultMessage: '<strong>WARNING!</strong>: Record will be <strong>legally registered</strong> via the outbox.<br></br>Further amends require a legal correction process.'
}
```

Currently used to render `supportingCopy` in the action confirmation dialog

Link this pull request to the GitHub issue (and optionally name the branch `ocrvs-<issue #>`)

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [x] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
