### PR TITLE
Codemod fixes

### DIFF
--- a/packages/toolkit/src/migrations/v2.0/checkout-upstream-files.ts
+++ b/packages/toolkit/src/migrations/v2.0/checkout-upstream-files.ts
@@ -47,8 +47,7 @@ import { execFileSync } from 'child_process'
 export const UPSTREAM_URL =
   'https://github.com/opencrvs/opencrvs-countryconfig.git'
 
-// @TODO: This needs to be changed to 'release-v2.0.0' once the branch is created
-export const UPSTREAM_BRANCH = 'develop'
+export const UPSTREAM_BRANCH = 'release-v2.0.0'
 
 // Remote name used only for the duration of this codemod. Prefixed to avoid
 // clashing with remotes the user may have (origin, upstream, etc.).

--- a/packages/toolkit/src/migrations/v2.0/delete-infrastructure-directory.ts
+++ b/packages/toolkit/src/migrations/v2.0/delete-infrastructure-directory.ts
@@ -16,33 +16,52 @@
  * via Docker Swarm. In that case the `infrastructure/` directory shipped
  * with opencrvs-countryconfig is no longer needed and can be removed.
  *
+ * Some non-Swarm deployments still need a small subset of
+ * `infrastructure/` (e.g. `postgres/` and `metabase/`). Pass `keep` to
+ * preserve those top-level subdirectories — everything else under
+ * `infrastructure/` is deleted, and the kept subdirectories can then be
+ * refreshed from upstream by `merge-infrastructure-directory.ts` with the
+ * matching `subdirs` option.
+ *
  * Usage:
  *   ts-node -r tsconfig-paths/register src/migrations/v2.0/delete-infrastructure-directory.ts
  *
  * What it does:
  *   1. Stages deletion of all tracked files under `infrastructure/` via
- *      `git rm -rf --ignore-unmatch -- infrastructure/`. This both removes
- *      the files from the working tree and records the deletion in the
+ *      `git rm -rf --ignore-unmatch -- <path>`. This both removes the
+ *      files from the working tree and records the deletion in the
  *      index, so it shows up in the upgrade commit alongside the other
- *      codemod changes.
+ *      codemod changes. When `keep` is provided, deletion is scoped to
+ *      the top-level entries that are NOT in `keep`.
  *   2. Cleans up any untracked files / empty directory that `git rm` left
- *      behind, so the path is fully gone from the working tree.
+ *      behind, so the deleted paths are fully gone from the working tree.
  *
  * Caveats:
- *   - Destructive: any local edits to `infrastructure/` are lost. Run on a
+ *   - Destructive: any local edits to deleted paths are lost. Run on a
  *     clean working tree (or after committing your local changes).
  *   - If `infrastructure/` doesn't exist, this codemod is a no-op.
  *   - Requires git to be installed and the country config working directory
  *     to be a git repo.
  */
 
-import { existsSync, rmSync } from 'fs'
+import { existsSync, readdirSync, rmSync } from 'fs'
 import { join } from 'path'
 import { assertIsGitRepo, runGit } from './checkout-upstream-files'
 
 const INFRASTRUCTURE_DIR = 'infrastructure'
 
-async function main(): Promise<void> {
+interface DeleteInfrastructureOptions {
+  /**
+   * Top-level entries directly under `infrastructure/` to preserve. Names
+   * match against the basename of each entry (file or directory). When
+   * empty (the default), the whole `infrastructure/` directory is deleted.
+   */
+  keep?: string[]
+}
+
+async function main({
+  keep = []
+}: DeleteInfrastructureOptions = {}): Promise<void> {
   const fullPath = join(process.cwd(), INFRASTRUCTURE_DIR)
 
   if (!existsSync(fullPath)) {
@@ -52,27 +71,87 @@ async function main(): Promise<void> {
     return
   }
 
-  console.log(`Deleting '${INFRASTRUCTURE_DIR}/'...\n`)
-
   assertIsGitRepo()
 
-  // `git rm -rf --ignore-unmatch` removes tracked files (working tree + index)
-  // and is a no-op for paths with no tracked entries, so it's safe to run
-  // even when `infrastructure/` exists only as untracked files.
-  runGit(['rm', '-rf', '--ignore-unmatch', '--', `${INFRASTRUCTURE_DIR}/`], {
-    silent: true
-  })
-  console.log(`  Staged deletion of tracked files under '${INFRASTRUCTURE_DIR}/'.`)
+  // ─── Whole-directory delete (legacy behavior) ────────────────────────
+  if (keep.length === 0) {
+    console.log(`Deleting '${INFRASTRUCTURE_DIR}/'...\n`)
 
-  // `git rm` leaves untracked files (and any now-empty directory) on disk;
-  // remove whatever's left so the path is fully gone.
-  if (existsSync(fullPath)) {
-    rmSync(fullPath, { recursive: true, force: true })
-    console.log(`  Removed remaining untracked files under '${INFRASTRUCTURE_DIR}/'.`)
+    // `git rm -rf --ignore-unmatch` removes tracked files (working tree +
+    // index) and is a no-op for paths with no tracked entries, so it's
+    // safe to run even when `infrastructure/` exists only as untracked
+    // files.
+    runGit(['rm', '-rf', '--ignore-unmatch', '--', `${INFRASTRUCTURE_DIR}/`], {
+      silent: true
+    })
+    console.log(
+      `  Staged deletion of tracked files under '${INFRASTRUCTURE_DIR}/'.`
+    )
+
+    // `git rm` leaves untracked files (and any now-empty directory) on
+    // disk; remove whatever's left so the path is fully gone.
+    if (existsSync(fullPath)) {
+      rmSync(fullPath, { recursive: true, force: true })
+      console.log(
+        `  Removed remaining untracked files under '${INFRASTRUCTURE_DIR}/'.`
+      )
+    }
+
+    console.log(
+      `\n  Done. Review the staged deletion with: git diff --cached -- '${INFRASTRUCTURE_DIR}/'`
+    )
+    return
+  }
+
+  // ─── Selective delete: keep listed top-level entries ─────────────────
+  const keepSet = new Set(keep)
+  console.log(
+    `Deleting contents of '${INFRASTRUCTURE_DIR}/' except: ${[...keepSet]
+      .map((name) => `'${name}'`)
+      .join(', ')}\n`
+  )
+
+  const topLevelEntries = readdirSync(fullPath, { withFileTypes: true })
+  let deleted = 0
+
+  for (const entry of topLevelEntries) {
+    if (keepSet.has(entry.name)) {
+      console.log(`  Keeping '${INFRASTRUCTURE_DIR}/${entry.name}'.`)
+      continue
+    }
+
+    // Append a trailing slash for directories so git treats it as a tree
+    // pathspec (matches the recursive behavior of `git rm -rf`).
+    const relPath = `${INFRASTRUCTURE_DIR}/${entry.name}${
+      entry.isDirectory() ? '/' : ''
+    }`
+    runGit(['rm', '-rf', '--ignore-unmatch', '--', relPath], { silent: true })
+
+    const fullEntryPath = join(fullPath, entry.name)
+    if (existsSync(fullEntryPath)) {
+      rmSync(fullEntryPath, { recursive: true, force: true })
+    }
+
+    console.log(`  Deleted '${relPath}'.`)
+    deleted++
+  }
+
+  // Note any requested keeps that weren't actually present, so the dev
+  // notices typos / missing directories.
+  const presentNames = new Set(topLevelEntries.map((e) => e.name))
+  const missingKeeps = [...keepSet].filter((name) => !presentNames.has(name))
+  if (missingKeeps.length > 0) {
+    console.warn(
+      `  [warn] Requested to keep ${missingKeeps
+        .map((n) => `'${n}'`)
+        .join(', ')} but they don't exist under '${INFRASTRUCTURE_DIR}/'.`
+    )
   }
 
   console.log(
-    `\n  Done. Review the staged deletion with: git diff --cached -- '${INFRASTRUCTURE_DIR}/'`
+    `\n  Done. Deleted ${deleted} top-level entr${
+      deleted === 1 ? 'y' : 'ies'
+    }. Review the staged deletions with: git diff --cached -- '${INFRASTRUCTURE_DIR}/'`
   )
 }
 

--- a/packages/toolkit/src/migrations/v2.0/index.ts
+++ b/packages/toolkit/src/migrations/v2.0/index.ts
@@ -36,13 +36,23 @@ import { main as mergeInfrastructureDirectory } from './merge-infrastructure-dir
 import { main as deleteInfrastructureDirectory } from './delete-infrastructure-directory'
 
 /**
+ * Top-level subdirectories of `infrastructure/` that non-Swarm deployments
+ * still need (e.g. Postgres init scripts, Metabase config). Everything else
+ * under `infrastructure/` is deleted, and these subdirectories are then
+ * merged with upstream so the country config picks up the v2.0 changes.
+ */
+const NON_SWARM_INFRA_SUBDIRS = ['postgres', 'metabase']
+
+/**
  * Run the upgrade process for the country config in the current working
  * directory.
  *
  * @param dockerSwarm - When true, the local `infrastructure/` directory is
- *   merged with upstream changes (Docker Swarm deployments still need it).
- *   When false (the default), `infrastructure/` is deleted entirely, since
- *   non-Swarm deployments no longer ship it.
+ *   merged with upstream changes in its entirety (Docker Swarm deployments
+ *   still need it all). When false (the default), everything under
+ *   `infrastructure/` is deleted EXCEPT the subdirectories listed in
+ *   `NON_SWARM_INFRA_SUBDIRS`, and those preserved subdirectories are then
+ *   merged with upstream.
  */
 export async function runUpgrade(dockerSwarm: boolean) {
   await migrateWorkqueueConfigs()
@@ -73,6 +83,7 @@ export async function runUpgrade(dockerSwarm: boolean) {
   if (dockerSwarm) {
     await mergeInfrastructureDirectory()
   } else {
-    await deleteInfrastructureDirectory()
+    await deleteInfrastructureDirectory({ keep: NON_SWARM_INFRA_SUBDIRS })
+    await mergeInfrastructureDirectory({ subdirs: NON_SWARM_INFRA_SUBDIRS })
   }
 }

--- a/packages/toolkit/src/migrations/v2.0/merge-infrastructure-directory.ts
+++ b/packages/toolkit/src/migrations/v2.0/merge-infrastructure-directory.ts
@@ -11,7 +11,7 @@
 
 /**
  * Codemod: Merge upstream changes into the local `infrastructure/` directory
- * from opencrvs/opencrvs-countryconfig.
+ * (or selected subdirectories of it) from opencrvs/opencrvs-countryconfig.
  *
  * Usage:
  *   ts-node -r tsconfig-paths/register src/migrations/v2.0/merge-infrastructure-directory.ts
@@ -22,8 +22,10 @@
  *        - the upstream "theirs" branch (v2.0) → `UPSTREAM_BRANCH`
  *        - the synthetic merge-base branch (latest 1.9 release line)
  *          → `BASE_BRANCH`
- *   2. For every file under `infrastructure/` on upstream "theirs", performs
- *      a file-scoped 3-way merge:
+ *   2. For every file under `infrastructure/` on upstream "theirs" (or, when
+ *      `subdirs` is provided, only files under
+ *      `infrastructure/<subdir>/` for each requested subdir), performs a
+ *      file-scoped 3-way merge:
  *        - new file on upstream → checked out and staged
  *        - existing file       → 3-way merged in place via `git merge-file`,
  *                                using the BASE_BRANCH version of the file
@@ -114,11 +116,33 @@ function gitShowBytes(ref: string, path: string): Uint8Array | null {
   }
 }
 
+interface MergeInfrastructureOptions {
+  /**
+   * Top-level subdirectories of `infrastructure/` to scope the merge to.
+   * When omitted or empty, the entire `infrastructure/` tree is merged
+   * (legacy behavior). Each name is relative to `infrastructure/` —
+   * e.g. `['postgres', 'metabase']` merges only
+   * `infrastructure/postgres/` and `infrastructure/metabase/`.
+   */
+  subdirs?: string[]
+}
+
 // ─── Entry point ─────────────────────────────────────────────────────────────
 
-async function main(): Promise<void> {
+async function main({
+  subdirs = []
+}: MergeInfrastructureOptions = {}): Promise<void> {
+  // Build the pathspec list passed to `git ls-tree`. Trailing slashes make
+  // git treat them as tree paths (recurse into them).
+  const pathspecs =
+    subdirs.length > 0
+      ? subdirs.map((s) => `${INFRASTRUCTURE_DIR}/${s}/`)
+      : [`${INFRASTRUCTURE_DIR}/`]
+
+  const scopeLabel = pathspecs.map((p) => `'${p}'`).join(', ')
+
   console.log(
-    `Merging '${INFRASTRUCTURE_DIR}/' from ${UPSTREAM_URL}@${UPSTREAM_BRANCH} (base: ${BASE_BRANCH})...\n`
+    `Merging ${scopeLabel} from ${UPSTREAM_URL}@${UPSTREAM_BRANCH} (base: ${BASE_BRANCH})...\n`
   )
 
   assertIsGitRepo()
@@ -141,17 +165,10 @@ async function main(): Promise<void> {
     const baseRef = `${TEMP_REMOTE}/${BASE_BRANCH}`
 
     // -z gives NUL-separated paths so filenames with spaces or newlines
-    // survive the round-trip.
+    // survive the round-trip. Multiple pathspecs after `--` are unioned
+    // by git, which scopes the listing to the requested subdirectories.
     const upstreamFiles = runGit(
-      [
-        'ls-tree',
-        '-r',
-        '--name-only',
-        '-z',
-        ref,
-        '--',
-        `${INFRASTRUCTURE_DIR}/`
-      ],
+      ['ls-tree', '-r', '--name-only', '-z', ref, '--', ...pathspecs],
       { silent: true }
     )
       .split('\0')
@@ -159,7 +176,7 @@ async function main(): Promise<void> {
 
     if (upstreamFiles.length === 0) {
       console.log(
-        `  No files found under '${INFRASTRUCTURE_DIR}/' on ${ref}. Nothing to merge.`
+        `  No files found under ${scopeLabel} on ${ref}. Nothing to merge.`
       )
       return
     }

--- a/packages/toolkit/src/migrations/v2.0/migrate-workqueue-configs.ts
+++ b/packages/toolkit/src/migrations/v2.0/migrate-workqueue-configs.ts
@@ -25,10 +25,20 @@
  *       - `actions: [{...}, {...}, ...]`     -> keeps first as `action`, warns about dropped extras
  *   - If `action` already exists, removes deprecated `actions` and keeps `action`
  *   - Removes unsupported `action.type` values (`DEFAULT`, `VALIDATE`, etc.)
+ *   - Ensures every workqueue ends up with a valid `action`. When none is
+ *     present (or the existing one is unsupported), falls back to
+ *     `action: { type: ActionType.READ }` and ensures `ActionType` is imported
+ *     from `@opencrvs/toolkit/events` in the file.
  *   - Saves modified files in-place
  */
 
-import { Node, ObjectLiteralExpression, Project, SyntaxKind } from 'ts-morph'
+import {
+  Node,
+  ObjectLiteralExpression,
+  Project,
+  SourceFile,
+  SyntaxKind
+} from 'ts-morph'
 import path from 'path'
 const DEFINE_WORKQUEUES_NAME = 'defineWorkqueues'
 const ACTIONS_PROPERTY_NAME = 'actions'
@@ -36,6 +46,10 @@ const ACTION_PROPERTY_NAME = 'action'
 const CONDITIONALS_PROPERTY_NAME = 'conditionals'
 const TYPE_PROPERTY_NAME = 'type'
 const SLUG_PROPERTY_NAME = 'slug'
+const READ_ACTION_TYPE = 'READ'
+const ACTION_TYPE_IMPORT_NAME = 'ActionType'
+const TOOLKIT_EVENTS_MODULE = '@opencrvs/toolkit/events'
+const READ_ACTION_FALLBACK_INITIALIZER = `{ type: ${ACTION_TYPE_IMPORT_NAME}.${READ_ACTION_TYPE} }`
 const SUPPORTED_WORKQUEUE_ACTION_TYPES = new Set([
   'READ',
   'DELETE',
@@ -94,112 +108,188 @@ function isUnsupportedActionType(action: ObjectLiteralExpression): boolean {
   return !SUPPORTED_WORKQUEUE_ACTION_TYPES.has(typeName)
 }
 
-function migrateWorkqueueActions(
+/**
+ * Ensures the workqueue has a valid singular `action` property. When the
+ * existing `action` is missing or has an unsupported type, replaces it with
+ * `action: { type: ActionType.READ }`.
+ *
+ * Returns whether anything was changed and whether the READ fallback was
+ * applied (so the caller can ensure `ActionType` is imported in the file).
+ */
+function ensureValidAction(
   workqueue: ObjectLiteralExpression,
   relPath: string
-): number {
-  const actionsProperty = workqueue.getProperty(ACTIONS_PROPERTY_NAME)
-  if (!actionsProperty || !Node.isPropertyAssignment(actionsProperty)) {
-    return 0
-  }
-
-  const actionsInitializer = actionsProperty.getInitializer()
-  if (!actionsInitializer || !Node.isArrayLiteralExpression(actionsInitializer)) {
-    return 0
-  }
-
+): { changed: boolean; usedReadFallback: boolean } {
   const workqueueLabel = getWorkqueueLabel(workqueue)
-  const existingActionProperty = workqueue.getProperty(ACTION_PROPERTY_NAME)
+  const actionProperty = workqueue.getProperty(ACTION_PROPERTY_NAME)
 
-  if (existingActionProperty) {
-    if (Node.isPropertyAssignment(existingActionProperty)) {
-      const existingActionInitializer = existingActionProperty.getInitializer()
-      if (existingActionInitializer && Node.isObjectLiteralExpression(existingActionInitializer)) {
-        const conditionalsProperty = existingActionInitializer.getProperty(
-          CONDITIONALS_PROPERTY_NAME
-        )
-        if (conditionalsProperty) {
-          conditionalsProperty.remove()
-          // eslint-disable-next-line no-console
-          console.log(
-            `  [${relPath}] Removed deprecated 'conditionals' from 'action' on workqueue '${workqueueLabel}'`
-          )
-        }
-
-        if (isUnsupportedActionType(existingActionInitializer)) {
-          existingActionProperty.remove()
-          // eslint-disable-next-line no-console
-          console.log(
-            `  [${relPath}] Removed unsupported 'action' type on workqueue '${workqueueLabel}'`
-          )
-        }
+  if (actionProperty && Node.isPropertyAssignment(actionProperty)) {
+    const initializer = actionProperty.getInitializer()
+    if (initializer && Node.isObjectLiteralExpression(initializer)) {
+      if (!isUnsupportedActionType(initializer)) {
+        return { changed: false, usedReadFallback: false }
       }
+
+      actionProperty.set({
+        name: ACTION_PROPERTY_NAME,
+        initializer: READ_ACTION_FALLBACK_INITIALIZER
+      })
+      // eslint-disable-next-line no-console
+      console.log(
+        `  [${relPath}] Replaced unsupported 'action' type with '${ACTION_TYPE_IMPORT_NAME}.${READ_ACTION_TYPE}' on workqueue '${workqueueLabel}'`
+      )
+      return { changed: true, usedReadFallback: true }
     }
-
-    actionsProperty.remove()
-    // eslint-disable-next-line no-console
-    console.log(
-      `  [${relPath}] Removed deprecated 'actions' from workqueue '${workqueueLabel}' (existing 'action' kept)`
-    )
-    return 1
   }
-
-  const actionCandidates = actionsInitializer
-    .getElements()
-    .filter((element): element is ObjectLiteralExpression =>
-      Node.isObjectLiteralExpression(element)
-    )
-
-  if (actionCandidates.length === 0) {
-    actionsProperty.remove()
-    // eslint-disable-next-line no-console
-    console.log(
-      `  [${relPath}] Removed empty 'actions' from workqueue '${workqueueLabel}'`
-    )
-    return 1
-  }
-
-  if (actionCandidates.length > 1) {
-    const droppedCount = actionCandidates.length - 1
-    // eslint-disable-next-line no-console
-    console.warn(
-      `  [${relPath}] Workqueue '${workqueueLabel}' has ${actionCandidates.length} actions; keeping first as 'action' and dropping ${droppedCount} extra action(s)`
-    )
-  }
-
-  const conditionalsProperty = actionCandidates[0].getProperty(
-    CONDITIONALS_PROPERTY_NAME
-  )
-  if (conditionalsProperty) {
-    conditionalsProperty.remove()
-    // eslint-disable-next-line no-console
-    console.log(
-      `  [${relPath}] Removed deprecated 'conditionals' from migrated 'action' on workqueue '${workqueueLabel}'`
-    )
-  }
-
-  if (isUnsupportedActionType(actionCandidates[0])) {
-    actionsProperty.remove()
-    // eslint-disable-next-line no-console
-    console.log(
-      `  [${relPath}] Removed deprecated 'actions' from workqueue '${workqueueLabel}' because action type is unsupported`
-    )
-    return 1
-  }
-
-  const firstActionText = actionCandidates[0].getText()
 
   workqueue.addPropertyAssignment({
     name: ACTION_PROPERTY_NAME,
-    initializer: firstActionText
+    initializer: READ_ACTION_FALLBACK_INITIALIZER
   })
-  actionsProperty.remove()
-
   // eslint-disable-next-line no-console
   console.log(
-    `  [${relPath}] Replaced 'actions' with 'action' on workqueue '${workqueueLabel}'`
+    `  [${relPath}] Added default 'action: ${READ_ACTION_FALLBACK_INITIALIZER}' to workqueue '${workqueueLabel}'`
   )
-  return 1
+  return { changed: true, usedReadFallback: true }
+}
+
+function migrateWorkqueueActions(
+  workqueue: ObjectLiteralExpression,
+  relPath: string
+): { changed: boolean; usedReadFallback: boolean } {
+  const workqueueLabel = getWorkqueueLabel(workqueue)
+  const actionsProperty = workqueue.getProperty(ACTIONS_PROPERTY_NAME)
+  let actionsArrayMigrated = false
+
+  if (actionsProperty && Node.isPropertyAssignment(actionsProperty)) {
+    const actionsInitializer = actionsProperty.getInitializer()
+    if (
+      actionsInitializer &&
+      Node.isArrayLiteralExpression(actionsInitializer)
+    ) {
+      const existingActionProperty = workqueue.getProperty(ACTION_PROPERTY_NAME)
+
+      if (existingActionProperty) {
+        if (Node.isPropertyAssignment(existingActionProperty)) {
+          const existingActionInitializer =
+            existingActionProperty.getInitializer()
+          if (
+            existingActionInitializer &&
+            Node.isObjectLiteralExpression(existingActionInitializer)
+          ) {
+            const conditionalsProperty = existingActionInitializer.getProperty(
+              CONDITIONALS_PROPERTY_NAME
+            )
+            if (conditionalsProperty) {
+              conditionalsProperty.remove()
+              // eslint-disable-next-line no-console
+              console.log(
+                `  [${relPath}] Removed deprecated 'conditionals' from 'action' on workqueue '${workqueueLabel}'`
+              )
+            }
+          }
+        }
+
+        actionsProperty.remove()
+        // eslint-disable-next-line no-console
+        console.log(
+          `  [${relPath}] Removed deprecated 'actions' from workqueue '${workqueueLabel}' (existing 'action' kept)`
+        )
+        actionsArrayMigrated = true
+      } else {
+        const actionCandidates = actionsInitializer
+          .getElements()
+          .filter((element): element is ObjectLiteralExpression =>
+            Node.isObjectLiteralExpression(element)
+          )
+
+        if (actionCandidates.length === 0) {
+          actionsProperty.remove()
+          // eslint-disable-next-line no-console
+          console.log(
+            `  [${relPath}] Removed empty 'actions' from workqueue '${workqueueLabel}'`
+          )
+          actionsArrayMigrated = true
+        } else {
+          if (actionCandidates.length > 1) {
+            const droppedCount = actionCandidates.length - 1
+            // eslint-disable-next-line no-console
+            console.warn(
+              `  [${relPath}] Workqueue '${workqueueLabel}' has ${actionCandidates.length} actions; keeping first as 'action' and dropping ${droppedCount} extra action(s)`
+            )
+          }
+
+          const conditionalsProperty = actionCandidates[0].getProperty(
+            CONDITIONALS_PROPERTY_NAME
+          )
+          if (conditionalsProperty) {
+            conditionalsProperty.remove()
+            // eslint-disable-next-line no-console
+            console.log(
+              `  [${relPath}] Removed deprecated 'conditionals' from migrated 'action' on workqueue '${workqueueLabel}'`
+            )
+          }
+
+          if (isUnsupportedActionType(actionCandidates[0])) {
+            actionsProperty.remove()
+            // eslint-disable-next-line no-console
+            console.log(
+              `  [${relPath}] Removed deprecated 'actions' from workqueue '${workqueueLabel}' because action type is unsupported`
+            )
+            actionsArrayMigrated = true
+          } else {
+            const firstActionText = actionCandidates[0].getText()
+            workqueue.addPropertyAssignment({
+              name: ACTION_PROPERTY_NAME,
+              initializer: firstActionText
+            })
+            actionsProperty.remove()
+            // eslint-disable-next-line no-console
+            console.log(
+              `  [${relPath}] Replaced 'actions' with 'action' on workqueue '${workqueueLabel}'`
+            )
+            actionsArrayMigrated = true
+          }
+        }
+      }
+    }
+  }
+
+  // Always ensure the workqueue ends up with a valid `action`. This both
+  // covers workqueues that never had an `actions` array, and patches up
+  // workqueues whose existing/migrated action type is unsupported.
+  const fallback = ensureValidAction(workqueue, relPath)
+
+  return {
+    changed: actionsArrayMigrated || fallback.changed,
+    usedReadFallback: fallback.usedReadFallback
+  }
+}
+
+/**
+ * Ensures `import { ActionType } from '@opencrvs/toolkit/events'` exists in
+ * the source file, merging into any existing import declaration from the
+ * same module specifier.
+ */
+function ensureActionTypeImport(sourceFile: SourceFile): void {
+  const existingImport = sourceFile.getImportDeclaration(
+    (decl) => decl.getModuleSpecifierValue() === TOOLKIT_EVENTS_MODULE
+  )
+
+  if (existingImport) {
+    const alreadyImported = existingImport
+      .getNamedImports()
+      .some((ni) => ni.getName() === ACTION_TYPE_IMPORT_NAME)
+    if (!alreadyImported) {
+      existingImport.addNamedImport(ACTION_TYPE_IMPORT_NAME)
+    }
+    return
+  }
+
+  sourceFile.addImportDeclaration({
+    moduleSpecifier: TOOLKIT_EVENTS_MODULE,
+    namedImports: [ACTION_TYPE_IMPORT_NAME]
+  })
 }
 
 function processFile(filePath: string, project: Project): number {
@@ -207,6 +297,7 @@ function processFile(filePath: string, project: Project): number {
   if (!sourceFile) return 0
 
   let migratedWorkqueues = 0
+  let needsActionTypeImport = false
   const relPath = path.relative(process.cwd(), filePath)
 
   const callExpressions = sourceFile.getDescendantsOfKind(
@@ -230,8 +321,14 @@ function processFile(filePath: string, project: Project): number {
 
     for (const element of workqueuesArg.getElements()) {
       if (!Node.isObjectLiteralExpression(element)) continue
-      migratedWorkqueues += migrateWorkqueueActions(element, relPath)
+      const result = migrateWorkqueueActions(element, relPath)
+      if (result.changed) migratedWorkqueues++
+      if (result.usedReadFallback) needsActionTypeImport = true
     }
+  }
+
+  if (needsActionTypeImport) {
+    ensureActionTypeImport(sourceFile)
   }
 
   return migratedWorkqueues


### PR DESCRIPTION
## Description

Codemod fixes:
* Set `release-v2.0.0` as upstream branch (instead of `develop`)
* Set `{ type: ActionType.READ }` to all workqueue configs by default (unless `actions` is already specified)
* Fix k8s infrastructure cleanup: keep and sync `infrastructure/postgres/` and `infrastructure/metabase/` (instead of deleting `infrastructure/` completely

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
