### PR TITLE
Performance testing

### DIFF
--- a/packages/client/src/v2-events/custom-api/index.ts
+++ b/packages/client/src/v2-events/custom-api/index.ts
@@ -75,7 +75,8 @@ export async function registerOnDeclare({
     annotation,
     eventId,
     transactionId,
-    keepAssignment: true
+    keepAssignment: true,
+    waitFor: true
   })
 
   if (hasPotentialDuplicates(declaredEvent, eventConfiguration)) {
@@ -86,7 +87,8 @@ export async function registerOnDeclare({
     declaration: {},
     annotation,
     eventId,
-    transactionId
+    transactionId,
+    waitFor: true
   })
 }
 
@@ -104,7 +106,8 @@ export async function editAndRegister({
     eventId,
     transactionId,
     keepAssignment: true,
-    content
+    content,
+    waitFor: true
   })
 
   const declaredEvent = await trpcClient.event.actions.declare.request.mutate({
@@ -112,7 +115,8 @@ export async function editAndRegister({
     annotation,
     eventId,
     transactionId,
-    keepAssignment: true
+    keepAssignment: true,
+    waitFor: true
   })
 
   if (hasPotentialDuplicates(declaredEvent, eventConfiguration)) {
@@ -123,7 +127,8 @@ export async function editAndRegister({
     declaration,
     annotation,
     eventId,
-    transactionId
+    transactionId,
+    waitFor: true
   })
 }
 
@@ -140,14 +145,16 @@ export async function editAndDeclare({
     eventId,
     transactionId,
     keepAssignment: true,
-    content
+    content,
+    waitFor: true
   })
 
   return trpcClient.event.actions.declare.request.mutate({
     declaration,
     annotation,
     eventId,
-    transactionId
+    transactionId,
+    waitFor: true
   })
 }
 
@@ -164,14 +171,16 @@ export async function editAndNotify({
     eventId,
     transactionId,
     keepAssignment: true,
-    content
+    content,
+    waitFor: true
   })
 
   return trpcClient.event.actions.notify.request.mutate({
     declaration,
     annotation,
     eventId,
-    transactionId
+    transactionId,
+    waitFor: true
   })
 }
 
@@ -189,6 +198,7 @@ export async function archiveOnDuplicate({
     transactionId,
     declaration,
     keepAssignment: true,
+    waitFor: true,
     ...(content.duplicateOf
       ? { content: { duplicateOf: content.duplicateOf } }
       : {})
@@ -197,7 +207,8 @@ export async function archiveOnDuplicate({
     eventId,
     transactionId,
     declaration,
-    content: { reason: content.reason }
+    content: { reason: content.reason },
+    waitFor: true
   })
 }
 
@@ -247,7 +258,8 @@ export async function makeCorrectionOnRequest({
       declaration,
       transactionId,
       annotation,
-      keepAssignment: true
+      keepAssignment: true,
+      waitFor: true
     })
 
   const requestId = response.actions.find(
@@ -268,6 +280,7 @@ export async function makeCorrectionOnRequest({
     requestId,
     annotation: {
       isImmediateCorrection: true
-    }
+    },
+    waitFor: true
   })
 }

--- a/packages/client/src/v2-events/features/events/useEvents/procedures/actions/action.ts
+++ b/packages/client/src/v2-events/features/events/useEvents/procedures/actions/action.ts
@@ -490,7 +490,8 @@ export function useEventAction<P extends DecorateMutationProcedure<any>>(
           event: findLocalEventDocument(eventId)
         }
       }),
-      annotation
+      annotation,
+      waitFor: true
     }
   }
 

--- a/packages/commons/src/events/ActionInput.ts
+++ b/packages/commons/src/events/ActionInput.ts
@@ -27,6 +27,7 @@ export const BaseActionInput = z.object({
   annotation: ActionUpdate.optional(),
   originalActionId: UUID.optional(), // should not be part of base action.
   keepAssignment: z.boolean().optional(),
+  waitFor: z.boolean().optional(),
   // For normal users, the createdAtLocation is resolved on the backend from the user's primaryOfficeId.
   // @TODO: createdAtLocation should be limited to actions that system users can perform. For normal users, it should not be part of the base action.
   createdAtLocation: UUID.nullish().describe(

--- a/packages/commons/src/events/FieldValue.ts
+++ b/packages/commons/src/events/FieldValue.ts
@@ -201,35 +201,26 @@ function schemaPriority(schema: z.ZodTypeAny) {
 export function safeUnion<T extends [z.ZodTypeAny, ...z.ZodTypeAny[]]>(
   schemas: T
 ) {
+  // Sort once at definition time so the first successful safeParse is always
+  // the highest-priority match. This avoids trying all schemas on every value.
+  const sortedSchemas = [...schemas].sort(
+    (a, b) => schemaPriority(a) - schemaPriority(b)
+  )
+
   return z
     .any()
     .superRefine((val, ctx) => {
-      const successful = schemas.filter((s) => s.safeParse(val).success)
-
-      if (successful.length === 1) {
-        return
+      for (const schema of sortedSchemas) {
+        if (schema.safeParse(val).success) {
+          return
+        }
       }
 
-      if (successful.length === 0) {
-        ctx.addIssue({
-          code: 'invalid_type',
-          expected: 'custom',
-          message: 'Value does not match any schema'
-        })
-        return
-      }
-
-      // Multiple matches, pick the best according to PRIORITY_ORDER
-      successful.sort((a, b) => schemaPriority(a) - schemaPriority(b))
-      const best = successful[0]
-
-      if (!best.safeParse(val).success) {
-        ctx.addIssue({
-          expected: 'custom',
-          code: 'invalid_type',
-          message: 'Value did not match the best schema'
-        })
-      }
+      ctx.addIssue({
+        code: 'invalid_type',
+        expected: 'custom',
+        message: 'Value does not match any schema'
+      })
     })
     .meta({
       description:

--- a/packages/events/src/router/event/actions/declare.ts
+++ b/packages/events/src/router/event/actions/declare.ts
@@ -18,7 +18,7 @@ import {
 } from '@opencrvs/commons/events'
 import * as middleware from '@events/router/middleware'
 import { userOnlyProcedure } from '@events/router/trpc'
-import { getEventById, processAction } from '@events/service/events/events'
+import { processAction } from '@events/service/events/events'
 import {
   defaultRequestHandler,
   getDefaultActionProcedures
@@ -57,7 +57,7 @@ export function declareActionProcedures() {
         }
 
         const configs = await getInMemoryEventConfigurations(token)
-        const event = await getEventById(input.eventId)
+        const event = ctx.event
 
         const config = configs.find((c) => c.id === event.type)
 
@@ -104,8 +104,6 @@ export function declareActionProcedures() {
           config
         )
 
-        const updatedEvent = await getEventById(input.eventId)
-
         if (duplicates.length > 0) {
           return processAction(
             {
@@ -122,7 +120,7 @@ export function declareActionProcedures() {
               }
             },
             {
-              eventId: updatedEvent.id,
+              eventId: declaredEvent.id,
               user,
               token,
               status: ActionStatus.Accepted,

--- a/packages/events/src/router/event/actions/index.ts
+++ b/packages/events/src/router/event/actions/index.ts
@@ -216,7 +216,8 @@ export async function defaultRequestHandler(
     input.eventId,
     input.type,
     token,
-    'customActionType' in input ? input.customActionType : undefined
+    'customActionType' in input ? input.customActionType : undefined,
+    event
   )
 
   const eventWithRequestedAction = await addAction(input, {
@@ -388,7 +389,7 @@ export function getDefaultActionProcedures(
       .mutation(async ({ ctx, input }) => {
         const { token, user, existingAction, duplicates } = ctx
         const { eventId } = input
-        const event = await getEventById(eventId)
+        const event = ctx.event
         const eventConfiguration = await getEventConfigurationById({
           token,
           eventType: event.type

--- a/packages/events/src/router/event/actions/index.ts
+++ b/packages/events/src/router/event/actions/index.ts
@@ -250,7 +250,11 @@ export async function defaultRequestHandler(
     })
     // For Async flow, we just return the event with the requested action and ensure it is indexed
   } else if (responseStatus === ActionConfirmationResponse.RequiresProcessing) {
-    await ensureEventIndexed(eventWithRequestedAction, configuration)
+    await ensureEventIndexed(
+      eventWithRequestedAction,
+      configuration,
+      input.waitFor ?? false
+    )
     return eventWithRequestedAction
   }
 

--- a/packages/events/src/router/event/index.ts
+++ b/packages/events/src/router/event/index.ts
@@ -259,7 +259,9 @@ export const eventRouter = router({
       await throwConflictIfActionNotAllowed(
         input.eventId,
         ActionType.DELETE,
-        ctx.token
+        ctx.token,
+        undefined,
+        ctx.event
       )
       return deleteEvent(input.eventId, { token: ctx.token })
     }),
@@ -276,7 +278,13 @@ export const eventRouter = router({
 
         // Consecutive middlewares lose some of the typing.
         const user = UserContext.parse(ctx.user)
-        await throwConflictIfActionNotAllowed(eventId, type, ctx.token)
+        await throwConflictIfActionNotAllowed(
+          eventId,
+          type,
+          ctx.token,
+          undefined,
+          ctx.event
+        )
 
         const previousDraft = await draftsRepo.findLatestDraftForAction(
           eventId,

--- a/packages/events/src/router/middleware/detect-duplicate.ts
+++ b/packages/events/src/router/middleware/detect-duplicate.ts
@@ -24,7 +24,7 @@ import { getUUID, TokenUserType } from '@opencrvs/commons'
 import { TrpcContext } from '@events/context'
 import { getInMemoryEventConfigurations } from '@events/service/config/config'
 import { searchForDuplicates } from '@events/service/deduplication/deduplication'
-import { processAction, getEventById } from '@events/service/events/events'
+import { processAction } from '@events/service/events/events'
 
 function requiresDedupCheck(
   input: ActionInputWithType
@@ -35,7 +35,7 @@ function requiresDedupCheck(
 export const detectDuplicate: MiddlewareFunction<
   TrpcContext,
   OpenApiMeta,
-  TrpcContext,
+  TrpcContext & { event: EventDocument },
   TrpcContext & {
     duplicates:
       | {
@@ -59,7 +59,7 @@ export const detectDuplicate: MiddlewareFunction<
   }
   const { user, token } = ctx
   const configs = await getInMemoryEventConfigurations(token)
-  const storedEvent = await getEventById(input.eventId)
+  const storedEvent = ctx.event
   const config = configs.find((c) => c.id === storedEvent.type)
 
   if (!config) {

--- a/packages/events/src/router/middleware/validate/index.ts
+++ b/packages/events/src/router/middleware/validate/index.ts
@@ -182,7 +182,9 @@ function validateDeclarationUpdateAction({
   // Only check keys from declarationUpdate (the client's input), not fields inherited from the previous state
   // that may have become hidden due to changes in the current update.
   const declarationUpdateOnlyComplete = Object.fromEntries(
-    Object.entries(completeDeclaration).filter(([key]) => key in declarationUpdate)
+    Object.entries(completeDeclaration).filter(
+      ([key]) => key in declarationUpdate
+    )
   )
   const invalidKeys = getInvalidUpdateKeys({
     update: declarationUpdateOnlyComplete,

--- a/packages/events/src/service/administrative-areas/index.ts
+++ b/packages/events/src/service/administrative-areas/index.ts
@@ -11,6 +11,7 @@
 
 import { UUID, AdministrativeArea } from '@opencrvs/commons'
 import * as administrativeAreaRepo from '@events/storage/postgres/administrative-hierarchy/administrative-areas'
+import { clearAdministrativeHierarchyCache } from '@events/service/indexing/indexing'
 
 export async function getAdministrativeAreas(params?: {
   isActive?: boolean
@@ -26,4 +27,5 @@ export async function setAdministrativeAreas(
   administrativeAreas: AdministrativeArea[]
 ) {
   await administrativeAreaRepo.setAdministrativeAreas(administrativeAreas)
+  clearAdministrativeHierarchyCache()
 }

--- a/packages/events/src/service/administrative-areas/index.ts
+++ b/packages/events/src/service/administrative-areas/index.ts
@@ -11,7 +11,7 @@
 
 import { UUID, AdministrativeArea } from '@opencrvs/commons'
 import * as administrativeAreaRepo from '@events/storage/postgres/administrative-hierarchy/administrative-areas'
-import { clearAdministrativeHierarchyCache } from '@events/service/indexing/indexing'
+import { clearAdministrativeHierarchyCache } from '@events/storage/postgres/administrative-hierarchy/locations'
 
 export async function getAdministrativeAreas(params?: {
   isActive?: boolean

--- a/packages/events/src/service/events/events.ts
+++ b/packages/events/src/service/events/events.ts
@@ -422,10 +422,11 @@ function isEventIndexable(event: EventDocument) {
 
 export async function ensureEventIndexed(
   event: EventDocument,
-  configuration: EventConfig
+  configuration: EventConfig,
+  waitFor = false
 ) {
   if (isEventIndexable(event)) {
-    await indexEvent(event, configuration)
+    await indexEvent(event, configuration, waitFor)
   }
 }
 
@@ -463,7 +464,7 @@ export async function processAction(
   })
 
   // Only send the event to Elasticsearch if it is not a draft
-  await ensureEventIndexed(updatedEvent, configuration)
+  await ensureEventIndexed(updatedEvent, configuration, input.waitFor ?? false)
   return updatedEvent
 }
 

--- a/packages/events/src/service/events/events.ts
+++ b/packages/events/src/service/events/events.ts
@@ -120,9 +120,10 @@ export async function throwConflictIfActionNotAllowed(
   eventId: UUID,
   actionType: ActionType,
   token: TokenWithBearer,
-  customActionType?: string
+  customActionType?: string,
+  existingEvent?: EventDocument
 ) {
-  const event = await getEventById(eventId)
+  const event = existingEvent ?? (await getEventById(eventId))
   const eventConfiguration = await getEventConfigurationById({
     eventType: event.type,
     token

--- a/packages/events/src/service/indexing/indexing.ts
+++ b/packages/events/src/service/indexing/indexing.ts
@@ -60,8 +60,6 @@ import {
   withJurisdictionFilters
 } from './query'
 
-// Administrative areas change only on initialisation/re-seeding, so a
-// process-level cache eliminates repeated recursive CTE queries per request.
 const administrativeHierarchyCache = new Map<string, string[]>()
 
 export function clearAdministrativeHierarchyCache() {
@@ -75,9 +73,7 @@ function eventToEventIndex(
   return encodeEventIndex(getCurrentEventState(event, config), config)
 }
 
-/*
- * This type ensures all properties of EventIndex are present in the mapping
- */
+/* This type ensures all properties of EventIndex are present in the mapping */
 type EventIndexMapping = { [key in keyof EventIndex]: estypes.MappingProperty }
 
 async function ensureAlias(indexName: string) {
@@ -246,9 +242,7 @@ function mapFieldTypeToElasticsearch(
         type: 'object',
         enabled: false
       }
-    /**
-     * Custom fields are not indexed as their structure is unknown.
-     */
+    /** Custom fields are not indexed as their structure is unknown. */
     case FieldType._EXPERIMENTAL_CUSTOM:
       return {
         type: 'object',
@@ -495,9 +489,7 @@ export async function findRecordsByQuery({
   acceptedScopes: RecordScopeV2[]
 }) {
   const esClient = getOrCreateClient()
-
   const { query, limit, offset } = search
-
   const resolvedScopes = acceptedScopes.map((scope) =>
     resolveRecordActionScopeToIds(scope, user)
   )
@@ -597,9 +589,7 @@ export async function getEventCount({
 
   return responses.reduce((acc: Record<string, number>, response, index) => {
     const slug = queries[index].slug
-
     const validatedResponse = MsearchResponseSchema.safeParse(response)
-
     return {
       ...acc,
       [slug]: validatedResponse.success

--- a/packages/events/src/service/indexing/indexing.ts
+++ b/packages/events/src/service/indexing/indexing.ts
@@ -60,12 +60,6 @@ import {
   withJurisdictionFilters
 } from './query'
 
-const administrativeHierarchyCache = new Map<string, string[]>()
-
-export function clearAdministrativeHierarchyCache() {
-  administrativeHierarchyCache.clear()
-}
-
 function eventToEventIndex(
   event: EventDocument,
   config: EventConfig
@@ -395,7 +389,6 @@ export type BulkResponse = estypes.BulkResponse
 export async function indexEventsInBulk(
   batch: EventDocument[],
   configs: EventConfig[],
-  locationHierarchyCache: Map<string, string[]> = new Map<string, string[]>(),
   indexNameOverrides?: Map<string, string>
 ) {
   const esClient = getOrCreateClient()
@@ -408,11 +401,7 @@ export async function indexEventsInBulk(
       const eventIndex = eventToEventIndex(doc, config)
 
       const eventIndexWithLocationHierarchy =
-        await getEventIndexWithAdministrativeHierarchy(
-          config,
-          eventIndex,
-          locationHierarchyCache
-        )
+        await getEventIndexWithAdministrativeHierarchy(config, eventIndex)
       return [
         {
           index: {
@@ -463,11 +452,7 @@ export async function indexEvent(
   const eventIndex = eventToEventIndex(event, config)
 
   const eventIndexWithAdministrativeHierarchy =
-    await getEventIndexWithAdministrativeHierarchy(
-      config,
-      eventIndex,
-      administrativeHierarchyCache
-    )
+    await getEventIndexWithAdministrativeHierarchy(config, eventIndex)
   return esClient.index<EventIndexWithAdministrativeHierarchy>({
     index: indexName,
     id: event.id,

--- a/packages/events/src/service/indexing/indexing.ts
+++ b/packages/events/src/service/indexing/indexing.ts
@@ -451,7 +451,11 @@ export async function indexEventsInBulk(
   return response
 }
 
-export async function indexEvent(event: EventDocument, config: EventConfig) {
+export async function indexEvent(
+  event: EventDocument,
+  config: EventConfig,
+  waitFor: boolean = false
+) {
   const esClient = getOrCreateClient()
   const indexName = getEventIndexName(event.type)
   const eventIndex = eventToEventIndex(event, config)
@@ -463,7 +467,7 @@ export async function indexEvent(event: EventDocument, config: EventConfig) {
     id: event.id,
     /** We derive the full state (without nulls) from eventToEventIndex, replace instead of update. */
     document: eventIndexWithAdministrativeHierarchy,
-    refresh: 'wait_for'
+    refresh: waitFor ? 'wait_for' : false
   })
 }
 

--- a/packages/events/src/service/indexing/indexing.ts
+++ b/packages/events/src/service/indexing/indexing.ts
@@ -60,6 +60,14 @@ import {
   withJurisdictionFilters
 } from './query'
 
+// Administrative areas change only on initialisation/re-seeding, so a
+// process-level cache eliminates repeated recursive CTE queries per request.
+const administrativeHierarchyCache = new Map<string, string[]>()
+
+export function clearAdministrativeHierarchyCache() {
+  administrativeHierarchyCache.clear()
+}
+
 function eventToEventIndex(
   event: EventDocument,
   config: EventConfig
@@ -461,7 +469,11 @@ export async function indexEvent(
   const eventIndex = eventToEventIndex(event, config)
 
   const eventIndexWithAdministrativeHierarchy =
-    await getEventIndexWithAdministrativeHierarchy(config, eventIndex)
+    await getEventIndexWithAdministrativeHierarchy(
+      config,
+      eventIndex,
+      administrativeHierarchyCache
+    )
   return esClient.index<EventIndexWithAdministrativeHierarchy>({
     index: indexName,
     id: event.id,

--- a/packages/events/src/service/indexing/utils.ts
+++ b/packages/events/src/service/indexing/utils.ts
@@ -241,8 +241,7 @@ export function getEventIndexWithoutLocationHierarchy(
  */
 export async function getEventIndexWithAdministrativeHierarchy(
   eventConfig: EventConfig,
-  event: EventIndex,
-  administrativeHierarchy?: Map<string, string[]>
+  event: EventIndex
 ) {
   const buildAdministrativeHierarchyById = async (
     id: UUID
@@ -251,15 +250,7 @@ export async function getEventIndexWithAdministrativeHierarchy(
       return []
     }
 
-    if (administrativeHierarchy && administrativeHierarchy.has(id)) {
-      return administrativeHierarchy.get(id) || [id]
-    }
-
-    const hierarchy = await getAdministrativeHierarchyById(id)
-    if (administrativeHierarchy) {
-      administrativeHierarchy.set(id, hierarchy)
-    }
-    return hierarchy
+    return getAdministrativeHierarchyById(id)
   }
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
   const tempEvent = { ...event, declaration: { ...event.declaration } } as any

--- a/packages/events/src/service/reindex/index.ts
+++ b/packages/events/src/service/reindex/index.ts
@@ -88,7 +88,6 @@ async function reindexSearch(
   onBatchProcessed?: (count: number) => Promise<void>
 ) {
   const configurations = await getInMemoryEventConfigurations(token)
-  const locationHierarchyCache = new Map<string, string[]>()
   const indexNameOverrides = new Map(
     configurations.map((config) => [
       config.id,
@@ -110,12 +109,7 @@ async function reindexSearch(
 
     await Promise.all([
       withRetry(async () =>
-        indexEventsInBulk(
-          batch,
-          configurations,
-          locationHierarchyCache,
-          indexNameOverrides
-        )
+        indexEventsInBulk(batch, configurations, indexNameOverrides)
       ),
       withRetry(async () => reindexBatchToCountryConfig(token, batch))
     ])

--- a/packages/events/src/storage/postgres/administrative-hierarchy/administrative-areas.ts
+++ b/packages/events/src/storage/postgres/administrative-hierarchy/administrative-areas.ts
@@ -114,21 +114,27 @@ export async function setAdministrativeAreas(
  *
  * @returns List of leaf level administrative area ids.
  */
-export async function getLeafLevelAdministrativeAreaIds() {
-  const db = getClient()
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let leafLevelAdministrativeAreaIdsCache: Promise<any[]> | null = null
 
-  const query = db
-    .selectFrom('administrativeAreas as a1')
-    .select(['a1.id'])
-    .where(({ not, exists, selectFrom }) =>
-      not(
-        exists(
-          selectFrom('administrativeAreas as a2')
-            .select('a2.id')
-            .whereRef('a2.parentId', '=', 'a1.id')
+export function getLeafLevelAdministrativeAreaIds() {
+  if (!leafLevelAdministrativeAreaIdsCache) {
+    const db = getClient()
+
+    leafLevelAdministrativeAreaIdsCache = db
+      .selectFrom('administrativeAreas as a1')
+      .select(['a1.id'])
+      .where(({ not, exists, selectFrom }) =>
+        not(
+          exists(
+            selectFrom('administrativeAreas as a2')
+              .select('a2.id')
+              .whereRef('a2.parentId', '=', 'a1.id')
+          )
         )
       )
-    )
+      .execute()
+  }
 
-  return query.execute()
+  return leafLevelAdministrativeAreaIdsCache
 }

--- a/packages/events/src/storage/postgres/administrative-hierarchy/administrative-areas.ts
+++ b/packages/events/src/storage/postgres/administrative-hierarchy/administrative-areas.ts
@@ -114,8 +114,7 @@ export async function setAdministrativeAreas(
  *
  * @returns List of leaf level administrative area ids.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let leafLevelAdministrativeAreaIdsCache: Promise<any[]> | null = null
+let leafLevelAdministrativeAreaIdsCache: Promise<{ id: UUID }[]> | null = null
 
 export function getLeafLevelAdministrativeAreaIds() {
   if (!leafLevelAdministrativeAreaIdsCache) {

--- a/packages/events/src/storage/postgres/administrative-hierarchy/administrative-hierarchy.ts
+++ b/packages/events/src/storage/postgres/administrative-hierarchy/administrative-hierarchy.ts
@@ -35,4 +35,6 @@ export async function setAdministrativeHierarchy({
 
     await locationRepo.setLocationsInTrx(trx, locations)
   })
+
+  locationRepo.clearAdministrativeHierarchyCache()
 }

--- a/packages/events/src/storage/postgres/administrative-hierarchy/locations.ts
+++ b/packages/events/src/storage/postgres/administrative-hierarchy/locations.ts
@@ -20,6 +20,14 @@ import Schema from '../events/schema/Database'
 // "bind message has ... parameter formats but 0 parameters"
 const INSERT_MAX_CHUNK_SIZE = 1000
 
+// Process-level cache for administrative hierarchies. Invalidated whenever
+// locations or administrative areas are written.
+const administrativeHierarchyByIdCache = new Map<string, Promise<UUID[]>>()
+
+export function clearAdministrativeHierarchyCache() {
+  administrativeHierarchyByIdCache.clear()
+}
+
 export async function setLocationsInTrx(
   trx: Kysely<Schema>,
   locations: NewLocations[]
@@ -203,13 +211,6 @@ export function getAdministrativeHierarchyByIdCte(
  * @param locationId
  * @returns The list of location hierarchy ids, ex: [admin_area_1_id, admin_area_2_id, locationId]
  */
-// Process-level cache for administrative hierarchies. Invalidated whenever
-// locations or administrative areas are written.
-const administrativeHierarchyByIdCache = new Map<string, Promise<UUID[]>>()
-
-export function clearAdministrativeHierarchyCache() {
-  administrativeHierarchyByIdCache.clear()
-}
 
 export function getAdministrativeHierarchyById(id: string): Promise<UUID[]> {
   const cached = administrativeHierarchyByIdCache.get(id)

--- a/packages/events/src/storage/postgres/administrative-hierarchy/locations.ts
+++ b/packages/events/src/storage/postgres/administrative-hierarchy/locations.ts
@@ -69,6 +69,7 @@ export async function setLocations(locations: NewLocations[]) {
   const db = getClient()
 
   await setLocationsInTrx(db, locations)
+  clearAdministrativeHierarchyCache()
 }
 
 export async function getLocations({
@@ -202,11 +203,19 @@ export function getAdministrativeHierarchyByIdCte(
  * @param locationId
  * @returns The list of location hierarchy ids, ex: [admin_area_1_id, admin_area_2_id, locationId]
  */
+// Process-level cache for administrative hierarchies. Invalidated whenever
+// locations or administrative areas are written.
 const administrativeHierarchyByIdCache = new Map<string, Promise<UUID[]>>()
+
+export function clearAdministrativeHierarchyCache() {
+  administrativeHierarchyByIdCache.clear()
+}
 
 export function getAdministrativeHierarchyById(id: string): Promise<UUID[]> {
   const cached = administrativeHierarchyByIdCache.get(id)
-  if (cached) { return cached }
+  if (cached) {
+    return cached
+  }
 
   const db = getClient()
   const query = sql<{ ids: UUID[] }>`

--- a/packages/events/src/storage/postgres/administrative-hierarchy/locations.ts
+++ b/packages/events/src/storage/postgres/administrative-hierarchy/locations.ts
@@ -202,16 +202,24 @@ export function getAdministrativeHierarchyByIdCte(
  * @param locationId
  * @returns The list of location hierarchy ids, ex: [admin_area_1_id, admin_area_2_id, locationId]
  */
-export async function getAdministrativeHierarchyById(id: string) {
-  const db = getClient()
+const administrativeHierarchyByIdCache = new Map<string, Promise<UUID[]>>()
 
+export function getAdministrativeHierarchyById(id: string): Promise<UUID[]> {
+  const cached = administrativeHierarchyByIdCache.get(id)
+  if (cached) { return cached }
+
+  const db = getClient()
   const query = sql<{ ids: UUID[] }>`
     ${getAdministrativeHierarchyByIdCte(id)}
     SELECT array_agg(id ORDER BY depth DESC) AS ids FROM area_chain;
   `
 
-  const result = await db.executeQuery(query.compile(db))
-  return result.rows.length > 0 ? result.rows[0].ids : []
+  const promise = db
+    .executeQuery(query.compile(db))
+    .then((result) => (result.rows.length > 0 ? result.rows[0].ids : []))
+
+  administrativeHierarchyByIdCache.set(id, promise)
+  return promise
 }
 
 export async function isLocationUnderAdministrativeArea({

--- a/packages/events/src/storage/postgres/events.ts
+++ b/packages/events/src/storage/postgres/events.ts
@@ -54,9 +54,13 @@ export function getClient() {
   return db.withSchema('app')
 }
 
-export function resetServer() {
+export async function resetServer() {
+  const previousPool = pool
   db = undefined
   pool = undefined
+  if (previousPool) {
+    await previousPool.end()
+  }
 }
 
 export async function ensureConnection() {

--- a/packages/events/src/tests/setup.ts
+++ b/packages/events/src/tests/setup.ts
@@ -10,7 +10,10 @@
  */
 import { Client } from 'pg'
 import { inject, vi } from 'vitest'
-import { getDeclarationFields, TENNIS_CLUB_MEMBERSHIP } from '@opencrvs/commons/events'
+import {
+  getDeclarationFields,
+  TENNIS_CLUB_MEMBERSHIP
+} from '@opencrvs/commons/events'
 import { tennisClubMembershipEvent } from '@opencrvs/commons/fixtures'
 import {
   getPool,
@@ -18,7 +21,10 @@ import {
 } from '@events/storage/postgres/events'
 
 import { createIndex } from '@events/service/indexing/indexing'
-import { getReindexingStatusIndexName, getTemporaryIndexName } from '@events/storage/__mocks__/elasticsearch'
+import {
+  getReindexingStatusIndexName,
+  getTemporaryIndexName
+} from '@events/storage/__mocks__/elasticsearch'
 import { getOrCreateClient } from '@events/storage/elasticsearch'
 import { mswServer } from './msw'
 import { createDatabase, initializeSchemaAccess, migrate } from './postgres'
@@ -39,12 +45,12 @@ async function resetESServer() {
 
   getEventIndexName.mockImplementation((type: string) => type + '_' + id)
   getEventAliasName.mockReturnValue('events_' + id)
-  getReindexingStatusIndexName.mockReturnValue(
-    'reindexing_status_' + id
+  getReindexingStatusIndexName.mockReturnValue('reindexing_status_' + id)
+  getTemporaryIndexName.mockImplementation(
+    (eventType: string, timestamp: number) => {
+      return `${getEventIndexName(eventType)}_${timestamp}`
+    }
   )
-  getTemporaryIndexName.mockImplementation((eventType: string, timestamp: number) => {
-    return `${getEventIndexName(eventType)}_${timestamp}`
-  })
 
   const client = getOrCreateClient()
 
@@ -64,13 +70,16 @@ async function resetESServer() {
   await client.cluster.putSettings({
     body: {
       persistent: {
-        "action.auto_create_index": "false"
+        'action.auto_create_index': 'false'
       }
     }
   })
 
   // Create concrete indices
-  await createIndex(getEventIndexName(TENNIS_CLUB_MEMBERSHIP), getDeclarationFields(tennisClubMembershipEvent))
+  await createIndex(
+    getEventIndexName(TENNIS_CLUB_MEMBERSHIP),
+    getDeclarationFields(tennisClubMembershipEvent)
+  )
 }
 
 async function resetPostgresServer() {
@@ -93,7 +102,7 @@ async function resetPostgresServer() {
   await initializeSchemaAccess(databaseInitializer)
   await databaseInitializer.end()
 
-  resetEventsPostgresServer()
+  await resetEventsPostgresServer()
   getPool(EVENTS_APP_POSTGRES_URI)
 }
 

--- a/packages/events/src/tests/utils.ts
+++ b/packages/events/src/tests/utils.ts
@@ -125,6 +125,47 @@ export function sanitizeForSnapshot(data: unknown, fields: string[]) {
 
 const { createCallerFactory } = t
 
+/**
+ * Wraps a tRPC test caller so every leaf procedure call merges
+ * `waitFor: true` into the input. Mirrors what the real web client does — the
+ * server defaults `refresh` to `false` so HTTP requests don't block on
+ * Elasticsearch, but tests do need to see indexed state synchronously.
+ *
+ * Tests can still opt into async behavior by passing `waitFor: false`
+ * explicitly — `...input` wins over the injected default.
+ */
+function withWaitFor<T>(caller: T): T {
+  if (
+    caller === null ||
+    (typeof caller !== 'object' && typeof caller !== 'function')
+  ) {
+    return caller
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return new Proxy(caller as any, {
+    get(target, prop) {
+      const value = target[prop]
+      if (
+        value !== null &&
+        (typeof value === 'function' || typeof value === 'object')
+      ) {
+        return withWaitFor(value)
+      }
+      return value
+    },
+    apply(target, thisArg, args) {
+      const [input, ...rest] = args
+      const isPlainObject =
+        input !== null &&
+        typeof input === 'object' &&
+        (Object.getPrototypeOf(input) === Object.prototype ||
+          Object.getPrototypeOf(input) === null)
+      const patched = isPlainObject ? { waitFor: true, ...input } : input
+      return Reflect.apply(target, thisArg, [patched, ...rest])
+    }
+  })
+}
+
 export const TEST_USER_DEFAULT_SCOPES = [
   encodeScope({
     type: 'workqueue',
@@ -305,7 +346,7 @@ export function createSystemTestClient(
     token
   })
 
-  return caller
+  return withWaitFor(caller)
 }
 
 export function createTestClient(
@@ -327,7 +368,7 @@ export function createTestClient(
     },
     token
   })
-  return caller
+  return withWaitFor(caller)
 }
 
 export function createInternalTestClient(tokenWithBearer?: TokenWithBearer) {
@@ -338,7 +379,7 @@ export function createInternalTestClient(tokenWithBearer?: TokenWithBearer) {
     token
   })
 
-  return caller
+  return withWaitFor(caller)
 }
 
 export function createInitialisationTestClient(
@@ -351,7 +392,7 @@ export function createInitialisationTestClient(
     token
   })
 
-  return caller
+  return withWaitFor(caller)
 }
 
 /**
@@ -372,7 +413,7 @@ export function createCountryConfigClient(
     },
     token
   })
-  return caller
+  return withWaitFor(caller)
 }
 
 /**


### PR DESCRIPTION
## Description

A number of improvements to increase the performance of OpenCRVS events service:

#### Remove the `wait_for` when using the API

Every request waits for elasticsearch to index the changes before returning. 
This is on an interval of once per second.
This is useful from the UI so that refresh only happens once elasticsearch is updated.
From a performance testing perspective, it makes it impossible to get real number.

Changed to `wait_for` on request from the client, API requests immediately return.

#### Improved Zod schema parsing

Code previously parsed all Zod schemas and then checked how many it parsed and then selected highest priority if the number of parse matches was greater than 1.

Changed to order schemas by priority and then parse until it found a match. Logic is equivalent but dramatically reduces amount of processing on every request.

#### Cache Admin Structure

Admin structure is requested on every write operation, multiple times.

Added a cache since this almost never changes. This was the biggest saving in the tests.

#### Remove repeat calls to `getEventById`

Multiple calls to `getEventById` in a single request. The event exists in `ctx.event` so does not need to be refetched.

Used `ctx.event` where possible and passed event as a parameter otherwise. There is still some possible further optimisation here.

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
