### PR TITLE
Remove explicit `ActionProcedure` type

### DIFF
--- a/packages/events/src/router/event/actions/index.ts
+++ b/packages/events/src/router/event/actions/index.ts
@@ -180,8 +180,8 @@ const AUDIT_LOG_OPERATION_MAP: Partial<
   [ActionType.REJECT_CORRECTION]: 'event.actions.correction.reject.request'
 }
 
-export async function defaultRequestHandler(
-  input: ActionInputWithType,
+export async function defaultRequestHandler<T extends ActionType>(
+  input: Extract<ActionInputWithType, { type: T }>,
   user: TrpcUserContext,
   token: TokenWithBearer,
   event: EventDocument,
@@ -330,9 +330,9 @@ const SYSTEM_USER_ALLOWED_ACTIONS = [
  *
  * @param actionType - The action type for which we want to create router handlers.
  */
-export function getDefaultActionProcedures(
-  actionType: keyof typeof ACTION_PROCEDURE_CONFIG
-) {
+export function getDefaultActionProcedures<
+  T extends keyof typeof ACTION_PROCEDURE_CONFIG
+>(actionType: T) {
   const actionConfig = ACTION_PROCEDURE_CONFIG[actionType]
 
   let asyncAcceptInputFields = AsyncActionConfirmationResponseSchema
@@ -378,7 +378,7 @@ export function getDefaultActionProcedures(
           return duplicates.event
         }
 
-        const result = await defaultRequestHandler(
+        const result = await defaultRequestHandler<T>(
           input,
           user,
           token,

--- a/packages/events/src/router/event/actions/index.ts
+++ b/packages/events/src/router/event/actions/index.ts
@@ -180,8 +180,8 @@ const AUDIT_LOG_OPERATION_MAP: Partial<
   [ActionType.REJECT_CORRECTION]: 'event.actions.correction.reject.request'
 }
 
-export async function defaultRequestHandler<T extends ActionType>(
-  input: Extract<ActionInputWithType, { type: T }>,
+export async function defaultRequestHandler(
+  input: ActionInputWithType,
   user: TrpcUserContext,
   token: TokenWithBearer,
   event: EventDocument,
@@ -330,9 +330,9 @@ const SYSTEM_USER_ALLOWED_ACTIONS = [
  *
  * @param actionType - The action type for which we want to create router handlers.
  */
-export function getDefaultActionProcedures<
-  T extends keyof typeof ACTION_PROCEDURE_CONFIG
->(actionType: T) {
+export function getDefaultActionProcedures(
+  actionType: keyof typeof ACTION_PROCEDURE_CONFIG
+) {
   const actionConfig = ACTION_PROCEDURE_CONFIG[actionType]
 
   let asyncAcceptInputFields = AsyncActionConfirmationResponseSchema
@@ -378,7 +378,7 @@ export function getDefaultActionProcedures<
           return duplicates.event
         }
 
-        const result = await defaultRequestHandler<T>(
+        const result = await defaultRequestHandler(
           input,
           user,
           token,

--- a/packages/events/src/router/event/actions/index.ts
+++ b/packages/events/src/router/event/actions/index.ts
@@ -9,7 +9,6 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 import { TRPCError } from '@trpc/server'
-import { MutationProcedure } from '@trpc/server/unstable-core-do-not-import'
 import * as z from 'zod/v4'
 import { OpenApiMeta } from 'trpc-to-openapi'
 import { logger, UUID } from '@opencrvs/commons'
@@ -17,7 +16,6 @@ import {
   ActionType,
   ActionStatus,
   EventDocument,
-  ActionInput,
   NotifyActionInput,
   RegisterActionInput,
   RejectDeclarationActionInput,
@@ -182,24 +180,6 @@ const AUDIT_LOG_OPERATION_MAP: Partial<
   [ActionType.REJECT_CORRECTION]: 'event.actions.correction.reject.request'
 }
 
-type ActionProcedure = {
-  request: MutationProcedure<{
-    input: ActionInput
-    output: EventDocument
-    meta: OpenApiMeta
-  }>
-  accept: MutationProcedure<{
-    input: ActionInput & { actionId: string }
-    output: EventDocument
-    meta: OpenApiMeta
-  }>
-  reject: MutationProcedure<{
-    input: { eventId: string; actionId: string; transactionId: string }
-    output: EventDocument
-    meta: OpenApiMeta
-  }>
-}
-
 export async function defaultRequestHandler(
   input: ActionInputWithType,
   user: TrpcUserContext,
@@ -352,7 +332,7 @@ const SYSTEM_USER_ALLOWED_ACTIONS = [
  */
 export function getDefaultActionProcedures(
   actionType: keyof typeof ACTION_PROCEDURE_CONFIG
-): ActionProcedure {
+) {
   const actionConfig = ACTION_PROCEDURE_CONFIG[actionType]
 
   let asyncAcceptInputFields = AsyncActionConfirmationResponseSchema

--- a/packages/toolkit/src/migrations/v2.0/fix-action-confirmation-handler-type.ts
+++ b/packages/toolkit/src/migrations/v2.0/fix-action-confirmation-handler-type.ts
@@ -1,0 +1,134 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+
+/**
+ * Codemod: Update action confirmation handler parameter type from:
+ *   action: ActionInput
+ * to:
+ *   action: Extract<ActionInput, { type?: 'REGISTER' }>
+ *
+ * What it does:
+ *   - Scans all TypeScript files under `src/`
+ *   - Finds function parameters named `action` with type exactly `ActionInput`
+ *   - Rewrites the type annotation to the extracted REGISTER action subtype
+ *   - Saves modified files in-place
+ */
+
+/* eslint-disable no-console */
+
+import { Project, SyntaxKind } from 'ts-morph'
+import path from 'path'
+const TARGET_FUNCTION_NAME = 'acceptRequestedRegistration'
+const ACTION_PARAMETER_NAME = 'action'
+const OLD_TYPE = 'ActionInput'
+const NEW_TYPE = "Extract<ActionInput, { type?: 'REGISTER' }>"
+
+function isTargetFunctionParameter(
+  parameter: import('ts-morph').ParameterDeclaration
+): boolean {
+  const functionDeclaration = parameter.getFirstAncestorByKind(
+    SyntaxKind.FunctionDeclaration
+  )
+
+  if (functionDeclaration?.getName() === TARGET_FUNCTION_NAME) {
+    return true
+  }
+
+  const arrowFunction = parameter.getFirstAncestorByKind(
+    SyntaxKind.ArrowFunction
+  )
+  const variableDeclaration = arrowFunction?.getFirstAncestorByKind(
+    SyntaxKind.VariableDeclaration
+  )
+
+  return variableDeclaration?.getName() === TARGET_FUNCTION_NAME
+}
+
+function processFile(filePath: string, project: Project): number {
+  const sourceFile = project.getSourceFile(filePath)
+  if (!sourceFile) return 0
+
+  let updatedCount = 0
+  const parameters = sourceFile.getDescendantsOfKind(SyntaxKind.Parameter)
+
+  for (const parameter of parameters) {
+    if (parameter.getName() !== ACTION_PARAMETER_NAME) {
+      continue
+    }
+    if (!isTargetFunctionParameter(parameter)) {
+      continue
+    }
+
+    const typeNode = parameter.getTypeNode()
+    if (!typeNode) continue
+
+    if (typeNode.getText() !== OLD_TYPE) {
+      continue
+    }
+
+    parameter.setType(NEW_TYPE)
+    updatedCount++
+    console.log(
+      `  [${path.relative(process.cwd(), filePath)}] Updated '${ACTION_PARAMETER_NAME}' parameter type to ${NEW_TYPE}`
+    )
+  }
+
+  return updatedCount
+}
+
+async function main() {
+  const srcDir = path.join(process.cwd(), 'src')
+  console.log(`Scanning for action confirmation handler types in: ${srcDir}\n`)
+
+  const project = new Project({
+    tsConfigFilePath: path.resolve(srcDir, '../tsconfig.json'),
+    skipAddingFilesFromTsConfig: false
+  })
+
+  const sourceFiles = project.getSourceFiles().filter((sf) => {
+    const filePath = sf.getFilePath()
+    return filePath.includes('/src/') && !filePath.includes('/node_modules/')
+  })
+
+  let totalUpdated = 0
+  const modifiedFiles: string[] = []
+
+  for (const sourceFile of sourceFiles) {
+    const filePath = sourceFile.getFilePath()
+    const updated = processFile(filePath, project)
+
+    if (updated > 0) {
+      totalUpdated += updated
+      modifiedFiles.push(filePath)
+    }
+  }
+
+  if (modifiedFiles.length === 0) {
+    console.log(
+      `No '${ACTION_PARAMETER_NAME}: ${OLD_TYPE}' parameter signatures found. Nothing to do.`
+    )
+    return
+  }
+
+  console.log(`\nSaving ${modifiedFiles.length} modified file(s)...`)
+
+  for (const filePath of modifiedFiles) {
+    const sourceFile = project.getSourceFileOrThrow(filePath)
+    await sourceFile.save()
+    console.log(`  Saved: ${path.relative(process.cwd(), filePath)}`)
+  }
+
+  console.log(
+    `\nDone. Updated ${totalUpdated} '${ACTION_PARAMETER_NAME}' parameter type annotation(s).`
+  )
+}
+
+export { main }

--- a/packages/toolkit/src/migrations/v2.0/index.ts
+++ b/packages/toolkit/src/migrations/v2.0/index.ts
@@ -34,6 +34,7 @@ import { main as addResendInviteNotification } from './add-resend-invite-notific
 import { main as simplifyAnalyticsPrecalculations } from './simplify-analytics-precalculations'
 import { main as mergeInfrastructureDirectory } from './merge-infrastructure-directory'
 import { main as deleteInfrastructureDirectory } from './delete-infrastructure-directory'
+import { main as fixActionConfirmationHandlerType } from './fix-action-confirmation-handler-type'
 
 /**
  * Run the upgrade process for the country config in the current working
@@ -65,6 +66,7 @@ export async function runUpgrade(dockerSwarm: boolean) {
   await removeDemoScope()
   await removeHearthMigrations()
   await createEventsIndex()
+  await fixActionConfirmationHandlerType()
   await checkoutUpstreamFiles()
   await addResendInviteNotification()
   await simplifyAnalyticsPrecalculations()


### PR DESCRIPTION
## Description

This improves types:

<img width="799" height="476" alt="Screenshot 2026-05-07 at 9 26 32" src="https://github.com/user-attachments/assets/92704b11-3648-4277-8ae9-12cd89fe9ca8" />


## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
