### PR TITLE
ResponsiveModal → Dialog + accessibility improvements

### DIFF
--- a/packages/client/src/components/SessionExpireConfirmation.tsx
+++ b/packages/client/src/components/SessionExpireConfirmation.tsx
@@ -11,7 +11,7 @@
 import * as React from 'react'
 import { connect } from 'react-redux'
 import { injectIntl, WrappedComponentProps as IntlShapeProps } from 'react-intl'
-import { ResponsiveModal } from '@opencrvs/components/lib/ResponsiveModal'
+import { Dialog } from '@opencrvs/components/lib/Dialog'
 import { PrimaryButton } from '@opencrvs/components/lib/buttons'
 import { IStoreState } from '@client/store'
 import { redirectToAuthentication } from '@client/profile/profileActions'
@@ -34,10 +34,8 @@ const SessionExpireComponent = ({
     return null
   }
   return (
-    <ResponsiveModal
+    <Dialog
       title={intl.formatMessage(messages.sessionExpireTxt)}
-      contentHeight={96}
-      responsive={false}
       actions={[
         <PrimaryButton
           key="login"
@@ -47,7 +45,7 @@ const SessionExpireComponent = ({
           {intl.formatMessage(buttonMessages.login)}
         </PrimaryButton>
       ]}
-      show={true}
+      isOpen={true}
     />
   )
 }

--- a/packages/client/src/v2-events/components/AssignModal.tsx
+++ b/packages/client/src/v2-events/components/AssignModal.tsx
@@ -38,9 +38,9 @@ export function AssignModal({ close }: { close: (result: boolean) => void }) {
           {intl.formatMessage(buttonMessages.cancel)}
         </Button>
       ]}
-      onClose={() => close(false)}
       id="assignment"
       title={intl.formatMessage(conflictsMessages.assignTitle)}
+      onClose={() => close(false)}
     >
       {intl.formatMessage(conflictsMessages.assignDesc)}
     </Dialog>

--- a/packages/client/src/v2-events/components/AssignModal.tsx
+++ b/packages/client/src/v2-events/components/AssignModal.tsx
@@ -10,7 +10,7 @@
  */
 import React from 'react'
 import { useIntl } from 'react-intl'
-import { ResponsiveModal, Button } from '@opencrvs/components'
+import { Dialog, Button } from '@opencrvs/components'
 import { buttonMessages } from '@client/i18n/messages'
 import { conflictsMessages } from '@client/i18n/messages/views/conflicts'
 
@@ -18,10 +18,8 @@ export function AssignModal({ close }: { close: (result: boolean) => void }) {
   const intl = useIntl()
 
   return (
-    <ResponsiveModal
-      autoHeight
-      preventClickOnParent
-      show
+    <Dialog
+      isOpen
       actions={[
         <Button
           key="assign-btn"
@@ -40,12 +38,11 @@ export function AssignModal({ close }: { close: (result: boolean) => void }) {
           {intl.formatMessage(buttonMessages.cancel)}
         </Button>
       ]}
-      handleClose={() => close(false)}
+      onClose={() => close(false)}
       id="assignment"
-      responsive={false}
       title={intl.formatMessage(conflictsMessages.assignTitle)}
     >
       {intl.formatMessage(conflictsMessages.assignDesc)}
-    </ResponsiveModal>
+    </Dialog>
   )
 }

--- a/packages/client/src/v2-events/components/ImageEditorModal.tsx
+++ b/packages/client/src/v2-events/components/ImageEditorModal.tsx
@@ -153,12 +153,12 @@ function ImageEditorModal({
           {intl.formatMessage(buttonMessages.apply)}
         </Button>
       ]}
-      onClose={() => onClose(null)}
       id="ImageEditorModal"
       isOpen={true}
       title={intl.formatMessage(messages.title)}
       variant="large"
       width={1080}
+      onClose={() => onClose(null)}
     >
       <Description>
         {error ? (

--- a/packages/client/src/v2-events/components/ImageEditorModal.tsx
+++ b/packages/client/src/v2-events/components/ImageEditorModal.tsx
@@ -13,7 +13,7 @@ import { useIntl } from 'react-intl'
 import Cropper from 'react-easy-crop'
 import type { Area, Point, Size } from 'react-easy-crop'
 import styled, { useTheme } from 'styled-components'
-import { ResponsiveModal } from '@opencrvs/components/lib/ResponsiveModal'
+import { Dialog } from '@opencrvs/components/lib/Dialog'
 import { Button, Link } from '@opencrvs/components'
 import { buttonMessages } from '@client/i18n/messages'
 import { useModal } from '@client/hooks/useModal'
@@ -144,8 +144,7 @@ function ImageEditorModal({
 
   const cropSize = useCropSize(theme.grid.breakpoints.md)
   return (
-    <ResponsiveModal
-      autoHeight
+    <Dialog
       actions={[
         <Button key="cancel" type="tertiary" onClick={() => onClose(null)}>
           {intl.formatMessage(buttonMessages.cancel)}
@@ -154,10 +153,11 @@ function ImageEditorModal({
           {intl.formatMessage(buttonMessages.apply)}
         </Button>
       ]}
-      handleClose={() => onClose(null)}
+      onClose={() => onClose(null)}
       id="ImageEditorModal"
-      show={true}
+      isOpen={true}
       title={intl.formatMessage(messages.title)}
+      variant="large"
       width={1080}
     >
       <Description>
@@ -198,7 +198,7 @@ function ImageEditorModal({
           <Slider value={zoom} onChange={(val) => setZoom(+val)} />
         </>
       )}
-    </ResponsiveModal>
+    </Dialog>
   )
 }
 

--- a/packages/client/src/v2-events/components/SaveAndExitModal.tsx
+++ b/packages/client/src/v2-events/components/SaveAndExitModal.tsx
@@ -68,12 +68,12 @@ export function useSaveAndExitModal() {
             {intl.formatMessage(saveAndExitModalMessages.confirm)}
           </Button>
         ]}
-        onClose={() => close(null)}
         id="save_declaration_confirmation"
         isOpen={true}
         title={intl.formatMessage(
           saveAndExitModalMessages.saveDeclarationConfirmModalTitle
         )}
+        onClose={() => close(null)}
       >
         <Stack>
           <Text color="grey500" element="p" variant="reg16">

--- a/packages/client/src/v2-events/components/SaveAndExitModal.tsx
+++ b/packages/client/src/v2-events/components/SaveAndExitModal.tsx
@@ -10,7 +10,7 @@
  */
 import React from 'react'
 import { defineMessages, useIntl } from 'react-intl'
-import { ResponsiveModal } from '@opencrvs/components/lib/ResponsiveModal'
+import { Dialog } from '@opencrvs/components/lib/Dialog'
 import { Button } from '@opencrvs/components/lib/Button'
 import { Stack, Text } from '@opencrvs/components'
 import { useModal } from '@client/v2-events/hooks/useModal'
@@ -45,8 +45,7 @@ export function useSaveAndExitModal() {
 
   async function handleSaveAndExit(onSaveAndExit: () => void) {
     const saveAndExitConfirm = await openModal<boolean | null>((close) => (
-      <ResponsiveModal
-        autoHeight
+      <Dialog
         actions={[
           <Button
             key="cancel_save_exit"
@@ -69,10 +68,9 @@ export function useSaveAndExitModal() {
             {intl.formatMessage(saveAndExitModalMessages.confirm)}
           </Button>
         ]}
-        handleClose={() => close(null)}
+        onClose={() => close(null)}
         id="save_declaration_confirmation"
-        responsive={false}
-        show={true}
+        isOpen={true}
         title={intl.formatMessage(
           saveAndExitModalMessages.saveDeclarationConfirmModalTitle
         )}
@@ -84,7 +82,7 @@ export function useSaveAndExitModal() {
             )}
           </Text>
         </Stack>
-      </ResponsiveModal>
+      </Dialog>
     ))
 
     if (saveAndExitConfirm) {

--- a/packages/client/src/v2-events/components/forms/inputs/SignatureField/components/SignatureCanvasModal.tsx
+++ b/packages/client/src/v2-events/components/forms/inputs/SignatureField/components/SignatureCanvasModal.tsx
@@ -70,12 +70,12 @@ export function SignatureCanvasModal({
           {intl.formatMessage(buttonMessages.apply)}
         </Button>
       ]}
-      onClose={onClose}
       id={`${id}_modal`}
       isOpen={true}
       title={title}
       variant="large"
       width={600}
+      onClose={onClose}
     >
       <SignatureDescription>
         {intl.formatMessage(messages.signatureInputDescription)}

--- a/packages/client/src/v2-events/components/forms/inputs/SignatureField/components/SignatureCanvasModal.tsx
+++ b/packages/client/src/v2-events/components/forms/inputs/SignatureField/components/SignatureCanvasModal.tsx
@@ -13,7 +13,7 @@ import { useState } from 'react'
 import { useIntl } from 'react-intl'
 import * as React from 'react'
 import styled from 'styled-components'
-import { ResponsiveModal } from '@opencrvs/components'
+import { Dialog } from '@opencrvs/components'
 import { Button } from '@opencrvs/components/lib/Button'
 import { messages } from '@client/i18n/messages/views/review'
 import { buttonMessages } from '@client/i18n/messages'
@@ -44,7 +44,7 @@ export function SignatureCanvasModal({
   const [signature, setSignature] = useState<string | undefined>(undefined)
 
   return (
-    <ResponsiveModal
+    <Dialog
       actions={[
         <Button
           key="cancel"
@@ -70,12 +70,11 @@ export function SignatureCanvasModal({
           {intl.formatMessage(buttonMessages.apply)}
         </Button>
       ]}
-      autoHeight={true}
-      handleClose={onClose}
+      onClose={onClose}
       id={`${id}_modal`}
-      show={true}
+      isOpen={true}
       title={title}
-      titleHeightAuto={true}
+      variant="large"
       width={600}
     >
       <SignatureDescription>
@@ -87,6 +86,6 @@ export function SignatureCanvasModal({
           setSignature(base64Src)
         }}
       />
-    </ResponsiveModal>
+    </Dialog>
   )
 }

--- a/packages/client/src/v2-events/features/events/actions/dedup/MarkAsDuplicateModal.tsx
+++ b/packages/client/src/v2-events/features/events/actions/dedup/MarkAsDuplicateModal.tsx
@@ -14,7 +14,7 @@ import { useIntl } from 'react-intl'
 import styled from 'styled-components'
 import {
   Button,
-  ResponsiveModal,
+  Dialog,
   Select,
   Stack,
   Text,
@@ -56,7 +56,7 @@ export function MarkAsDuplicateModal({
     setComment(event.target.value)
   }
   return (
-    <ResponsiveModal
+    <Dialog
       actions={[
         <Button
           key="cancel"
@@ -78,17 +78,16 @@ export function MarkAsDuplicateModal({
           {intl.formatMessage(duplicateMessages.markAsDuplicateButton)}
         </Button>
       ]}
-      autoHeight={true}
-      handleClose={() => close()}
+      onClose={() => close()}
       id="mark-as-duplicate-modal"
-      show={true}
+      isOpen={true}
       title={intl.formatMessage(
         duplicateMessages.markAsDuplicateConfirmationTitle,
         {
           trackingId: originalTrackingId
         }
       )}
-      titleHeightAuto={true}
+      variant="large"
       width={840}
     >
       {
@@ -119,6 +118,6 @@ export function MarkAsDuplicateModal({
           />
         </Stack>
       }
-    </ResponsiveModal>
+    </Dialog>
   )
 }

--- a/packages/client/src/v2-events/features/events/actions/dedup/MarkAsDuplicateModal.tsx
+++ b/packages/client/src/v2-events/features/events/actions/dedup/MarkAsDuplicateModal.tsx
@@ -78,7 +78,6 @@ export function MarkAsDuplicateModal({
           {intl.formatMessage(duplicateMessages.markAsDuplicateButton)}
         </Button>
       ]}
-      onClose={() => close()}
       id="mark-as-duplicate-modal"
       isOpen={true}
       title={intl.formatMessage(
@@ -89,6 +88,7 @@ export function MarkAsDuplicateModal({
       )}
       variant="large"
       width={840}
+      onClose={() => close()}
     >
       {
         <Stack alignItems="stretch" direction="column" gap={10}>

--- a/packages/client/src/v2-events/features/events/actions/dedup/MarkAsNotDuplicateModal.tsx
+++ b/packages/client/src/v2-events/features/events/actions/dedup/MarkAsNotDuplicateModal.tsx
@@ -46,7 +46,6 @@ export function MarkAsNotDuplicateModal({
           {intl.formatMessage(buttonMessages.confirm)}
         </Button>
       ]}
-      onClose={() => close(false)}
       id="not-duplicate-modal"
       isOpen={true}
       title={intl.formatMessage(
@@ -56,6 +55,7 @@ export function MarkAsNotDuplicateModal({
           trackingId
         }
       )}
+      onClose={() => close(false)}
     />
   )
 }

--- a/packages/client/src/v2-events/features/events/actions/dedup/MarkAsNotDuplicateModal.tsx
+++ b/packages/client/src/v2-events/features/events/actions/dedup/MarkAsNotDuplicateModal.tsx
@@ -11,7 +11,7 @@
 
 import * as React from 'react'
 import { useIntl } from 'react-intl'
-import { Button, ResponsiveModal } from '@opencrvs/components'
+import { Button, Dialog } from '@opencrvs/components'
 import { buttonMessages } from '@client/i18n/messages'
 import { duplicateMessages } from './ReviewDuplicate'
 
@@ -27,7 +27,7 @@ export function MarkAsNotDuplicateModal({
   const intl = useIntl()
 
   return (
-    <ResponsiveModal
+    <Dialog
       actions={[
         <Button
           key="not-duplicateRegistration-cancel"
@@ -46,11 +46,9 @@ export function MarkAsNotDuplicateModal({
           {intl.formatMessage(buttonMessages.confirm)}
         </Button>
       ]}
-      autoHeight={true}
-      handleClose={() => close(false)}
+      onClose={() => close(false)}
       id="not-duplicate-modal"
-      responsive={false}
-      show={true}
+      isOpen={true}
       title={intl.formatMessage(
         duplicateMessages.notDuplicateContentConfirmationTitle,
         {
@@ -58,7 +56,6 @@ export function MarkAsNotDuplicateModal({
           trackingId
         }
       )}
-      titleHeightAuto={true}
     />
   )
 }

--- a/packages/client/src/v2-events/features/events/actions/edit/EditActionMenu.tsx
+++ b/packages/client/src/v2-events/features/events/actions/edit/EditActionMenu.tsx
@@ -29,7 +29,7 @@ import { DropdownMenu } from '@opencrvs/components/lib/Dropdown'
 import { CaretDown } from '@opencrvs/components/lib/Icon/all-icons'
 import {
   Icon,
-  ResponsiveModal,
+  Dialog,
   Button,
   Stack,
   Text,
@@ -111,10 +111,8 @@ function EditActionModal({
   const [comment, setComment] = useState('')
 
   return (
-    <ResponsiveModal
-      autoHeight
-      show
-      showHeaderBorder
+    <Dialog
+      isOpen
       actions={[
         <Button
           key={'cancel_edit'}
@@ -133,8 +131,9 @@ function EditActionModal({
           {intl.formatMessage(messages.confirm)}
         </Button>
       ]}
-      handleClose={() => close({ confirmed: false })}
+      onClose={() => close({ confirmed: false })}
       title={intl.formatMessage(title)}
+      variant="large"
       width={800}
     >
       <Stack>
@@ -150,7 +149,7 @@ function EditActionModal({
         value={comment}
         onChange={(e) => setComment(e.target.value)}
       />
-    </ResponsiveModal>
+    </Dialog>
   )
 }
 

--- a/packages/client/src/v2-events/features/events/actions/edit/EditActionMenu.tsx
+++ b/packages/client/src/v2-events/features/events/actions/edit/EditActionMenu.tsx
@@ -131,10 +131,10 @@ function EditActionModal({
           {intl.formatMessage(messages.confirm)}
         </Button>
       ]}
-      onClose={() => close({ confirmed: false })}
       title={intl.formatMessage(title)}
       variant="large"
       width={800}
+      onClose={() => close({ confirmed: false })}
     >
       <Stack>
         <Text color="grey500" element="p" variant="reg16">

--- a/packages/client/src/v2-events/features/events/actions/print-certificate/Review.tsx
+++ b/packages/client/src/v2-events/features/events/actions/print-certificate/Review.tsx
@@ -288,10 +288,10 @@ export function Review() {
             {intl.formatMessage(messages.print)}
           </Button>
         ]}
-        onClose={() => close(false)}
         id="confirm-print-modal"
         isOpen={true}
         title={intl.formatMessage(messages.printAndIssueModalTitle)}
+        onClose={() => close(false)}
       >
         {intl.formatMessage(messages.printAndIssueModalBody)}
       </Dialog>

--- a/packages/client/src/v2-events/features/events/actions/print-certificate/Review.tsx
+++ b/packages/client/src/v2-events/features/events/actions/print-certificate/Review.tsx
@@ -38,7 +38,7 @@ import {
   Content,
   Frame,
   Icon,
-  ResponsiveModal,
+  Dialog,
   Spinner,
   Stack,
   Toast
@@ -266,7 +266,7 @@ export function Review() {
 
   const handlePrint = async () => {
     const confirmed = await openModal<boolean>((close) => (
-      <ResponsiveModal
+      <Dialog
         actions={[
           <Button
             key="close-modal"
@@ -288,14 +288,13 @@ export function Review() {
             {intl.formatMessage(messages.print)}
           </Button>
         ]}
-        contentHeight={100}
-        handleClose={() => close(false)}
+        onClose={() => close(false)}
         id="confirm-print-modal"
-        show={true}
+        isOpen={true}
         title={intl.formatMessage(messages.printAndIssueModalTitle)}
       >
         {intl.formatMessage(messages.printAndIssueModalBody)}
-      </ResponsiveModal>
+      </Dialog>
     ))
 
     /**

--- a/packages/client/src/v2-events/features/events/components/Review.tsx
+++ b/packages/client/src/v2-events/features/events/components/Review.tsx
@@ -627,9 +627,9 @@ function EditModal({
           )}
         </Button>
       ]}
-      onClose={() => close(null)}
       isOpen={true}
       title={intl.formatMessage(copy?.title || reviewMessages.changeModalTitle)}
+      onClose={() => close(null)}
     >
       <Stack>
         <Text color="grey500" element="p" variant="reg16">
@@ -684,10 +684,10 @@ function AcceptActionModal({
           {intl.formatMessage(copy.onConfirm)}
         </Button>
       ]}
-      onClose={() => close(null)}
       title={intl.formatMessage(copy.title, { event: eventType })}
       variant="large"
       width={600}
+      onClose={() => close(null)}
     >
       <Stack>
         {copy.supportingCopy && (
@@ -779,12 +779,12 @@ function RejectActionModal({
   return (
     <Dialog
       actions={actions}
-      onClose={() => close(null)}
       id="reject-modal"
       isOpen={true}
       title={intl.formatMessage(reviewMessages.rejectModalTitle)}
       variant="large"
       width={918}
+      onClose={() => close(null)}
     >
       <Stack alignItems="left" direction="column">
         <Text color="grey500" element="p" variant="reg16">

--- a/packages/client/src/v2-events/features/events/components/Review.tsx
+++ b/packages/client/src/v2-events/features/events/components/Review.tsx
@@ -21,7 +21,7 @@ import {
   Checkbox,
   Link,
   ListReview,
-  ResponsiveModal,
+  Dialog,
   Stack,
   Text,
   TextArea
@@ -602,9 +602,7 @@ function EditModal({
 }) {
   const intl = useIntl()
   return (
-    <ResponsiveModal
-      autoHeight
-      showHeaderBorder
+    <Dialog
       actions={[
         <Button
           key="cancel_edit"
@@ -629,9 +627,8 @@ function EditModal({
           )}
         </Button>
       ]}
-      handleClose={() => close(null)}
-      responsive={false}
-      show={true}
+      onClose={() => close(null)}
+      isOpen={true}
       title={intl.formatMessage(copy?.title || reviewMessages.changeModalTitle)}
     >
       <Stack>
@@ -641,7 +638,7 @@ function EditModal({
           )}
         </Text>
       </Stack>
-    </ResponsiveModal>
+    </Dialog>
   )
 }
 
@@ -663,9 +660,8 @@ function AcceptActionModal({
   const intl = useIntl()
 
   return (
-    <ResponsiveModal
-      autoHeight
-      show
+    <Dialog
+      isOpen
       actions={[
         <Button
           key={'cancel_' + action}
@@ -688,9 +684,9 @@ function AcceptActionModal({
           {intl.formatMessage(copy.onConfirm)}
         </Button>
       ]}
-      handleClose={() => close(null)}
-      showHeaderBorder={!!copy.supportingCopy}
+      onClose={() => close(null)}
       title={intl.formatMessage(copy.title, { event: eventType })}
+      variant="large"
       width={600}
     >
       <Stack>
@@ -703,7 +699,7 @@ function AcceptActionModal({
           />
         )}
       </Stack>
-    </ResponsiveModal>
+    </Dialog>
   )
 }
 
@@ -781,14 +777,13 @@ function RejectActionModal({
   ]
 
   return (
-    <ResponsiveModal
-      showHeaderBorder
+    <Dialog
       actions={actions}
-      contentHeight={270}
-      handleClose={() => close(null)}
+      onClose={() => close(null)}
       id="reject-modal"
-      show={true}
+      isOpen={true}
       title={intl.formatMessage(reviewMessages.rejectModalTitle)}
+      variant="large"
       width={918}
     >
       <Stack alignItems="left" direction="column">
@@ -813,7 +808,7 @@ function RejectActionModal({
           }
         />
       </Stack>
-    </ResponsiveModal>
+    </Dialog>
   )
 }
 

--- a/packages/client/src/v2-events/features/events/components/VerificationWizard.tsx
+++ b/packages/client/src/v2-events/features/events/components/VerificationWizard.tsx
@@ -76,9 +76,9 @@ export const VerificationWizard = ({
             {intl.formatMessage(messages.confirm)}
           </Button>
         ]}
-        onClose={() => close()}
         isOpen={true}
         title={intl.formatMessage(pageConfig.actions.cancel.confirmation.title)}
+        onClose={() => close()}
       >
         <Stack>
           <Text color="grey500" element="p" variant="reg16">

--- a/packages/client/src/v2-events/features/events/components/VerificationWizard.tsx
+++ b/packages/client/src/v2-events/features/events/components/VerificationWizard.tsx
@@ -13,7 +13,7 @@ import { defineMessages, useIntl } from 'react-intl'
 import { EventState, VerificationPageConfig } from '@opencrvs/commons/client'
 import { Check, Cross } from '@opencrvs/components/lib/icons'
 import {
-  ResponsiveModal,
+  Dialog,
   Text,
   Frame,
   Icon,
@@ -55,8 +55,7 @@ export const VerificationWizard = ({
 
   const onCancelButtonClick = () => {
     void openCancelModal<void>((close) => (
-      <ResponsiveModal
-        autoHeight
+      <Dialog
         actions={[
           <Button
             key="cancel"
@@ -77,9 +76,8 @@ export const VerificationWizard = ({
             {intl.formatMessage(messages.confirm)}
           </Button>
         ]}
-        handleClose={() => close()}
-        responsive={false}
-        show={true}
+        onClose={() => close()}
+        isOpen={true}
         title={intl.formatMessage(pageConfig.actions.cancel.confirmation.title)}
       >
         <Stack>
@@ -87,7 +85,7 @@ export const VerificationWizard = ({
             {intl.formatMessage(pageConfig.actions.cancel.confirmation.body)}
           </Text>
         </Stack>
-      </ResponsiveModal>
+      </Dialog>
     ))
   }
 

--- a/packages/client/src/v2-events/features/events/registered-fields/VerificationStatus.tsx
+++ b/packages/client/src/v2-events/features/events/registered-fields/VerificationStatus.tsx
@@ -106,9 +106,9 @@ function Input({
             {intl.formatMessage(buttonMessages.continueButton)}
           </Button>
         ]}
-        onClose={() => close(false)}
         id="assignment"
         title={intl.formatMessage(messages[value].resetConfirmation.title)}
+        onClose={() => close(false)}
       >
         {intl.formatMessage(messages[value].resetConfirmation.description)}
       </Dialog>

--- a/packages/client/src/v2-events/features/events/registered-fields/VerificationStatus.tsx
+++ b/packages/client/src/v2-events/features/events/registered-fields/VerificationStatus.tsx
@@ -16,7 +16,7 @@ import {
   Button,
   Icon,
   Pill,
-  ResponsiveModal,
+  Dialog,
   Stack,
   Text
 } from '@opencrvs/components'
@@ -86,10 +86,8 @@ function Input({
 
   const handleReset = async () => {
     const confirm = await openModal((close) => (
-      <ResponsiveModal
-        autoHeight
-        preventClickOnParent
-        show
+      <Dialog
+        isOpen
         actions={[
           <Button
             key="cancel-btn"
@@ -108,13 +106,12 @@ function Input({
             {intl.formatMessage(buttonMessages.continueButton)}
           </Button>
         ]}
-        handleClose={() => close(false)}
+        onClose={() => close(false)}
         id="assignment"
-        responsive={false}
         title={intl.formatMessage(messages[value].resetConfirmation.title)}
       >
         {intl.formatMessage(messages[value].resetConfirmation.description)}
-      </ResponsiveModal>
+      </Dialog>
     ))
     if (confirm) {
       onReset()

--- a/packages/client/src/v2-events/features/events/useEventFormNavigation.tsx
+++ b/packages/client/src/v2-events/features/events/useEventFormNavigation.tsx
@@ -11,7 +11,7 @@
 import React from 'react'
 import { defineMessages, useIntl } from 'react-intl'
 import { useNavigate } from 'react-router-dom'
-import { Button, ResponsiveModal, Stack, Text } from '@opencrvs/components'
+import { Button, Dialog, Stack, Text } from '@opencrvs/components'
 import { EventIndex, isUndeclaredDraft } from '@opencrvs/commons/client'
 import { ROUTES } from '@client/v2-events/routes'
 import { useModal } from '@client/v2-events/hooks/useModal'
@@ -102,8 +102,7 @@ export function useEventFormNavigation() {
 
   async function exit(event: EventIndex) {
     const exitConfirm = await openModal<boolean | null>((close) => (
-      <ResponsiveModal
-        autoHeight
+      <Dialog
         actions={[
           <Button
             key="cancel_save_without_exit"
@@ -126,9 +125,8 @@ export function useEventFormNavigation() {
             {intl.formatMessage(modalMessages.confirm)}
           </Button>
         ]}
-        handleClose={() => close(null)}
-        responsive={false}
-        show={true}
+        onClose={() => close(null)}
+        isOpen={true}
         title={intl.formatMessage(modalMessages.exitWithoutSavingTitle)}
       >
         <Stack>
@@ -136,7 +134,7 @@ export function useEventFormNavigation() {
             {intl.formatMessage(modalMessages.exitWithoutSavingDescription)}
           </Text>
         </Stack>
-      </ResponsiveModal>
+      </Dialog>
     ))
 
     if (!exitConfirm) {
@@ -156,8 +154,7 @@ export function useEventFormNavigation() {
     workqueueToGoBackTo?: string
   ) {
     const deleteConfirm = await openModal<boolean | null>((close) => (
-      <ResponsiveModal
-        autoHeight
+      <Dialog
         actions={[
           <Button
             key="cancel_delete"
@@ -180,9 +177,8 @@ export function useEventFormNavigation() {
             {intl.formatMessage(modalMessages.confirm)}
           </Button>
         ]}
-        handleClose={() => close(null)}
-        responsive={false}
-        show={true}
+        onClose={() => close(null)}
+        isOpen={true}
         title={intl.formatMessage(modalMessages.deleteDeclarationTitle)}
       >
         <Stack>
@@ -190,7 +186,7 @@ export function useEventFormNavigation() {
             {intl.formatMessage(modalMessages.deleteDeclarationDescription)}
           </Text>
         </Stack>
-      </ResponsiveModal>
+      </Dialog>
     ))
 
     if (deleteConfirm) {

--- a/packages/client/src/v2-events/features/events/useEventFormNavigation.tsx
+++ b/packages/client/src/v2-events/features/events/useEventFormNavigation.tsx
@@ -125,9 +125,9 @@ export function useEventFormNavigation() {
             {intl.formatMessage(modalMessages.confirm)}
           </Button>
         ]}
-        onClose={() => close(null)}
         isOpen={true}
         title={intl.formatMessage(modalMessages.exitWithoutSavingTitle)}
+        onClose={() => close(null)}
       >
         <Stack>
           <Text color="grey500" element="p" variant="reg16">
@@ -177,9 +177,9 @@ export function useEventFormNavigation() {
             {intl.formatMessage(modalMessages.confirm)}
           </Button>
         ]}
-        onClose={() => close(null)}
         isOpen={true}
         title={intl.formatMessage(modalMessages.deleteDeclarationTitle)}
+        onClose={() => close(null)}
       >
         <Stack>
           <Text color="grey500" element="p" variant="reg16">

--- a/packages/client/src/v2-events/features/settings/Settings.interaction.stories.tsx
+++ b/packages/client/src/v2-events/features/settings/Settings.interaction.stories.tsx
@@ -184,7 +184,7 @@ export const ChangePasswordStateClears: Story = {
 
     await step('Close modal', async () => {
       await userEvent.click(
-        canvasElement.querySelector('#close-btn') as HTMLElement
+        canvasElement.querySelector('[data-testid="close-dialog"]') as HTMLElement
       )
     })
 

--- a/packages/client/src/v2-events/features/workqueues/EventOverview/components/EventHistory/EventHistoryDialog/EventHistoryDialog.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/components/EventHistory/EventHistoryDialog/EventHistoryDialog.tsx
@@ -11,7 +11,7 @@
 import React from 'react'
 import { defineMessages, useIntl } from 'react-intl'
 import format from 'date-fns/format'
-import { ResponsiveModal, Stack, Table } from '@opencrvs/components'
+import { Dialog, Stack, Table } from '@opencrvs/components'
 import { Text } from '@opencrvs/components/lib/Text'
 import {
   ActionDocument,
@@ -120,14 +120,13 @@ export function EventHistoryDialog({
   const duplicateOf = prepareDuplicateOf(action, history)
 
   return (
-    <ResponsiveModal
-      autoHeight
+    <Dialog
       actions={[]}
-      handleClose={close}
+      onClose={close}
       id="event-history-modal"
-      responsive={true}
-      show={true}
+      isOpen={true}
       title={title}
+      variant="large"
       width={1024}
     >
       <Stack>
@@ -192,6 +191,6 @@ export function EventHistoryDialog({
         fullEvent={fullEvent}
         validatorContext={validatorContext}
       />
-    </ResponsiveModal>
+    </Dialog>
   )
 }

--- a/packages/client/src/v2-events/features/workqueues/EventOverview/components/EventHistory/EventHistoryDialog/EventHistoryDialog.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/components/EventHistory/EventHistoryDialog/EventHistoryDialog.tsx
@@ -122,12 +122,12 @@ export function EventHistoryDialog({
   return (
     <Dialog
       actions={[]}
-      onClose={close}
       id="event-history-modal"
       isOpen={true}
       title={title}
       variant="large"
       width={1024}
+      onClose={close}
     >
       <Stack>
         <Text color="grey500" element="p" variant="reg19">

--- a/packages/client/src/views/Modals/ReloadModal.tsx
+++ b/packages/client/src/views/Modals/ReloadModal.tsx
@@ -9,7 +9,7 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 
-import { ResponsiveModal } from '@opencrvs/components'
+import { Dialog } from '@opencrvs/components'
 import { PrimaryButton } from '@opencrvs/components/src/buttons'
 import React from 'react'
 import { useSelector } from 'react-redux'
@@ -51,20 +51,16 @@ export const ReloadModal = () => {
   }
 
   return (
-    <ResponsiveModal
+    <Dialog
       title={intl.formatMessage(messages.title)}
-      responsive={false}
-      showCloseButton={false}
-      autoHeight={true}
-      titleHeightAuto={true}
       actions={[
         <PrimaryButton key="reload" id="reload" onClick={handleReload}>
           {intl.formatMessage(messages.update)}
         </PrimaryButton>
       ]}
-      show={visibility}
+      isOpen={visibility}
     >
       {intl.formatMessage(messages.body, { app_name: app_name })}
-    </ResponsiveModal>
+    </Dialog>
   )
 }

--- a/packages/client/src/views/Settings/AvatarChangeModal.tsx
+++ b/packages/client/src/views/Settings/AvatarChangeModal.tsx
@@ -9,7 +9,7 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 import * as React from 'react'
-import { ResponsiveModal } from '@opencrvs/components/lib/ResponsiveModal'
+import { Dialog } from '@opencrvs/components/lib/Dialog'
 import { useIntl } from 'react-intl'
 import { userMessages as messages, buttonMessages } from '@client/i18n/messages'
 import {
@@ -207,11 +207,11 @@ function AvatarChangeModalComp({
   }
 
   return (
-    <ResponsiveModal
+    <Dialog
       id="ChangeAvatarModal"
+      variant="large"
       width={1080}
-      autoHeight
-      show={showChangeAvatar}
+      isOpen={showChangeAvatar}
       title={intl.formatMessage(messages.changeAvatar)}
       actions={[
         <TertiaryButton key="cancel" id="modal_cancel" onClick={handleCancel}>
@@ -226,7 +226,7 @@ function AvatarChangeModalComp({
           {intl.formatMessage(buttonMessages.apply)}
         </PrimaryButton>
       ]}
-      handleClose={handleCancel}
+      onClose={handleCancel}
     >
       <Description>
         {!error && intl.formatMessage(messages.resizeAvatar)}
@@ -274,7 +274,7 @@ function AvatarChangeModalComp({
           />
         </>
       )}
-    </ResponsiveModal>
+    </Dialog>
   )
 }
 

--- a/packages/client/src/views/Settings/ChangeEmailModal/ChangeEmailView.tsx
+++ b/packages/client/src/views/Settings/ChangeEmailModal/ChangeEmailView.tsx
@@ -9,7 +9,7 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 import { Toast } from '@opencrvs/components/lib/Toast'
-import { ResponsiveModal } from '@opencrvs/components/lib/ResponsiveModal'
+import { Dialog } from '@opencrvs/components/lib/Dialog'
 import * as React from 'react'
 import { TertiaryButton, PrimaryButton } from '@opencrvs/components/lib/buttons'
 import { userMessages as messages, buttonMessages } from '@client/i18n/messages'
@@ -93,9 +93,9 @@ export function ChangeEmailView({ show, onSuccess, onClose }: IProps) {
   }, [show])
 
   return (
-    <ResponsiveModal
+    <Dialog
       id="ChangeEmailAddressModal"
-      show={show}
+      isOpen={show}
       title={intl.formatMessage(messages.changeEmailLabel)}
       actions={[
         <TertiaryButton key="cancel" id="modal_cancel" onClick={onClose}>
@@ -112,9 +112,7 @@ export function ChangeEmailView({ show, onSuccess, onClose }: IProps) {
           {intl.formatMessage(buttonMessages.continueButton)}
         </PrimaryButton>
       ]}
-      handleClose={onClose}
-      contentHeight={150}
-      contentScrollableY={true}
+      onClose={onClose}
     >
       <InputField
         id="emailAddress"
@@ -155,6 +153,6 @@ export function ChangeEmailView({ show, onSuccess, onClose }: IProps) {
           {intl.formatMessage(errorMessages.unknownErrorTitle)}
         </Toast>
       )}
-    </ResponsiveModal>
+    </Dialog>
   )
 }

--- a/packages/client/src/views/Settings/ChangePhoneModal/ChangeNumberView.tsx
+++ b/packages/client/src/views/Settings/ChangePhoneModal/ChangeNumberView.tsx
@@ -9,7 +9,7 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 import { Toast } from '@opencrvs/components/lib/Toast'
-import { ResponsiveModal } from '@opencrvs/components/lib/ResponsiveModal'
+import { Dialog } from '@opencrvs/components/lib/Dialog'
 import * as React from 'react'
 import { TertiaryButton, PrimaryButton } from '@opencrvs/components/lib/buttons'
 import { userMessages as messages, buttonMessages } from '@client/i18n/messages'
@@ -97,9 +97,9 @@ export function ChangeNumberView({ show, onSuccess, onClose }: IProps) {
   }, [show])
 
   return (
-    <ResponsiveModal
+    <Dialog
       id="ChangePhoneNumberModal"
-      show={show}
+      isOpen={show}
       title={intl.formatMessage(messages.changePhoneLabel)}
       actions={[
         <TertiaryButton key="cancel" id="modal_cancel" onClick={onClose}>
@@ -120,9 +120,7 @@ export function ChangeNumberView({ show, onSuccess, onClose }: IProps) {
           {intl.formatMessage(buttonMessages.continueButton)}
         </PrimaryButton>
       ]}
-      handleClose={onClose}
-      contentHeight={150}
-      contentScrollableY={true}
+      onClose={onClose}
     >
       <InputField
         id="phoneNumber"
@@ -174,6 +172,6 @@ export function ChangeNumberView({ show, onSuccess, onClose }: IProps) {
           {intl.formatMessage(errorMessages.unknownErrorTitle)}
         </Toast>
       )}
-    </ResponsiveModal>
+    </Dialog>
   )
 }

--- a/packages/client/src/views/Settings/ChangePhoneModal/VerifyCodeView.tsx
+++ b/packages/client/src/views/Settings/ChangePhoneModal/VerifyCodeView.tsx
@@ -15,7 +15,7 @@ import { getUserDetails } from '@client/profile/profileSelectors'
 import { EMPTY_STRING } from '@client/utils/constants'
 import { Message } from '@client/views/Settings/items/components'
 import { InputField } from '@opencrvs/components/lib/InputField'
-import { ResponsiveModal } from '@opencrvs/components/lib/ResponsiveModal'
+import { Dialog } from '@opencrvs/components/lib/Dialog'
 import { TextInput } from '@opencrvs/components/lib/TextInput'
 import { TertiaryButton, PrimaryButton } from '@opencrvs/components/lib/buttons'
 import * as React from 'react'
@@ -134,9 +134,9 @@ export function VerifyCodeView({
   }, [show])
 
   return (
-    <ResponsiveModal
+    <Dialog
       id="VerifyCodeModal"
-      show={show}
+      isOpen={show}
       title={intl.formatMessage(messages.verifyPhoneLabel)}
       actions={[
         <TertiaryButton key="cancel" id="modal_cancel" onClick={onClose}>
@@ -151,9 +151,7 @@ export function VerifyCodeView({
           {intl.formatMessage(buttonMessages.continueButton)}
         </PrimaryButton>
       ]}
-      handleClose={onClose}
-      contentHeight={150}
-      contentScrollableY={true}
+      onClose={onClose}
     >
       <Message>
         {data.phoneNumber
@@ -192,6 +190,6 @@ export function VerifyCodeView({
           onChange={onChangeVerifyCode}
         />
       </InputField>
-    </ResponsiveModal>
+    </Dialog>
   )
 }

--- a/packages/client/src/views/Settings/PasswordChangeModal.tsx
+++ b/packages/client/src/views/Settings/PasswordChangeModal.tsx
@@ -200,7 +200,7 @@ export function PasswordChangeModal({
     <Dialog
       id="ChangePasswordModal"
       title={intl.formatMessage(messages.changePassword)}
-      isOpen={showPasswordChange}
+      isOpen={true}
       actions={[
         <PrimaryButton
           id="confirm-button"

--- a/packages/client/src/views/Settings/PasswordChangeModal.tsx
+++ b/packages/client/src/views/Settings/PasswordChangeModal.tsx
@@ -13,7 +13,7 @@ import { InputField } from '@opencrvs/components/lib/InputField'
 import { TextInput } from '@opencrvs/components/lib/TextInput'
 import { ErrorMessage } from '@opencrvs/components/lib/ErrorMessage'
 import { TickOff, TickOn } from '@opencrvs/components/lib/icons'
-import { ResponsiveModal } from '@opencrvs/components/lib/ResponsiveModal'
+import { Dialog } from '@opencrvs/components/lib/Dialog'
 import { userMessages as messages } from '@client/i18n/messages'
 import { getUserDetails } from '@client/profile/profileSelectors'
 import styled from 'styled-components'
@@ -199,11 +199,10 @@ export function PasswordChangeModal({
   }
 
   return (
-    <ResponsiveModal
+    <Dialog
       id="ChangePasswordModal"
       title={intl.formatMessage(messages.changePassword)}
-      show={showPasswordChange}
-      contentHeight={420}
+      isOpen={showPasswordChange}
       actions={[
         <PrimaryButton
           id="confirm-button"
@@ -220,8 +219,9 @@ export function PasswordChangeModal({
           {intl.formatMessage(messages.confirmButtonLabel)}
         </PrimaryButton>
       ]}
+      variant="large"
       width={1000}
-      handleClose={hideModal}
+      onClose={hideModal}
     >
       <Message>{intl.formatMessage(messages.changePasswordMessage)}</Message>
 
@@ -387,6 +387,6 @@ export function PasswordChangeModal({
           </ValidationRulesSectionLg>
         </Row>
       </form>
-    </ResponsiveModal>
+    </Dialog>
   )
 }

--- a/packages/client/src/views/Settings/items/Language.tsx
+++ b/packages/client/src/views/Settings/items/Language.tsx
@@ -11,7 +11,7 @@
 import * as React from 'react'
 import { ListViewItemSimplified } from '@opencrvs/components/lib/ListViewSimplified'
 import { Toast } from '@opencrvs/components/lib/Toast'
-import { ResponsiveModal } from '@opencrvs/components/lib/ResponsiveModal'
+import { Dialog } from '@opencrvs/components/lib/Dialog'
 import { useIntl, FormattedMessage } from 'react-intl'
 import {
   userMessages,
@@ -112,10 +112,10 @@ export function Language() {
           </DynamicHeightLinkButton>
         }
       />
-      <ResponsiveModal
+      <Dialog
         id="ChangeLanguageModal"
         title={intl.formatMessage(userMessages.changeLanguageTitle)}
-        show={showModal}
+        isOpen={showModal}
         actions={[
           <TertiaryButton
             key="cancel"
@@ -128,9 +128,7 @@ export function Language() {
             {intl.formatMessage(buttonMessages.apply)}
           </PrimaryButton>
         ]}
-        handleClose={cancelLanguageSettings}
-        contentHeight={175}
-        contentScrollableY={true}
+        onClose={cancelLanguageSettings}
       >
         <Message>
           {intl.formatMessage(userMessages.changeLanguageMessege)}
@@ -145,7 +143,7 @@ export function Language() {
           options={langChoice}
           placeholder=""
         />
-      </ResponsiveModal>
+      </Dialog>
       {showSuccessNotification && (
         <Toast type="success" onClose={toggleSuccessNotification}>
           <FormattedMessage {...userMessages.changeLanguageSuccessMessage} />

--- a/packages/client/src/views/SysAdmin/Communications/AllUserEmail/AllUserEmail.tsx
+++ b/packages/client/src/views/SysAdmin/Communications/AllUserEmail/AllUserEmail.tsx
@@ -19,7 +19,7 @@ import {
   TextInput,
   Button,
   Icon,
-  ResponsiveModal
+  Dialog
 } from '@opencrvs/components'
 import styled from 'styled-components'
 import { useMutation } from '@tanstack/react-query'
@@ -116,11 +116,10 @@ const AllUserEmail = () => {
           </Button>
         </Form>
       </Content>
-      <ResponsiveModal
+      <Dialog
         title={intl.formatMessage(messages.emailAllUsersModalTitle)}
-        show={isConfirmationModalOpen}
-        handleClose={hideModal}
-        autoHeight
+        isOpen={isConfirmationModalOpen}
+        onClose={hideModal}
         actions={[
           <Button key="cancel" type="tertiary" onClick={hideModal}>
             {intl.formatMessage(buttonMessages.cancel)}
@@ -131,7 +130,7 @@ const AllUserEmail = () => {
         ]}
       >
         {intl.formatMessage(messages.emailAllUsersModalSupportingCopy)}
-      </ResponsiveModal>
+      </Dialog>
     </>
   )
 }

--- a/packages/client/src/views/SysAdmin/Config/Systems/Systems.tsx
+++ b/packages/client/src/views/SysAdmin/Config/Systems/Systems.tsx
@@ -31,7 +31,7 @@ import {
 import { Button } from '@opencrvs/components/lib/Button'
 import { Content } from '@opencrvs/components/lib/Content'
 import { Icon } from '@opencrvs/components/lib/Icon'
-import { ResponsiveModal } from '@opencrvs/components/lib/ResponsiveModal'
+import { Dialog } from '@opencrvs/components/lib/Dialog'
 import { Text } from '@opencrvs/components/lib/Text'
 import React, { useCallback, useState } from 'react'
 import { FormattedMessage, useIntl } from 'react-intl'
@@ -370,13 +370,12 @@ export function SystemList() {
 
       {/* Client Details Modal */}
       {clientDetails && (
-        <ResponsiveModal
+        <Dialog
           title={intl.formatMessage(integrationMessages.clientDetails)}
-          autoHeight={true}
+          variant="large"
           width={512}
-          titleHeightAuto={true}
-          show={true}
-          handleClose={() => setClientDetails(null)}
+          isOpen={true}
+          onClose={() => setClientDetails(null)}
           actions={[
             <Button
               type="tertiary"
@@ -408,19 +407,17 @@ export function SystemList() {
               </ScopeList>
             </Stack>
           </Stack>
-        </ResponsiveModal>
+        </Dialog>
       )}
 
       {/* Toggle Activation Modal */}
       {toggleActivation.integration && (
-        <ResponsiveModal
+        <Dialog
           title={
             toggleActivation.integration.status === 'active'
               ? intl.formatMessage(integrationMessages.deactivateClient)
               : intl.formatMessage(integrationMessages.activateClient)
           }
-          contentHeight={50}
-          responsive={false}
           actions={[
             <Button
               type="tertiary"
@@ -440,21 +437,19 @@ export function SystemList() {
               {intl.formatMessage(buttonMessages.confirm)}
             </Button>
           ]}
-          show={true}
-          handleClose={() => setToggleActivation({ integration: null })}
+          isOpen={true}
+          onClose={() => setToggleActivation({ integration: null })}
         >
           {toggleActivation.integration.status === 'active'
             ? intl.formatMessage(integrationMessages.deactivateClientText)
             : intl.formatMessage(integrationMessages.activateClientText)}
-        </ResponsiveModal>
+        </Dialog>
       )}
 
       {/* Delete Confirmation Modal */}
       {deleteConfirm.integration && (
-        <ResponsiveModal
+        <Dialog
           title={intl.formatMessage(integrationMessages.delete)}
-          contentHeight={50}
-          responsive={false}
           actions={[
             <Button
               type="tertiary"
@@ -474,25 +469,24 @@ export function SystemList() {
               {intl.formatMessage(integrationMessages.delete)}
             </Button>
           ]}
-          show={true}
-          handleClose={() => setDeleteConfirm({ integration: null })}
+          isOpen={true}
+          onClose={() => setDeleteConfirm({ integration: null })}
         >
           <FormattedMessage {...integrationMessages.deleteSystemText} />
-        </ResponsiveModal>
+        </Dialog>
       )}
 
       {/* Reveal Keys Modal */}
-      <ResponsiveModal
+      <Dialog
         actions={[
           <Link key="cancel-link" onClick={closeRevealKeys}>
             {intl.formatMessage(buttonMessages.cancel)}
           </Link>
         ]}
-        autoHeight={true}
+        variant="large"
         width={512}
-        titleHeightAuto={true}
-        show={revealKeys.visible}
-        handleClose={closeRevealKeys}
+        isOpen={revealKeys.visible}
+        onClose={closeRevealKeys}
         title={revealKeys.integration?.name ?? ''}
       >
         <Text variant="reg16" element="p" id="revealKeyId">
@@ -560,10 +554,10 @@ export function SystemList() {
             </Stack>
           </Stack>
         )}
-      </ResponsiveModal>
+      </Dialog>
 
       {/* Create Client Modal */}
-      <ResponsiveModal
+      <Dialog
         actions={
           createResult
             ? []
@@ -591,11 +585,10 @@ export function SystemList() {
                 </Button>
               ]
         }
+        variant="large"
         width={512}
-        autoHeight={true}
-        titleHeightAuto={true}
-        show={showModal}
-        handleClose={() => {
+        isOpen={showModal}
+        onClose={() => {
           toggleModal()
           clearNewSystemDraft()
           resetCreate()
@@ -767,7 +760,7 @@ export function SystemList() {
             </Stack>
           </Stack>
         )}
-      </ResponsiveModal>
+      </Dialog>
 
       {createError && (
         <Toast

--- a/packages/client/src/views/SysAdmin/Team/user/UserActivationModal.tsx
+++ b/packages/client/src/views/SysAdmin/Team/user/UserActivationModal.tsx
@@ -10,7 +10,7 @@
  */
 import { buttonMessages } from '@client/i18n/messages'
 import { User } from '@opencrvs/commons/client'
-import { ResponsiveModal } from '@opencrvs/components'
+import { Dialog } from '@opencrvs/components'
 import { Button } from '@opencrvs/components/lib/Button'
 import React from 'react'
 import { useIntl } from 'react-intl'
@@ -64,10 +64,10 @@ export function UserActivationModal({
     })
 
   return (
-    <ResponsiveModal
+    <Dialog
       id={`${updatedStatus}-user-modal`}
-      show={true}
-      handleClose={onClose}
+      isOpen={true}
+      onClose={onClose}
       title={intl.formatMessage(actionConfig.title, {
         name
       })}
@@ -89,12 +89,10 @@ export function UserActivationModal({
           {intl.formatMessage(actionConfig.cta)}
         </Button>
       ]}
-      responsive={false}
-      autoHeight={true}
     >
       {intl.formatMessage(actionConfig.subtitle, {
         name
       })}
-    </ResponsiveModal>
+    </Dialog>
   )
 }

--- a/packages/client/src/views/SysAdmin/Team/user/UserList.tsx
+++ b/packages/client/src/views/SysAdmin/Team/user/UserList.tsx
@@ -43,7 +43,7 @@ import { NoWifi } from '@opencrvs/components/lib/icons'
 import { ListUser } from '@opencrvs/components/lib/ListUser'
 import { Pagination } from '@opencrvs/components/lib/Pagination'
 import { Pill } from '@opencrvs/components/lib/Pill'
-import { ResponsiveModal } from '@opencrvs/components/lib/ResponsiveModal'
+import { Dialog } from '@opencrvs/components/lib/Dialog'
 import { Stack } from '@opencrvs/components/lib/Stack'
 import { ITheme } from '@opencrvs/components/lib/theme'
 import { Toast } from '@opencrvs/components/lib/Toast'
@@ -632,10 +632,10 @@ function UserListComponent({ userDetails }: UserListProps) {
               }}
             />
           )}
-          <ResponsiveModal
+          <Dialog
             id="username-reminder-modal"
-            show={toggleUsernameReminder.modalVisible}
-            handleClose={() => toggleUsernameReminderModal()}
+            isOpen={toggleUsernameReminder.modalVisible}
+            onClose={() => toggleUsernameReminderModal()}
             title={intl.formatMessage(
               messages.sendUsernameReminderInviteModalTitle
             )}
@@ -662,8 +662,6 @@ function UserListComponent({ userDetails }: UserListProps) {
                 {intl.formatMessage(buttonMessages.send)}
               </Button>
             ]}
-            responsive={false}
-            autoHeight={true}
           >
             {intl.formatMessage(
               messages.sendUsernameReminderInviteModalMessage,
@@ -675,11 +673,11 @@ function UserListComponent({ userDetails }: UserListProps) {
                 deliveryMethod
               }
             )}
-          </ResponsiveModal>
-          <ResponsiveModal
+          </Dialog>
+          <Dialog
             id="user-reset-password-modal"
-            show={toggleResetPassword.modalVisible}
-            handleClose={() => toggleUserResetPasswordModal()}
+            isOpen={toggleResetPassword.modalVisible}
+            onClose={() => toggleUserResetPasswordModal()}
             title={intl.formatMessage(messages.resetUserPasswordModalTitle)}
             actions={[
               <Button
@@ -704,8 +702,6 @@ function UserListComponent({ userDetails }: UserListProps) {
                 {intl.formatMessage(buttonMessages.send)}
               </Button>
             ]}
-            responsive={false}
-            autoHeight={true}
           >
             {intl.formatMessage(messages.resetUserPasswordModalMessage, {
               deliveryMethod,
@@ -714,7 +710,7 @@ function UserListComponent({ userDetails }: UserListProps) {
                   ? toggleResetPassword.selectedUser?.mobile
                   : toggleResetPassword.selectedUser?.email
             })}
-          </ResponsiveModal>
+          </Dialog>
         </UserTable>
       )
     },

--- a/packages/client/src/views/UserAudit/UserAudit.tsx
+++ b/packages/client/src/views/UserAudit/UserAudit.tsx
@@ -31,7 +31,7 @@ import { Button } from '@opencrvs/components/lib/Button'
 import { Content, ContentSize } from '@opencrvs/components/lib/Content'
 import { Icon } from '@opencrvs/components/lib/Icon'
 import { Loader } from '@opencrvs/components/lib/Loader'
-import { ResponsiveModal } from '@opencrvs/components/lib/ResponsiveModal'
+import { Dialog } from '@opencrvs/components/lib/Dialog'
 import { Summary } from '@opencrvs/components/lib/Summary'
 import { Toast } from '@opencrvs/components/lib/Toast'
 import { ToggleMenu } from '@opencrvs/components/lib/ToggleMenu'
@@ -257,15 +257,15 @@ export const UserAudit = () => {
           </>
           {/* {user.id ? (
             <UserAuditActionModal
-              show={modalVisible}
+              isOpen={modalVisible}
               userId={user.id}
               onClose={() => toggleUserActivationModal()}
             />
           ) : null} */}
-          <ResponsiveModal
+          <Dialog
             id="username-reminder-modal"
-            show={toggleUsernameReminder}
-            handleClose={() => toggleUsernameReminderModal()}
+            isOpen={toggleUsernameReminder}
+            onClose={() => toggleUsernameReminderModal()}
             title={intl.formatMessage(
               sysMessages.sendUsernameReminderInviteModalTitle
             )}
@@ -292,8 +292,6 @@ export const UserAudit = () => {
                 {intl.formatMessage(buttonMessages.send)}
               </Button>
             ]}
-            responsive={false}
-            autoHeight={true}
           >
             {intl.formatMessage(
               sysMessages.sendUsernameReminderInviteModalMessage,
@@ -302,11 +300,11 @@ export const UserAudit = () => {
                 deliveryMethod
               }
             )}
-          </ResponsiveModal>
-          <ResponsiveModal
+          </Dialog>
+          <Dialog
             id="user-reset-password-modal"
-            show={toggleResetPassword}
-            handleClose={() => toggleUserResetPasswordModal()}
+            isOpen={toggleResetPassword}
+            onClose={() => toggleUserResetPasswordModal()}
             title={intl.formatMessage(sysMessages.resetUserPasswordModalTitle)}
             actions={[
               <Button
@@ -331,14 +329,12 @@ export const UserAudit = () => {
                 {intl.formatMessage(buttonMessages.send)}
               </Button>
             ]}
-            responsive={false}
-            autoHeight={true}
           >
             {intl.formatMessage(sysMessages.resetUserPasswordModalMessage, {
               deliveryMethod,
               recipient: deliveryMethod === 'sms' ? user.mobile : user.email
             })}
-          </ResponsiveModal>
+          </Dialog>
           {showResendInviteSuccess && (
             <Toast
               id="resend_invite_success"

--- a/packages/client/src/views/UserAudit/UserAuditHistory.tsx
+++ b/packages/client/src/views/UserAudit/UserAuditHistory.tsx
@@ -26,7 +26,7 @@ import { orderBy } from 'lodash'
 
 import subMonths from 'date-fns/subMonths'
 
-import { ResponsiveModal } from '@opencrvs/components/lib/ResponsiveModal'
+import { Dialog } from '@opencrvs/components/lib/Dialog'
 import format from '@client/utils/date-formatting'
 import { Text } from '@opencrvs/components/lib/Text'
 import { useWindowSize } from '@opencrvs/components/src/hooks'
@@ -354,14 +354,13 @@ function UserAuditHistoryComponent(props: Props) {
             }
           />
           {state.actionDetailsData && (
-            <ResponsiveModal
+            <Dialog
               actions={[]}
-              handleClose={() => toggleActionDetails(null)}
-              show={state.showModal}
-              responsive={true}
+              onClose={() => toggleActionDetails(null)}
+              isOpen={state.showModal}
               title={getActionMessage(state.actionDetailsData)}
+              variant="large"
               width={1024}
-              autoHeight={true}
             >
               <AuditContent>
                 {props.userName} -{' '}
@@ -370,7 +369,7 @@ function UserAuditHistoryComponent(props: Props) {
                   'MMMM dd, yyyy hh:mm a'
                 )}
               </AuditContent>
-            </ResponsiveModal>
+            </Dialog>
           )}
         </TableDiv>
       )}

--- a/packages/components/src/Dialog/Dialog.tsx
+++ b/packages/components/src/Dialog/Dialog.tsx
@@ -8,11 +8,12 @@
  *
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
-import React, { useRef } from 'react'
+import React, { useId, useRef } from 'react'
 import styled from 'styled-components'
 import { Text } from '../Text'
 import { Button } from '../Button'
 import { Icon } from '../Icon'
+import { useDialogA11y } from './useDialogA11y'
 
 export interface IDialogProps {
   id?: string
@@ -47,7 +48,7 @@ const DialogContainer = styled.div<{
   width?: number
 }>`
   position: relative;
-  ${({ variant, width }) =>
+  ${({ variant, width, theme }) =>
     variant === 'small'
       ? `
         width: 480px;
@@ -57,13 +58,13 @@ const DialogContainer = styled.div<{
         min-height: 118px;
         height: auto;
         width: ${width ? `${width}px` : '80%'};
-            @media (max-width: 768px) and (orientation: portrait) {
-             width: 100%;
-             height: 100%;
-             max-width: 100%;
-             max-height: 100%;
-             border-radius: 0;
-             }
+        @media (max-width: ${theme.grid.breakpoints.lg}px) {
+          width: 100%;
+          height: 100%;
+          max-width: 100%;
+          max-height: 100%;
+          border-radius: 0;
+        }
       `}
   background-color: ${({ theme }) => theme.colors.white};
   border-radius: 4px;
@@ -97,6 +98,12 @@ const DialogFooter = styled.div`
   gap: 8px;
   justify-content: flex-end;
   border-top: 1px solid ${({ theme }) => theme.colors.grey200};
+  @media (max-width: ${({ theme }) => theme.grid.breakpoints.md}px) {
+    flex-direction: column-reverse;
+    & > * {
+      width: 100%;
+    }
+  }
 `
 
 export function Dialog({
@@ -111,11 +118,17 @@ export function Dialog({
   titleIcon
 }: IDialogProps) {
   const dialogRef = useRef<HTMLDivElement>(null)
+  const generatedTitleId = useId()
+  const titleId = id ? `${id}-title` : generatedTitleId
+  const contentId = `${titleId}-content`
+
   const handleClose = () => {
     if (onClose) {
       onClose()
     }
   }
+
+  useDialogA11y(dialogRef, isOpen, onClose)
 
   const hasActions = actions && actions.length > 0
 
@@ -140,24 +153,31 @@ export function Dialog({
             variant={variant}
             ref={dialogRef}
             role="dialog"
+            aria-modal="true"
+            aria-labelledby={titleId}
+            aria-describedby={contentId}
+            tabIndex={-1}
           >
             <DialogHeader>
               <DialogTitle>
                 {titleIcon}
-                <Text variant="h2" element="h2" color="grey600">
+                <Text id={titleId} variant="h2" element="h2" color="grey600">
                   {title}
                 </Text>
               </DialogTitle>
-              <Button
-                data-testid="close-dialog"
-                type="icon"
-                size="medium"
-                onClick={handleClose}
-              >
-                <Icon name="X" size="large" weight="bold" />
-              </Button>
+              {onClose && (
+                <Button
+                  data-testid="close-dialog"
+                  aria-label="Close dialog"
+                  type="icon"
+                  size="medium"
+                  onClick={handleClose}
+                >
+                  <Icon name="X" size="large" weight="bold" />
+                </Button>
+              )}
             </DialogHeader>
-            <DialogContent>{children}</DialogContent>
+            <DialogContent id={contentId}>{children}</DialogContent>
             {hasActions && <DialogFooter>{actions}</DialogFooter>}
           </DialogContainer>
         </DialogWrapper>

--- a/packages/components/src/Dialog/useDialogA11y.ts
+++ b/packages/components/src/Dialog/useDialogA11y.ts
@@ -1,0 +1,90 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+import { RefObject, useEffect, useRef } from 'react'
+
+const FOCUSABLE =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+
+// Tracks how many dialogs are currently open so nested dialogs don't prematurely
+// restore scroll when an inner dialog closes while an outer one is still mounted.
+let openDialogCount = 0
+
+export function useDialogA11y(
+  ref: RefObject<HTMLElement>,
+  isOpen: boolean,
+  onClose: (() => void) | undefined
+) {
+  const onCloseRef = useRef(onClose)
+  useEffect(() => {
+    onCloseRef.current = onClose
+  })
+
+  useEffect(() => {
+    if (!isOpen || !ref.current) return
+
+    const trigger = document.activeElement as HTMLElement | null
+
+    openDialogCount++
+    if (openDialogCount === 1) {
+      document.body.style.overflow = 'hidden'
+    }
+
+    const raf = requestAnimationFrame(() => {
+      ref.current?.focus()
+    })
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        onCloseRef.current?.()
+        return
+      }
+
+      if (event.key !== 'Tab') return
+
+      const focusable = Array.from(
+        ref.current?.querySelectorAll<HTMLElement>(FOCUSABLE) ?? []
+      ).filter((el) => el.offsetParent !== null)
+
+      if (focusable.length === 0) {
+        event.preventDefault()
+        return
+      }
+
+      const first = focusable[0]
+      const last = focusable[focusable.length - 1]
+
+      if (event.shiftKey) {
+        if (document.activeElement === first) {
+          event.preventDefault()
+          last.focus()
+        }
+      } else {
+        if (document.activeElement === last) {
+          event.preventDefault()
+          first.focus()
+        }
+      }
+    }
+
+    document.addEventListener('keydown', onKeyDown)
+
+    return () => {
+      cancelAnimationFrame(raf)
+      document.removeEventListener('keydown', onKeyDown)
+      openDialogCount--
+      if (openDialogCount === 0) {
+        document.body.style.removeProperty('overflow')
+      }
+      trigger?.focus()
+    }
+  }, [isOpen, ref])
+}

--- a/packages/login/src/views/ReloadModal.tsx
+++ b/packages/login/src/views/ReloadModal.tsx
@@ -9,7 +9,7 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 
-import { ResponsiveModal } from '@opencrvs/components'
+import { Dialog } from '@opencrvs/components'
 import { PrimaryButton } from '@opencrvs/components/src/buttons'
 import React from 'react'
 import { useSelector } from 'react-redux'
@@ -50,20 +50,16 @@ export const ReloadModal = () => {
   }
 
   return (
-    <ResponsiveModal
+    <Dialog
       title={intl.formatMessage(messages.title)}
-      responsive={false}
-      showCloseButton={false}
-      autoHeight={true}
-      titleHeightAuto={true}
       actions={[
         <PrimaryButton key="reload" id="reload" onClick={handleReload}>
           {intl.formatMessage(messages.update)}
         </PrimaryButton>
       ]}
-      show={visibility}
+      isOpen={visibility}
     >
       {intl.formatMessage(messages.body, { app_name: app_name })}
-    </ResponsiveModal>
+    </Dialog>
   )
 }


### PR DESCRIPTION
---

Summary

- Migrate ResponsiveModal → Dialog (28 call sites) across packages/client and packages/login. Replaces the legacy show/handleClose/responsive/autoHeight/contentHeight API with isOpen/onClose; adds variant="large" where a width prop was present. Net deletion: 44 lines.
- Accessibility hardening (Dialog.tsx + useDialogA11y.ts):
    - Body scroll lock via a module-level openDialogCount counter — nested dialogs don't prematurely restore scroll when an inner dialog closes.
    - Focus-on-open via requestAnimationFrame; return-focus-on-close to the triggering element.
    - Escape key closes the dialog; Tab/Shift+Tab cycle is trapped within the dialog's focusable children.
    - aria-modal="true", aria-labelledby (stable useId-generated), aria-describedby wired to DialogContent.
    - Close button now conditionally rendered — omitted entirely when no onClose is provided (e.g. ReloadModal), preventing an inert keyboard target.
    - onClose removed from useEffect deps; a useRef wrapper keeps the callback current without triggering spurious effect cycles on inline-function re-renders.
- Responsive fixes (Dialog.tsx):
    - Large-variant mobile breakpoint: @media (max-width: 768px) and
    (orientation: portrait) → @media (max-width: ${theme.grid.breakpoints.lg}px) — portrait qualifier removed so
    landscape phones get the full-screen treatment.
    - Footer actions stack column-reverse at [[breakpoints.md](http://breakpoints.md/)](http://breakpoints.md/) and below, each button full-width — primary action stays visually first on mobile.
