### PR TITLE
Refactor: Only use Button.tsx

### DIFF
--- a/packages/client/src/components/DateRangePicker.tsx
+++ b/packages/client/src/components/DateRangePicker.tsx
@@ -11,11 +11,7 @@
 import { buttonMessages, constantsMessages } from '@client/i18n/messages'
 import styled from 'styled-components'
 import format from '@client/utils/date-formatting'
-import {
-  CircleButton,
-  PrimaryButton,
-  SecondaryButton
-} from '@opencrvs/components/lib/buttons'
+import { Button } from '@opencrvs/components/lib/Button'
 import { IActionObject } from '@opencrvs/components/lib/common-types'
 import {
   Calendar,
@@ -114,10 +110,6 @@ interface MonthSelectorProps {
   selectedDate: Date
 }
 
-export const PickerButton = styled(SecondaryButton)`
-  height: 32px;
-  padding: 0;
-`
 export const ContentWrapper = styled.div`
   display: flex;
   justify-content: space-between;
@@ -371,10 +363,6 @@ export const CancelableArea = styled.div`
     opacity: 0.5;
   }
 `
-const StyledPrimaryButton = styled(PrimaryButton)`
-  padding: 8px 16px;
-  height: auto;
-`
 function DateRangePickerComponent(props: IDateRangePickerProps) {
   const [modalVisible, setModalVisible] = useState<boolean>(
     props.usedInsideHOC ? true : false
@@ -495,22 +483,24 @@ function DateRangePickerComponent(props: IDateRangePickerProps) {
               : label}
           </LabelContainer>
           <NavigatorContainer>
-            <CircleButton
+            <Button
               data-testid={`${id}-prev`}
               id={`${id}-prev`}
+              type="icon"
               onClick={() => onNavigateDate(subYears(date, 1))}
             >
               <ChevronLeft />
-            </CircleButton>
+            </Button>
             <YearLabelContainer
               id={`${id}-year-label`}
               data-testid={`${id}-year-label`}
             >
               {format(date, 'yyyy')}
             </YearLabelContainer>
-            <CircleButton
+            <Button
               id={`${id}-next`}
               data-testid={`${id}-next`}
+              type="icon"
               onClick={() => {
                 const nextDate = addYears(date, 1)
                 const finalDateNavigateTo = isAfter(nextDate, todaysDate)
@@ -521,7 +511,7 @@ function DateRangePickerComponent(props: IDateRangePickerProps) {
               disabled={isSameYear(date, todaysDate)}
             >
               <ChevronRight />
-            </CircleButton>
+            </Button>
           </NavigatorContainer>
         </MonthSelectorHeader>
         <MonthButtonsContainer>
@@ -665,8 +655,10 @@ function DateRangePickerComponent(props: IDateRangePickerProps) {
   return (
     <div>
       {!props.usedInsideHOC && (
-        <PickerButton
+        <Button
           id="date-range-picker-action"
+          type="secondary"
+          size="small"
           onClick={() => setModalVisible(true)}
         >
           <ContentWrapper>
@@ -680,7 +672,7 @@ function DateRangePickerComponent(props: IDateRangePickerProps) {
             </span>
             <Calendar />
           </ContentWrapper>
-        </PickerButton>
+        </Button>
       )}
       {modalVisible && (
         <>
@@ -690,16 +682,16 @@ function DateRangePickerComponent(props: IDateRangePickerProps) {
                 <CalendarGrey />
                 <span>{intl.formatMessage(constantsMessages.timePeriod)}</span>
               </TitleContent>
-              <CircleButton
+              <Button
                 id="close-btn"
-                type="button"
+                type="icon"
                 onClick={() => {
                   setModalVisible(false)
                   props.closeModalFromHOC && props.closeModalFromHOC()
                 }}
               >
                 <Cross color="currentColor" />
-              </CircleButton>
+              </Button>
             </ModalHeader>
             <ModalBody>
               {!props.usedInsideHOC && (
@@ -741,8 +733,9 @@ function DateRangePickerComponent(props: IDateRangePickerProps) {
               {routes[activeRoute].renderComponent()}
             </ModalBodyMobile>
             <ModalFooter>
-              <StyledPrimaryButton
+              <Button
                 id="date-range-confirm-action"
+                type="primary"
                 onClick={() => {
                   props.onDatesChange({
                     startDate: startDate,
@@ -754,7 +747,7 @@ function DateRangePickerComponent(props: IDateRangePickerProps) {
                 disabled={isAfter(startDate, endDate)}
               >
                 {intl.formatMessage(buttonMessages.select)}
-              </StyledPrimaryButton>
+              </Button>
             </ModalFooter>
           </ModalContainer>
           <CancelableArea

--- a/packages/client/src/components/LocationPicker.tsx
+++ b/packages/client/src/components/LocationPicker.tsx
@@ -20,10 +20,9 @@ import {
   LocationSearch
 } from '@opencrvs/components/lib/LocationSearch'
 import { buttonMessages, constantsMessages } from '@client/i18n/messages'
-import { CircleButton } from '@opencrvs/components/lib/buttons'
+import { Button } from '@opencrvs/components/lib/Button'
 import { colors } from '@opencrvs/components/lib/colors'
 import {
-  PickerButton,
   ContentWrapper,
   ModalContainer as CommonModalContainer,
   ModalHeader,
@@ -145,8 +144,10 @@ export function LocationPicker({
   }, [modalVisible])
   return (
     <div>
-      <PickerButton
+      <Button
         id="location-range-picker-action"
+        type="secondary"
+        size="small"
         onClick={() => setModalVisible(true)}
         disabled={disabled}
       >
@@ -158,7 +159,7 @@ export function LocationPicker({
           </span>
           <MapPin color={disabled ? colors.grey200 : undefined} />
         </ContentWrapper>
-      </PickerButton>
+      </Button>
       {modalVisible && (
         <>
           <ModalContainer id="picker-modal">
@@ -167,13 +168,13 @@ export function LocationPicker({
                 <LocationIcon />
                 <span>{intl.formatMessage(constantsMessages.location)}</span>
               </TitleContent>
-              <CircleButton
+              <Button
                 id="close-btn"
-                type="button"
+                type="icon"
                 onClick={() => setModalVisible(false)}
               >
                 <Cross color="currentColor" />
-              </CircleButton>
+              </Button>
             </ModalHeader>
             <ModalBody>
               <StyledLocationSearch

--- a/packages/client/src/components/SessionExpireConfirmation.tsx
+++ b/packages/client/src/components/SessionExpireConfirmation.tsx
@@ -12,7 +12,7 @@ import * as React from 'react'
 import { connect } from 'react-redux'
 import { injectIntl, WrappedComponentProps as IntlShapeProps } from 'react-intl'
 import { ResponsiveModal } from '@opencrvs/components/lib/ResponsiveModal'
-import { PrimaryButton } from '@opencrvs/components/lib/buttons'
+import { Button } from '@opencrvs/components/lib/Button'
 import { IStoreState } from '@client/store'
 import { redirectToAuthentication } from '@client/profile/profileActions'
 import { messages } from '@client/i18n/messages/views/session'
@@ -39,13 +39,14 @@ const SessionExpireComponent = ({
       contentHeight={96}
       responsive={false}
       actions={[
-        <PrimaryButton
+        <Button
           key="login"
           id="login"
+          type="primary"
           onClick={() => redirectToAuthentication(true)}
         >
           {intl.formatMessage(buttonMessages.login)}
-        </PrimaryButton>
+        </Button>
       ]}
       show={true}
     />

--- a/packages/client/src/components/StyledErrorBoundary.tsx
+++ b/packages/client/src/components/StyledErrorBoundary.tsx
@@ -13,7 +13,7 @@ import * as Sentry from '@sentry/react'
 import styled from 'styled-components'
 import { injectIntl, WrappedComponentProps as IntlShapeProps } from 'react-intl'
 import { PageWrapper } from '@opencrvs/components/lib/PageWrapper'
-import { TertiaryButton } from '@opencrvs/components/lib/buttons'
+import { Button } from '@opencrvs/components/lib/Button'
 import { Box } from '@opencrvs/components/lib/Box'
 import { errorMessages, buttonMessages } from '@client/i18n/messages'
 
@@ -70,12 +70,14 @@ const StyledErrorBoundaryComponent = ({ intl, children }: IFullProps) => {
             <ErrorMessage>
               {intl.formatMessage(errorMessages.unknownErrorDescription)}
             </ErrorMessage>
-            <TertiaryButton
+            <Button
               id="GoToHomepage"
+              type="tertiary"
+              size="small"
               onClick={() => (window.location.href = '/')}
             >
               {intl.formatMessage(buttonMessages.goToHomepage)}
-            </TertiaryButton>
+            </Button>
           </ErrorContainer>
         </PageWrapper>
       }

--- a/packages/client/src/v2-events/features/events/actions/correct/request/Review.tsx
+++ b/packages/client/src/v2-events/features/events/actions/correct/request/Review.tsx
@@ -20,7 +20,7 @@ import {
   getDeclaration,
   getCurrentEventState
 } from '@opencrvs/commons/client'
-import { PrimaryButton } from '@opencrvs/components/lib/buttons'
+import { Button } from '@opencrvs/components/lib/Button'
 import { buttonMessages } from '@client/i18n/messages'
 import { Review as ReviewComponent } from '@client/v2-events/features/events/components/Review'
 import { useEventConfiguration } from '@client/v2-events/features/events/useEventConfiguration'
@@ -113,8 +113,9 @@ export function Review() {
           )
         }}
       >
-        <PrimaryButton
+        <Button
           key="continue_button"
+          type="primary"
           disabled={!anyValuesHaveChanged || incomplete}
           id="continue_button"
           onClick={() => {
@@ -127,7 +128,7 @@ export function Review() {
           }}
         >
           {intl.formatMessage(buttonMessages.continueButton)}
-        </PrimaryButton>
+        </Button>
       </ReviewComponent.Body>
     </FormLayout>
   )

--- a/packages/client/src/v2-events/features/events/actions/correct/request/Review.tsx
+++ b/packages/client/src/v2-events/features/events/actions/correct/request/Review.tsx
@@ -115,9 +115,9 @@ export function Review() {
       >
         <Button
           key="continue_button"
-          type="primary"
           disabled={!anyValuesHaveChanged || incomplete}
           id="continue_button"
+          type="primary"
           onClick={() => {
             navigate(
               ROUTES.V2.EVENTS.REQUEST_CORRECTION.SUMMARY.buildPath(

--- a/packages/client/src/v2-events/features/events/actions/correct/request/Summary/Summary.tsx
+++ b/packages/client/src/v2-events/features/events/actions/correct/request/Summary/Summary.tsx
@@ -28,7 +28,6 @@ import { ActionPageLight } from '@opencrvs/components/lib/ActionPageLight'
 import { Button } from '@opencrvs/components/lib/Button'
 import { Content } from '@opencrvs/components/lib/Content'
 import { Dialog } from '@opencrvs/components/lib/Dialog/Dialog'
-import { SecondaryButton } from '@opencrvs/components/lib/buttons'
 import { Check } from '@opencrvs/components/lib/icons'
 import { Text } from '@opencrvs/components/lib/Text'
 import { messages as registerMessages } from '@client/i18n/messages/views/register'
@@ -207,9 +206,10 @@ export function Summary() {
           showTitleOnMobile={true}
           title={intl.formatMessage(correctionMessages.correctionSummaryTitle)}
           topActionButtons={[
-            <SecondaryButton
+            <Button
               key="back-to-review"
               id="back-to-review"
+              type="secondary"
               onClick={() =>
                 navigate(
                   ROUTES.V2.EVENTS.REQUEST_CORRECTION.REVIEW.buildPath(
@@ -222,7 +222,7 @@ export function Summary() {
               }
             >
               {intl.formatMessage(registerMessages.backToReviewButton)}
-            </SecondaryButton>
+            </Button>
           ]}
         >
           <CorrectionDetails

--- a/packages/client/src/v2-events/features/events/actions/declare/DeclareActionMenu.tsx
+++ b/packages/client/src/v2-events/features/events/actions/declare/DeclareActionMenu.tsx
@@ -21,7 +21,7 @@ import {
   getAvailableActionsForEvent,
   getActionConfig
 } from '@opencrvs/commons/client'
-import { PrimaryButton } from '@opencrvs/components/lib/buttons'
+import { Button } from '@opencrvs/components/lib/Button'
 import { DropdownMenu } from '@opencrvs/components/lib/Dropdown'
 import { CaretDown } from '@opencrvs/components/lib/Icon/all-icons'
 import { Icon } from '@opencrvs/components'
@@ -234,13 +234,14 @@ export function DeclareActionMenu({ event }: { event: EventDocument }) {
     <>
       <DropdownMenu id="action">
         <DropdownMenu.Trigger asChild>
-          <PrimaryButton
+          <Button
             data-testid="action-dropdownMenu"
-            icon={() => <CaretDown />}
             size="medium"
+            type="primary"
           >
             {intl.formatMessage(messages.action)}
-          </PrimaryButton>
+            <CaretDown />
+          </Button>
         </DropdownMenu.Trigger>
         <DropdownMenu.Content>
           {actions.map(({ onClick, icon, label, disabled }, index) => (

--- a/packages/client/src/v2-events/features/events/actions/quick-actions/useQuickActionModal.tsx
+++ b/packages/client/src/v2-events/features/events/actions/quick-actions/useQuickActionModal.tsx
@@ -12,12 +12,7 @@ import React from 'react'
 import { MessageDescriptor, useIntl } from 'react-intl'
 import { useNavigate } from 'react-router-dom'
 import { v4 as uuid } from 'uuid'
-import { Dialog } from '@opencrvs/components'
-import {
-  DangerButton,
-  PrimaryButton,
-  TertiaryButton
-} from '@opencrvs/components/lib/buttons'
+import { Button, Dialog } from '@opencrvs/components'
 import { Icon, IconProps } from '@opencrvs/components/src/Icon'
 import { Stack } from '@opencrvs/components/lib/Stack'
 import {
@@ -109,9 +104,6 @@ function QuickActionModal({
   const eventDocument = getEvent.useGetOrDownloadEvent(eventId)
   const event = getCurrentEventState(eventDocument, eventConfiguration)
 
-  const ConfirmButton =
-    config.confirmButtonType === 'danger' ? DangerButton : PrimaryButton
-
   const handleChange = (values: Record<string, FieldUpdateValue>) => {
     setModalValues((prev) => ({
       ...prev,
@@ -143,24 +135,26 @@ function QuickActionModal({
   return (
     <Dialog
       actions={[
-        <TertiaryButton
+        <Button
           key="cancel"
           id="cancel-btn"
+          size="small"
+          type="tertiary"
           onClick={() => close({ result: false })}
         >
           {intl.formatMessage(buttonMessages.cancel)}
-        </TertiaryButton>,
-        <ConfirmButton
+        </Button>,
+        <Button
           key="confirm"
-          bg={'primaryBlue'}
           disabled={errorsOnField.length > 0}
           id="confirm-btn"
+          type={config.confirmButtonType === 'danger' ? 'negative' : 'primary'}
           onClick={confirm}
         >
           {intl.formatMessage(
             config.confirmButtonLabel || buttonMessages.confirm
           )}
-        </ConfirmButton>
+        </Button>
       ]}
       id={`quick-action-modal-${config.label.id}`}
       isOpen={true}

--- a/packages/client/src/v2-events/features/workqueues/EventOverview/components/ActionMenu.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/components/ActionMenu.tsx
@@ -14,7 +14,7 @@ import { useIntl } from 'react-intl'
 import { useTypedSearchParams } from 'react-router-typesafe-routes/dom'
 import { Icon } from '@opencrvs/components/lib/Icon'
 import { CaretDown } from '@opencrvs/components/lib/Icon/all-icons'
-import { PrimaryButton } from '@opencrvs/components/lib/buttons'
+import { Button } from '@opencrvs/components/lib/Button'
 import { DropdownMenu } from '@opencrvs/components/lib/Dropdown'
 import {
   EventConfig,
@@ -181,13 +181,14 @@ export function ActionMenu({
     <>
       <DropdownMenu id="action">
         <DropdownMenu.Trigger asChild>
-          <PrimaryButton
+          <Button
             data-testid="action-dropdownMenu"
-            icon={() => <CaretDown />}
             size="medium"
+            type="primary"
           >
             {intl.formatMessage(messages.action)}
-          </PrimaryButton>
+            <CaretDown />
+          </Button>
         </DropdownMenu.Trigger>
         <DropdownMenu.Content>
           {assignedToOther && (

--- a/packages/client/src/v2-events/routes/TRPCErrorBoundary.tsx
+++ b/packages/client/src/v2-events/routes/TRPCErrorBoundary.tsx
@@ -16,7 +16,7 @@ import { TRPCClientError } from '@trpc/client'
 import { connect } from 'react-redux'
 import { injectIntl, WrappedComponentProps as IntlShapeProps } from 'react-intl'
 import { PageWrapper } from '@opencrvs/components/lib/PageWrapper'
-import { TertiaryButton } from '@opencrvs/components/lib/buttons'
+import { Button } from '@opencrvs/components/lib/Button'
 import { Box } from '@opencrvs/components/lib/Box'
 import { errorMessages, buttonMessages } from '@client/i18n/messages'
 import { redirectToAuthentication } from '@client/profile/profileActions'
@@ -156,12 +156,14 @@ class ErrorBoundary extends Component<Props, State> {
                   <ErrorMessage>
                     {intl.formatMessage(errorMessages.errorCodeUnauthorized)}
                   </ErrorMessage>
-                  <TertiaryButton
+                  <Button
                     id="GoToLoginPage"
+                    size="small"
+                    type="tertiary"
                     onClick={() => redirectToAuthentication(true)}
                   >
                     {intl.formatMessage(buttonMessages.login)}
-                  </TertiaryButton>
+                  </Button>
                 </>
               ) : (
                 <>
@@ -169,12 +171,14 @@ class ErrorBoundary extends Component<Props, State> {
                     {intl.formatMessage(errorMessages.errorTitle)}
                   </ErrorTitle>
                   <ErrorMessage>{message}</ErrorMessage>
-                  <TertiaryButton
+                  <Button
                     id="GoToHomepage"
+                    size="small"
+                    type="tertiary"
                     onClick={() => (window.location.href = buttonPath)}
                   >
                     {buttonLabel}
-                  </TertiaryButton>
+                  </Button>
                 </>
               )}
             </ErrorContainer>

--- a/packages/client/src/views/Modals/ReloadModal.tsx
+++ b/packages/client/src/views/Modals/ReloadModal.tsx
@@ -10,7 +10,7 @@
  */
 
 import { ResponsiveModal } from '@opencrvs/components'
-import { PrimaryButton } from '@opencrvs/components/src/buttons'
+import { Button } from '@opencrvs/components/lib/Button'
 import React from 'react'
 import { useSelector } from 'react-redux'
 import { IStoreState } from '@client/store'
@@ -58,9 +58,9 @@ export const ReloadModal = () => {
       autoHeight={true}
       titleHeightAuto={true}
       actions={[
-        <PrimaryButton key="reload" id="reload" onClick={handleReload}>
+        <Button key="reload" id="reload" type="primary" onClick={handleReload}>
           {intl.formatMessage(messages.update)}
-        </PrimaryButton>
+        </Button>
       ]}
       show={visibility}
     >

--- a/packages/client/src/views/Settings/AvatarChangeModal.tsx
+++ b/packages/client/src/views/Settings/AvatarChangeModal.tsx
@@ -12,11 +12,8 @@ import * as React from 'react'
 import { ResponsiveModal } from '@opencrvs/components/lib/ResponsiveModal'
 import { useIntl } from 'react-intl'
 import { userMessages as messages, buttonMessages } from '@client/i18n/messages'
-import {
-  PrimaryButton,
-  TertiaryButton,
-  LinkButton
-} from '@opencrvs/components/lib/buttons'
+import { Button } from '@opencrvs/components/lib/Button'
+import { LinkButton } from '@opencrvs/components/lib/buttons'
 import Cropper from 'react-easy-crop'
 import type { Point, Area, Size } from 'react-easy-crop'
 import styled, { useTheme } from 'styled-components'
@@ -214,17 +211,18 @@ function AvatarChangeModalComp({
       show={showChangeAvatar}
       title={intl.formatMessage(messages.changeAvatar)}
       actions={[
-        <TertiaryButton key="cancel" id="modal_cancel" onClick={handleCancel}>
+        <Button key="cancel" id="modal_cancel" type="tertiary" size="small" onClick={handleCancel}>
           {intl.formatMessage(buttonMessages.cancel)}
-        </TertiaryButton>,
-        <PrimaryButton
+        </Button>,
+        <Button
           key="apply"
           id="apply_change"
+          type="primary"
           disabled={!isOnline || !!error}
           onClick={handleApply}
         >
           {intl.formatMessage(buttonMessages.apply)}
-        </PrimaryButton>
+        </Button>
       ]}
       handleClose={handleCancel}
     >

--- a/packages/client/src/views/Settings/ChangeEmailModal/ChangeEmailView.tsx
+++ b/packages/client/src/views/Settings/ChangeEmailModal/ChangeEmailView.tsx
@@ -11,7 +11,7 @@
 import { Toast } from '@opencrvs/components/lib/Toast'
 import { ResponsiveModal } from '@opencrvs/components/lib/ResponsiveModal'
 import * as React from 'react'
-import { TertiaryButton, PrimaryButton } from '@opencrvs/components/lib/buttons'
+import { Button } from '@opencrvs/components/lib/Button'
 import { userMessages as messages, buttonMessages } from '@client/i18n/messages'
 import { InputField } from '@opencrvs/components/lib/InputField'
 import { TextInput } from '@opencrvs/components/lib/TextInput'
@@ -98,19 +98,20 @@ export function ChangeEmailView({ show, onSuccess, onClose }: IProps) {
       show={show}
       title={intl.formatMessage(messages.changeEmailLabel)}
       actions={[
-        <TertiaryButton key="cancel" id="modal_cancel" onClick={onClose}>
+        <Button key="cancel" id="modal_cancel" type="tertiary" size="small" onClick={onClose}>
           {intl.formatMessage(buttonMessages.cancel)}
-        </TertiaryButton>,
-        <PrimaryButton
+        </Button>,
+        <Button
           id="continue-button"
           key="continue"
+          type="primary"
           onClick={() => {
             continueButtonHandler(emailAddress)
           }}
           disabled={!Boolean(emailAddress.length) || isInvalidEmailAddress}
         >
           {intl.formatMessage(buttonMessages.continueButton)}
-        </PrimaryButton>
+        </Button>
       ]}
       handleClose={onClose}
       contentHeight={150}

--- a/packages/client/src/views/Settings/ChangePhoneModal/ChangeNumberView.tsx
+++ b/packages/client/src/views/Settings/ChangePhoneModal/ChangeNumberView.tsx
@@ -11,7 +11,7 @@
 import { Toast } from '@opencrvs/components/lib/Toast'
 import { ResponsiveModal } from '@opencrvs/components/lib/ResponsiveModal'
 import * as React from 'react'
-import { TertiaryButton, PrimaryButton } from '@opencrvs/components/lib/buttons'
+import { Button } from '@opencrvs/components/lib/Button'
 import { userMessages as messages, buttonMessages } from '@client/i18n/messages'
 import { InputField } from '@opencrvs/components/lib/InputField'
 import { TextInput } from '@opencrvs/components/lib/TextInput'
@@ -102,12 +102,13 @@ export function ChangeNumberView({ show, onSuccess, onClose }: IProps) {
       show={show}
       title={intl.formatMessage(messages.changePhoneLabel)}
       actions={[
-        <TertiaryButton key="cancel" id="modal_cancel" onClick={onClose}>
+        <Button key="cancel" id="modal_cancel" type="tertiary" size="small" onClick={onClose}>
           {intl.formatMessage(buttonMessages.cancel)}
-        </TertiaryButton>,
-        <PrimaryButton
+        </Button>,
+        <Button
           id="continue-button"
           key="continue"
+          type="primary"
           onClick={() => {
             const internationalFormat = convertToMSISDN(
               phoneNumber,
@@ -118,7 +119,7 @@ export function ChangeNumberView({ show, onSuccess, onClose }: IProps) {
           disabled={!Boolean(phoneNumber.length) || isInvalidPhoneNumber}
         >
           {intl.formatMessage(buttonMessages.continueButton)}
-        </PrimaryButton>
+        </Button>
       ]}
       handleClose={onClose}
       contentHeight={150}

--- a/packages/client/src/views/Settings/ChangePhoneModal/VerifyCodeView.tsx
+++ b/packages/client/src/views/Settings/ChangePhoneModal/VerifyCodeView.tsx
@@ -17,7 +17,7 @@ import { Message } from '@client/views/Settings/items/components'
 import { InputField } from '@opencrvs/components/lib/InputField'
 import { ResponsiveModal } from '@opencrvs/components/lib/ResponsiveModal'
 import { TextInput } from '@opencrvs/components/lib/TextInput'
-import { TertiaryButton, PrimaryButton } from '@opencrvs/components/lib/buttons'
+import { Button } from '@opencrvs/components/lib/Button'
 import * as React from 'react'
 import { useIntl } from 'react-intl'
 import { useDispatch, useSelector } from 'react-redux'
@@ -139,17 +139,18 @@ export function VerifyCodeView({
       show={show}
       title={intl.formatMessage(messages.verifyPhoneLabel)}
       actions={[
-        <TertiaryButton key="cancel" id="modal_cancel" onClick={onClose}>
+        <Button key="cancel" id="modal_cancel" type="tertiary" size="small" onClick={onClose}>
           {intl.formatMessage(buttonMessages.cancel)}
-        </TertiaryButton>,
-        <PrimaryButton
+        </Button>,
+        <Button
           key="verify"
           id="verify-button"
+          type="primary"
           onClick={submitVerification}
           disabled={!isValidLength}
         >
           {intl.formatMessage(buttonMessages.continueButton)}
-        </PrimaryButton>
+        </Button>
       ]}
       handleClose={onClose}
       contentHeight={150}

--- a/packages/client/src/views/Settings/PasswordChangeModal.tsx
+++ b/packages/client/src/views/Settings/PasswordChangeModal.tsx
@@ -8,7 +8,7 @@
  *
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
-import { PrimaryButton } from '@opencrvs/components/lib/buttons'
+import { Button } from '@opencrvs/components/lib/Button'
 import { InputField } from '@opencrvs/components/lib/InputField'
 import { TextInput } from '@opencrvs/components/lib/TextInput'
 import { ErrorMessage } from '@opencrvs/components/lib/ErrorMessage'
@@ -205,9 +205,10 @@ export function PasswordChangeModal({
       show={showPasswordChange}
       contentHeight={420}
       actions={[
-        <PrimaryButton
+        <Button
           id="confirm-button"
           key="confirm"
+          type="primary"
           onClick={handleChangePassword}
           disabled={
             !Boolean(currentPassword.length) ||
@@ -218,7 +219,7 @@ export function PasswordChangeModal({
           }
         >
           {intl.formatMessage(messages.confirmButtonLabel)}
-        </PrimaryButton>
+        </Button>
       ]}
       width={1000}
       handleClose={hideModal}

--- a/packages/client/src/views/Settings/items/Language.tsx
+++ b/packages/client/src/views/Settings/items/Language.tsx
@@ -26,7 +26,7 @@ import {
   Label
 } from '@client/views/Settings/items/components'
 import { useSelector, useDispatch } from 'react-redux'
-import { TertiaryButton, PrimaryButton } from '@opencrvs/components/lib/buttons'
+import { Button } from '@opencrvs/components/lib/Button'
 import { Select } from '@opencrvs/components/lib/Select'
 import { getAvailableLanguages } from '@client/i18n/utils'
 import { getUserDetails } from '@client/profile/profileSelectors'
@@ -117,16 +117,18 @@ export function Language() {
         title={intl.formatMessage(userMessages.changeLanguageTitle)}
         show={showModal}
         actions={[
-          <TertiaryButton
+          <Button
             key="cancel"
             id="modal_cancel"
+            type="tertiary"
+            size="small"
             onClick={cancelLanguageSettings}
           >
             {intl.formatMessage(buttonMessages.cancel)}
-          </TertiaryButton>,
-          <PrimaryButton key="apply" id="apply_change" onClick={changeLanguage}>
+          </Button>,
+          <Button key="apply" id="apply_change" type="primary" onClick={changeLanguage}>
             {intl.formatMessage(buttonMessages.apply)}
-          </PrimaryButton>
+          </Button>
         ]}
         handleClose={cancelLanguageSettings}
         contentHeight={175}

--- a/packages/client/src/views/SysAdmin/Team/user/userEditor/UserEditor.tsx
+++ b/packages/client/src/views/SysAdmin/Team/user/userEditor/UserEditor.tsx
@@ -28,11 +28,6 @@ import {
 } from '@opencrvs/commons/client'
 import { AppBar, Frame, Spinner } from '@opencrvs/components'
 import { Button } from '@opencrvs/components/lib/Button'
-import {
-  CircleButton,
-  ICON_ALIGNMENT,
-  SuccessButton
-} from '@opencrvs/components/lib/buttons'
 import { Check, Cross } from '@opencrvs/components/lib/icons'
 import { ActionPageLight } from '@opencrvs/components/lib/ActionPageLight'
 import { Toast } from '@opencrvs/components/lib/Toast'
@@ -562,8 +557,9 @@ const ReviewUserComponent = () => {
             {intl.formatMessage(buttonMessages.createUser)}
           </Button>
         ) : (
-          <SuccessButton
+          <Button
             id="submit-edit-user-form"
+            type="positive"
             onClick={() => {
               resetErrors()
               const data: Record<string, FieldValue> = Object.fromEntries(
@@ -598,11 +594,10 @@ const ReviewUserComponent = () => {
                 onError: handleMutationError
               })
             }}
-            icon={() => <Check />}
-            align={ICON_ALIGNMENT.LEFT}
           >
+            <Check />
             {intl.formatMessage(buttonMessages.confirm)}
-          </SuccessButton>
+          </Button>
         )}
       </ReviewComponent.Body>
     </FormLayout>
@@ -684,14 +679,15 @@ function FormHeader({
 }) {
   const getHeaderRight = () => {
     return (
-      <CircleButton
+      <Button
         data-testid="crcl-btn"
         id="crcl-btn"
+        type="icon"
         onClick={onClose}
         key="crcl-btn"
       >
         <Cross color="currentColor" />
-      </CircleButton>
+      </Button>
     )
   }
 

--- a/packages/client/src/views/UserSetup/CreatePassword.tsx
+++ b/packages/client/src/views/UserSetup/CreatePassword.tsx
@@ -12,7 +12,7 @@ import * as React from 'react'
 import { useIntl } from 'react-intl'
 import styled from 'styled-components'
 import { ActionPageLight } from '@opencrvs/components/lib/ActionPageLight'
-import { PrimaryButton } from '@opencrvs/components/lib/buttons'
+import { Button } from '@opencrvs/components/lib/Button'
 import { InputField } from '@opencrvs/components/lib/InputField'
 import { TextInput } from '@opencrvs/components/lib/TextInput'
 import { WarningMessage } from '@opencrvs/components/lib/WarningMessage'
@@ -124,13 +124,14 @@ export function CreatePassword({ setupData, goToStep }: IProps) {
   }
 
   const continueActionButton = (
-    <PrimaryButton
+    <Button
       id="Continue"
+      type="primary"
       onClick={whatNext}
       disabled={!hasCases || !hasNumber || !validLength}
     >
       {intl.formatMessage(buttonMessages.continueButton)}
-    </PrimaryButton>
+    </Button>
   )
 
   return (

--- a/packages/client/src/views/UserSetup/SetupConfirmationPage.tsx
+++ b/packages/client/src/views/UserSetup/SetupConfirmationPage.tsx
@@ -13,7 +13,7 @@ import styled from 'styled-components'
 import { useIntl } from 'react-intl'
 import { useDispatch, useSelector } from 'react-redux'
 import { CountryLogo } from '@opencrvs/components/lib/icons'
-import { PrimaryButton } from '@opencrvs/components/lib/buttons'
+import { Button } from '@opencrvs/components/lib/Button'
 import { redirectToAuthentication } from '@client/profile/profileActions'
 import {
   Page,
@@ -36,7 +36,7 @@ const InstructionHolder = styled.div`
   ${({ theme }) => theme.fonts.reg16};
   padding: 40px 60px 30px 60px;
 `
-const LoginButton = styled(PrimaryButton)`
+const LoginButton = styled(Button)`
   box-shadow: 0 0 13px 0 rgba(0, 0, 0, 0.27);
 `
 
@@ -67,6 +67,7 @@ export function SetupConfirmationPage() {
           </InstructionHolder>
           <LoginButton
             id="setup-login-button"
+            type="primary"
             onClick={() => dispatch(redirectToAuthentication())}
           >
             {intl.formatMessage(buttonMessages.login)}

--- a/packages/login/src/views/ReloadModal.tsx
+++ b/packages/login/src/views/ReloadModal.tsx
@@ -10,7 +10,7 @@
  */
 
 import { ResponsiveModal } from '@opencrvs/components'
-import { PrimaryButton } from '@opencrvs/components/src/buttons'
+import { Button } from '@opencrvs/components/lib/Button'
 import React from 'react'
 import { useSelector } from 'react-redux'
 import { getReloadModalVisibility } from '@login/login/selectors'
@@ -57,9 +57,9 @@ export const ReloadModal = () => {
       autoHeight={true}
       titleHeightAuto={true}
       actions={[
-        <PrimaryButton key="reload" id="reload" onClick={handleReload}>
+        <Button key="reload" id="reload" type="primary" onClick={handleReload}>
           {intl.formatMessage(messages.update)}
-        </PrimaryButton>
+        </Button>
       ]}
       show={visibility}
     >


### PR DESCRIPTION
## Migrate deprecated button components to `Button`

  Replaces all usages of the deprecated `PrimaryButton`,
  `SecondaryButton`, `TertiaryButton`, `DangerButton`,
  `SuccessButton`, and `CircleButton` components with the new unified
  `<Button type="...">` API. `FloatingActionButton` and `LinkButton`
  are out of scope.

  ### Mapping

  | Deprecated | New |
  |---|---|
  | `PrimaryButton` | `<Button type="primary">` |
  | `SecondaryButton` | `<Button type="secondary">` |
  | `TertiaryButton` | `<Button type="tertiary" size="small">` |
  | `DangerButton` | `<Button type="negative">` |
  | `SuccessButton` | `<Button type="positive">` |
  | `CircleButton` | `<Button type="icon">` |

  ### Changes

  - **21 files** migrated across `packages/client` and
  `packages/login`
  - Converted old `icon` render-prop pattern (`icon={() => <Icon />}`)
   to icon as a child node, consistent with the new API
  - Removed the `ConfirmButton` component-variable pattern in
  `useQuickActionModal` — replaced with an inline `type` conditional
  on a single `<Button>`
  - Removed `PickerButton` and `StyledPrimaryButton` styled-component
  wrappers in `DateRangePicker` — replaced with `<Button>` directly at
   both usage sites (`DateRangePicker`, `LocationPicker`)
  - Fixed incorrect import path in `ReloadModal` files
  (`@opencrvs/components/src/buttons` →
  `@opencrvs/components/lib/Button`)
  - Removed `ICON_ALIGNMENT` usage from `UserEditor` (no longer
  needed)