### PR TITLE
fix(scopes): merge AND-paired legacy scopes during v1.9→v2 migration …

### DIFF
--- a/packages/commons/src/scopes.deprecated.do-not-use.ts
+++ b/packages/commons/src/scopes.deprecated.do-not-use.ts
@@ -457,17 +457,8 @@ export function migrateLegacyScopesToV2(scopes: string[]): string[] {
     .filter((scope): scope is EncodedScope => !!scope)
 }
 
-/**
- * v2 scope types whose options legitimately combine `accessLevel` and `role`
- * on a single object (`AllUserScopeOptions` in `./scopes`). For these, a v1.9
- * role array may contain TWO legacy entries — one literal (e.g.
- * `user.create:my-jurisdiction`) and one configurable (e.g.
- * `user.create[role=X|Y]`) — that v1.9 evaluated with AND semantics. v2.0
- * scope arrays use OR semantics, so the pair must be merged into one v2 scope
- * to preserve the original restriction.
- *
- * Kept in sync with `ScopesWithRoleOption` at packages/commons/src/scopes.ts.
- */
+// Scope types whose v2 options object carries both `accessLevel` and `role`.
+// Kept in sync with `ScopesWithRoleOption` at packages/commons/src/scopes.ts.
 const MERGEABLE_USER_SCOPE_TYPES = ['user.create', 'user.edit'] as const
 
 type MergeableUserScopeType = (typeof MERGEABLE_USER_SCOPE_TYPES)[number]
@@ -478,124 +469,110 @@ function isMergeableUserScopeType(
   return (MERGEABLE_USER_SCOPE_TYPES as readonly string[]).includes(type)
 }
 
+type DecodedEntry = { legacy: string; scope: Scope }
+
+function decodeLegacyScope(legacy: string): DecodedEntry {
+  const encoded = legacyScopeToV2Scope(legacy)
+  const scope = decodeScope(encoded)
+  if (!scope) {
+    throw new Error(
+      `Could not decode migrated scope from legacy '${legacy}' (encoded: '${encoded}').`
+    )
+  }
+  return { legacy, scope }
+}
+
+function groupByType(entries: DecodedEntry[]): Record<string, DecodedEntry[]> {
+  return entries.reduce<Record<string, DecodedEntry[]>>(
+    (groups, entry) => ({
+      ...groups,
+      [entry.scope.type]: [...(groups[entry.scope.type] ?? []), entry]
+    }),
+    {}
+  )
+}
+
+// Keep first occurrence of each unique scope (by deep equality).
+function deduplicateEntries(entries: DecodedEntry[]): DecodedEntry[] {
+  return entries.filter(
+    (entry, index) =>
+      entries.findIndex((e) => isEqual(e.scope, entry.scope)) === index
+  )
+}
+
+// Merges disjoint options from AND-paired v1.9 scopes into one v2 scope object.
+// Throws if two entries both define the same option key — resolve manually.
+function mergeEntries(
+  type: MergeableUserScopeType,
+  entries: DecodedEntry[]
+): Scope {
+  const optionsList = entries.map((e) =>
+    'options' in e.scope && e.scope.options
+      ? (e.scope.options as Record<string, unknown>)
+      : {}
+  )
+
+  // Detect key conflicts before merging — same key in two different entries.
+  const allKeys = optionsList.flatMap((opts) =>
+    Object.keys(opts).filter((k) => opts[k] !== undefined)
+  )
+  const conflictKey = allKeys.find((key, i) => allKeys.indexOf(key) !== i)
+  if (conflictKey) {
+    const conflicting = entries
+      .filter(
+        (e) => conflictKey in (('options' in e.scope && e.scope.options) || {})
+      )
+      .map((e) => JSON.stringify(e.legacy))
+    throw new Error(
+      `Cannot auto-merge two '${type}' scopes that both define '${conflictKey}'. ` +
+        `Conflicting legacy scopes: [${conflicting.join(', ')}]. ` +
+        `Resolve manually in roles.ts and re-run.`
+    )
+  }
+
+  const mergedOptions = Object.assign({}, ...optionsList)
+  const merged =
+    Object.keys(mergedOptions).length > 0
+      ? { type, options: mergedOptions }
+      : { type }
+  const parsed = Scope.safeParse(merged)
+  if (!parsed.success) {
+    throw new Error(
+      `Merged '${type}' scope failed schema validation: ${parsed.error.message}. ` +
+        `Legacy scopes: [${entries.map((e) => JSON.stringify(e.legacy)).join(', ')}].`
+    )
+  }
+  return parsed.data
+}
+
 /**
- * Helper for porting an ENTIRE legacy scopes array to v2, preserving AND
- * semantics for pairs of legacy scopes that targeted the same v2 type.
- *
- * v1.9 expressed restrictions like "create users in my jurisdiction AND only
- * with roles X|Y" using two separate scope strings:
- *
- *   ['user.create:my-jurisdiction', 'user.create[role=X|Y]']
- *
- * Per-string migration would produce two independent v2 scopes — which in v2
- * are evaluated with OR semantics, broadening the user's permissions
- * (privilege escalation, see issue #12489). This helper merges such pairs
- * into a single v2 scope:
- *
- *   { type: 'user.create', options: { accessLevel: 'administrativeArea', role: ['X', 'Y'] } }
- *
- * Merging is restricted to `MERGEABLE_USER_SCOPE_TYPES` because v1.9 grammar
- * has no other documented AND-paired patterns. For other v2 types that
- * appear more than once after dedup, all entries are kept and a warning is
- * logged so authoring oddities surface for review.
- *
- * If two scopes of the same mergeable type both define the same option key
- * (e.g. both define `role`), the function throws so the caller can stop the
- * migration and resolve the conflict manually rather than silently choosing
- * union (re-introduces the bug class) or intersection (silently restrictive).
+ * Migrates a v1.9 role scope array to v2. Merges AND-paired strings like
+ * `['user.create:my-jurisdiction', 'user.create[role=X|Y]']` into one v2 object
+ * to prevent privilege escalation from v2's OR semantics (issue #12489).
  *
  * @deprecated - will be removed after migration to V2 scopes is complete.
- *
- * @param legacyScopes - legacy v1.8/v1.9 scope strings for ONE role.
- * @returns array of decoded v2 Scope objects with AND pairs merged.
  */
 export function migrateLegacyScopesArrayToV2Scopes(
   legacyScopes: string[]
 ): Scope[] {
-  const decoded: Array<{ legacy: string; scope: Scope }> = legacyScopes.map(
-    (legacy) => {
-      const encoded = legacyScopeToV2Scope(legacy)
-      const scope = decodeScope(encoded)
-      if (!scope) {
-        throw new Error(
-          `Could not decode migrated scope from legacy '${legacy}' (encoded: '${encoded}').`
-        )
-      }
-      return { legacy, scope }
-    }
-  )
+  const groups = groupByType(legacyScopes.map(decodeLegacyScope))
 
-  const groups = new Map<string, Array<{ legacy: string; scope: Scope }>>()
-  for (const entry of decoded) {
-    const list = groups.get(entry.scope.type) ?? []
-    list.push(entry)
-    groups.set(entry.scope.type, list)
-  }
+  return Object.entries(groups).flatMap(([type, entries]) => {
+    const deduped = deduplicateEntries(entries)
 
-  const result: Scope[] = []
-
-  for (const [type, entries] of groups) {
-    const deduped: Array<{ legacy: string; scope: Scope }> = []
-    for (const entry of entries) {
-      if (!deduped.some((existing) => isEqual(existing.scope, entry.scope))) {
-        deduped.push(entry)
-      }
-    }
-
-    if (deduped.length <= 1) {
-      result.push(...deduped.map((e) => e.scope))
-      continue
-    }
+    if (deduped.length <= 1) return deduped.map((e) => e.scope)
 
     if (!isMergeableUserScopeType(type)) {
+      // Unexpected duplicates outside the known AND-pair pattern — keep all and warn.
       // eslint-disable-next-line no-console
       console.warn(
         `Multiple non-mergeable '${type}' scopes detected after dedup — kept all as-is. ` +
           `Legacy scopes: [${deduped.map((e) => JSON.stringify(e.legacy)).join(', ')}]. ` +
           `Review whether the duplication is intentional.`
       )
-      result.push(...deduped.map((e) => e.scope))
-      continue
+      return deduped.map((e) => e.scope)
     }
 
-    const mergedOptions: Record<string, unknown> = {}
-    const optionSources = new Map<string, string[]>()
-
-    for (const entry of deduped) {
-      const opts =
-        'options' in entry.scope && entry.scope.options
-          ? (entry.scope.options as Record<string, unknown>)
-          : {}
-      for (const [key, value] of Object.entries(opts)) {
-        if (value === undefined) continue
-        if (key in mergedOptions) {
-          const previous = optionSources.get(key) ?? []
-          const conflicting = [...previous, entry.legacy]
-          throw new Error(
-            `Cannot auto-merge two '${type}' scopes that both define '${key}'. ` +
-              `Conflicting legacy scopes: [${conflicting.map((s) => JSON.stringify(s)).join(', ')}]. ` +
-              `Resolve manually in roles.ts and re-run.`
-          )
-        }
-        mergedOptions[key] = value
-        optionSources.set(key, [entry.legacy])
-      }
-    }
-
-    const merged: unknown =
-      Object.keys(mergedOptions).length > 0
-        ? { type, options: mergedOptions }
-        : { type }
-
-    const parsed = Scope.safeParse(merged)
-    if (!parsed.success) {
-      throw new Error(
-        `Merged '${type}' scope failed schema validation: ${parsed.error.message}. ` +
-          `Legacy scopes: [${deduped.map((e) => JSON.stringify(e.legacy)).join(', ')}].`
-      )
-    }
-    result.push(parsed.data)
-  }
-
-  return result
+    return [mergeEntries(type, deduped)]
+  })
 }

--- a/packages/commons/src/scopes.deprecated.do-not-use.ts
+++ b/packages/commons/src/scopes.deprecated.do-not-use.ts
@@ -10,7 +10,9 @@
  */
 
 import * as z from 'zod/v4'
+import { isEqual } from 'lodash'
 import {
+  decodeScope,
   EncodedScope,
   encodeScope,
   // RecordScopeTypeV2,
@@ -453,4 +455,147 @@ export function migrateLegacyScopesToV2(scopes: string[]): string[] {
       }
     })
     .filter((scope): scope is EncodedScope => !!scope)
+}
+
+/**
+ * v2 scope types whose options legitimately combine `accessLevel` and `role`
+ * on a single object (`AllUserScopeOptions` in `./scopes`). For these, a v1.9
+ * role array may contain TWO legacy entries — one literal (e.g.
+ * `user.create:my-jurisdiction`) and one configurable (e.g.
+ * `user.create[role=X|Y]`) — that v1.9 evaluated with AND semantics. v2.0
+ * scope arrays use OR semantics, so the pair must be merged into one v2 scope
+ * to preserve the original restriction.
+ *
+ * Kept in sync with `ScopesWithRoleOption` at packages/commons/src/scopes.ts.
+ */
+const MERGEABLE_USER_SCOPE_TYPES = ['user.create', 'user.edit'] as const
+
+type MergeableUserScopeType = (typeof MERGEABLE_USER_SCOPE_TYPES)[number]
+
+function isMergeableUserScopeType(
+  type: string
+): type is MergeableUserScopeType {
+  return (MERGEABLE_USER_SCOPE_TYPES as readonly string[]).includes(type)
+}
+
+/**
+ * Helper for porting an ENTIRE legacy scopes array to v2, preserving AND
+ * semantics for pairs of legacy scopes that targeted the same v2 type.
+ *
+ * v1.9 expressed restrictions like "create users in my jurisdiction AND only
+ * with roles X|Y" using two separate scope strings:
+ *
+ *   ['user.create:my-jurisdiction', 'user.create[role=X|Y]']
+ *
+ * Per-string migration would produce two independent v2 scopes — which in v2
+ * are evaluated with OR semantics, broadening the user's permissions
+ * (privilege escalation, see issue #12489). This helper merges such pairs
+ * into a single v2 scope:
+ *
+ *   { type: 'user.create', options: { accessLevel: 'administrativeArea', role: ['X', 'Y'] } }
+ *
+ * Merging is restricted to `MERGEABLE_USER_SCOPE_TYPES` because v1.9 grammar
+ * has no other documented AND-paired patterns. For other v2 types that
+ * appear more than once after dedup, all entries are kept and a warning is
+ * logged so authoring oddities surface for review.
+ *
+ * If two scopes of the same mergeable type both define the same option key
+ * (e.g. both define `role`), the function throws so the caller can stop the
+ * migration and resolve the conflict manually rather than silently choosing
+ * union (re-introduces the bug class) or intersection (silently restrictive).
+ *
+ * @deprecated - will be removed after migration to V2 scopes is complete.
+ *
+ * @param legacyScopes - legacy v1.8/v1.9 scope strings for ONE role.
+ * @returns array of decoded v2 Scope objects with AND pairs merged.
+ */
+export function migrateLegacyScopesArrayToV2Scopes(
+  legacyScopes: string[]
+): Scope[] {
+  const decoded: Array<{ legacy: string; scope: Scope }> = legacyScopes.map(
+    (legacy) => {
+      const encoded = legacyScopeToV2Scope(legacy)
+      const scope = decodeScope(encoded)
+      if (!scope) {
+        throw new Error(
+          `Could not decode migrated scope from legacy '${legacy}' (encoded: '${encoded}').`
+        )
+      }
+      return { legacy, scope }
+    }
+  )
+
+  const groups = new Map<string, Array<{ legacy: string; scope: Scope }>>()
+  for (const entry of decoded) {
+    const list = groups.get(entry.scope.type) ?? []
+    list.push(entry)
+    groups.set(entry.scope.type, list)
+  }
+
+  const result: Scope[] = []
+
+  for (const [type, entries] of groups) {
+    const deduped: Array<{ legacy: string; scope: Scope }> = []
+    for (const entry of entries) {
+      if (!deduped.some((existing) => isEqual(existing.scope, entry.scope))) {
+        deduped.push(entry)
+      }
+    }
+
+    if (deduped.length <= 1) {
+      result.push(...deduped.map((e) => e.scope))
+      continue
+    }
+
+    if (!isMergeableUserScopeType(type)) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `Multiple non-mergeable '${type}' scopes detected after dedup — kept all as-is. ` +
+          `Legacy scopes: [${deduped.map((e) => JSON.stringify(e.legacy)).join(', ')}]. ` +
+          `Review whether the duplication is intentional.`
+      )
+      result.push(...deduped.map((e) => e.scope))
+      continue
+    }
+
+    const mergedOptions: Record<string, unknown> = {}
+    const optionSources = new Map<string, string[]>()
+
+    for (const entry of deduped) {
+      const opts =
+        'options' in entry.scope && entry.scope.options
+          ? (entry.scope.options as Record<string, unknown>)
+          : {}
+      for (const [key, value] of Object.entries(opts)) {
+        if (value === undefined) continue
+        if (key in mergedOptions) {
+          const previous = optionSources.get(key) ?? []
+          const conflicting = [...previous, entry.legacy]
+          throw new Error(
+            `Cannot auto-merge two '${type}' scopes that both define '${key}'. ` +
+              `Conflicting legacy scopes: [${conflicting.map((s) => JSON.stringify(s)).join(', ')}]. ` +
+              `Resolve manually in roles.ts and re-run.`
+          )
+        }
+        mergedOptions[key] = value
+        optionSources.set(key, [entry.legacy])
+      }
+    }
+
+    const merged: unknown =
+      Object.keys(mergedOptions).length > 0
+        ? { type, options: mergedOptions }
+        : { type }
+
+    const parsed = Scope.safeParse(merged)
+    if (!parsed.success) {
+      throw new Error(
+        `Merged '${type}' scope failed schema validation: ${parsed.error.message}. ` +
+          `Legacy scopes: [${deduped.map((e) => JSON.stringify(e.legacy)).join(', ')}].`
+      )
+    }
+    result.push(parsed.data)
+  }
+
+  return result
 }

--- a/packages/commons/src/scopes.test.ts
+++ b/packages/commons/src/scopes.test.ts
@@ -22,6 +22,7 @@ import {
 
 import {
   migrateLegacyScopesToV2,
+  migrateLegacyScopesArrayToV2Scopes,
   legacyScopeToV2Scope
 } from './scopes.deprecated.do-not-use'
 
@@ -456,4 +457,156 @@ it('migrate legacy scopes to v2', () => {
     'type=record.unassign-others&event=birth,death,tennis-club-membership',
     'type=record.review-duplicates&event=birth,death,tennis-club-membership'
   ])
+})
+
+describe('migrateLegacyScopesArrayToV2Scopes() — AND-pair merge', () => {
+  // Regression: issue #12489. v1.9 expressed "in my jurisdiction AND only
+  // these roles" as two scope strings on the same role. v2.0 scope arrays
+  // use OR semantics, so the pair must collapse to a single v2 scope object
+  // to avoid privilege escalation.
+
+  it('merges user.create + my-jurisdiction + role list into one scope', () => {
+    const result = migrateLegacyScopesArrayToV2Scopes([
+      'user.create:my-jurisdiction',
+      'user.create[role=FIELD_AGENT|HOSPITAL_CLERK]'
+    ])
+
+    expect(result).toEqual([
+      {
+        type: 'user.create',
+        options: {
+          accessLevel: 'administrativeArea',
+          role: ['FIELD_AGENT', 'HOSPITAL_CLERK']
+        }
+      }
+    ])
+  })
+
+  it('merges user.create:all + role list into a role-only scope', () => {
+    // `user.create:all` decodes to `{ type: 'user.create' }` with no options.
+    // Merging with `[role=X|Y]` should yield only the role restriction.
+    const result = migrateLegacyScopesArrayToV2Scopes([
+      'user.create:all',
+      'user.create[role=FIELD_AGENT|REGISTRATION_AGENT]'
+    ])
+
+    expect(result).toEqual([
+      {
+        type: 'user.create',
+        options: { role: ['FIELD_AGENT', 'REGISTRATION_AGENT'] }
+      }
+    ])
+  })
+
+  it('merges v1 user.update:my-jurisdiction with v1 user.edit[role=...]', () => {
+    // `user.update:*` maps to v2 `user.edit`. Grouping must happen by
+    // post-conversion v2 type, not the v1 string.
+    const result = migrateLegacyScopesArrayToV2Scopes([
+      'user.update:my-jurisdiction',
+      'user.edit[role=FIELD_AGENT|LOCAL_REGISTRAR]'
+    ])
+
+    expect(result).toEqual([
+      {
+        type: 'user.edit',
+        options: {
+          accessLevel: 'administrativeArea',
+          role: ['FIELD_AGENT', 'LOCAL_REGISTRAR']
+        }
+      }
+    ])
+  })
+
+  it('throws when two scopes of the same type both define role', () => {
+    // The realistic v1.9 conflict shape: two distinct `[role=...]` strings
+    // for the same v2 type. We refuse to silently choose union (re-introduces
+    // the privilege-escalation bug) or intersection (silently restrictive),
+    // and let the operator resolve manually.
+    expect(() =>
+      migrateLegacyScopesArrayToV2Scopes([
+        'user.create[role=A|B]',
+        'user.create[role=C|D]'
+      ])
+    ).toThrow(
+      /Cannot auto-merge two 'user.create' scopes that both define 'role'/
+    )
+  })
+
+  it('dedups identical entries before deciding whether to merge', () => {
+    // Same logical scope listed twice — no merge needed, dedup to one.
+    const result = migrateLegacyScopesArrayToV2Scopes([
+      'user.create:my-jurisdiction',
+      'user.create:my-jurisdiction'
+    ])
+
+    expect(result).toEqual([
+      {
+        type: 'user.create',
+        options: { accessLevel: 'administrativeArea' }
+      }
+    ])
+  })
+
+  it('does not merge non-mergeable types appearing more than once', () => {
+    // record.declare has no AND-paired v1.9 pattern. Two distinct
+    // record.declare scopes should pass through unchanged.
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const result = migrateLegacyScopesArrayToV2Scopes([
+        'record.declare[event=birth]',
+        'record.declare[event=death]'
+      ])
+
+      expect(result).toHaveLength(2)
+      expect(result).toEqual([
+        { type: 'record.declare', options: { event: ['birth'] } },
+        { type: 'record.declare', options: { event: ['death'] } }
+      ])
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Multiple non-mergeable 'record.declare' scopes detected"
+        )
+      )
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  it('is order-independent: scope strings can appear in either order', () => {
+    const a = migrateLegacyScopesArrayToV2Scopes([
+      'user.create:my-jurisdiction',
+      'user.create[role=FIELD_AGENT]'
+    ])
+    const b = migrateLegacyScopesArrayToV2Scopes([
+      'user.create[role=FIELD_AGENT]',
+      'user.create:my-jurisdiction'
+    ])
+
+    expect(a).toEqual(b)
+  })
+
+  it('preserves unrelated scopes alongside merged pairs', () => {
+    // Mixed input: a user.create pair to merge, plus unrelated scopes.
+    const result = migrateLegacyScopesArrayToV2Scopes([
+      'performance.read',
+      'user.create:my-jurisdiction',
+      'record.declare[event=birth]',
+      'user.create[role=FIELD_AGENT]'
+    ])
+
+    // 4 inputs → 3 outputs (one merge happened).
+    expect(result).toHaveLength(3)
+    expect(result).toContainEqual({ type: 'performance.read' })
+    expect(result).toContainEqual({
+      type: 'record.declare',
+      options: { event: ['birth'] }
+    })
+    expect(result).toContainEqual({
+      type: 'user.create',
+      options: {
+        accessLevel: 'administrativeArea',
+        role: ['FIELD_AGENT']
+      }
+    })
+  })
 })

--- a/packages/toolkit/src/migrations/v2.0/migrate-scopes.ts
+++ b/packages/toolkit/src/migrations/v2.0/migrate-scopes.ts
@@ -12,10 +12,7 @@
 import { Node, Project, SyntaxKind, Expression } from 'ts-morph'
 import path from 'path'
 import {
-  decodeScope,
-} from '@opencrvs/commons/scopes'
-import {
-  legacyScopeToV2Scope,
+  migrateLegacyScopesArrayToV2Scopes,
   SCOPES
 } from '@opencrvs/commons/scopes.deprecated.do-not-use'
 const ROLES_FILE_RELATIVE_PATH = 'src/data-seeding/roles/roles.ts'
@@ -72,37 +69,61 @@ function resolveLegacyScopeFromElement(element: Expression): string | null {
   return null
 }
 
+/**
+ * Walks each `scopes: [...]` array in the roles file, classifies elements,
+ * and rewrites the whole array using `migrateLegacyScopesArrayToV2Scopes`
+ * (which preserves v1.9 AND semantics by merging pairs of legacy scopes
+ * that targeted the same v2 type). See issue #12489.
+ *
+ * Elements are partitioned into three kinds:
+ *   - drop: `SCOPES.X` references where X is not in the SCOPES map (warned
+ *     and removed, matching pre-refactor behavior).
+ *   - raw: non-literal expressions we cannot statically resolve (e.g.
+ *     `...sharedScopes` spreads). Preserved verbatim in output so authoring
+ *     intent isn't lost.
+ *   - legacy: literal strings or resolvable `SCOPES.X` references.
+ *     Collected and passed as a batch to the merge function.
+ *
+ * The output array text is `[...rawTexts, ...mergedScopesAsJson]`. Order of
+ * legacy entries relative to raw expressions is not preserved — scopes in a
+ * v2 array compose with OR, so position is semantically irrelevant.
+ */
 function migrateScopesArrays(
   rolesFilePath: string,
   project: Project
-): { migratedCount: number; removedCount: number } {
+): { migratedCount: number; removedCount: number; mergedCount: number } {
   const sourceFile = project.getSourceFile(rolesFilePath)
-  if (!sourceFile) return { migratedCount: 0, removedCount: 0 }
+  if (!sourceFile) {
+    return { migratedCount: 0, removedCount: 0, mergedCount: 0 }
+  }
 
   let migratedCount = 0
   let removedCount = 0
+  let mergedCount = 0
 
   const scopesProperties = sourceFile
     .getDescendantsOfKind(SyntaxKind.PropertyAssignment)
     .filter((prop) => prop.getName() === SCOPES_PROPERTY_NAME)
 
+  const relPath = path.relative(process.cwd(), rolesFilePath)
+
   for (const scopesProp of scopesProperties) {
     const initializer = scopesProp.getInitializer()
     if (!initializer || !Node.isArrayLiteralExpression(initializer)) continue
 
-    const elements = initializer.getElements()
-    for (let index = elements.length - 1; index >= 0; index--) {
-      const element = elements[index]
-      if (!Node.isExpression(element)) continue
+    const rawTexts: string[] = []
+    const legacyStrings: string[] = []
+    let anyChange = false
 
+    for (const element of initializer.getElements()) {
       const scopeKey = resolveScopeKeyFromElementAccess(element)
       if (scopeKey && !(scopeKey in SCOPES)) {
         // eslint-disable-next-line no-console
         console.warn(
-          `  [${path.relative(process.cwd(), rolesFilePath)}] Removing unknown scope reference: SCOPES.${scopeKey}`
+          `  [${relPath}] Removing unknown scope reference: SCOPES.${scopeKey}`
         )
-        initializer.removeElement(index)
         removedCount++
+        anyChange = true
         continue
       }
 
@@ -110,42 +131,48 @@ function migrateScopesArrays(
       if (!legacyScope) {
         // eslint-disable-next-line no-console
         console.warn(
-          `  [${path.relative(process.cwd(), rolesFilePath)}] Skipping non-literal scope expression: ${element.getText()}`
+          `  [${relPath}] Preserving non-literal scope expression verbatim: ${element.getText()}`
         )
+        rawTexts.push(element.getText())
         continue
       }
 
-      try {
-        const migratedScope = legacyScopeToV2Scope(legacyScope)
-        const scope = decodeScope(migratedScope)
-
-        if (!scope) {
-          // eslint-disable-next-line no-console
-          console.warn(
-            `  [${path.relative(process.cwd(), rolesFilePath)}] Could not decode migrated scope '${migratedScope}'.`
-          )
-          continue
-        }
-
-        element.replaceWithText(JSON.stringify(scope))
-        migratedCount++
-      } catch (error) {
-        // eslint-disable-next-line no-console
-        console.warn(
-          `  [${path.relative(process.cwd(), rolesFilePath)}] Could not migrate scope '${legacyScope}': ${error}`
-        )
-      }
+      legacyStrings.push(legacyScope)
+      anyChange = true
     }
+
+    if (!anyChange) continue
+
+    let mergedScopes
+    try {
+      mergedScopes = migrateLegacyScopesArrayToV2Scopes(legacyStrings)
+    } catch (error) {
+      throw new Error(
+        `[${relPath}] Failed to migrate scopes for role: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        { cause: error }
+      )
+    }
+
+    migratedCount += legacyStrings.length
+    mergedCount += legacyStrings.length - mergedScopes.length
+
+    const outputElements = [
+      ...rawTexts,
+      ...mergedScopes.map((s) => JSON.stringify(s))
+    ]
+    scopesProp.setInitializer(`[${outputElements.join(', ')}]`)
   }
 
   if (removedCount > 0) {
     // eslint-disable-next-line no-console
     console.log(
-      `  Removed ${removedCount} unknown SCOPES reference(s) from '${path.relative(process.cwd(), rolesFilePath)}'.`
+      `  Removed ${removedCount} unknown SCOPES reference(s) from '${relPath}'.`
     )
   }
 
-  return { migratedCount, removedCount }
+  return { migratedCount, removedCount, mergedCount }
 }
 
 function ensureScopesHelpersImport(
@@ -364,7 +391,7 @@ async function main() {
   }
 
   const importChanged = ensureScopesHelpersImport(rolesFilePath, project)
-  const { migratedCount, removedCount } = migrateScopesArrays(
+  const { migratedCount, removedCount, mergedCount } = migrateScopesArrays(
     rolesFilePath,
     project
   )
@@ -392,7 +419,7 @@ async function main() {
 
   await sourceFile.save()
   console.log(
-    `Done. Migrated ${migratedCount} legacy scope(s), removed ${removedCount} unknown SCOPES reference(s), wrapped ${wrappedScopesCount} scope array(s) with defineScopes()${wrappedRoles ? ', wrapped roles with defineRoles()' : ''}${removedRoleType ? ', and removed Role type definition' : ''}${importChanged ? '. Updated toolkit/scopes imports.' : '.'}`
+    `Done. Migrated ${migratedCount} legacy scope(s), merged ${mergedCount} AND-paired scope(s) into single v2 objects (privilege-escalation fix, see issue #12489), removed ${removedCount} unknown SCOPES reference(s), wrapped ${wrappedScopesCount} scope array(s) with defineScopes()${wrappedRoles ? ', wrapped roles with defineRoles()' : ''}${removedRoleType ? ', and removed Role type definition' : ''}${importChanged ? '. Updated toolkit/scopes imports.' : '.'}`
   )
 }
 


### PR DESCRIPTION
## Description

https://github.com/opencrvs/opencrvs-core/issues/12489
## Summary

Fixes a privilege escalation bug in the v1.9→v2.0 scope migration. In v1.9, 
```
scopes: ['user.create:my-jurisdiction', 'user.create[role=FIELD_AGENT]']
```
 meant AND — both restrictions applied. The old migration converted each string independently, producing two OR-composed v2 scopes that granted full country-wide access or any-role creation. This PR adds `migrateLegacyScopesArrayToV2Scopes()` which merges AND-paired scopes into a single v2 object: 
```
{ type: 'user.create', options: { accessLevel: 'administrativeArea', role: ['FIELD_AGENT'] } }
```

## Changes

- **commons** — new `migrateLegacyScopesArrayToV2Scopes()` export that groups, deduplicates,
  and merges `user.create`/`user.edit` scope pairs; throws on irresolvable key conflicts
- **toolkit** — `migrate-scopes.ts` refactored to collect-merge-replace pattern using the new function
- **tests** — 8 unit tests covering merge, dedup, conflict-abort, and edge cases

## How to Test

```bash
cd packages/commons && yarn test scopes.test.ts -t 'migrateLegacyScopesArrayToV2Scopes'
```
All 8 tests should pass. In migrated role files, `localSystemAdmin`/`nationalSystemAdmin`
should each have exactly one `user.create` and one `user.edit` object — both carrying
accessLevel and role — not two separate objects.




## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
