### PR TITLE
suppress mobile PIN re-lock during file and signature uploads

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -64,9 +64,7 @@ export const routesConfig = [
         <NotificationComponent>
           <Page>
             <MainSection>
-              <ProtectedPage
-                unprotectedRouteElements={['documents', 'affidavit']}
-              >
+              <ProtectedPage>
                 <Outlet />
               </ProtectedPage>
             </MainSection>

--- a/packages/client/src/components/ProtectedPage.tsx
+++ b/packages/client/src/components/ProtectedPage.tsx
@@ -33,11 +33,10 @@ import { LoadingBar } from '@opencrvs/components/src/LoadingBar/LoadingBar'
 import { RouteComponentProps, withRouter } from './WithRouterProps'
 import { getAuthenticated } from '@client/profile/profileSelectors'
 import { IStoreState } from '@client/store'
+import { shouldBypassLock } from '@client/utils/lockBypass'
 export const SCREEN_LOCK = 'screenLock'
 
-type OwnProps = PropsWithChildren<{
-  unprotectedRouteElements: string[]
-}>
+type OwnProps = PropsWithChildren<{}>
 
 type DispatchProps = {
   onNumPadVisible: () => void
@@ -116,13 +115,11 @@ class ProtectedPageComponent extends React.Component<Props, IProtectPageState> {
   async handleVisibilityChange(isVisible: boolean) {
     const alreadyLocked = isVisible || (await storage.getItem(SCREEN_LOCK))
 
-    const onUnprotectedPage = this.props.unprotectedRouteElements?.some(
-      (route) => this.props.router.location.pathname.includes(route)
-    )
+    const lockShouldBeBypassed = shouldBypassLock()
 
     const newState = { ...this.state }
 
-    if (!alreadyLocked && !onUnprotectedPage) {
+    if (!alreadyLocked && !lockShouldBeBypassed) {
       newState.secured = false
       if (await this.getPIN()) {
         newState.pinExists = true

--- a/packages/client/src/utils/lockBypass.ts
+++ b/packages/client/src/utils/lockBypass.ts
@@ -24,8 +24,6 @@
  * {@link shouldBypassLock} on visibility change to decide whether to lock.
  */
 
-const LOCK_BYPASS_KEY = 'lockBypass'
-
 /**
  * How long the bypass stays valid (3 minutes).
  *
@@ -36,35 +34,31 @@ const LOCK_BYPASS_KEY = 'lockBypass'
 const LOCK_BYPASS_TTL_MS = 180_000
 
 /**
+ * The expiry timestamp of the pending bypass. `0` means no bypass pending.
+ * Comparing against `Date.now()` enforces the TTL with no need for a timer.
+ */
+let bypassValidUntil = 0
+
+/**
  * Tells `ProtectedPage` to skip the PIN lock on the next visibility change.
  *
  * Call this right before any user action that temporarily backgrounds the
  * tab — opening a native picker, launching the camera, redirecting to an
- * external app, etc. The flag auto-clears after 3 minutes so a stuck flag
+ * external app, etc. The flag auto-expires after 3 minutes so a stuck flag
  * can't disable the lock forever.
- *
- * No-ops if `sessionStorage` is blocked (e.g. Safari private mode) — the
- * PIN screen will show, which is safe.
  *
  * @example
  * <button onClick={setLockBypass}>Open camera</button>
  */
 export function setLockBypass(): void {
-  try {
-    sessionStorage.setItem(LOCK_BYPASS_KEY, '1')
-    setTimeout(() => {
-      try {
-        sessionStorage.removeItem(LOCK_BYPASS_KEY)
-      } catch {}
-    }, LOCK_BYPASS_TTL_MS)
-  } catch {}
+  bypassValidUntil = Date.now() + LOCK_BYPASS_TTL_MS
 }
 
 /**
  * Returns `true` if the PIN lock should be skipped because a backgrounding
  * action was just intentionally triggered, `false` otherwise.
  *
- * Single-shot: when it returns `true` it also clears the flag, so each
+ * Single-shot: each call reads and clears the pending bypass, so each
  * {@link setLockBypass} grants exactly one skip. A later unrelated
  * background event will still trigger the PIN — that's the point.
  *
@@ -73,13 +67,7 @@ export function setLockBypass(): void {
  * @returns `true` to skip the lock, `false` to lock as usual.
  */
 export function shouldBypassLock(): boolean {
-  try {
-    const pending = sessionStorage.getItem(LOCK_BYPASS_KEY) === '1'
-    if (pending) {
-      sessionStorage.removeItem(LOCK_BYPASS_KEY)
-    }
-    return pending
-  } catch {
-    return false
-  }
+  const pending = bypassValidUntil > Date.now()
+  bypassValidUntil = 0
+  return pending
 }

--- a/packages/client/src/utils/lockBypass.ts
+++ b/packages/client/src/utils/lockBypass.ts
@@ -1,0 +1,85 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+
+/**
+ * @module lockBypass
+ *
+ * Lets the app skip the mobile PIN lock when an intentional user action
+ * sends the tab to the background.
+ *
+ * On mobile, many user actions briefly background the tab — opening a file
+ * picker, launching the camera, redirecting to an external app, and so on.
+ * Without this, the PIN screen would appear every time the user comes back.
+ *
+ * Callers signal the upcoming background by calling {@link setLockBypass}
+ * just before the action. `ProtectedPage` checks via
+ * {@link shouldBypassLock} on visibility change to decide whether to lock.
+ */
+
+const LOCK_BYPASS_KEY = 'lockBypass'
+
+/**
+ * How long the bypass stays valid (3 minutes).
+ *
+ * Long enough for slow user actions like camera permission prompts. Short
+ * enough that a forgotten flag can't disable the PIN lock on a later real
+ * background event.
+ */
+const LOCK_BYPASS_TTL_MS = 180_000
+
+/**
+ * Tells `ProtectedPage` to skip the PIN lock on the next visibility change.
+ *
+ * Call this right before any user action that temporarily backgrounds the
+ * tab — opening a native picker, launching the camera, redirecting to an
+ * external app, etc. The flag auto-clears after 3 minutes so a stuck flag
+ * can't disable the lock forever.
+ *
+ * No-ops if `sessionStorage` is blocked (e.g. Safari private mode) — the
+ * PIN screen will show, which is safe.
+ *
+ * @example
+ * <button onClick={setLockBypass}>Open camera</button>
+ */
+export function setLockBypass(): void {
+  try {
+    sessionStorage.setItem(LOCK_BYPASS_KEY, '1')
+    setTimeout(() => {
+      try {
+        sessionStorage.removeItem(LOCK_BYPASS_KEY)
+      } catch {}
+    }, LOCK_BYPASS_TTL_MS)
+  } catch {}
+}
+
+/**
+ * Returns `true` if the PIN lock should be skipped because a backgrounding
+ * action was just intentionally triggered, `false` otherwise.
+ *
+ * Single-shot: when it returns `true` it also clears the flag, so each
+ * {@link setLockBypass} grants exactly one skip. A later unrelated
+ * background event will still trigger the PIN — that's the point.
+ *
+ * Called by `ProtectedPage` on every visibility change.
+ *
+ * @returns `true` to skip the lock, `false` to lock as usual.
+ */
+export function shouldBypassLock(): boolean {
+  try {
+    const pending = sessionStorage.getItem(LOCK_BYPASS_KEY) === '1'
+    if (pending) {
+      sessionStorage.removeItem(LOCK_BYPASS_KEY)
+    }
+    return pending
+  } catch {
+    return false
+  }
+}

--- a/packages/client/src/utils/lockBypass.ts
+++ b/packages/client/src/utils/lockBypass.ts
@@ -19,9 +19,12 @@
  * picker, launching the camera, redirecting to an external app, and so on.
  * Without this, the PIN screen would appear every time the user comes back.
  *
- * Callers signal the upcoming background by calling {@link setLockBypass}
- * just before the action. `ProtectedPage` checks via
- * {@link shouldBypassLock} on visibility change to decide whether to lock.
+ * Flow:
+ *   1. Caller arms the bypass via {@link setLockBypass} just before the action.
+ *   2. `ProtectedPage` checks via {@link shouldBypassLock} on visibility
+ *      change to decide whether to lock.
+ *   3. The bypass is cleared when the window regains focus — i.e. when the
+ *      user actually returns from the external action.
  */
 
 /**
@@ -40,12 +43,27 @@ const LOCK_BYPASS_TTL_MS = 180_000
 let bypassValidUntil = 0
 
 /**
+ * Clear the bypass as soon as the user returns to the tab.
+ *
+ * The `focus` event on `window` fires when the tab regains focus — i.e.
+ * the user closed the file picker / camera / external app and is back.
+ * Tying the clear to this event (rather than to the lock check) keeps the
+ * read in {@link shouldBypassLock} side-effect-free, and ensures the
+ * bypass survives until the user actually returns.
+ */
+if (typeof window !== 'undefined') {
+  window.addEventListener('focus', () => {
+    bypassValidUntil = 0
+  })
+}
+
+/**
  * Tells `ProtectedPage` to skip the PIN lock on the next visibility change.
  *
  * Call this right before any user action that temporarily backgrounds the
  * tab — opening a native picker, launching the camera, redirecting to an
- * external app, etc. The flag auto-expires after 3 minutes so a stuck flag
- * can't disable the lock forever.
+ * external app, etc. The flag is cleared the moment the window regains
+ * focus, and auto-expires after 3 minutes as a safety net.
  *
  * @example
  * <button onClick={setLockBypass}>Open camera</button>
@@ -55,19 +73,17 @@ export function setLockBypass(): void {
 }
 
 /**
- * Returns `true` if the PIN lock should be skipped because a backgrounding
- * action was just intentionally triggered, `false` otherwise.
+ * Pure query: returns `true` if a bypass is currently pending, `false`
+ * otherwise.
  *
- * Single-shot: each call reads and clears the pending bypass, so each
- * {@link setLockBypass} grants exactly one skip. A later unrelated
- * background event will still trigger the PIN — that's the point.
+ * Has no side effect — multiple calls return the same value until either
+ * the window regains focus (cleared by the focus listener) or the TTL
+ * elapses.
  *
- * Called by `ProtectedPage` on every visibility change.
+ * Called by `ProtectedPage` on visibility change to decide whether to lock.
  *
  * @returns `true` to skip the lock, `false` to lock as usual.
  */
 export function shouldBypassLock(): boolean {
-  const pending = bypassValidUntil > Date.now()
-  bypassValidUntil = 0
-  return pending
+  return bypassValidUntil > Date.now()
 }

--- a/packages/client/src/v2-events/components/forms/inputs/FileInput/DocumentUploaderWithOption.tsx
+++ b/packages/client/src/v2-events/components/forms/inputs/FileInput/DocumentUploaderWithOption.tsx
@@ -27,6 +27,7 @@ import { buttonMessages, formMessages as messages } from '@client/i18n/messages'
 import { useIntlWithFormData } from '@client/v2-events/messages/utils'
 import { useImageEditorModal } from '@client/v2-events/components/ImageEditorModal'
 import { useImageProcessing } from '@client/utils/imageUtils'
+import { setLockBypass } from '@client/utils/lockBypass'
 import { DocumentUploader } from './SimpleDocumentUploader'
 import { DocumentListPreview } from './DocumentListPreview'
 import { DocumentPreview } from './DocumentPreview'
@@ -266,6 +267,7 @@ function DocumentUploaderWithOption({
           id={name}
           name={name}
           onChange={handleFileChange}
+          onClick={setLockBypass}
         >
           {intl.formatMessage(messages.uploadFile)}
         </DocumentUploader>

--- a/packages/client/src/v2-events/components/forms/inputs/FileInput/SimpleDocumentUploader.tsx
+++ b/packages/client/src/v2-events/components/forms/inputs/FileInput/SimpleDocumentUploader.tsx
@@ -15,6 +15,7 @@ import { MimeType, FieldValue, FileFieldValue } from '@opencrvs/commons/client'
 import { ErrorText } from '@opencrvs/components/lib/ErrorText'
 import { ImageUploader } from '@opencrvs/components/lib/ImageUploader'
 import { formMessages as messages } from '@client/i18n/messages'
+import { setLockBypass } from '@client/utils/lockBypass'
 import { DocumentPreview } from './DocumentPreview'
 import { SingleDocumentPreview } from './SingleDocumentPreview'
 import { useOnFileChange } from './useOnFileChange'
@@ -133,6 +134,7 @@ export function SimpleDocumentUploader({
         id={name}
         name={name}
         onChange={handleFileChange}
+        onClick={setLockBypass}
       >
         {intl.formatMessage(messages.uploadFile)}
       </DocumentUploader>

--- a/packages/client/src/v2-events/components/forms/inputs/SignatureField/SignatureField.interaction.stories.tsx
+++ b/packages/client/src/v2-events/components/forms/inputs/SignatureField/SignatureField.interaction.stories.tsx
@@ -305,34 +305,53 @@ export const UploadButtonsArmLockBypass: StoryObj<
     const getUploadButtons = async () =>
       canvas.findAllByRole('button', { name: 'Upload' })
 
+    /**
+     * Dispatching a `focus` event on `window` simulates the user returning
+     * from the native picker / camera / external app — the same signal the
+     * lockBypass module listens for to clear the pending bypass.
+     */
+    const simulateReturnFromPicker = () =>
+      window.dispatchEvent(new Event('focus'))
+
     await step('Bypass flag is not armed before user interacts', async () => {
-      // Drain any flag a previous story may have left behind, then confirm
-      // a fresh read returns false.
-      shouldBypassLock()
+      // Drain any pending bypass a previous story may have left behind.
+      simulateReturnFromPicker()
       await expect(shouldBypassLock()).toBe(false)
     })
 
     await step(
-      'SignatureField upload arms the bypass exactly once',
+      'SignatureField upload arms the bypass, focus return clears it',
       async () => {
         const [signatureUpload] = await getUploadButtons()
         await userEvent.click(signatureUpload)
 
+        // Upload click armed the bypass — repeated reads stay true because
+        // shouldBypassLock is a pure query.
         await expect(shouldBypassLock()).toBe(true)
+        await expect(shouldBypassLock()).toBe(true)
+
+        // User returns from the picker → focus listener clears the flag,
+        // so a later real background event still triggers the PIN re-lock.
+        simulateReturnFromPicker()
         await expect(shouldBypassLock()).toBe(false)
       }
     )
 
-    await step('FILE field upload arms the bypass exactly once', async () => {
-      const [, fileUpload] = await getUploadButtons()
-      await userEvent.click(fileUpload)
+    await step(
+      'FILE field upload arms the bypass, focus return clears it',
+      async () => {
+        const [, fileUpload] = await getUploadButtons()
+        await userEvent.click(fileUpload)
 
-      await expect(shouldBypassLock()).toBe(true)
-      await expect(shouldBypassLock()).toBe(false)
-    })
+        await expect(shouldBypassLock()).toBe(true)
+
+        simulateReturnFromPicker()
+        await expect(shouldBypassLock()).toBe(false)
+      }
+    )
 
     await step(
-      'FILE_WITH_OPTIONS upload arms the bypass exactly once',
+      'FILE_WITH_OPTIONS upload arms the bypass, focus return clears it',
       async () => {
         // The Upload button is disabled until a document type is picked.
         // Open the react-select dropdown and choose an option to enable it.
@@ -346,6 +365,8 @@ export const UploadButtonsArmLockBypass: StoryObj<
         await userEvent.click(fileWithOptionUpload)
 
         await expect(shouldBypassLock()).toBe(true)
+
+        simulateReturnFromPicker()
         await expect(shouldBypassLock()).toBe(false)
       }
     )

--- a/packages/client/src/v2-events/components/forms/inputs/SignatureField/SignatureField.interaction.stories.tsx
+++ b/packages/client/src/v2-events/components/forms/inputs/SignatureField/SignatureField.interaction.stories.tsx
@@ -220,19 +220,23 @@ export const SignatureFileUpload: StoryObj<typeof StyledFormFieldGenerator> = {
 /**
  * Regression test for the mobile PIN-lock-during-upload fix.
  *
- * When the user taps the "Upload" button on a SignatureField, the uploader
- * must arm the file-picker bypass flag (via `setLockBypass`) before the OS
- * picker is invoked. Otherwise `ProtectedPage.handleVisibilityChange`
- * triggers the PIN re-lock as soon as the picker sends the page to
- * background — interrupting the upload mid-flow.
+ * Every uploader that opens a native picker — `SignatureField`,
+ * `SimpleDocumentUploader` (FILE), and `DocumentUploaderWithOption`
+ * (FILE_WITH_OPTIONS) — must arm the bypass flag (via `setLockBypass`)
+ * before the picker is invoked. Otherwise `ProtectedPage` triggers the
+ * PIN re-lock as soon as the picker sends the page to background,
+ * interrupting the upload mid-flow.
  *
- * Asserts via `shouldBypassLock()`, which atomically reads-and-clears the
- * flag — same call `ProtectedPage` would make on the visibility transition.
+ * Renders all three uploaders on the same form and checks each Upload
+ * button in turn. Asserts via `shouldBypassLock()` — the same call
+ * `ProtectedPage` would make on a visibility transition. Single-shot:
+ * the second call must return `false` so a later real background still
+ * triggers the PIN.
  */
-export const SignatureUploadArmsLockBypass: StoryObj<
+export const UploadButtonsArmLockBypass: StoryObj<
   typeof StyledFormFieldGenerator
 > = {
-  name: 'Upload button arms PIN-lock bypass before opening picker',
+  name: 'Upload buttons arm PIN-lock bypass (Signature / File / FileWithOptions)',
   parameters: {
     layout: 'centered',
     reactRouter: {
@@ -250,6 +254,34 @@ export const SignatureUploadArmsLockBypass: StoryObj<
                 },
                 signaturePromptLabel: generateTranslationConfig('Signature'),
                 label: generateTranslationConfig('Upload signature')
+              },
+              {
+                id: 'storybook.file',
+                type: FieldType.FILE,
+                configuration: {
+                  maxFileSize: 1 * 1024 * 1024,
+                  acceptedFileTypes: [MimeType.enum['image/png']]
+                },
+                label: generateTranslationConfig('Upload document')
+              },
+              {
+                id: 'storybook.fileWithOption',
+                type: FieldType.FILE_WITH_OPTIONS,
+                configuration: {
+                  maxFileSize: 1 * 1024 * 1024,
+                  acceptedFileTypes: [MimeType.enum['image/png']]
+                },
+                label: generateTranslationConfig('Upload supporting document'),
+                options: [
+                  {
+                    value: 'forest',
+                    label: generateTranslationConfig('Forest')
+                  },
+                  {
+                    value: 'beach',
+                    label: generateTranslationConfig('Beach')
+                  }
+                ]
               }
             ]}
             id="my-form"
@@ -264,6 +296,15 @@ export const SignatureUploadArmsLockBypass: StoryObj<
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement)
 
+    /**
+     * Both `formMessages.uploadFile` and `buttonMessages.upload` resolve to
+     * the string "Upload", so all three uploader buttons share that name.
+     * `findAllByRole` returns them in DOM order, which matches the order of
+     * the `fields` array above: [signature, file, fileWithOption].
+     */
+    const getUploadButtons = async () =>
+      canvas.findAllByRole('button', { name: 'Upload' })
+
     await step('Bypass flag is not armed before user interacts', async () => {
       // Drain any flag a previous story may have left behind, then confirm
       // a fresh read returns false.
@@ -271,20 +312,43 @@ export const SignatureUploadArmsLockBypass: StoryObj<
       await expect(shouldBypassLock()).toBe(false)
     })
 
-    await step('Tapping Upload arms the bypass exactly once', async () => {
-      const uploadButton = await canvas.findByRole('button', {
-        name: 'Upload'
-      })
+    await step(
+      'SignatureField upload arms the bypass exactly once',
+      async () => {
+        const [signatureUpload] = await getUploadButtons()
+        await userEvent.click(signatureUpload)
 
-      await userEvent.click(uploadButton)
+        await expect(shouldBypassLock()).toBe(true)
+        await expect(shouldBypassLock()).toBe(false)
+      }
+    )
 
-      // First check sees the bypass the upload button just armed.
+    await step('FILE field upload arms the bypass exactly once', async () => {
+      const [, fileUpload] = await getUploadButtons()
+      await userEvent.click(fileUpload)
+
       await expect(shouldBypassLock()).toBe(true)
-
-      // Second check sees no bypass — the flag is single-shot, so a later
-      // genuine background event would still trigger the PIN re-lock.
       await expect(shouldBypassLock()).toBe(false)
     })
+
+    await step(
+      'FILE_WITH_OPTIONS upload arms the bypass exactly once',
+      async () => {
+        // The Upload button is disabled until a document type is picked.
+        // Open the react-select dropdown and choose an option to enable it.
+        const selectControl = canvasElement.querySelector(
+          '.react-select__control'
+        ) as HTMLElement
+        await userEvent.click(selectControl)
+        await userEvent.click(await canvas.findByText('Forest'))
+
+        const [, , fileWithOptionUpload] = await getUploadButtons()
+        await userEvent.click(fileWithOptionUpload)
+
+        await expect(shouldBypassLock()).toBe(true)
+        await expect(shouldBypassLock()).toBe(false)
+      }
+    )
   }
 }
 

--- a/packages/client/src/v2-events/components/forms/inputs/SignatureField/SignatureField.interaction.stories.tsx
+++ b/packages/client/src/v2-events/components/forms/inputs/SignatureField/SignatureField.interaction.stories.tsx
@@ -28,6 +28,7 @@ import {
 import { FormFieldGenerator } from '@client/v2-events/components/forms/FormFieldGenerator'
 import { AppRouter, TRPCProvider } from '@client/v2-events/trpc'
 import { TestImage } from '@client/v2-events/features/events/fixtures'
+import { shouldBypassLock } from '@client/utils/lockBypass'
 import { getTestValidatorContext } from '../../../../../../.storybook/decorators'
 
 const meta: Meta<typeof FormFieldGenerator> = {
@@ -212,6 +213,77 @@ export const SignatureFileUpload: StoryObj<typeof StyledFormFieldGenerator> = {
 
       // alt text of the image
       await canvas.findByAltText('Signature')
+    })
+  }
+}
+
+/**
+ * Regression test for the mobile PIN-lock-during-upload fix.
+ *
+ * When the user taps the "Upload" button on a SignatureField, the uploader
+ * must arm the file-picker bypass flag (via `setLockBypass`) before the OS
+ * picker is invoked. Otherwise `ProtectedPage.handleVisibilityChange`
+ * triggers the PIN re-lock as soon as the picker sends the page to
+ * background — interrupting the upload mid-flow.
+ *
+ * Asserts via `shouldBypassLock()`, which atomically reads-and-clears the
+ * flag — same call `ProtectedPage` would make on the visibility transition.
+ */
+export const SignatureUploadArmsLockBypass: StoryObj<
+  typeof StyledFormFieldGenerator
+> = {
+  name: 'Upload button arms PIN-lock bypass before opening picker',
+  parameters: {
+    layout: 'centered',
+    reactRouter: {
+      router: {
+        path: '/event/:eventId',
+        element: (
+          <StyledFormFieldGenerator
+            fields={[
+              {
+                id: 'storybook.signature',
+                type: FieldType.SIGNATURE,
+                configuration: {
+                  maxFileSize: 1 * 1024 * 1024,
+                  acceptedFileTypes: [MimeType.enum['image/png']]
+                },
+                signaturePromptLabel: generateTranslationConfig('Signature'),
+                label: generateTranslationConfig('Upload signature')
+              }
+            ]}
+            id="my-form"
+            validatorContext={getTestValidatorContext()}
+          />
+        )
+      },
+      initialPath: '/event/123-abcd-213'
+    },
+    chromatic: { disableSnapshot: true }
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+
+    await step('Bypass flag is not armed before user interacts', async () => {
+      // Drain any flag a previous story may have left behind, then confirm
+      // a fresh read returns false.
+      shouldBypassLock()
+      await expect(shouldBypassLock()).toBe(false)
+    })
+
+    await step('Tapping Upload arms the bypass exactly once', async () => {
+      const uploadButton = await canvas.findByRole('button', {
+        name: 'Upload'
+      })
+
+      await userEvent.click(uploadButton)
+
+      // First check sees the bypass the upload button just armed.
+      await expect(shouldBypassLock()).toBe(true)
+
+      // Second check sees no bypass — the flag is single-shot, so a later
+      // genuine background event would still trigger the PIN re-lock.
+      await expect(shouldBypassLock()).toBe(false)
     })
   }
 }

--- a/packages/client/src/v2-events/components/forms/inputs/SignatureField/SignatureField.tsx
+++ b/packages/client/src/v2-events/components/forms/inputs/SignatureField/SignatureField.tsx
@@ -26,6 +26,7 @@ import { messages } from '@client/i18n/messages/views/review'
 import { buttonMessages, validationMessages } from '@client/i18n/messages'
 import { useFileUpload } from '@client/v2-events/features/files/useFileUpload'
 import { cacheFile, toFileUrl } from '@client/v2-events/cache'
+import { setLockBypass } from '@client/utils/lockBypass'
 import { useOnFileChange } from '../FileInput/useOnFileChange'
 import { SignatureCanvasModal } from './components/SignatureCanvasModal'
 
@@ -144,7 +145,11 @@ function SignatureFieldInput({
               <Icon name="Pen" />
               {intl.formatMessage(messages.signatureOpenSignatureInput)}
             </Button>
-            <ImageUploader disabled={disabled} onChange={handleFileChange}>
+            <ImageUploader
+              disabled={disabled}
+              onChange={handleFileChange}
+              onClick={setLockBypass}
+            >
               {intl.formatMessage(buttonMessages.upload)}
             </ImageUploader>
           </Stack>


### PR DESCRIPTION
## Description

https://github.com/opencrvs/opencrvs-core/issues/12646

On mobile, uploading a file or signature interrupts the user with the "Enter your PIN" screen.

Tapping the upload button opens the OS file picker, which sends the tab to background. When the user returns with their file, `ProtectedPage` thinks the app was backgrounded normally and shows the PIN screen — mid-upload.

`FileField` worked by accident before, because its form page URL contains the literal substring `documents` and `affidavit` did a brittle URL-substring bypass. `SignatureField` lives on `/review`, which doesn't match, so the bug only showed up there.

## The fix

Action-scoped bypass using a tab-local `sessionStorage` flag.

- New util `packages/client/src/utils/lockBypass.ts`:
  - `setLockBypass()` — callers signal *"the next visibility change is intentional, don't lock."*
  - `shouldBypassLock()` — `ProtectedPage` reads (and atomically clears) the flag on visibility change.
- Uploader components wire `onClick={setLockBypass}` on their upload buttons.
- 3-minute `setTimeout` safety net auto-clears the flag if it's never consumed.
- Removed the dead `unprotectedRouteElements` URL-substring bypass.

## Why this design

- **Action-scoped, not page-scoped.** Only the specific picker round-trip is allowed to skip the PIN. The review page still locks normally if the user is just sitting on it.
- **Generic.** Works for any user action that briefly backgrounds the tab — file picker, camera, external app redirect.
- **Single-shot.** Each `setLockBypass` grants exactly one skip. Later genuine background events still trigger the PIN.
- **Fail-secure.** If `sessionStorage` is blocked or the flag is stuck, the PIN screen appears — annoying, but never insecure.

## Files changed

- **New:** `packages/client/src/utils/lockBypass.ts`
- `packages/client/src/components/ProtectedPage.tsx` — calls `shouldBypassLock()` inside `handleVisibilityChange`.
- `packages/client/src/App.tsx` — drops the `unprotectedRouteElements` prop (no longer needed).
- Uploader wrappers — add `onClick={setLockBypass}`:
  - `SimpleDocumentUploader.tsx`
  - `DocumentUploaderWithOption.tsx`
  - `SignatureField.tsx`
- `SignatureField.interaction.stories.tsx` — new regression story asserts the flag is armed on Upload click and that it's single-shot.

## Test plan

- [ ] Mobile review page → Signature field → **Upload** → pick image → no PIN screen.
- [ ] Mobile documents page → FileField → upload → no PIN screen.
- [ ] Mobile, on review page, no upload action → manually background the app → return → **PIN screen appears** (lock still works for normal backgrounds).
- [ ] Mobile → tap Upload → cancel picker → wait 3+ minutes → background the app → return → PIN screen appears (TTL cleared the stale flag).
- [ ] Storybook → run *"Upload button arms PIN-lock bypass before opening picker"* → passes.

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
