### PR TITLE
Fix bug on optional DateField having empty string value

### DIFF
--- a/packages/client/src/v2-events/features/events/registered-fields/DateField.tsx
+++ b/packages/client/src/v2-events/features/events/registered-fields/DateField.tsx
@@ -39,14 +39,14 @@ function DateInput({
   value = '',
   ...props
 }: DateFieldProps & {
-  onChange: (newValue: string) => void
+  onChange: (newValue: string | undefined) => void
   value: string
 }) {
   /**
    * Component library returns '--' for empty dates when input has been touched.
    * We limit the behavior to this component, while still allowing partial values. (e.g. '2021-01-')
    */
-  const cleanEmpty = (val: string) => (val === EMPTY_DATE ? '' : val)
+  const cleanEmpty = (val: string) => (val === EMPTY_DATE ? undefined : val)
   const cleanOnChange = (val: string) => onChange(cleanEmpty(val))
 
   return (

--- a/packages/client/src/v2-events/features/events/registered-fields/DateRangeField.stories.tsx
+++ b/packages/client/src/v2-events/features/events/registered-fields/DateRangeField.stories.tsx
@@ -37,7 +37,7 @@ const initialRangeValue: DateRangeFieldValue = {
 
 // Input Story
 export const DateRangeInput: StoryFn = (args) => {
-  const [value, setValue] = useState<string | DateRangeFieldValue>(
+  const [value, setValue] = useState<string | DateRangeFieldValue | undefined>(
     initialExactValue
   )
 

--- a/packages/client/src/v2-events/features/events/registered-fields/DateRangeField.tsx
+++ b/packages/client/src/v2-events/features/events/registered-fields/DateRangeField.tsx
@@ -112,7 +112,7 @@ function DateRangeInput({
   value,
   ...props
 }: Omit<DateFieldProps, 'value' | 'onChange'> & {
-  onChange: (newValue: string | DateRangeFieldValue) => void
+  onChange: (newValue: string | DateRangeFieldValue | undefined) => void
   value?: string | DateRangeFieldValue
 }) {
   const intl = useIntl()
@@ -123,7 +123,7 @@ function DateRangeInput({
    * Component library returns '--' for empty dates when input has been touched.
    * We limit the behavior to this component, while still allowing partial values. (e.g. '2021-01-')
    */
-  const cleanEmpty = (val: string) => (val === EMPTY_DATE ? '' : val)
+  const cleanEmpty = (val: string) => (val === EMPTY_DATE ? undefined : val)
   const cleanOnChange = (val: string) => onChange(cleanEmpty(val))
   const [modalVisible, setModalVisible] = useState<boolean>(false)
 

--- a/packages/components/src/DateField/DateField.tsx
+++ b/packages/components/src/DateField/DateField.tsx
@@ -28,7 +28,7 @@ type IProps = {
   focusInput?: boolean
   notice?: string
   ignorePlaceHolder?: boolean
-  onChange: (dateString: string | undefined) => void
+  onChange: (dateString: string) => void
   /**
    * Test id for the component. Ids will receive postfix (-mm, -dd, -yyyy) based on the input.
    */
@@ -114,8 +114,7 @@ export const DateField = ({
       const updatedValue = { ...date, [segmentType]: val }
       setDate(updatedValue)
 
-      const isEmpty = !updatedValue.dd && !updatedValue.mm && !updatedValue.yyyy
-      onChange(isEmpty ? undefined: `${updatedValue.yyyy}-${updatedValue.mm}-${updatedValue.dd}`)
+      onChange(`${updatedValue.yyyy}-${updatedValue.mm}-${updatedValue.dd}`)
     }
   }
 

--- a/packages/components/src/DateField/DateField.tsx
+++ b/packages/components/src/DateField/DateField.tsx
@@ -28,7 +28,7 @@ type IProps = {
   focusInput?: boolean
   notice?: string
   ignorePlaceHolder?: boolean
-  onChange: (dateString: string) => void
+  onChange: (dateString: string | undefined) => void
   /**
    * Test id for the component. Ids will receive postfix (-mm, -dd, -yyyy) based on the input.
    */
@@ -114,7 +114,8 @@ export const DateField = ({
       const updatedValue = { ...date, [segmentType]: val }
       setDate(updatedValue)
 
-      onChange(`${updatedValue.yyyy}-${updatedValue.mm}-${updatedValue.dd}`)
+      const isEmpty = !updatedValue.dd && !updatedValue.mm && !updatedValue.yyyy
+      onChange(isEmpty ? undefined: `${updatedValue.yyyy}-${updatedValue.mm}-${updatedValue.dd}`)
     }
   }
 


### PR DESCRIPTION
## Description

The optional DateField contains an empty string value when a date is entered and then removed.

Link this pull request to the GitHub issue: https://github.com/opencrvs/opencrvs-core/issues/12667
## Checklist

- [x] I have linked the correct Github issue
- [x] I have tested the changes locally
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
