### PR TITLE
Reviewing a correction request must not crash when the most recent write action is something other than REQUEST_CORRECTION

### DIFF
--- a/packages/client/src/v2-events/features/events/actions/correct/review/CorrectionReview.interaction.stories.tsx
+++ b/packages/client/src/v2-events/features/events/actions/correct/review/CorrectionReview.interaction.stories.tsx
@@ -13,7 +13,16 @@ import React from 'react'
 import { Outlet } from 'react-router-dom'
 
 import { expect, waitFor, within, userEvent } from '@storybook/test'
-import { TestUserRole } from '@opencrvs/commons/client'
+import {
+  ActionType,
+  EventDocument,
+  generateActionDocument,
+  generateTrackingId,
+  TENNIS_CLUB_MEMBERSHIP,
+  tennisClubMembershipEvent,
+  TestUserRole,
+  UUID
+} from '@opencrvs/commons/client'
 import { testDataGenerator } from '@client/tests/test-data-generators'
 import { tennisClubMembershipEventWithCorrectionRequest } from '@client/v2-events/features/events/fixtures'
 import { ROUTES } from '@client/v2-events/routes'
@@ -168,6 +177,106 @@ export const RejectCorrectionModal: Story = {
     }
 
     await userEvent.click(canvas.getByTestId('close-dialog'))
+  }
+}
+
+// Regression test for #12636: reviewing a correction request must not crash
+// when the most recent write action is something other than REQUEST_CORRECTION
+// (e.g. a custom action recorded after the correction was requested).
+
+const correctionEventId = 'b1d2e3f4-5678-4abc-9def-0123456789ab' as UUID
+
+const actionDefaults = {
+  createdBy: generator.user.id.localRegistrar,
+  createdByRole: TestUserRole.enum.LOCAL_REGISTRAR,
+  createdAtLocation: '028d2c85-ca31-426d-b5d1-2cef545a4902' as UUID
+}
+
+const tennisClubMembershipEventWithCorrectionRequestThenCustomAction: EventDocument =
+  {
+    type: TENNIS_CLUB_MEMBERSHIP,
+    id: correctionEventId,
+    trackingId: generateTrackingId(() => 0.1),
+    createdAt: '2025-01-23T05:30:00.000Z',
+    updatedAt: '2025-01-24T05:35:27.689Z',
+    actions: [
+      generateActionDocument({
+        configuration: tennisClubMembershipEvent,
+        action: ActionType.CREATE,
+        defaults: { ...actionDefaults, createdAt: '2025-01-23T05:30:00.000Z' }
+      }),
+      generateActionDocument({
+        configuration: tennisClubMembershipEvent,
+        action: ActionType.DECLARE,
+        defaults: { ...actionDefaults, createdAt: '2025-01-23T05:31:00.000Z' },
+        declarationOverrides: {
+          'applicant.name': { firstname: 'Riku', surname: 'Rouvila' },
+          'applicant.dob': '2025-01-23',
+          'recommender.name': { firstname: 'Euan', surname: 'Millar' }
+        }
+      }),
+      generateActionDocument({
+        configuration: tennisClubMembershipEvent,
+        action: ActionType.REGISTER,
+        defaults: { ...actionDefaults, createdAt: '2025-01-23T05:32:00.000Z' }
+      }),
+      generateActionDocument({
+        configuration: tennisClubMembershipEvent,
+        action: ActionType.REQUEST_CORRECTION,
+        defaults: { ...actionDefaults, createdAt: '2025-01-23T05:33:00.000Z' },
+        declarationOverrides: {
+          'applicant.name': { firstname: 'Corrected', surname: 'Name' }
+        }
+      }),
+      generateActionDocument({
+        configuration: tennisClubMembershipEvent,
+        action: ActionType.CUSTOM,
+        defaults: { ...actionDefaults, createdAt: '2025-01-24T05:35:27.689Z' }
+      })
+    ]
+  }
+
+export const OtherActionsCanBeAddedAfterCorrectionRequest: Story = {
+  loaders: [
+    async () => {
+      window.localStorage.setItem(
+        'opencrvs',
+        generator.user.token.localRegistrar
+      )
+      await new Promise((resolve) => setTimeout(resolve, 50))
+    }
+  ],
+  parameters: {
+    chromatic: { disableSnapshot: true },
+    offline: {
+      events: [tennisClubMembershipEventWithCorrectionRequestThenCustomAction]
+    },
+    reactRouter: {
+      router: {
+        path: '/',
+        element: <Outlet />,
+        children: [router]
+      },
+      initialPath: ROUTES.V2.EVENTS.REVIEW_CORRECTION.REVIEW.buildPath({
+        eventId: correctionEventId
+      })
+    }
+  },
+
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await waitFor(async () => {
+      await expect(
+        canvas.getByRole('button', { name: /approve/i })
+      ).toBeInTheDocument()
+    })
+
+    await waitFor(async () => {
+      await expect(
+        canvas.getByRole('button', { name: /reject/i })
+      ).toBeInTheDocument()
+    })
   }
 }
 

--- a/packages/client/src/v2-events/features/events/actions/correct/review/Review.tsx
+++ b/packages/client/src/v2-events/features/events/actions/correct/review/Review.tsx
@@ -18,7 +18,8 @@ import {
   deepMerge,
   ActionDocument,
   getAcceptedActions,
-  getCurrentEventState
+  getCurrentEventState,
+  findPendingCorrectionAction,
 } from '@opencrvs/commons/client'
 import { Review as ReviewComponent } from '@client/v2-events/features/events/components/Review'
 import { useEventConfiguration } from '@client/v2-events/features/events/useEventConfiguration'
@@ -56,13 +57,14 @@ export function Review() {
       `Action config for ${ActionType.REQUEST_CORRECTION} was not found. This should never happen`
     )
   }
-  const writeActions: ActionDocument[] = getAcceptedActions(event).filter(
+  const writeActions = getAcceptedActions(event).filter(
     (a) => !isMetaAction(a.type)
   )
-  const correctionRequestAction = writeActions[writeActions.length - 1]
-
-  if (correctionRequestAction.type !== ActionType.REQUEST_CORRECTION) {
-    throw new Error('Expected last write action to be REQUEST_CORRECTION')
+  const correctionRequestAction = findPendingCorrectionAction(writeActions)
+  if (!correctionRequestAction) {
+    throw new Error(
+      'Pending REQUEST_CORRECTION action was not found. This should never happen'
+    )
   }
 
   const formValuesAfterCorrection = deepMerge(

--- a/packages/commons/src/client.ts
+++ b/packages/commons/src/client.ts
@@ -26,5 +26,6 @@ export * from './events/mocks.test.utils'
 export { TriggerEvent } from './notification'
 export * from './application-config'
 export * from './icons'
+export { findPendingCorrectionAction } from './events/state/flags'
 /** @knipignore */
 export { findScope } from './scopes.deprecated.do-not-use'

--- a/packages/commons/src/events/state/flags.test.ts
+++ b/packages/commons/src/events/state/flags.test.ts
@@ -8,14 +8,15 @@
  *
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
-import { ActionStatus } from '../ActionDocument'
+
+import { Action, ActionStatus } from '../ActionDocument'
 import { ActionType } from '../ActionType'
 import { EventConfig } from '../EventConfig'
 import { EventDocument } from '../EventDocument'
 import { field } from '../field'
 import { FieldType } from '../FieldType'
 import { PageTypes } from '../PageConfig'
-import { resolveEventCustomFlags } from './flags'
+import { findPendingCorrectionAction, resolveEventCustomFlags } from './flags'
 import { subDays, formatISO } from 'date-fns'
 import { not, user } from '../../conditionals/conditionals'
 
@@ -314,5 +315,54 @@ describe('resolveEventCustomFlags()', () => {
     // @ts-expect-error - allow partial actions and event config
     const flags = resolveEventCustomFlags(event, eventConfig)
     expect(flags).toEqual(['executed-by-admin-flag'])
+  })
+})
+
+describe('findPendingCorrectionAction()', () => {
+  const a = (type: ActionType, status: ActionStatus = ActionStatus.Accepted) =>
+    ({ type, status }) as Action
+
+  test('returns undefined for empty actions', () => {
+    expect(findPendingCorrectionAction([])).toBeUndefined()
+  })
+
+  test('returns the request when it is the last write action', () => {
+    const req = a(ActionType.REQUEST_CORRECTION)
+    expect(findPendingCorrectionAction([req])).toBe(req)
+  })
+
+  test('returns the request when followed by non-correction actions', () => {
+    const req = a(ActionType.REQUEST_CORRECTION)
+    expect(findPendingCorrectionAction([req, a(ActionType.CUSTOM)])).toBe(req)
+  })
+
+  test('returns undefined when the request has been approved', () => {
+    expect(
+      findPendingCorrectionAction([
+        a(ActionType.REQUEST_CORRECTION),
+        a(ActionType.APPROVE_CORRECTION)
+      ])
+    ).toBeUndefined()
+  })
+
+  test('returns undefined when the request has been rejected', () => {
+    expect(
+      findPendingCorrectionAction([
+        a(ActionType.REQUEST_CORRECTION),
+        a(ActionType.REJECT_CORRECTION)
+      ])
+    ).toBeUndefined()
+  })
+
+  test('returns the second request after a completed correction cycle', () => {
+    const secondReq = a(ActionType.REQUEST_CORRECTION)
+    expect(
+      findPendingCorrectionAction([
+        a(ActionType.REQUEST_CORRECTION),
+        a(ActionType.APPROVE_CORRECTION),
+        secondReq,
+        a(ActionType.CUSTOM)
+      ])
+    ).toBe(secondReq)
   })
 })

--- a/packages/commons/src/events/state/flags.ts
+++ b/packages/commons/src/events/state/flags.ts
@@ -12,7 +12,12 @@
 import { uniq } from 'lodash'
 import { joinValues } from '../../utils'
 import { getStatusFromActions } from '.'
-import { Action, ActionStatus, EventState } from '../ActionDocument'
+import {
+  Action,
+  ActionStatus,
+  EventState,
+  RequestedCorrectionAction
+} from '../ActionDocument'
 import { ActionType, isMetaAction } from '../ActionType'
 import { EventStatus } from '../EventMetadata'
 import { InherentFlags, Flag, CustomFlag } from '../Flag'
@@ -33,19 +38,34 @@ function isEditInProgress(actions: Action[]) {
   return actions.at(-1)?.type === ActionType.EDIT
 }
 
+// Walk from the end: the latest correction-lifecycle action determines state.
+// If it's an APPROVE/REJECT_CORRECTION, there is no pending request.
+// If it's a REQUEST_CORRECTION, that's the pending one we want.
+export function findPendingCorrectionAction(
+  writeActions: Action[]
+): RequestedCorrectionAction | undefined {
+  let correctionRequestAction: RequestedCorrectionAction | undefined
+  for (let i = writeActions.length - 1; i >= 0; i--) {
+    const action = writeActions[i]
+    if (action.status === ActionStatus.Accepted) {
+      if (
+        action.type === ActionType.APPROVE_CORRECTION ||
+        action.type === ActionType.REJECT_CORRECTION
+      ) {
+        break
+      }
+      if (action.type === ActionType.REQUEST_CORRECTION) {
+        correctionRequestAction = action as RequestedCorrectionAction
+        break
+      }
+    }
+  }
+
+  return correctionRequestAction
+}
+
 function isCorrectionRequested(actions: Action[]) {
-  return actions.reduce<boolean>((prev, { type }) => {
-    if (type === ActionType.REQUEST_CORRECTION) {
-      return true
-    }
-    if (type === ActionType.APPROVE_CORRECTION) {
-      return false
-    }
-    if (type === ActionType.REJECT_CORRECTION) {
-      return false
-    }
-    return prev
-  }, false)
+  return findPendingCorrectionAction(actions) !== undefined
 }
 
 function isDeclarationIncomplete(actions: Action[]): boolean {
@@ -119,7 +139,7 @@ export function resolveEventCustomFlags(
     .filter(({ type }) => !isMetaAction(type))
     .sort((a, b) => a.createdAt.localeCompare(b.createdAt))
 
-  return actions.reduce((acc, action, idx) => {
+  return actions.reduce<CustomFlag[]>((acc, action, idx) => {
     let actionConfig
     if (isActionConfigType(action.type)) {
       actionConfig = getActionConfig({


### PR DESCRIPTION
## Summary
https://github.com/opencrvs/opencrvs-core/issues/12636
https://github.com/opencrvs/opencrvs-farajaland/pull/2166


## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
