### PR TITLE
Remove 'Upload' button from `<DocumentViewer/>`

### DIFF
--- a/packages/client/src/v2-events/features/events/actions/dedup/DuplicateComparison.tsx
+++ b/packages/client/src/v2-events/features/events/actions/dedup/DuplicateComparison.tsx
@@ -35,7 +35,6 @@ import { summaryMessages } from '@client/v2-events/features/workqueues/EventOver
 import { useIntlFormatMessageWithFlattenedParams } from '@client/v2-events/messages/utils'
 import { flattenEventIndex, getUsersFullName } from '@client/v2-events/utils'
 import { useUsers } from '@client/v2-events/hooks/useUsers'
-import { noop } from '@client/v2-events'
 import { useValidatorContext } from '@client/v2-events/hooks/useValidatorContext'
 import { useLocations } from '@client/v2-events/hooks/useLocations'
 import { useAdministrativeAreas } from '@client/v2-events/hooks/useAdministrativeAreas'
@@ -389,11 +388,9 @@ export function DuplicateComparison({
               </Text>
               <DocumentViewer
                 comparisonView={true}
-                disabled={true}
                 form={originalDeclaration}
                 formConfig={eventConfiguration.declaration}
                 showInMobile={false}
-                onEdit={noop}
               />
               <MobileOnly>
                 <SupportingDocumentList
@@ -408,11 +405,9 @@ export function DuplicateComparison({
               </Text>
               <DocumentViewer
                 comparisonView={true}
-                disabled={true}
                 form={potentialDuplicateDeclaration}
                 formConfig={eventConfiguration.declaration}
                 showInMobile={false}
-                onEdit={noop}
               />
               <MobileOnly>
                 <SupportingDocumentList

--- a/packages/client/src/v2-events/features/events/components/DocumentViewer.stories.tsx
+++ b/packages/client/src/v2-events/features/events/components/DocumentViewer.stories.tsx
@@ -11,7 +11,6 @@
 
 import type { Meta, StoryObj } from '@storybook/react'
 import React from 'react'
-import { noop } from 'lodash'
 import {
   tennisClubMembershipEvent,
   generateTranslationConfig,
@@ -38,7 +37,6 @@ export const EmptyDocumentViewer: StoryObj<typeof DocumentViewer> = {
       <DocumentViewer
         form={{}}
         formConfig={getDeclaration(tennisClubMembershipEvent)}
-        onEdit={noop}
       />
     )
   }
@@ -134,7 +132,6 @@ export const DocumentViewerWithFiles: StoryObj<typeof DocumentViewer> = {
           ],
           label: generateTranslationConfig('form label')
         })}
-        onEdit={noop}
       />
     )
   }
@@ -242,7 +239,6 @@ export const SameOptionsForDifferentFields: StoryObj<typeof DocumentViewer> = {
           ],
           label: generateTranslationConfig('form label')
         })}
-        onEdit={noop}
       />
     )
   }

--- a/packages/client/src/v2-events/features/events/components/DocumentViewer.tsx
+++ b/packages/client/src/v2-events/features/events/components/DocumentViewer.tsx
@@ -13,7 +13,6 @@ import { defineMessages, useIntl, IntlShape } from 'react-intl'
 import styled from 'styled-components'
 import React from 'react'
 import { isNil } from 'lodash'
-import { Link } from '@opencrvs/components'
 import {
   EventState,
   FormConfig,
@@ -139,31 +138,21 @@ const reviewMessages = defineMessages({
     defaultMessage: 'No supporting documents',
     description: 'Zero documents text',
     id: 'review.documents.zeroDocumentsTextForAnySection'
-  },
-  editDocuments: {
-    defaultMessage: 'Add attachment',
-    description: 'Edit documents text',
-    id: 'review.documents.editDocuments'
   }
 })
 
 export function DocumentViewer({
   form,
   formConfig,
-  onEdit,
   showInMobile,
-  disabled,
   comparisonView
 }: {
   formConfig: FormConfig
   form: EventState
-  onEdit: () => void
   showInMobile?: boolean
-  disabled?: boolean
   comparisonView?: boolean
 }) {
   const intl = useIntl()
-
   const fileOptions = getFileOptions(form, formConfig, intl)
 
   return (
@@ -175,17 +164,6 @@ export function DocumentViewer({
         {fileOptions.length === 0 && (
           <ZeroDocument id={`zero_document`}>
             {intl.formatMessage(reviewMessages.zeroDocumentsTextForAnySection)}
-            {!disabled && (
-              <Link
-                id="edit-document"
-                onClick={(e) => {
-                  e.stopPropagation()
-                  onEdit()
-                }}
-              >
-                {intl.formatMessage(reviewMessages.editDocuments)}
-              </Link>
-            )}
           </ZeroDocument>
         )}
       </DocumentViewerComponent>

--- a/packages/client/src/v2-events/features/events/components/Review.tsx
+++ b/packages/client/src/v2-events/features/events/components/Review.tsx
@@ -581,14 +581,7 @@ function ReviewComponent({
       </LeftColumn>
       {pageIdsWithFile.length > 0 && (
         <RightColumn>
-          <DocumentViewer
-            disabled={readonlyMode || isCorrection || isReviewCorrection}
-            form={form}
-            formConfig={formConfig}
-            onEdit={() =>
-              onEdit({ pageId: pageIdsWithFile[0], confirmation: true })
-            }
-          />
+          <DocumentViewer form={form} formConfig={formConfig} />
         </RightColumn>
       )}
     </Row>


### PR DESCRIPTION
## Description

Resolves https://github.com/opencrvs/opencrvs-core/issues/12577

Remove 'Upload' button from DocumentViewer

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
