### PR TITLE
fix: ensure select overlays icon

### DIFF
--- a/packages/client/src/v2-events/features/events/registered-fields/Search.tsx
+++ b/packages/client/src/v2-events/features/events/registered-fields/Search.tsx
@@ -174,6 +174,7 @@ const SearchWrapper = styled.div`
   position: relative;
   display: flex;
   width: 100%;
+  z-index: 1;
   align-items: stretch;
 `
 

--- a/packages/client/src/v2-events/features/events/registered-fields/Select.stories.tsx
+++ b/packages/client/src/v2-events/features/events/registered-fields/Select.stories.tsx
@@ -18,7 +18,9 @@ import {
   ConditionalType,
   FieldType,
   not,
-  alwaysTrue
+  alwaysTrue,
+  generateTranslationConfig,
+  defineConditional
 } from '@opencrvs/commons/client'
 import {
   FormFieldGenerator,
@@ -195,6 +197,90 @@ export const WithDisabledOption: Story = {
                 }
               }
             ]
+          }
+        ]}
+        id="my-form"
+      />
+    )
+  }
+}
+
+export const OptionsHideUnderlyingElement: Story = {
+  parameters: {
+    layout: 'centered'
+  },
+  play: async ({ canvasElement }) => {
+    const control = await waitFor(() => {
+      const el = canvasElement.querySelector('.react-select__control')
+      if (!el) {
+        throw new Error('Dropdown not found')
+      }
+      return el
+    })
+    await userEvent.click(control)
+  },
+  render: function Component(args) {
+    return (
+      <StyledFormFieldGenerator
+        {...args}
+        fields={[
+          {
+            id: 'storybook.select',
+            type: FieldType.SELECT,
+            label: {
+              id: 'storybook.select.label',
+              defaultMessage: 'Favourite fruit',
+              description: 'The label for the select input'
+            },
+            options: [
+              {
+                value: 'apple',
+                label: generateTranslationConfig('Apple')
+              },
+              {
+                value: 'banana',
+                label: generateTranslationConfig('Banana')
+              },
+              {
+                value: 'cherry',
+                label: generateTranslationConfig('Cherry')
+              },
+              {
+                value: 'Citrus',
+                label: generateTranslationConfig('Citrus')
+              },
+              {
+                value: 'Pear',
+                label: generateTranslationConfig('Pear')
+              },
+              {
+                value: 'Strawberry',
+                label: generateTranslationConfig('Strawberry')
+              }
+            ]
+          },
+          {
+            id: 'child.brn-search',
+            type: FieldType.SEARCH,
+            label: generateTranslationConfig('Farmer id'),
+            placeholder: generateTranslationConfig('Enter farmer id'),
+            helperText: generateTranslationConfig('Enter a 10-digit farmer id'),
+            configuration: {
+              validation: {
+                validator: defineConditional({
+                  type: 'string',
+                  pattern: '^[0-9]{10}$',
+                  description: 'Must be numeric and 10 digits long'
+                }),
+                message: generateTranslationConfig('Invalid value')
+              },
+              query: {
+                type: 'or' as const,
+                clauses: []
+              },
+              limit: 10,
+              offset: 0
+            }
           }
         ]}
         id="my-form"


### PR DESCRIPTION
## Description
Add z-index for search to avoid underlying elements being visible

<img width="1213" height="596" alt="options-layover" src="https://github.com/user-attachments/assets/dc2e39cf-f8b7-4ead-bc5b-836a10d6f8b0" />


Link this pull request to the GitHub issue (and optionally name the branch `ocrvs-<issue #>`)

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
