### PR TITLE
Add InfraScan workflow for security auditing

### DIFF
--- a/.github/workflows/infrascan.yml
+++ b/.github/workflows/infrascan.yml
@@ -1,0 +1,32 @@
+name: InfraScan Audit
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  infrascan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create Reports Directory
+        run: |
+          mkdir -p infrascan-reports
+          chmod 777 infrascan-reports
+
+      - name: Run InfraScan
+        uses: soldevelo/infrascan@v1.0.6
+        with:
+          scanner: comprehensive
+          format: html
+          out: infrascan-reports/report.html
+            
+      - name: Upload InfraScan Report
+        uses: actions/upload-artifact@v4
+        if: always() # Upload report even if the scan step fails
+        with:
+          name: infrascan-report
+          path: infrascan-reports/report.html
+          retention-days: 14


### PR DESCRIPTION
## Description

This PR introduces an automated InfraScan GitHub Actions workflow to the OpenCRVS repository in order to improve infrastructure security visibility and proactively detect vulnerable or outdated container images and IaC misconfigurations.

The workflow runs on every `push` and `pull_request` event and performs a comprehensive infrastructure scan using InfraScan. It generates an HTML report and uploads it as a build artifact for later review.

This change is a follow-up to the discussion in:
https://github.com/opencrvs/opencrvs-core/discussions/12220

This workflow enables continuous monitoring so issues can be detected early in future changes.

The full scan report is available here:
https://infrascan.soldevelo.com/report/opencrvs-core-9943ed1c-8e54-4520-abff-fd038f0f5829

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly