### PR TITLE
OCRVS-12777 Improve location caching to avoid re-rendering

### DIFF
--- a/packages/client/src/v2-events/hooks/useAdministrativeAreas.ts
+++ b/packages/client/src/v2-events/hooks/useAdministrativeAreas.ts
@@ -10,6 +10,7 @@
  */
 
 import { useSuspenseQuery } from '@tanstack/react-query'
+import { useMemo } from 'react'
 import { AdministrativeArea, UUID } from '@opencrvs/commons/client'
 import { trpcOptionsProxy, useTRPC } from '@client/v2-events/trpc'
 import { setQueryDefaults } from '../features/events/useEvents/procedures/utils'
@@ -57,11 +58,15 @@ export function useAdministrativeAreas() {
           })
         }).data
 
-        const administrativeAreasMap = new Map<UUID, AdministrativeArea>(
-          administrativeAreas.map((administrativeArea) => [
-            administrativeArea.id,
-            administrativeArea
-          ])
+        const administrativeAreasMap = useMemo(
+          () =>
+            new Map<UUID, AdministrativeArea>(
+              administrativeAreas.map((administrativeArea) => [
+                administrativeArea.id,
+                administrativeArea
+              ])
+            ),
+          [administrativeAreas]
         )
         return administrativeAreasMap
       }
@@ -99,30 +104,25 @@ export function getLeafAdministrativeAreaIds(
   return result
 }
 
-// Ref works since arrays are compared by reference.
-let cachedAdministrativeAreasRef: unknown = null
-/** In-memory cache of leaf administrative area IDs */
+let cachedRawDataRef: AdministrativeArea[] | null = null
 let cachedLeafAdministrativeAreaIds: { id: UUID }[] | null = null
 
-/**
- * Uses in-memory caching to avoid recomputation on re-renders. Becomes costly with large datasets.
- *
- * @returns array of leaf administrative area IDs.
- */
 export function useSuspenseGetLeafAdministrativeAreaIds() {
-  const { getAdministrativeAreas } = useAdministrativeAreas()
-  const administrativeAreas = getAdministrativeAreas.useSuspenseQuery()
+  const trpc = useTRPC()
+  const { queryFn, ...rest } =
+    trpcOptionsProxy.administrativeAreas.list.queryOptions()
+  const rawData = useSuspenseQuery({
+    ...rest,
+    queryKey: trpc.administrativeAreas.list.queryKey()
+  }).data
 
-  if (
-    cachedLeafAdministrativeAreaIds &&
-    cachedAdministrativeAreasRef === administrativeAreas
-  ) {
+  if (cachedLeafAdministrativeAreaIds && cachedRawDataRef === rawData) {
     return cachedLeafAdministrativeAreaIds
   }
 
-  const leafIds = getLeafAdministrativeAreaIds(administrativeAreas)
-  cachedAdministrativeAreasRef = administrativeAreas
+  const map = new Map<UUID, AdministrativeArea>(rawData.map((a) => [a.id, a]))
+  const leafIds = getLeafAdministrativeAreaIds(map)
+  cachedRawDataRef = rawData
   cachedLeafAdministrativeAreaIds = leafIds
-
   return leafIds
 }


### PR DESCRIPTION
## Description

getAdministrativeAreas.useSuspenseQuery() was constructing a new Map on every call, causing the module-level cache in useSuspenseGetLeafAdministrativeAreaIds to miss every time (reference equality always failed against a new object).
With large datasets this made getLeafAdministrativeAreaIds run on every render of every component in the tree, causing a 2.7s main-thread block on click.

Wrap the Map construction in useMemo so the reference is stable within each component, and key the module-level leaf-IDs cache on the raw React Query array instead of the derived Map — the raw array is the same reference across all component instances querying the same key, so getLeafAdministrativeAreaIds now runs at most once regardless of render count.

Before fix call takes 3s:
<img width="547" height="107" alt="screenshot-2026-05-27_15-09-19" src="https://github.com/user-attachments/assets/f5ada01d-dca7-4ac5-aafe-750f54b118a2" />


After fix, the whole call is less than 300ms;
<img width="404" height="87" alt="image" src="https://github.com/user-attachments/assets/5fc0a517-f1a2-4784-9366-f1aa11913693" />


Fixed: https://github.com/opencrvs/opencrvs-core/issues/12777

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
