### PR TITLE
feat: Add flexible configuration options for Cloud providers

### DIFF
--- a/charts/dependencies/Chart.yaml
+++ b/charts/dependencies/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opencrvs-dependencies-chart
 description: Dependencies required by OpenCRVS
 type: application
-version: v2.0.0
-appVersion: v2.0.0
+version: v2.0.0-azure
+appVersion: v2.0.0-azure

--- a/charts/dependencies/README.md
+++ b/charts/dependencies/README.md
@@ -69,8 +69,10 @@ This section allows you to configure the postgres deployment within your infrast
 |--------------------------|---------|----|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | enabled | bool | true | Enable or disable the Postgres deployment. |
 | use_default_credentials | bool | true | If true, deploys Postgres with default user/password: postgres/postgres |
-| data_storage_size | string | 1Gi | Persistent volume claim size for Postgres data volume |
-| storage_type | string | `pvc` | Kubernetes storage type, available options are `pvc` or `host_path`. More information are at [Storage Configuration](#storage-configuration) |
+| storage_type | string | `n/a` | Kubernetes storage type, available options are `pvc` or `host_path`. More information are at [Storage Configuration](#storage-configuration) |
+| pvc.storage_class | string | `n/a` | StorageClass name used for dynamic volume provisioning |
+| pvc.storage_size | string | 10Gi | Persistent volume claim size for Postgres data volume |
+| pvc.access_mode | string | ReadWriteOnce | Kubernetes PVC access mode |
 | host_data_path | string | `/data/postgres` | Path to persistent data on VM (host) |
 | node_selector | dict | `{}` | Label selector for datastore nodes, usually used to keep data persistent |
 | backup.{} | dict | `{}` | Backup configuration section, for more information please check `values.yaml` and **Backup section** in this README |
@@ -98,8 +100,10 @@ This section allows you to configure the deployment and authentication settings 
 | ----------------------- | ------- | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | enabled                 | boolean | true                  | Enable or disable the Elasticsearch deployment.                                                                                              |
 | use_default_credentials | boolean | true                  | Deploy Elasticsearch without enabled authentication.                                                                                         |
-| data_storage_size       | string  | 5Gi                   | Persistent volume claim size for Elasticsearch data volume                                                                                   |
 | storage_type            | string  | `pvc`                 | Kubernetes storage type, available options are `pvc` or `host_path`. More information are at [Storage Configuration](#storage-configuration) |
+| pvc.storage_class | string | `n/a` | StorageClass name used for dynamic volume provisioning |
+| pvc.storage_size | string | 10Gi | Persistent volume claim size for Postgres data volume |
+| pvc.access_mode | string | ReadWriteOnce | Kubernetes PVC access mode |
 | host_data_path          | string  | `/data/elasticsearch` | Path to persistent data on VM (host)                                                                                                         |
 | node_selector           | dict    | `{}`                  | Label selector for datastore nodes, usually used to keep data persistent                                                                     |
 
@@ -111,8 +115,10 @@ This section allows you to configure the deployment and authentication settings 
 | ----------------------- | ------ | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | enabled                 | bool   | true                            | Enable or disable minio service                                                                                                              |
 | use_default_credentials | bool   | true                            | Default credentials for MinIO are username `minioadmin` and password `minioadmin`.                                                           |
-| data_storage_size       | string | 1Gi                             | Persistent volume claim size                                                                                                                 |
 | storage_type            | string | `pvc`                           | Kubernetes storage type, available options are `pvc` or `host_path`. More information are at [Storage Configuration](#storage-configuration) |
+| pvc.storage_class | string | `n/a` | StorageClass name used for dynamic volume provisioning |
+| pvc.storage_size | string | 10Gi | Persistent volume claim size for Postgres data volume |
+| pvc.access_mode | string | ReadWriteOnce | Kubernetes PVC access mode |
 | host_data_path          | string | `/data/minio`                   | Path to persistent data on VM (host)                                                                                                         |
 | node_selector           | dict   | `{}`                            | Label selector for datastore nodes, usually used to keep data persistent                                                                     |
 | backup.{}               | dict   | `{}`                            | Backup configuration section, for more information please check `values.yaml` and **Backup section** in this README                          |
@@ -251,7 +257,10 @@ You control persistence using the `storage_type` option, which can be set **glob
 - **`storage_type`**, available options:
   - **`pvc`** – Use the default Kubernetes StorageClass to create a PersistentVolumeClaim.
   - **`host_path`** – Use a directory on the Kubernetes node for persistence. The directory must be created with the appropriate permissions. This option is the default for legacy VMs running Docker Swarm that have been migrated to Kubernetes.
-- **`data_storage_size`** – Define the size of the PVC claim per datastore/service. Please check the Values file for supported keys.
+- **`pvc`**:
+  - `storage_class`: StorageClass name used for dynamic volume provisioning
+  - `storage_size`: Persistent volume claim size for Postgres data volume
+  - `access_mode`: Kubernetes PVC access mode
 - **`host_data_path`** – Optionally specify data path per datastore/service. For example, Elasticsearch use the `host_data_path` property to specify where data should be stored. If the directory does not exist, it will be created during deployment.
 - **`node_selector`** – Use a node selector to control where the pod is scheduled. This option can be defined globally or per service.
 
@@ -263,9 +272,10 @@ You control persistence using the `storage_type` option, which can be set **glob
 
 ```yaml
 elasticsearch:
-  # storage_type: pvc  # Not required; pvc is default
-  data_storage_size: 5Gi
-  storage_class_name: "" # Optional: specify a StorageClass or leave as "" for default
+  storage_type: pvc  # Not required; pvc is default
+  pvc:
+    storage_size: 5Gi
+    storage_class: "azurefile-premium" # Optional: specify a StorageClass or leave as "" for default
 ```
 
 #### Use hostPath for MinIO data (legacy volumes, on-prem, etc):

--- a/charts/dependencies/templates/elasticsearch.yaml
+++ b/charts/dependencies/templates/elasticsearch.yaml
@@ -8,11 +8,14 @@ metadata:
     app: elasticsearch
   name: elasticsearch
 spec:
+  {{- if .Values.elasticsearch.pvc.storage_class }}
+  storageClassName: {{ .Values.elasticsearch.pvc.storage_class | quote }}
+  {{- end }}
   accessModes:
-    - ReadWriteOnce
+    - {{ .Values.elasticsearch.pvc.access_mode }}
   resources:
     requests:
-      storage: {{ default "5Gi" .Values.elasticsearch.data_storage_size }}
+      storage: {{ .Values.elasticsearch.pvc.storage_size }}
 {{- end }}
 ---
 apiVersion: v1

--- a/charts/dependencies/templates/minio.yaml
+++ b/charts/dependencies/templates/minio.yaml
@@ -8,11 +8,14 @@ metadata:
     app: minio
   name: minio
 spec:
+  {{- if .Values.minio.pvc.storage_class }}
+  storageClassName: {{ .Values.minio.pvc.storage_class | quote }}
+  {{- end }}
   accessModes:
-    - ReadWriteOnce
+    - {{ .Values.minio.pvc.access_mode }}
   resources:
     requests:
-      storage: {{ default "1Gi" .Values.minio.data_storage_size }}
+      storage: {{ .Values.minio.pvc.storage_size }}
 {{- end }}
 ---
 apiVersion: traefik.io/v1alpha1

--- a/charts/dependencies/templates/postgres.yaml
+++ b/charts/dependencies/templates/postgres.yaml
@@ -10,11 +10,14 @@ metadata:
     app: postgres
   name: postgres-data
 spec:
+  {{- if .Values.postgres.pvc.storage_class }}
+  storageClassName: {{ .Values.postgres.pvc.storage_class | quote }}
+  {{- end }}
   accessModes:
-    - ReadWriteOnce
+    - {{ .Values.postgres.pvc.access_mode }}
   resources:
     requests:
-      storage: {{ default "1Gi" .Values.postgres.data_storage_size }}
+      storage: {{ .Values.postgres.pvc.storage_size }}
 {{- end }}
 ---
 apiVersion: v1

--- a/charts/dependencies/values.yaml
+++ b/charts/dependencies/values.yaml
@@ -66,6 +66,29 @@ postgres:
   # admin user name is postgres, define password here:
   # admin_user_password:
 
+  # Persistent Volume Claim (PVC) configuration
+  # NOTE: This configuration is used only when `storage_type` is set to `pvc`.
+  # For `host_path` storage, data is stored on the host filesystem at the path defined in `postgres.host_data_path`.
+  pvc:
+
+    # StorageClass name used for dynamic volume provisioning.
+    # Set to:
+    # - a specific StorageClass name (e.g. gp3, standard, managed-csi)
+    # - "default" to use the cluster default StorageClass
+    # - "" to disable dynamic provisioning / default StorageClass usage
+    # storage_class: "default"
+
+    # Kubernetes PVC access mode.
+    # Common values:
+    # - ReadWriteOnce (RWO)  : mounted read-write by a single node
+    # - ReadOnlyMany (ROX)   : mounted read-only by multiple nodes
+    # - ReadWriteMany (RWX)  : mounted read-write by multiple nodes
+    access_mode: "ReadWriteOnce"
+
+    # Requested persistent storage size
+    storage_size: "10Gi"
+
+
   # Backup section
   backup:
     # Enable/Disable backup
@@ -141,9 +164,17 @@ elasticsearch:
     - KIBANA_SYSTEM:kibana_system
     - METRICBEAT:beats_system
     - APM:apm_system
-  # TEMPORAL SECRET TO STORE ELASTICSEARCH USERS
+
+  # Secret to store OpenCRVS users credentials:
   users_secret: elasticsearch-opencrvs-users
   urls_secret: elasticsearch-opencrvs-urls
+
+  # PVC Configuration
+  pvc:
+    # storage_class: "default"
+    access_mode: "ReadWriteOnce"
+    storage_size: "10Gi"
+
   resources:
     memoryRequest: "2Gi"
     cpuRequest: "2"
@@ -201,6 +232,11 @@ minio:
   use_default_credentials: true
 
   # storage_type: host_path
+  # PVC Configuration
+  pvc:
+    # storage_class: "default"
+    access_mode: "ReadWriteOnce"
+    storage_size: "10Gi"
 
   # Path to persistent data on the VM (when storage_type is host_path).
   host_data_path: /data/minio


### PR DESCRIPTION
## Description

Goal of this PR is to bring support of cloud native storage management:
- Persistent Volume Claim
- Persistent Volume

## Testing

Build helm charts: https://github.com/opencrvs/opencrvs-core/actions/runs/26524028324/job/78122739636

Tests performed on Azure cloud:

Custom storage size and type were configured:
<img width="408" height="240" alt="image" src="https://github.com/user-attachments/assets/3e2d7a5e-17fe-478f-917e-006520766054" />

Dependencies workflow deployed:
<img width="1660" height="323" alt="image" src="https://github.com/user-attachments/assets/24ce6c33-2756-44b1-b5f0-1766e1f45c48" />

Helm chart was taken from github OCI registry:
<img width="1143" height="681" alt="image" src="https://github.com/user-attachments/assets/9012332b-83ac-4c48-a84e-748b52f38205" />

Changes successfully applied:
<img width="1698" height="530" alt="image" src="https://github.com/user-attachments/assets/c5fc49f8-aaf0-4952-a8fd-894f5bb73c1c" />



## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
