### PR TITLE
Sort REVIEW_CORRECTION_REQUEST as REQUEST_CORRECTION

### DIFF
--- a/packages/client/src/v2-events/features/workqueues/EventOverview/components/ActionMenu.test.ts
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/components/ActionMenu.test.ts
@@ -8,7 +8,11 @@
  *
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
-import { ActionType, tennisClubMembershipEvent } from '@opencrvs/commons/client'
+import {
+  ActionType,
+  ClientSpecificAction,
+  tennisClubMembershipEvent
+} from '@opencrvs/commons/client'
 import { ActionMenuItem } from '../../Actions/utils'
 import { sortActions } from './ActionMenu'
 
@@ -67,6 +71,53 @@ describe('sortActions()', () => {
       { type: ActionType.REJECT },
       { type: ActionType.EDIT },
       { type: ActionType.REGISTER }
+    ])
+  })
+
+  it('should sort REVIEW_CORRECTION_REQUEST right after REQUEST_CORRECTION using default action order', () => {
+    const availableActions = [
+      { type: ActionType.UNASSIGN },
+      { type: ClientSpecificAction.REVIEW_CORRECTION_REQUEST },
+      { type: ActionType.PRINT_CERTIFICATE },
+      { type: ActionType.REGISTER }
+    ] as ActionMenuItem[]
+
+    const sortedActions = sortActions(
+      availableActions,
+      tennisClubMembershipEvent
+    )
+
+    expect(sortedActions).toEqual([
+      { type: ActionType.REGISTER },
+      { type: ActionType.PRINT_CERTIFICATE },
+      { type: ClientSpecificAction.REVIEW_CORRECTION_REQUEST },
+      { type: ActionType.UNASSIGN }
+    ])
+  })
+
+  it('should sort REVIEW_CORRECTION_REQUEST at the same position as REQUEST_CORRECTION in the configured action order', () => {
+    const availableActions = [
+      { type: ActionType.UNASSIGN },
+      { type: ClientSpecificAction.REVIEW_CORRECTION_REQUEST },
+      { type: ActionType.REGISTER },
+      { type: ActionType.EDIT }
+    ] as ActionMenuItem[]
+
+    const sortedActions = sortActions(availableActions, {
+      ...tennisClubMembershipEvent,
+      actionOrder: [
+        ActionType.REGISTER,
+        ActionType.REQUEST_CORRECTION,
+        ActionType.EDIT,
+        ActionType.UNASSIGN
+      ]
+    })
+
+    expect(sortedActions).toEqual([
+      { type: ActionType.REGISTER },
+      { type: ClientSpecificAction.REVIEW_CORRECTION_REQUEST },
+      { type: ActionType.EDIT },
+      { type: ActionType.UNASSIGN }
     ])
   })
 

--- a/packages/client/src/v2-events/features/workqueues/EventOverview/components/ActionMenu.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/components/ActionMenu.tsx
@@ -67,19 +67,22 @@ export function sortActions(
     return sortedByDefault
   }
 
-  return sortedByDefault.sort((a, b) => {
-    const aIndex =
-      'customActionType' in a && a.customActionType
-        ? actionOrder.indexOf(a.customActionType)
-        : actionOrder.indexOf(a.type)
+  const getActionIndex = (item: ActionMenuItem) => {
+    // `REVIEW_CORRECTION_REQUEST` is a client-specific action that is not part
+    // of `actionOrder`. Since it and `REQUEST_CORRECTION` are never available
+    // at the same time, sort it at the same position as `REQUEST_CORRECTION`.
+    if (item.type === ClientSpecificAction.REVIEW_CORRECTION_REQUEST) {
+      return actionOrder.indexOf(ActionType.REQUEST_CORRECTION)
+    }
 
-    const bIndex =
-      'customActionType' in b && b.customActionType
-        ? actionOrder.indexOf(b.customActionType)
-        : actionOrder.indexOf(b.type)
+    if ('customActionType' in item && item.customActionType) {
+      return actionOrder.indexOf(item.customActionType)
+    }
 
-    return aIndex - bIndex
-  })
+    return actionOrder.indexOf(item.type)
+  }
+
+  return sortedByDefault.sort((a, b) => getActionIndex(a) - getActionIndex(b))
 }
 
 function ActionMenuItems({


### PR DESCRIPTION
## Description

Fix sorting for `REVIEW_CORRECTION_REQUEST`

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
