### PR TITLE
fix: Enable 2FA by default

### DIFF
--- a/charts/opencrvs-services/values.yaml
+++ b/charts/opencrvs-services/values.yaml
@@ -397,7 +397,6 @@ events:
     name: ocrvs-events
   env:
     ES_INDEX_PREFIX: events
-    DEFAULT_USER_PASSWORD: "test"
     TWO_FA_ENABLED: true
   probes:
     liveness:

--- a/charts/opencrvs-services/values.yaml
+++ b/charts/opencrvs-services/values.yaml
@@ -278,7 +278,7 @@ platform:
 auth:
   port: 4040
   env:
-    TWO_FA_ENABLED: false
+    TWO_FA_ENABLED: true
   image:
     name: ocrvs-auth
     # optional overrides:
@@ -342,29 +342,12 @@ documents:
   image:
     name: ocrvs-documents
 
-events:
-  port: 5555
-  image:
-    name: ocrvs-events
-  env:
-    ES_INDEX_PREFIX: events
-  probes:
-    liveness:
-      path: /health/ready
-      timeoutSeconds: 10
-    readiness:
-      path: /health/ready
-      timeoutSeconds: 10
-    startup:
-      path: /health/ready
-
 gateway:
   port: 7070
   image:
     name: ocrvs-gateway
 
   env:
-    TWO_FA_ENABLED: false
     CHECK_INVALID_TOKEN: "true"
     CONFIG_SMS_CODE_EXPIRY_SECONDS: "600"
     CONFIG_TOKEN_EXPIRY_SECONDS: "604800"
@@ -408,14 +391,14 @@ login:
       httpGet:
         path: /health/ready
 
-
 events:
   port: 5555
   image:
     name: ocrvs-events
   env:
+    ES_INDEX_PREFIX: events
     DEFAULT_USER_PASSWORD: "test"
-    TWO_FA_ENABLED: false
+    TWO_FA_ENABLED: true
   probes:
     liveness:
       path: /health/ready


### PR DESCRIPTION
## Description

Related issue: https://github.com/opencrvs/opencrvs-core/issues/12800

Enable 2FA authentication by defaults.

2FA can be configured in the following places:
- At environment setup stage: https://github.com/opencrvs/infrastructure/blob/develop/infrastructure/environments/setup-environment.ts#L1324
- For e2e: https://github.com/opencrvs/e2e/blob/develop/k8s-env/opencrvs/values.yaml#L155

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
