### PR TITLE
Remove auth.* public subdomain — auth is now only reachable via gateway proxy

### DIFF
--- a/.github/workflows/cd-manual-e2e.yml
+++ b/.github/workflows/cd-manual-e2e.yml
@@ -11,7 +11,7 @@ name: Manual E2E - New Feature on Staging
 env:
   CYPRESS_LOGIN_URL: https://login.farajaland-staging.opencrvs.org/
   CYPRESS_CLIENT_URL: https://register.farajaland-staging.opencrvs.org/
-  CYPRESS_AUTH_URL: https://auth.farajaland-staging.opencrvs.org/
+  CYPRESS_AUTH_URL: https://gateway.farajaland-staging.opencrvs.org/auth/
   CYPRESS_GATEWAY_URL: https://gateway.farajaland-staging.opencrvs.org/
   CYPRESS_COUNTRYCONFIG_URL: https://countryconfig.farajaland-staging.opencrvs.org/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@ The Webhook integration client and its `webhooks` service have been removed and 
 
 `POST /api/events/events/notifications` has been renamed to `POST /api/events/events/{eventId}/notify`. The two-step "create event, then notify" flow is unchanged otherwise. A new single-request convenience endpoint `POST /api/events/events/notify` is also available for system clients that need to create and notify in one call. Integration clients must update their request paths.
 
+#### Auth service no longer exposed on its own subdomain
+
+The public `auth.{hostname}` Traefik route has been removed — the auth service is now reachable only through the gateway proxy at `gateway.{hostname}/auth/*`. Remove the `auth.*` DNS record and TLS certificate from your deployment. The gateway's `/auth/authenticate-super-user` route is now rate limited on a constant key (it previously keyed on a `username` field that super user auth does not send).
+
 ### New features
 
 #### Rich text support in MessageDescriptor.defaultMessage

--- a/charts/opencrvs-services/templates/auth-deployment.yaml
+++ b/charts/opencrvs-services/templates/auth-deployment.yaml
@@ -1,33 +1,3 @@
----
-apiVersion: traefik.io/v1alpha1
-kind: IngressRoute
-metadata:
-  name: auth-route
-spec:
-  entryPoints:
-  {{- if or .Values.ingress.ssl_enabled .Values.ingress.tls_resolver }}
-    - websecure
-  {{- end }}
-  {{- if or .Values.ingress.tls_resolver (not .Values.ingress.ssl_enabled) }}
-    - web
-  {{- end }}
-  routes:
-  - match: 'Host(`{{ include "render-external-subdomain" (dict "service_name" "auth" "Values" .Values) }}`)'
-    kind: Rule
-    services:
-    - name: auth
-      namespace: {{ .Release.Namespace }}
-      port: {{ .Values.auth.port }}
-    middlewares:
-      - name: sts-and-basic-response-headers
-  {{- if .Values.ingress.tls_resolver }}
-  tls:
-    certResolver: {{ .Values.ingress.tls_resolver }}
-  {{- else if .Values.ingress.tls_secret_name }}
-  tls:
-    secretName: {{ .Values.ingress.tls_secret_name }}
-  {{- end }}
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -71,12 +41,6 @@ spec:
                   key: AUTH_REDIS_USERNAME
                   name: {{ .Values.redis.users_secret }}
           {{- end }}
-            - name: COUNTRY_CONFIG_URL_EXTERNAL
-              value: {{ include "render-external-url" (dict "service_name" "countryconfig" "Values" .Values) }}
-            - name: CLIENT_APP_URL
-              value: {{ include "render-external-url" (dict "service_name" "register" "Values" .Values) }}
-            - name: LOGIN_URL
-              value: {{ include "render-external-url" (dict "service_name" "login" "Values" .Values) }}
             - name: CERT_PRIVATE_KEY_PATH
               value: /secrets/private-key.pem
             - name: CERT_PUBLIC_KEY_PATH

--- a/packages/auth/src/environment.ts
+++ b/packages/auth/src/environment.ts
@@ -19,10 +19,7 @@ export const env = cleanEnv(process.env, {
   AUTH_PORT: port({ default: 4040 }),
   EVENTS_URL: url({ devDefault: 'http://localhost:5555/' }),
   DOMAIN: str({ devDefault: '*' }),
-  COUNTRY_CONFIG_URL_EXTERNAL: url({ devDefault: 'http://localhost:3040/' }), // used for external requests (CORS whitelist)
-  COUNTRY_CONFIG_URL_INTERNAL: url({ devDefault: 'http://localhost:3040/' }), // used for internal service-to-service communication
-  LOGIN_URL: url({ devDefault: 'http://localhost:3020/' }),
-  CLIENT_APP_URL: url({ devDefault: 'http://localhost:3000/' }),
+  COUNTRY_CONFIG_URL_INTERNAL: url({ devDefault: 'http://localhost:3040/' }),
   CERT_PRIVATE_KEY_PATH: str({ devDefault: '../../.secrets/private-key.pem' }),
   CERT_PUBLIC_KEY_PATH: str({ devDefault: '../../.secrets/public-key.pem' }),
   SENTRY_DSN: str({ default: undefined }),

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -75,20 +75,11 @@ export type AuthServer = {
 }
 
 export async function createServer() {
-  let whitelist: string[] = [env.DOMAIN]
-  if (env.DOMAIN[0] !== '*') {
-    whitelist = [
-      env.COUNTRY_CONFIG_URL_EXTERNAL,
-      env.LOGIN_URL,
-      env.CLIENT_APP_URL
-    ]
-  }
-  logger.info(`Whitelist: ${JSON.stringify(whitelist)}`)
   const server = new Hapi.Server({
     host: env.AUTH_HOST,
     port: env.AUTH_PORT,
     routes: {
-      cors: { origin: whitelist },
+      cors: false,
       payload: { maxBytes: 52428800, timeout: DEFAULT_TIMEOUT },
       response: {
         failAction: async (req, _2, err: Error | undefined) => {

--- a/packages/data-seeder/src/environment.ts
+++ b/packages/data-seeder/src/environment.ts
@@ -11,7 +11,6 @@
 import { bool, cleanEnv, str, url } from 'envalid'
 
 export const env = cleanEnv(process.env, {
-  AUTH_HOST: url({ devDefault: 'http://localhost:4040' }),
   COUNTRY_CONFIG_HOST: url({ devDefault: 'http://localhost:3040' }),
   GATEWAY_HOST: url({ devDefault: 'http://localhost:7070' }),
   SUPER_USER_PASSWORD: str({ devDefault: 'password' }),

--- a/packages/data-seeder/src/index.ts
+++ b/packages/data-seeder/src/index.ts
@@ -32,7 +32,10 @@ export const createInitialisationClient = (token: string) => {
 }
 
 async function getToken(): Promise<string> {
-  const authUrl = new URL('authenticate-super-user', env.AUTH_HOST).toString()
+  const authUrl = new URL(
+    '/auth/authenticate-super-user',
+    env.GATEWAY_HOST
+  ).toString()
   const res = await fetch(authUrl, {
     method: 'POST',
     body: JSON.stringify({

--- a/packages/gateway/src/config/proxies.ts
+++ b/packages/gateway/src/config/proxies.ts
@@ -72,7 +72,9 @@ export const rateLimitedAuthProxy = {
     method: 'POST',
     path: '/auth/authenticate-super-user',
     handler: rateLimitedRoute(
-      { requestsPerMinute: 10, pathForKey: 'username' },
+      // Super user auth only sends a password, so there's no per-user field to
+      // key on — rate limit all super user attempts on a shared constant key.
+      { requestsPerMinute: 10, staticKey: 'authenticate-super-user' },
       (_, h) =>
         h.proxy({
           uri: AUTH_URL + '/authenticate-super-user'

--- a/packages/gateway/src/rate-limit.test.ts
+++ b/packages/gateway/src/rate-limit.test.ts
@@ -1,0 +1,76 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+import { rateLimitedRoute } from '@gateway/rate-limit'
+
+/**
+ * DISABLE_RATE_LIMIT defaults to `true` in the test (dev) environment, so
+ * `withRateLimit` short-circuits and never touches Redis. These tests therefore
+ * exercise the *key resolution* logic that runs before rate limiting kicks in —
+ * which is exactly where the super user 500 originated.
+ */
+
+const makeArgs = (payload: unknown, path = '/auth/some-route') => {
+  const request = {
+    headers: {},
+    payload: Buffer.from(JSON.stringify(payload))
+  }
+  const h = { request: { path } }
+  // The handler is invoked by Hapi as (request, h)
+  return [request, h] as unknown as Parameters<
+    ReturnType<typeof rateLimitedRoute>
+  >
+}
+
+describe('rateLimitedRoute', () => {
+  it('keys on a payload field when pathForKey is provided', () => {
+    const fn = jest.fn(() => 'OK')
+    const handler = rateLimitedRoute(
+      { requestsPerMinute: 10, pathForKey: 'username' },
+      fn
+    )
+
+    const result = handler(...makeArgs({ username: 'alice', password: 'pw' }))
+
+    expect(result).toBe('OK')
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('throws when the pathForKey field is missing from the payload', () => {
+    const fn = jest.fn(() => 'OK')
+    const handler = rateLimitedRoute(
+      { requestsPerMinute: 10, pathForKey: 'username' },
+      fn
+    )
+
+    // Super user auth only sends a password — this is the case that used to 500.
+    expect(() => handler(...makeArgs({ password: 'pw' }))).toThrow(
+      "Couldn't find the value for a rate limiting key in payload"
+    )
+    expect(fn).not.toHaveBeenCalled()
+  })
+
+  it('rate limits on a constant key without inspecting the payload when staticKey is provided', () => {
+    const fn = jest.fn(() => 'OK')
+    const handler = rateLimitedRoute(
+      { requestsPerMinute: 10, staticKey: 'authenticate-super-user' },
+      fn
+    )
+
+    // No per-user field in the payload, yet it must not throw — this is the fix
+    // that lets the data-seeder authenticate the super user through the gateway.
+    const result = handler(
+      ...makeArgs({ password: 'pw' }, '/auth/authenticate-super-user')
+    )
+
+    expect(result).toBe('OK')
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/gateway/src/rate-limit.ts
+++ b/packages/gateway/src/rate-limit.ts
@@ -65,6 +65,7 @@ interface RateLimitedRouteOptions {
   /** e.g. "username" or "user.name" */
   pathForKey: string
   pathOptionsForKey?: never
+  staticKey?: never
 }
 
 interface RateLimitedRouteMultipleOptions {
@@ -72,6 +73,18 @@ interface RateLimitedRouteMultipleOptions {
   pathForKey?: never
   /** Works the same as `pathForKey` but uses the first value that gets resolved of the keys */
   pathOptionsForKey: string[]
+  staticKey?: never
+}
+
+interface RateLimitedRouteStaticKeyOptions {
+  requestsPerMinute: number
+  pathForKey?: never
+  pathOptionsForKey?: never
+  /**
+   * A constant key to rate limit on, used when the payload has no
+   * per-user field to key on (e.g. super user auth only sends a password).
+   */
+  staticKey: string
 }
 
 export const rateLimitedRoute =
@@ -84,8 +97,12 @@ export const rateLimitedRoute =
     {
       requestsPerMinute,
       pathForKey,
-      pathOptionsForKey
-    }: RateLimitedRouteOptions | RateLimitedRouteMultipleOptions,
+      pathOptionsForKey,
+      staticKey
+    }:
+      | RateLimitedRouteOptions
+      | RateLimitedRouteMultipleOptions
+      | RateLimitedRouteStaticKeyOptions,
     fn: (...args: A) => R
   ) =>
   (...args: A) => {
@@ -96,9 +113,20 @@ export const rateLimitedRoute =
       return fn(...args)
     }
 
+    const route = args[1].request.path
+
+    if (staticKey) {
+      return withRateLimit(
+        {
+          key: `${staticKey}:${route}`,
+          requestsPerMinute
+        },
+        fn
+      )(...args)
+    }
+
     if (pathForKey) pathOptionsForKey = [pathForKey]
 
-    const route = args[1].request.path
     const payload = JSON.parse(args[0].payload.toString())
 
     const key = pathOptionsForKey!.find(


### PR DESCRIPTION
# Auth Subdomain Removal — Behavior Before & After

**Ticket:** [#12734](https://github.com/opencrvs/opencrvs-core/issues/12734)
**Branch:** `ocrvs-12734` (opencrvs-core, opencrvs-countryconfig, opencrvs-farajaland, e2e)
**Commit (all repos):** _Remove auth.* public subdomain — auth is now only reachable via gateway proxy_
Related PRs:
- core: https://github.com/opencrvs/opencrvs-core/pull/12820
- country: https://github.com/opencrvs/opencrvs-countryconfig/pull/1442
- farajaland: https://github.com/opencrvs/opencrvs-farajaland/pull/2181
- infrastructure: https://github.com/opencrvs/infrastructure/pull/320

---

## Summary

The auth service used to be reachable two ways: directly from the public internet
on its own `auth.{hostname}` subdomain, **and** through the gateway proxy at
`gateway.{hostname}/auth/*`. This change removes the public subdomain entirely.
Auth is now reachable **only** through the gateway.

Functionally this is invisible to real users and internal services — they already
used the gateway path. What changes is the attack surface: auth's only public
entry point is now the gateway, where rate limiting, CORS, and request validation
are enforced.

---

## The core change: one fewer public door

### Before

The auth service had **two** entry points:

1. **Directly, from the public internet** — a dedicated Traefik route on its own subdomain:
   - **K8s:** an `IngressRoute` matching `Host(auth.{hostname})` → auth pod port 4040
   - **Docker (countryconfig/farajaland):** Traefik labels publishing `Host(auth.{hostname})` with its own TLS cert
   - **e2e:** `Host(auth.${STACK}.{{hostname}})` with a wildcard cert

   `https://auth.register.example.org/authenticate` resolved, had a real TLS
   certificate, and hit auth **directly — bypassing the gateway**.

2. **Through the gateway proxy** — `https://gateway.{hostname}/auth/*` → auth internally.

Because browsers *could* hit auth directly cross-origin, auth ran its own **CORS
whitelist** (`packages/auth/src/server.ts`) allowing origins
`COUNTRY_CONFIG_URL_EXTERNAL`, `LOGIN_URL`, and `CLIENT_APP_URL`. Those three env
vars were injected into the auth container in every deployment.

A special guard also existed: `/internal/reindexing-token` was explicitly *blocked*
at the subdomain (the `block-auth-reindexing-token` router with an invalid-IP
whitelist), because the subdomain was otherwise wide open and that one internal
endpoint had to stay private.

### After

The auth service is reachable **only** through the gateway proxy at
`https://gateway.{hostname}/auth/*`.

- The `IngressRoute` is deleted (K8s); the Docker Traefik labels are replaced with
  `traefik.enable=false` (auth is no longer published on *any* host).
- `https://auth.{hostname}/...` now **fails to resolve / 404s** — there is no route
  and no cert provisioned for that subdomain anymore.
- The auth pod keeps running unchanged inside the cluster; only its public entry
  point is gone. The gateway still reaches it over the internal network.

---

## Consequences that follow

### CORS is now `cors: false` on auth

No browser ever has auth as an origin anymore — everything is same-origin
`/auth/*` through the gateway, and the gateway owns CORS for external clients. The
whitelist became dead logic. Auth now sees only server-to-server traffic, so it
rejects all cross-origin browser preflights outright.

The three env vars (`COUNTRY_CONFIG_URL_EXTERNAL`, `LOGIN_URL`, `CLIENT_APP_URL`)
are removed from both the auth code and every deployment manifest.
`COUNTRY_CONFIG_URL_INTERNAL` is the only one kept (still used for the server-side
roles lookup).

### The `/internal/reindexing-token` block is no longer needed in auth's config

Before, that endpoint had to be explicitly firewalled because the subdomain exposed
everything. Now that auth has no public route at all, the special block-rule is
simply gone — nothing on auth is publicly exposed.

> Note: farajaland keeps a *separate* `block-internal` rule for
> `countryconfig.../internal` — that is unrelated and was left untouched.

---

## Risk-elimination edits (callers that used the subdomain)

These would have broken if left alone, since they pointed at the now-dead subdomain:

| Caller | Before | After |
|--------|--------|-------|
| **data-seeder** (`opencrvs-core/packages/data-seeder/src/index.ts`) | `POST {AUTH_HOST}/authenticate-super-user` | `POST {GATEWAY_HOST}/auth/authenticate-super-user`; `AUTH_HOST` env removed |
| **farajaland data generator** (`src/data-generator/generate-tennis-club.js`) | `https://auth.farajaland-dev.../authenticate` & `/verifyCode` | `https://gateway.farajaland-dev.../auth/authenticate` & `/auth/verifyCode` |
| **core E2E CI** (`.github/workflows/cd-manual-e2e.yml`) | `CYPRESS_AUTH_URL=https://auth.farajaland-staging...` | `...gateway.farajaland-staging.../auth/` |
| **e2e seed CI** (`.github/workflows/seed-data.yml`) | passed `AUTH_HOST` to seeder | removed (seeder uses `GATEWAY_HOST`) |
| **env provisioning** (`setup-environment.ts` ×3 repos) | generated `AUTH_HOST=https://auth.{domain}` → DNS A-record + TLS cert for the subdomain | removed — no orphan DNS/cert provisioned for `auth.*` |

---

## What is unchanged

- **End-user login/auth flows** — browsers already called `/api/auth/*` (relative,
  via the gateway). No user-visible behavior change; tokens, refresh, and invalidate
  all still work.
- **Internal server-to-server calls** that used Kubernetes/Docker DNS
  (`auth:4040` / `auth.{ns}.svc.cluster.local`) — those never touched the subdomain
  and are untouched.
- **MOSIP** — verified to use internal docker service URLs (`http://mosip-mock:...`),
  not the auth subdomain, so its callbacks are unaffected.

---

## Net effect

Functionally identical for real users and internal services, but the auth service's
public attack surface collapses from "its own internet-facing subdomain with its own
cert and its own CORS/header middleware" down to "internal-only, reachable solely
through the gateway." Rate limiting, CORS, and request validation at the gateway
become the single enforced entry point, and the deployment stops provisioning a DNS
record + TLS certificate that no longer serves anything.

---

## Files changed

### opencrvs-core
- `charts/opencrvs-services/templates/auth-deployment.yaml` — removed `IngressRoute`; removed CORS env vars
- `packages/auth/src/environment.ts` — removed `COUNTRY_CONFIG_URL_EXTERNAL`, `LOGIN_URL`, `CLIENT_APP_URL`
- `packages/auth/src/server.ts` — `cors` whitelist → `cors: false`
- `packages/data-seeder/src/environment.ts` — removed `AUTH_HOST`
- `packages/data-seeder/src/index.ts` — auth call rerouted through `GATEWAY_HOST`
- `.github/workflows/cd-manual-e2e.yml` — `CYPRESS_AUTH_URL` → gateway path

### opencrvs-countryconfig
- `infrastructure/docker-compose.deploy.yml` — removed auth Traefik labels + CORS env vars (`traefik.enable=false`)
- `infrastructure/environments/setup-environment.ts` — removed `AUTH_HOST` (derived + computed)

### opencrvs-farajaland
- `infrastructure/docker-compose.deploy.yml` — same as countryconfig (kept unrelated `block-internal` rule)
- `infrastructure/environments/setup-environment.ts` — removed `AUTH_HOST` (derived + computed)
- `src/data-generator/generate-tennis-club.js` — auth calls rerouted through gateway

### e2e
- `infrastructure/docker-compose.app.yml` — removed auth Traefik labels (`traefik.enable=false`)
- `infrastructure/environments/setup-environment.ts` — removed `AUTH_HOST` (derived + computed)
- `.github/workflows/seed-data.yml` — removed `AUTH_HOST` env var

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
