### PR TITLE
Deep drop nulls from annotation

### DIFF
--- a/packages/client/src/v2-events/features/events/useEvents/procedures/actions/action.ts
+++ b/packages/client/src/v2-events/features/events/useEvents/procedures/actions/action.ts
@@ -26,6 +26,7 @@ import {
   EventDocument,
   omitHiddenAnnotationFields,
   omitHiddenPaginatedFields,
+  deepDropNulls,
   deepMerge,
   EventState,
   EventConfig,
@@ -501,11 +502,13 @@ export function useEventAction<P extends DecorateMutationProcedure<any>>(
       : {}
 
     const annotation = actionConfiguration
-      ? omitHiddenAnnotationFields(
-          actionConfiguration,
-          originalDeclaration,
-          restParams.annotation,
-          {}
+      ? deepDropNulls(
+          omitHiddenAnnotationFields(
+            actionConfiguration,
+            originalDeclaration,
+            restParams.annotation,
+            {}
+          )
         )
       : {}
 


### PR DESCRIPTION
## Description

Resolves https://github.com/opencrvs/opencrvs-core/issues/12803

Fixes bug where null fields were sent in annotation, causing failures in notification/declaration

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
