### PR TITLE
fix: duplicate client env variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,6 @@ services:
       - LOGIN_URL=http://login:3020
       - AUTH_URL_INTERNAL=http://auth:4040
       - GATEWAY_URL_INTERNAL=http://gateway:7070
-      - LOGIN_URL=http://login:3020
   login:
     image: ghcr.io/opencrvs/ocrvs-login:${VERSION}
     #platform: linux/amd64


### PR DESCRIPTION
Deployment to e2e server was failing due to this error, which is most likely a result of a mistaken merge conflict resolution 

https://github.com/opencrvs/opencrvs-farajaland/actions/runs/26942157554/job/79486468301#step:14:1002

```
services.client.environment array items[1,4] must be unique
```