### PR TITLE
fix: Set default data view to filebeat

### DIFF
--- a/charts/dependencies/files/kibana/setup.sh
+++ b/charts/dependencies/files/kibana/setup.sh
@@ -95,3 +95,8 @@ _curl --connect-timeout 60 -u elastic:$ELASTICSEARCH_SUPERUSER_PASSWORD "$kibana
   _curl --connect-timeout 60 -X POST -H 'kbn-xsrf: true' -u elastic:$ELASTICSEARCH_SUPERUSER_PASSWORD "${KIBANA_URL}/api/alerting/rule/$id/_disable"
   _curl --connect-timeout 60 -X POST -H 'kbn-xsrf: true' -u elastic:$ELASTICSEARCH_SUPERUSER_PASSWORD "${KIBANA_URL}/api/alerting/rule/$id/_enable"
 done
+
+echo "Setting default data view to filebeat-*"
+_curl --connect-timeout 60 -X POST -H 'Content-Type: application/json' -H 'kbn-xsrf: true' -u elastic:$ELASTICSEARCH_SUPERUSER_PASSWORD "${KIBANA_URL}/api/kibana/settings/defaultIndex" -d '{"value": "filebeat-*"}' || echo "Failed to set default data view, please check Kibana configuration"
+
+echo "Kibana setup completed successfully"


### PR DESCRIPTION
## Description

Configure Kibana to use `filebeat-*` as the default data view, providing direct access to collected logs in Discover.

## Testing

Navigate to Logs Explorer and make sure no logs are displayed by default
<img width="1222" height="852" alt="image" src="https://github.com/user-attachments/assets/70cf7180-2209-40af-830a-2d9501ba58eb" />

Navigate to Stack management -> Kibana -> Data views. Make sure default Data view is set to `APM`
<img width="1220" height="707" alt="image" src="https://github.com/user-attachments/assets/7d8b214a-07b0-4eab-baa5-f22c91e037f8" />

Get existing release values:
```
helm get values opencrvs-deps > opencrvs-deps-demo.yaml
```

Upgrade release:
```
helm upgrade -f opencrvs-deps-demo.yaml \
      opencrvs-deps \
      charts/dependencies/
```
Wait for `kibana-on-deploy-*` pod startup

Check logs:
```
Setting default data view to filebeat-*
{"settings":{"buildNum":{"userValue":87477},"isDefaultIndexMigrated":{"userValue":true},"defaultIndex":{"userValue":"filebeat-*"},"aiAssistant:preferredAIAssistantType":{"userValue":"never"},"observability:newLogsOverview":{"userValue":true},"defaultRoute":{"isOverridden":true,"userValue":"/app/observability/overview"}}}
Kibana setup completed successfully
```

Login back to Kibana and check logs explorer:
<img width="1224" height="861" alt="image" src="https://github.com/user-attachments/assets/a65cd42e-37cc-4ca8-a528-5f6bb09fb807" />

Navigate to Stack management -> Kibana -> Data views. Make sure default Data view is set to `filebeat-*`
<img width="1209" height="510" alt="image" src="https://github.com/user-attachments/assets/a4b5f568-34f9-4de2-a5e7-fd1db64a7a07" />



## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
