### PR TITLE
feat: create e2e branch during release init

### DIFF
--- a/.github/workflows/init-release.yml
+++ b/.github/workflows/init-release.yml
@@ -234,6 +234,33 @@ jobs:
               }
             })
 
+      - name: Create release branch in e2e repo
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.E2E_WORKFLOW_TOKEN }}
+          script: |
+            const branchRef = 'refs/heads/release/${{ inputs.version }}'
+            const { data: ref } = await github.rest.git.getRef({
+              owner: context.repo.owner,
+              repo: 'e2e',
+              ref: 'heads/${{ steps.get_base_branch.outputs.base_branch }}'
+            })
+            try {
+              await github.rest.git.createRef({
+                owner: context.repo.owner,
+                repo: 'e2e',
+                ref: branchRef,
+                sha: ref.object.sha
+              })
+              console.log(`Created ${branchRef} in e2e`)
+            } catch (err) {
+              if (err.status === 422) {
+                console.log(`Branch ${branchRef} already exists in e2e, skipping.`)
+              } else {
+                throw err
+              }
+            }
+
       # Create a draft release so the release notes page exists immediately.
       # The tag is deleted right after: the publish workflow re-creates it when
       # the release PR is merged into master, which is the canonical tag point.


### PR DESCRIPTION
Create a release branch in the e2e repo so that latest changes made in the infra level doesn't affect the current/previous release