### PR TITLE
fix(commons): include requested actions in event update metadata

### DIFF
--- a/packages/commons/src/events/state/index.test.ts
+++ b/packages/commons/src/events/state/index.test.ts
@@ -1005,6 +1005,160 @@ describe('correction requests', () => {
     expect(applicantName.surname).toBe('John')
   })
 
+  test('updatedAtLocation reflects the registrar who submitted REGISTER while it awaits async confirmation', () => {
+    const createAction = generateActionDocument({
+      configuration: tennisClubMembershipEvent,
+      action: ActionType.CREATE,
+      defaults: {
+        status: ActionStatus.Accepted,
+        createdAt: '2023-01-01T00:00:00.000Z',
+        createdBy: 'user1',
+        createdByUserType: TokenUserType.enum.user,
+        createdAtLocation: 'location1' as UUID,
+        createdByRole: 'FIELD_AGENT'
+      }
+    })
+
+    const declareAction = generateActionDocument({
+      configuration: tennisClubMembershipEvent,
+      action: ActionType.DECLARE,
+      defaults: {
+        status: ActionStatus.Accepted,
+        createdAt: '2023-02-01T00:00:00.000Z',
+        createdBy: 'user2',
+        createdByUserType: TokenUserType.enum.user,
+        createdAtLocation: 'location2' as UUID,
+        createdByRole: 'FIELD_AGENT'
+      }
+    })
+
+    // Registrar clicks Register — countryconfig returns 202, Accepted not yet written
+    const registerRequestAction = generateActionDocument({
+      configuration: tennisClubMembershipEvent,
+      action: ActionType.REGISTER,
+      defaults: {
+        status: ActionStatus.Requested,
+        createdAt: '2023-03-01T00:00:00.000Z',
+        createdBy: 'user3',
+        createdByUserType: TokenUserType.enum.user,
+        createdAtLocation: 'location3' as UUID,
+        createdByRole: 'LOCAL_REGISTRAR'
+      }
+    })
+
+    const event = {
+      trackingId: getUUID(),
+      type: tennisClubMembershipEvent.id,
+      id: getUUID(),
+      createdAt: '2023-01-01T00:00:00.000Z',
+      updatedAt: '2023-03-01T00:00:00.000Z',
+      actions: [createAction, declareAction, registerRequestAction]
+    }
+
+    const state = getCurrentEventState(event, tennisClubMembershipEvent)
+
+    // Still DECLARED — REGISTERED requires an Accepted REGISTER
+    expect(state.status).toBe(EventStatus.enum.DECLARED)
+
+    // Metadata reflects the registrar who submitted the request, not the 3rd party
+    expect(state.updatedBy).toBe(registerRequestAction.createdBy)
+    expect(state.updatedAtLocation).toBe(
+      registerRequestAction.createdAtLocation
+    )
+    expect(state.updatedByUserRole).toBe(registerRequestAction.createdByRole)
+
+    // REGISTERED legalStatus not set yet
+    expect(state.legalStatuses[EventStatus.enum.REGISTERED]).toBeUndefined()
+
+    // Flag marks the record as pending external validation
+    expect(state.flags).toContain('register:requested')
+  })
+
+  test('updatedAtLocation uses the Requested action metadata once REGISTER is asynchronously accepted', () => {
+    const createAction = generateActionDocument({
+      configuration: tennisClubMembershipEvent,
+      action: ActionType.CREATE,
+      defaults: {
+        status: ActionStatus.Accepted,
+        createdAt: '2023-01-01T00:00:00.000Z',
+        createdBy: 'user1',
+        createdByUserType: TokenUserType.enum.user,
+        createdAtLocation: 'location1' as UUID,
+        createdByRole: 'FIELD_AGENT'
+      }
+    })
+
+    const declareAction = generateActionDocument({
+      configuration: tennisClubMembershipEvent,
+      action: ActionType.DECLARE,
+      defaults: {
+        status: ActionStatus.Accepted,
+        createdAt: '2023-02-01T00:00:00.000Z',
+        createdBy: 'user2',
+        createdByUserType: TokenUserType.enum.user,
+        createdAtLocation: 'location2' as UUID,
+        createdByRole: 'FIELD_AGENT'
+      }
+    })
+
+    const registerRequestAction = generateActionDocument({
+      configuration: tennisClubMembershipEvent,
+      action: ActionType.REGISTER,
+      defaults: {
+        status: ActionStatus.Requested,
+        createdAt: '2023-03-01T00:00:00.000Z',
+        createdBy: 'user3',
+        createdByUserType: TokenUserType.enum.user,
+        createdAtLocation: 'location3' as UUID,
+        createdByRole: 'LOCAL_REGISTRAR'
+      }
+    })
+
+    // 3rd party accepts — carries originalActionId pointing back to the Requested action
+    const registerAcceptAction = generateActionDocument({
+      configuration: tennisClubMembershipEvent,
+      action: ActionType.REGISTER,
+      defaults: {
+        status: ActionStatus.Accepted,
+        createdAt: '2023-04-01T00:00:00.000Z',
+        createdBy: 'system',
+        createdByUserType: TokenUserType.enum.system,
+        createdAtLocation: 'system-location' as UUID,
+        createdByRole: undefined,
+        registrationNumber: 'REG-123',
+        originalActionId: registerRequestAction.id
+      }
+    })
+
+    const event = {
+      trackingId: getUUID(),
+      type: tennisClubMembershipEvent.id,
+      id: getUUID(),
+      createdAt: '2023-01-01T00:00:00.000Z',
+      updatedAt: '2023-04-01T00:00:00.000Z',
+      actions: [
+        createAction,
+        declareAction,
+        registerRequestAction,
+        registerAcceptAction
+      ]
+    }
+
+    const state = getCurrentEventState(event, tennisClubMembershipEvent)
+
+    expect(state.status).toBe(EventStatus.enum.REGISTERED)
+
+    // Metadata should still point to the registrar, NOT the 3rd-party system
+    expect(state.updatedBy).toBe(registerRequestAction.createdBy)
+    expect(state.updatedAtLocation).toBe(
+      registerRequestAction.createdAtLocation
+    )
+    expect(state.updatedByUserRole).toBe(registerRequestAction.createdByRole)
+
+    // register:requested flag is no longer present once accepted
+    expect(state.flags).not.toContain('register:requested')
+  })
+
   test('approval declaration is merged on top of approved correction request', () => {
     const correctionRequestId = generateUuid()
     const correctionRequestAction = {

--- a/packages/commons/src/events/state/utils.ts
+++ b/packages/commons/src/events/state/utils.ts
@@ -10,7 +10,12 @@
  */
 
 import { ActionType, ActionTypes } from '../ActionType'
-import { Action, ActionStatus, RegisterAction } from '../ActionDocument'
+import {
+  Action,
+  ActionBase,
+  ActionStatus,
+  RegisterAction
+} from '../ActionDocument'
 import { EventStatus } from '../EventMetadata'
 import { getOrThrow } from '../../utils'
 import { pick } from 'lodash'
@@ -99,12 +104,17 @@ const updateActions = ActionTypes.extract([
 ])
 
 /**
- * Given action type and actions, returns the action creation metadata for the event.
- * Since we do not consistently store the request action, we need to check if it exists.
- * @returns details of last user who triggered **Declaration** action.
- * @see EventIndex for the description of the returned object.
+ * Returns the creation metadata of the last update action (Requested or Accepted).
+ * Requested actions are included so that async flows (202) correctly reflect the
+ * metadata of the user who triggered the action before country config accepts it.
  *
- * */
+ * When an Accepted action carries an originalActionId, its metadata is sourced from
+ * the original Requested action (the human who triggered it), not from the system
+ * or 3rd party that accepted it.
+ *
+ * @returns metadata of the last user who triggered a status-changing action.
+ * @see EventIndex for the description of the returned object.
+ */
 export function getActionUpdateMetadata(actions: Action[]) {
   const createAction = getOrThrow(
     actions.find((action) => action.type === ActionType.CREATE),
@@ -117,12 +127,11 @@ export function getActionUpdateMetadata(actions: Action[]) {
     'createdByUserType',
     'createdAtLocation',
     'createdByRole'
-  ]
+  ] as const
 
   return actions
     .filter(({ type }) => updateActions.safeParse(type).success)
-    .filter(({ status }) => status === ActionStatus.Accepted)
-    .reduce(
+    .reduce<Pick<ActionBase, (typeof metadataFields)[number]>>(
       (_, action) => {
         if (action.originalActionId) {
           const originalAction =

--- a/yarn.lock
+++ b/yarn.lock
@@ -28363,7 +28363,7 @@ zod-validation-error@^5.0.0:
   resolved "https://registry.yarnpkg.com/zod-validation-error/-/zod-validation-error-5.0.0.tgz#96db948070b7bfcb13bfec5134113e580f9eee38"
   integrity sha512-hmk+pkyKq7Q71PiWVSDUc3VfpzpvcRHZ3QPw9yEMVvmtCekaMeOHnbr3WbxfrgEnQTv6haGP4cmv0Ojmihzsxw==
 
-zod@^3.24.4:
+zod@^3.23.8, zod@^3.24.4:
   version "3.25.76"
   resolved "https://registry.yarnpkg.com/zod/-/zod-3.25.76.tgz#26841c3f6fd22a6a2760e7ccb719179768471e34"
   integrity sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==


### PR DESCRIPTION
## Description

Fixes issue #12742 — birth/death registration records were not routing to the "Pending external validation" workqueue and the audit log was missing after registration.

**Root cause**

`getActionUpdateMetadata` in `packages/commons/src/events/state/utils.ts` filtered actions down to `status === Accepted` before computing `updatedAtLocation`, `updatedBy`, and `updatedByUserRole`. In the async (202) REGISTER flow — where countryconfig returns 202 and a 3rd-party integration (e.g. MOSIP) confirms later — only the `REGISTER:Requested` action exists in the event at index-time. Because Requested actions were excluded, `updatedAtLocation` fell back to the CREATE action's location instead of the registrar's office. Workqueue queries that filter by `updatedAtLocation` therefore found no match, so the record never appeared in the "Pending external validation" queue.

**Fix**

Removed the `.filter(({ status }) => status === ActionStatus.Accepted)` from `getActionUpdateMetadata`. The function now considers both Requested and Accepted update actions when computing the last updater's metadata. When an Accepted action carries `originalActionId`, its metadata is still sourced from the original Requested action (the human who triggered it), not from the 3rd-party system that accepted it.

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [x] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly