### PR TITLE
Fix user assigned office on settings page

### DIFF
--- a/packages/client/src/v2-events/features/settings/Settings.tsx
+++ b/packages/client/src/v2-events/features/settings/Settings.tsx
@@ -25,6 +25,7 @@ import {
 import { WorkqueueLayout } from '@client/v2-events/layouts/workqueues'
 import { EmailAddress } from '@client/views/Settings/items/EmailAddress'
 import { AssignedOffice } from '@client/views/Settings/items/AssignedOffice'
+import { withSuspense } from '@client/v2-events/components/withSuspense'
 
 const settingsTitle = {
   id: 'home.header.settingsTitle',
@@ -32,7 +33,7 @@ const settingsTitle = {
   description: 'settings title'
 }
 
-export function SettingsPage() {
+function SettingsPageComponent() {
   const intl = useIntl()
   return (
     <WorkqueueLayout title={intl.formatMessage(settingsTitle)}>
@@ -55,3 +56,5 @@ export function SettingsPage() {
     </WorkqueueLayout>
   )
 }
+
+export const SettingsPage = withSuspense(SettingsPageComponent)

--- a/packages/client/src/views/Settings/items/AssignedOffice.tsx
+++ b/packages/client/src/views/Settings/items/AssignedOffice.tsx
@@ -10,14 +10,14 @@
  */
 import { buttonMessages } from '@client/i18n/messages'
 import { messages as userSetupMessages } from '@client/i18n/messages/views/userSetup'
-import { getOfflineData } from '@client/offline/selectors'
 import { getUserDetails } from '@client/profile/profileSelectors'
-import { IStoreState } from '@client/store'
 import {
   DynamicHeightLinkButton,
   LabelContainer,
   ValueContainer
 } from '@client/views/Settings/items/components'
+import { useLocations } from '@client/v2-events/hooks/useLocations'
+import { UUID } from '@opencrvs/commons/client'
 import { ListViewItemSimplified } from '@opencrvs/components/lib/ListViewSimplified'
 import * as React from 'react'
 import { useIntl } from 'react-intl'
@@ -25,11 +25,14 @@ import { useSelector } from 'react-redux'
 
 export function AssignedOffice() {
   const intl = useIntl()
-  const officeName = useSelector<IStoreState, string>((state) => {
-    const userDetails = getUserDetails(state)
-    if (!userDetails?.primaryOfficeId) return ''
-    return getOfflineData(state).offices?.[userDetails.primaryOfficeId]?.name ?? ''
-  })
+  const userDetails = useSelector(getUserDetails)
+  const { getLocations } = useLocations()
+  const locations = getLocations.useSuspenseQuery()
+
+  const officeName = userDetails?.primaryOfficeId
+    ? (locations.get(userDetails.primaryOfficeId as UUID)?.name ?? '')
+    : ''
+
   return (
     <ListViewItemSimplified
       label={


### PR DESCRIPTION
## Description

Resolves: https://github.com/opencrvs/opencrvs-core/issues/12828
e2e test: https://github.com/opencrvs/opencrvs-farajaland/pull/2198

Fix users assigned office not displaying on settings page

Before:
<img width="700" alt="Screenshot 2026-06-05 at 12 41 05" src="https://github.com/user-attachments/assets/a7fc4e7a-5535-4391-b206-35439039a255" />


After:
<img width="700" alt="Screenshot 2026-06-05 at 12 40 27" src="https://github.com/user-attachments/assets/37665e29-568d-473d-ad0a-ea9ef9f00825" />

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
