### PR TITLE
Require assignment for duplication actions

### DIFF
--- a/packages/events/src/router/event/event.index.flag.test.ts
+++ b/packages/events/src/router/event/event.index.flag.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 /*
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -546,8 +547,6 @@ suite(InherentFlags.POTENTIAL_DUPLICATE, () => {
     const [duplicateEvent, client, generator, user] =
       await createDuplicateEvent()
 
-    // The preceding DECLARE unassigns the creator, so re-assign before the
-    // duplicate action — otherwise `requireAssignment` would reject the call.
     await client.event.actions.assignment.assign(
       generator.event.actions.assign(duplicateEvent.id, {
         assignedTo: user.id
@@ -566,8 +565,6 @@ suite(InherentFlags.POTENTIAL_DUPLICATE, () => {
     const [duplicateEvent, client, generator, user] =
       await createDuplicateEvent()
 
-    // Same as above — re-assign before the duplicate action so it isn't
-    // rejected by `requireAssignment`.
     await client.event.actions.assignment.assign(
       generator.event.actions.assign(duplicateEvent.id, {
         assignedTo: user.id
@@ -588,9 +585,6 @@ suite(InherentFlags.POTENTIAL_DUPLICATE, () => {
     const assignedClient = createTestClient(assignedUser)
     const unassignedClient = createTestClient(unassignedUser)
 
-    // The creator of an event is auto-assigned, so the second user is the
-    // unassigned one. requireAssignment must reject their attempt before
-    // the route reaches the action handler.
     const event = await assignedClient.event.create(generator.event.create())
 
     await expect(

--- a/packages/events/src/router/event/event.index.flag.test.ts
+++ b/packages/events/src/router/event/event.index.flag.test.ts
@@ -531,7 +531,7 @@ suite(InherentFlags.POTENTIAL_DUPLICATE, () => {
       })
     )
 
-    return [declaredDuplicateEvent, client, generator] as const
+    return [declaredDuplicateEvent, client, generator, user] as const
   }
 
   test(`Adds the flag after ${ActionType.DECLARE} if duplicates are detected`, async () => {
@@ -543,7 +543,16 @@ suite(InherentFlags.POTENTIAL_DUPLICATE, () => {
   })
 
   test(`Removes the flag after ${ActionType.MARK_AS_NOT_DUPLICATE}`, async () => {
-    const [duplicateEvent, client, generator] = await createDuplicateEvent()
+    const [duplicateEvent, client, generator, user] =
+      await createDuplicateEvent()
+
+    // The preceding DECLARE unassigns the creator, so re-assign before the
+    // duplicate action — otherwise `requireAssignment` would reject the call.
+    await client.event.actions.assignment.assign(
+      generator.event.actions.assign(duplicateEvent.id, {
+        assignedTo: user.id
+      })
+    )
 
     const event = await client.event.actions.duplicate.markNotDuplicate(
       generator.event.actions.duplicate.markNotDuplicate(duplicateEvent.id)
@@ -554,7 +563,16 @@ suite(InherentFlags.POTENTIAL_DUPLICATE, () => {
   })
 
   test(`Removes the flag after ${ActionType.MARK_AS_DUPLICATE}`, async () => {
-    const [duplicateEvent, client, generator] = await createDuplicateEvent()
+    const [duplicateEvent, client, generator, user] =
+      await createDuplicateEvent()
+
+    // Same as above — re-assign before the duplicate action so it isn't
+    // rejected by `requireAssignment`.
+    await client.event.actions.assignment.assign(
+      generator.event.actions.assign(duplicateEvent.id, {
+        assignedTo: user.id
+      })
+    )
 
     const event = await client.event.actions.duplicate.markAsDuplicate(
       generator.event.actions.duplicate.markAsDuplicate(duplicateEvent.id)
@@ -562,5 +580,38 @@ suite(InherentFlags.POTENTIAL_DUPLICATE, () => {
     expect(
       getCurrentEventState(event, tennisClubMembershipEvent).flags
     ).not.toContain(InherentFlags.POTENTIAL_DUPLICATE)
+  })
+
+  test(`Rejects ${ActionType.MARK_AS_DUPLICATE} when the caller is not assigned to the event`, async () => {
+    const { users, generator } = await setupTestCase()
+    const [assignedUser, unassignedUser] = users
+    const assignedClient = createTestClient(assignedUser)
+    const unassignedClient = createTestClient(unassignedUser)
+
+    // The creator of an event is auto-assigned, so the second user is the
+    // unassigned one. requireAssignment must reject their attempt before
+    // the route reaches the action handler.
+    const event = await assignedClient.event.create(generator.event.create())
+
+    await expect(
+      unassignedClient.event.actions.duplicate.markAsDuplicate(
+        generator.event.actions.duplicate.markAsDuplicate(event.id)
+      )
+    ).rejects.toThrow('You are not assigned to this event')
+  })
+
+  test(`Rejects ${ActionType.MARK_AS_NOT_DUPLICATE} when the caller is not assigned to the event`, async () => {
+    const { users, generator } = await setupTestCase()
+    const [assignedUser, unassignedUser] = users
+    const assignedClient = createTestClient(assignedUser)
+    const unassignedClient = createTestClient(unassignedUser)
+
+    const event = await assignedClient.event.create(generator.event.create())
+
+    await expect(
+      unassignedClient.event.actions.duplicate.markNotDuplicate(
+        generator.event.actions.duplicate.markNotDuplicate(event.id)
+      )
+    ).rejects.toThrow('You are not assigned to this event')
   })
 })

--- a/packages/events/src/router/event/index.ts
+++ b/packages/events/src/router/event/index.ts
@@ -389,6 +389,7 @@ export const eventRouter = router({
     duplicate: router({
       markAsDuplicate: userOnlyProcedure
         .input(MarkAsDuplicateActionInput)
+        .use(middleware.canAccessEventWithScopes(['record.review-duplicates']))
         .use(middleware.requireAssignment)
         .use(middleware.validateAction)
         .mutation(async (options) => {
@@ -421,6 +422,7 @@ export const eventRouter = router({
         }),
       markNotDuplicate: userOnlyProcedure
         .input(MarkNotDuplicateActionInput)
+        .use(middleware.canAccessEventWithScopes(['record.review-duplicates']))
         .use(middleware.requireAssignment)
         .use(middleware.validateAction)
         .mutation(async (options) => {

--- a/packages/events/src/router/event/index.ts
+++ b/packages/events/src/router/event/index.ts
@@ -389,6 +389,7 @@ export const eventRouter = router({
     duplicate: router({
       markAsDuplicate: userOnlyProcedure
         .input(MarkAsDuplicateActionInput)
+        .use(middleware.requireAssignment)
         .use(middleware.validateAction)
         .mutation(async (options) => {
           const { user, token } = options.ctx
@@ -420,6 +421,7 @@ export const eventRouter = router({
         }),
       markNotDuplicate: userOnlyProcedure
         .input(MarkNotDuplicateActionInput)
+        .use(middleware.requireAssignment)
         .use(middleware.validateAction)
         .mutation(async (options) => {
           const { user, token } = options.ctx

--- a/packages/events/src/tests/utils.ts
+++ b/packages/events/src/tests/utils.ts
@@ -203,6 +203,12 @@ export const TEST_USER_DEFAULT_SCOPES = [
     options: {
       event: ['birth', 'death', 'tennis-club-membership', 'child-onboarding']
     }
+  }),
+  encodeScope({
+    type: 'record.review-duplicates',
+    options: {
+      event: ['birth', 'death', 'tennis-club-membership', 'child-onboarding']
+    }
   })
 ]
 


### PR DESCRIPTION
## Description

Resolves https://github.com/opencrvs/opencrvs-core/issues/12878

* Require assignment for `markAsDuplicate` and `markAsNotDuplicate` endpoints
* Bonus: Require `record.review-duplicates` scope for these endpoints

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
