### PR TITLE
fix(client): two bugs in Upload Signature step of user creation/edit

### DIFF
--- a/packages/client/src/v2-events/components/forms/inputs/SignatureField/SignatureField.interaction.stories.tsx
+++ b/packages/client/src/v2-events/components/forms/inputs/SignatureField/SignatureField.interaction.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 /*
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -26,7 +27,10 @@ import {
   MimeType,
   tennisClubMembershipEvent
 } from '@opencrvs/commons/client'
-import { FormFieldGenerator } from '@client/v2-events/components/forms/FormFieldGenerator'
+import {
+  FormFieldGenerator,
+  type FormFieldGeneratorHandle
+} from '@client/v2-events/components/forms/FormFieldGenerator'
 import { AppRouter, TRPCProvider } from '@client/v2-events/trpc'
 import { TestImage } from '@client/v2-events/features/events/fixtures'
 import { shouldBypassLock } from '@client/utils/lockBypass'
@@ -99,6 +103,8 @@ async function drawSignature(canvas: HTMLCanvasElement) {
 const StyledFormFieldGenerator = styled(FormFieldGenerator)`
   width: '400px';
 `
+
+const noDuplicateErrorFormRef = React.createRef<FormFieldGeneratorHandle>()
 const tRPCMsw = createTRPCMsw<AppRouter>({
   links: [
     httpLink({
@@ -532,6 +538,85 @@ export const SignatureCanvasUpload: StoryObj<typeof StyledFormFieldGenerator> =
       })
     }
   }
+
+/**
+ * Regression test for: duplicate "Required" error appearing after deleting a signature.
+ *
+ * Root cause: SignatureFieldInput had its own local <InputError> that rendered
+ * "Required" when local `touched` was true (set by the delete button's onClick)
+ * and the field was empty. At the same time, InputField was already rendering
+ * "Required" from Formik's meta.error + meta.touched — producing two identical
+ * error messages simultaneously.
+ *
+ * Fix: removed all local "Required" rendering from SignatureFieldInput. InputField
+ * is now the sole error renderer for validation errors.
+ */
+export const NoDuplicateErrorAfterDelete: StoryObj<
+  typeof StyledFormFieldGenerator
+> = {
+  name: 'No duplicate "Required" error after deleting signature',
+  parameters: {
+    layout: 'centered',
+    chromatic: { disableSnapshot: true },
+    reactRouter: {
+      router: {
+        path: '/event/:eventId',
+        element: (
+          <StyledFormFieldGenerator
+            ref={noDuplicateErrorFormRef}
+            fields={[
+              {
+                id: 'storybook.signature',
+                type: FieldType.SIGNATURE,
+                required: true,
+                configuration: {
+                  maxFileSize: 1 * 1024 * 1024,
+                  acceptedFileTypes: [MimeType.enum['image/png']]
+                },
+                signaturePromptLabel: generateTranslationConfig('Signature'),
+                label: generateTranslationConfig('Upload signature')
+              }
+            ]}
+            formTouched={{ 'storybook.signature': true }}
+            formValues={{
+              'storybook.signature': {
+                path: 'signature-test.png' as DocumentPath,
+                originalFilename: 'signature-test.png',
+                type: MimeType.enum['image/png']
+              }
+            }}
+            id="my-form"
+            validatorContext={getTestValidatorContext()}
+          />
+        )
+      },
+      initialPath: '/event/123-abcd-213'
+    }
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+
+    await step('Signature preview is visible', async () => {
+      await canvas.findByAltText('Signature')
+    })
+
+    await step('Delete the signature', async () => {
+      await userEvent.click(
+        await canvas.findByRole('button', { name: 'Delete' })
+      )
+    })
+
+    await step('Trigger validation via submit', async () => {
+      noDuplicateErrorFormRef.current?.submit()
+    })
+
+    await step('Exactly one Required error — no duplicate', async () => {
+      await waitFor(() => {
+        expect(canvas.getAllByText('Required')).toHaveLength(1)
+      })
+    })
+  }
+}
 
 export const ToCertificateVariables: StoryObj<typeof FormFieldGenerator> = {
   name: 'Certificate Variables',

--- a/packages/client/src/v2-events/components/forms/inputs/SignatureField/SignatureField.interaction.stories.tsx
+++ b/packages/client/src/v2-events/components/forms/inputs/SignatureField/SignatureField.interaction.stories.tsx
@@ -606,14 +606,14 @@ export const NoDuplicateErrorAfterDelete: StoryObj<
       )
     })
 
-    await step('Trigger validation via submit', async () => {
+    await step('Trigger validation via submit', () => {
       noDuplicateErrorFormRef.current?.submit()
     })
 
     await step('Exactly one Required error — no duplicate', async () => {
-      await waitFor(() => {
+      await waitFor(async () =>
         expect(canvas.getAllByText('Required')).toHaveLength(1)
-      })
+      )
     })
   }
 }

--- a/packages/client/src/v2-events/components/forms/inputs/SignatureField/SignatureField.tsx
+++ b/packages/client/src/v2-events/components/forms/inputs/SignatureField/SignatureField.tsx
@@ -13,7 +13,7 @@ import { useState } from 'react'
 import { useIntl } from 'react-intl'
 import * as React from 'react'
 import styled from 'styled-components'
-import { ImageUploader, InputError } from '@opencrvs/components'
+import { ImageUploader } from '@opencrvs/components'
 import { Stack } from '@opencrvs/components/lib/Stack'
 import { Button } from '@opencrvs/components/lib/Button'
 import { Icon } from '@opencrvs/components/lib/Icon'
@@ -23,7 +23,7 @@ import {
   MimeType
 } from '@opencrvs/commons/client'
 import { messages } from '@client/i18n/messages/views/review'
-import { buttonMessages, validationMessages } from '@client/i18n/messages'
+import { buttonMessages } from '@client/i18n/messages'
 import { useFileUpload } from '@client/v2-events/features/files/useFileUpload'
 import { cacheFile, toFileUrl } from '@client/v2-events/cache'
 import { setLockBypass } from '@client/utils/lockBypass'
@@ -107,25 +107,11 @@ function SignatureFieldInput({
     uploadFile(newFile)
   }
 
-  const { error: onUploadError, handleFileChange } = useOnFileChange({
+  const { handleFileChange } = useOnFileChange({
     acceptedFileTypes,
     onComplete,
     maxFileSize
   })
-
-  const errorMessage = React.useMemo(() => {
-    if (onUploadError) {
-      return onUploadError
-    }
-
-    if (!signature) {
-      return touched && required
-        ? intl.formatMessage(validationMessages.required)
-        : undefined
-    }
-
-    return undefined
-  }, [signature, touched, required, onUploadError, intl])
 
   return (
     <>
@@ -138,8 +124,6 @@ function SignatureFieldInput({
               type="secondary"
               onClick={() => {
                 setIsModalOpen(true)
-
-                setTouched(true)
               }}
             >
               <Icon name="Pen" />
@@ -165,16 +149,12 @@ function SignatureFieldInput({
           onClick={() => {
             onChange(null)
             setSignature(undefined)
-            setTouched(true)
           }}
         >
           {intl.formatMessage(messages.signatureDelete)}
         </Button>
       )}
 
-      {errorMessage && (
-        <InputError id={`${name}_error`}>{errorMessage}</InputError>
-      )}
       {isModalOpen && (
         <SignatureCanvasModal
           id={name}

--- a/packages/client/src/v2-events/components/forms/inputs/SignatureField/SignatureField.tsx
+++ b/packages/client/src/v2-events/components/forms/inputs/SignatureField/SignatureField.tsx
@@ -9,7 +9,7 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useIntl } from 'react-intl'
 import * as React from 'react'
 import styled from 'styled-components'
@@ -81,7 +81,11 @@ function SignatureFieldInput({
 
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [signature, setSignature] = useState<FileFieldValue | undefined>(value)
-  const [touched, setTouched] = useState(false)
+  // Formik's enableReinitialize updates `value` asynchronously after mount,
+  // so useState(value) alone misses the first update. Sync explicitly here.
+  useEffect(() => {
+    setSignature(value)
+  }, [value])
 
   const { uploadFile } = useFileUpload(filePath, name, {
     onSuccess: ({ path, originalFilename, type }) => {

--- a/packages/client/src/v2-events/components/forms/inputs/SignatureField/SignatureField.tsx
+++ b/packages/client/src/v2-events/components/forms/inputs/SignatureField/SignatureField.tsx
@@ -13,7 +13,7 @@ import { useState, useEffect } from 'react'
 import { useIntl } from 'react-intl'
 import * as React from 'react'
 import styled from 'styled-components'
-import { ImageUploader } from '@opencrvs/components'
+import { ImageUploader, InputError } from '@opencrvs/components'
 import { Stack } from '@opencrvs/components/lib/Stack'
 import { Button } from '@opencrvs/components/lib/Button'
 import { Icon } from '@opencrvs/components/lib/Icon'
@@ -111,7 +111,7 @@ function SignatureFieldInput({
     uploadFile(newFile)
   }
 
-  const { handleFileChange } = useOnFileChange({
+  const { error: onUploadError, handleFileChange } = useOnFileChange({
     acceptedFileTypes,
     onComplete,
     maxFileSize
@@ -159,6 +159,9 @@ function SignatureFieldInput({
         </Button>
       )}
 
+      {onUploadError && (
+        <InputError id={`${name}_error`}>{onUploadError}</InputError>
+      )}
       {isModalOpen && (
         <SignatureCanvasModal
           id={name}

--- a/packages/client/src/views/SysAdmin/Team/user/userEditor/UserEditor.interaction.stories.tsx
+++ b/packages/client/src/views/SysAdmin/Team/user/userEditor/UserEditor.interaction.stories.tsx
@@ -806,6 +806,90 @@ export const SignatureRequiredForRegistrar: StoryObj = {
   }
 }
 
+/**
+ * Regression test for: signature preview disappearing after navigating back
+ * from user.signature to user.details and then returning.
+ *
+ * Root cause: SignatureFieldInput initialised local `signature` state from the
+ * `value` prop on mount. Formik's enableReinitialize fires asynchronously, so
+ * on the first render after navigation the prop was still undefined — the local
+ * state was frozen at that wrong initial value and never recovered even though
+ * the prop was subsequently corrected.
+ *
+ * Fix: a useEffect that syncs `value` → local `signature` state whenever the
+ * prop changes, so the async Formik reinitialise is picked up correctly.
+ */
+export const SignaturePreviewRestoredAfterBackNavigation: StoryObj = {
+  parameters: {
+    chromatic: { disableSnapshot: true },
+    reactRouter: {
+      router: routesConfig,
+      initialPath: ROUTES.V2.SETTINGS.USER.EDIT.buildPath({
+        userId: createTemporaryId(),
+        pageId: 'user.details'
+      })
+    },
+    msw: {
+      handlers: {
+        userRoles: [
+          tRPCMsw.user.roles.list.query(() => rolesWithSignatureScopes)
+        ]
+      }
+    }
+  },
+  beforeEach: () => {
+    useUserFormState.getState().setUserForm({
+      primaryOfficeId: mockUser.primaryOfficeId,
+      role: TestUserRole.enum.LOCAL_REGISTRAR,
+      name: { firstname: 'Test', surname: 'User' },
+      email: 'test@opencrvs.org',
+      'user.staffId': 'test-staff-001',
+      signature: {
+        path: 'signature-test.png' as DocumentPath,
+        originalFilename: 'signature-test.png',
+        type: 'image/png'
+      }
+    })
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+
+    await step('Navigate to the signature page', async () => {
+      await userEvent.click(
+        await canvas.findByRole('button', { name: 'Continue' })
+      )
+    })
+
+    await step(
+      'Signature preview is visible on the signature page',
+      async () => {
+        await canvas.findByAltText(/signature/i)
+      }
+    )
+
+    await step('Navigate back to the user details page', async () => {
+      await userEvent.click(await canvas.findByRole('button', { name: 'Back' }))
+    })
+
+    await step('Navigate forward to the signature page again', async () => {
+      await userEvent.click(
+        await canvas.findByRole('button', { name: 'Continue' })
+      )
+    })
+
+    await step(
+      'Signature preview is still visible after back-navigation',
+      async () => {
+        await waitFor(async () => {
+          await expect(
+            canvas.findByAltText(/signature/i)
+          ).resolves.toBeInTheDocument()
+        })
+      }
+    )
+  }
+}
+
 export const SignatureNotRequiredForCommunityLeader: StoryObj = {
   parameters: {
     chromatic: { disableSnapshot: true },


### PR DESCRIPTION
## Description

Fixes two independent bugs in `SignatureField` on the Upload Signature page of the user creation/edit flow (issue #12844).

**Bug 1 — Signature preview lost after back-navigation**

`useState(value)` captures the initial prop value at mount. Formik's `enableReinitialize` later updates `value` asynchronously (after the form's data is loaded), but the local state never re-synced. The preview was blank when navigating back to a page that had an existing signature.

Fix: added a `useEffect(() => { setSignature(value) }, [value])` to keep local state in sync with the Formik-managed prop.

**Bug 2 — Duplicate "Required" error after deleting a signature**

`SignatureFieldInput` maintained its own `touched` local state, set to `true` on the Delete button click. This produced a local `<InputError>Required</InputError>` that rendered simultaneously with the `InputField` wrapper's error (driven by Formik's `meta.touched` + `meta.error`). After a user had previously submitted the form without a signature (setting `meta.touched = true`), uploaded a signature, and then deleted it, both renderers fired at once — showing "Required" twice.

Fix: removed all local `touched` tracking and the local `<InputError>` for required validation. `InputField` is now the sole renderer for validation errors. The initial fix accidentally also dropped the `<InputError>` for file format/size violations (`onUploadError` from `useOnFileChange`) — this was restored in a follow-up commit.

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [x] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly