### PR TITLE
fix: update print certificate flow to unassign after printing is done

### DIFF
--- a/packages/client/src/v2-events/features/events/actions/print-certificate/PrintCertificate.interaction.stories.tsx
+++ b/packages/client/src/v2-events/features/events/actions/print-certificate/PrintCertificate.interaction.stories.tsx
@@ -418,7 +418,7 @@ export const RedirectAfterPrint: Story = {
         { timeout: 7000 } // Generating the PDF takes a long time.
       )
 
-      expect(canvas.getByTestId('assignedTo-value')).toHaveTextContent(
+      await expect(canvas.getByTestId('assignedTo-value')).toHaveTextContent(
         'Not assigned'
       )
     })

--- a/packages/client/src/v2-events/features/events/actions/print-certificate/PrintCertificate.interaction.stories.tsx
+++ b/packages/client/src/v2-events/features/events/actions/print-certificate/PrintCertificate.interaction.stories.tsx
@@ -17,12 +17,16 @@ import { within, userEvent, expect, waitFor, fireEvent } from '@storybook/test'
 import { Outlet } from 'react-router-dom'
 import { http, HttpResponse } from 'msw'
 import {
+  ActionDocument,
+  ActionStatus,
   ActionType,
   generateEventDocument,
   generateWorkqueues,
   getCurrentEventState,
   tennisClubMembershipEvent,
-  never
+  never,
+  UUID,
+  generateActionDocument
 } from '@opencrvs/commons/client'
 import { tennisClubMembershipEventDocument } from '@client/v2-events/features/events/fixtures'
 import { ROUTES, routesConfig } from '@client/v2-events/routes'
@@ -279,6 +283,17 @@ export const ContinuingAndGoingBack: Story = {
 }
 
 const generator = testDataGenerator()
+const user = { id: generator.user.id.localRegistrar }
+
+const eventDocument = generateEventDocument({
+  configuration: tennisClubMembershipEvent,
+  actions: [
+    { type: ActionType.CREATE, user },
+    { type: ActionType.ASSIGN, user },
+    { type: ActionType.DECLARE, user },
+    { type: ActionType.REGISTER, user }
+  ]
+})
 
 export const RedirectAfterPrint: Story = {
   parameters: {
@@ -292,23 +307,43 @@ export const RedirectAfterPrint: Story = {
     msw: {
       handlers: {
         event: [
+          tRPCMsw.event.actions.assignment.unassign.mutation(() => {
+            Object.assign(
+              eventDocument,
+              generateEventDocument({
+                configuration: tennisClubMembershipEvent,
+                actions: [
+                  { type: ActionType.CREATE, user },
+                  { type: ActionType.ASSIGN, user },
+                  { type: ActionType.DECLARE, user },
+                  { type: ActionType.REGISTER, user },
+                  { type: ActionType.PRINT_CERTIFICATE, user },
+                  { type: ActionType.UNASSIGN, user }
+                ]
+              })
+            )
+            return eventDocument
+          }),
           tRPCMsw.event.actions.printCertificate.request.mutation(() => {
-            return generateEventDocument({
-              configuration: tennisClubMembershipEvent,
-              actions: [
-                { type: ActionType.DECLARE },
-                { type: ActionType.REGISTER },
-                { type: ActionType.PRINT_CERTIFICATE }
-              ]
-            })
+            Object.assign(
+              eventDocument,
+              generateEventDocument({
+                configuration: tennisClubMembershipEvent,
+                actions: [
+                  { type: ActionType.CREATE, user },
+                  { type: ActionType.ASSIGN, user },
+                  { type: ActionType.DECLARE, user },
+                  { type: ActionType.REGISTER, user },
+                  { type: ActionType.PRINT_CERTIFICATE, user }
+                ]
+              })
+            )
+            return eventDocument
           }),
           tRPCMsw.event.search.query(() => {
             return {
               results: [
-                getCurrentEventState(
-                  tennisClubMembershipEventDocument,
-                  tennisClubMembershipEvent
-                )
+                getCurrentEventState(eventDocument, tennisClubMembershipEvent)
               ],
               total: 1
             }
@@ -327,11 +362,11 @@ export const RedirectAfterPrint: Story = {
       }
     },
     offline: {
-      events: [tennisClubMembershipEventDocument],
+      events: [eventDocument],
 
       drafts: [
         generator.event.draft({
-          eventId: tennisClubMembershipEventDocument.id,
+          eventId: eventDocument.id,
           actionType: ActionType.PRINT_CERTIFICATE,
           annotation: {
             [CERT_TEMPLATE_ID]: 'tennis-club-membership-certified-certificate',
@@ -350,7 +385,7 @@ export const RedirectAfterPrint: Story = {
       },
       initialPath: ROUTES.V2.EVENTS.PRINT_CERTIFICATE.REVIEW.buildPath(
         {
-          eventId: tennisClubMembershipEventDocument.id
+          eventId: eventDocument.id
         },
         {
           templateId: 'tennis-club-membership-certificate'
@@ -385,6 +420,10 @@ export const RedirectAfterPrint: Story = {
           await canvas.findByText('Certificate is ready to print')
         },
         { timeout: 7000 } // Generating the PDF takes a long time.
+      )
+
+      expect(canvas.getByTestId('assignedTo-value')).toHaveTextContent(
+        'Not assigned'
       )
     })
   }

--- a/packages/client/src/v2-events/features/events/actions/print-certificate/PrintCertificate.interaction.stories.tsx
+++ b/packages/client/src/v2-events/features/events/actions/print-certificate/PrintCertificate.interaction.stories.tsx
@@ -17,16 +17,12 @@ import { within, userEvent, expect, waitFor, fireEvent } from '@storybook/test'
 import { Outlet } from 'react-router-dom'
 import { http, HttpResponse } from 'msw'
 import {
-  ActionDocument,
-  ActionStatus,
   ActionType,
   generateEventDocument,
   generateWorkqueues,
   getCurrentEventState,
   tennisClubMembershipEvent,
-  never,
-  UUID,
-  generateActionDocument
+  never
 } from '@opencrvs/commons/client'
 import { tennisClubMembershipEventDocument } from '@client/v2-events/features/events/fixtures'
 import { ROUTES, routesConfig } from '@client/v2-events/routes'

--- a/packages/client/src/v2-events/features/events/actions/print-certificate/Review.tsx
+++ b/packages/client/src/v2-events/features/events/actions/print-certificate/Review.tsx
@@ -162,7 +162,11 @@ export function Review() {
   const isOnline = useOnlineStatus()
   const [modal, openModal] = useModal()
 
-  const { getEvent, onlineActions } = useEvents()
+  const {
+    getEvent,
+    onlineActions,
+    actions: { assignment }
+  } = useEvents()
   const fullEvent = getEvent.getFromCache(eventId)
   const { eventConfiguration } = useEventConfiguration(fullEvent.type)
   const fullEventIndex = getCurrentEventState(fullEvent, eventConfiguration)
@@ -303,6 +307,7 @@ export function Review() {
         const printCertificate = await preparePdfCertificate(fullEvent)
 
         await onlineActions.printCertificate.mutateAsync({
+          keepAssignment: true,
           eventId: fullEvent.id,
           fullEvent,
           declaration: {},
@@ -313,6 +318,11 @@ export function Review() {
         })
 
         printCertificate()
+
+        await assignment.unassign.mutateAsync({
+          eventId,
+          transactionId: getUUID()
+        })
 
         toast.custom(
           <Toast
@@ -328,9 +338,11 @@ export function Review() {
         )
 
         if (backTo) {
-          navigate(backTo)
+          navigate(backTo, { replace: true })
         } else {
-          navigate(ROUTES.V2.EVENTS.EVENT.buildPath({ eventId }))
+          navigate(ROUTES.V2.EVENTS.EVENT.buildPath({ eventId }), {
+            replace: true
+          })
         }
       } catch (error) {
         // TODO: add notification alert

--- a/packages/client/src/v2-events/features/events/useEvents/procedures/actions/action.ts
+++ b/packages/client/src/v2-events/features/events/useEvents/procedures/actions/action.ts
@@ -250,7 +250,6 @@ setMutationDefaults(trpcOptionsProxy.event.actions.printCertificate.request, {
   ),
   retry: retryUnlessConflict,
   retryDelay,
-  onSuccess: deleteLocalEvent,
   onError: errorToastOnConflict,
   meta: { actionType: ActionType.PRINT_CERTIFICATE }
 })

--- a/packages/client/src/v2-events/features/events/useEvents/procedures/actions/action.ts
+++ b/packages/client/src/v2-events/features/events/useEvents/procedures/actions/action.ts
@@ -250,6 +250,9 @@ setMutationDefaults(trpcOptionsProxy.event.actions.printCertificate.request, {
   ),
   retry: retryUnlessConflict,
   retryDelay,
+  // We can't delete the local event immediately
+  // because we're still on the certificate review page for a short time.
+  // It will be deleted when unassigned.
   onError: errorToastOnConflict,
   meta: { actionType: ActionType.PRINT_CERTIFICATE }
 })


### PR DESCRIPTION
## Description

Clearly describe what has been changed. Include relevant context or background.
Explain how the issue was fixed (if applicable) and the root cause.

Link this pull request to the GitHub issue (and optionally name the branch `ocrvs-<issue #>`)

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
