### PR TITLE
fix: invalidate user.search queries when admin resets password

### DIFF
--- a/packages/client/src/v2-events/hooks/useUsers.ts
+++ b/packages/client/src/v2-events/hooks/useUsers.ts
@@ -199,6 +199,10 @@ setMutationDefaults(trpcOptionsProxy.user.sendResetPasswordInvite, {
     await queryClient.invalidateQueries({
       queryKey: trpcOptionsProxy.user.get.queryKey(variables)
     })
+
+    await queryClient.invalidateQueries({
+      queryKey: trpcOptionsProxy.user.search.queryKey()
+    })
   }
 })
 


### PR DESCRIPTION
## Description

Clearly describe what has been changed. Include relevant context or background.
Explain how the issue was fixed (if applicable) and the root cause.

Link this pull request to the GitHub issue (and optionally name the branch `ocrvs-<issue #>`)

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
