### PR TITLE
feat: allow cc to use dynamic location types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,39 @@ V1 are deprecated. 2.0.0 onwards, locations are fetched from `events` service.
 - **events-service location APIs changes**
   Administrative areas (v1 `locationType: 'ADMIN_STRUCTURE'`) are exposed from a separate endpoint. See the [definition of the administrative hierarchy](/ADMINISTRATIVE-HIERARCHY.md) 2.0.0 onwards.
 
+#### Country config `GET /config/locations` response shape
+
+The data-seeder now expects `GET /config/locations` to return a structured object instead of a flat array. Country configuration's locations endpoint needs to be updated accordingly.
+
+**Before:**
+
+```ts
+Array<{
+  id: string
+  name: string
+  alias?: string
+  partOf: string
+  locationType: 'ADMIN_STRUCTURE' | 'HEALTH_FACILITY' | 'CRVS_OFFICE'
+}>
+```
+
+**After:**
+
+```ts
+{
+  administrativeAreas: Array<{ id: string; name: string; partOf: string }>
+  locations: Array<{
+    id: string
+    name: string
+    partOf: string
+    locationType: string
+  }>
+}
+```
+
+- `alias` has been removed and is no longer accepted.
+- `locationType` in the `locations` array is now a free-form `string` — country configurations are no longer restricted to the three built-in values and may define custom location types.
+
 #### Workqueue configurations
 
 - `actions: [{ type: CtaActionType }]`. is deprecated in favor of `action: { type: CtaActionType }`

--- a/charts/opencrvs-services/templates/_reindex-helper.tpl
+++ b/charts/opencrvs-services/templates/_reindex-helper.tpl
@@ -13,7 +13,7 @@
 {{- end }}
 {{- define "elasticsearch-reindex.initContainerSpec" -}}
 - name: copy-assets
-  image: "{{ .Values.countryconfig.image.name }}:{{ .Values.countryconfig.image.tag }}-assets"
+  image: {{ include "opencrvs.image" (dict "root" . "service" .Values.countryconfig) }}-assets
   command:
     - sh
     - -c

--- a/packages/client/src/v2-events/features/events/Search/AdvancedSearch.interaction.stories.tsx
+++ b/packages/client/src/v2-events/features/events/Search/AdvancedSearch.interaction.stories.tsx
@@ -604,6 +604,22 @@ export const JurisdictionScope_Location: Story = {
   }
 }
 
+const locationsUnderAdministration = [
+  'Ibombo District Office',
+  'Chamakubi Health Post',
+  'Ibombo Rural Health Centre',
+  'Chikobo Rural Health Centre',
+  'Chilochabalenje Health Post',
+  'Chipeso Rural Health Centre',
+  'Chisamba Rural Health Centre',
+  'Chitanda Rural Health Centre',
+  'Golden Valley Rural Health Centre',
+  'Ipongo Rural Health Centre',
+  'Itumbwe Health Post',
+  'Kabangalala Rural Health Centre',
+  'Klow Village Office'
+]
+
 /**
  * record.search[registeredIn=administrativeArea] — dropdown restricted to
  * offices within the user's administrative area (multiple offices visible).
@@ -626,21 +642,36 @@ export const JurisdictionScope_AdministrativeArea: Story = {
         )
         const options = within(listbox).queryAllByRole('listitem')
 
-        await expect(options).toHaveLength(2)
-        await expect(options[0]).toHaveTextContent('Ibombo District Office')
-        await expect(options[1]).toHaveTextContent('Klow Village Office')
+        await expect(options.length).toEqual(locationsUnderAdministration.length)
+        locationsUnderAdministration.forEach(async (office) => {
+          await expect(
+            options.some((o) => o.textContent?.includes(office))
+          ).toBe(true)
+        })
       }
     )
   }
 }
 
-const allOffices = [
+const allLocations = [
   'Central Provincial Office',
+  'Central Health Post',
   'Ibombo District Office',
   'Isamba District Office',
   'Isango District Office',
   'Sulaka Provincial Office',
   'Ilanga District Office',
+  'Chamakubi Health Post',
+  'Ibombo Rural Health Centre',
+  'Chikobo Rural Health Centre',
+  'Chilochabalenje Health Post',
+  'Chipeso Rural Health Centre',
+  'Chisamba Rural Health Centre',
+  'Chitanda Rural Health Centre',
+  'Golden Valley Rural Health Centre',
+  'Ipongo Rural Health Centre',
+  'Itumbwe Health Post',
+  'Kabangalala Rural Health Centre',
   'Klow Village Office'
 ]
 
@@ -666,8 +697,8 @@ export const JurisdictionScope_All: Story = {
         )
         const options = within(listbox).queryAllByRole('listitem')
 
-        await expect(options.length).toEqual(allOffices.length)
-        allOffices.forEach(async (office) => {
+        await expect(options.length).toEqual(allLocations.length)
+        allLocations.forEach(async (office) => {
           await expect(
             options.some((o) => o.textContent?.includes(office))
           ).toBe(true)
@@ -699,8 +730,8 @@ export const JurisdictionScope_AllBeatsLocation: Story = {
         )
         const options = within(listbox).queryAllByRole('listitem')
 
-        await expect(options.length).toEqual(allOffices.length)
-        allOffices.forEach(async (office) => {
+        await expect(options.length).toEqual(allLocations.length)
+        allLocations.forEach(async (office) => {
           await expect(
             options.some((o) => o.textContent?.includes(office))
           ).toBe(true)
@@ -841,9 +872,12 @@ export const JurisdictionScope_MultipleScopes_MostRelaxedWins: Story = {
         )
         const options = within(listbox).queryAllByRole('listitem')
 
-        await expect(options).toHaveLength(2)
-        await expect(options[0]).toHaveTextContent('Ibombo District Office')
-        await expect(options[1]).toHaveTextContent('Klow Village Office')
+        await expect(options.length).toEqual(locationsUnderAdministration.length)
+        locationsUnderAdministration.forEach(async (office) => {
+          await expect(
+            options.some((o) => o.textContent?.includes(office))
+          ).toBe(true)
+        })
       }
     )
   }

--- a/packages/client/src/v2-events/features/events/Search/utils.ts
+++ b/packages/client/src/v2-events/features/events/Search/utils.ts
@@ -78,7 +78,6 @@ const defaultSearchFieldGenerator: Record<
       id: 'advancedSearch.registeredAtLocation.helperText'
     },
     configuration: {
-      locationTypes: ['ADMIN_STRUCTURE', 'CRVS_OFFICE'],
       allowedLocations: user.jurisdiction(
         user.scope('record.search').attribute('registeredIn')
       )

--- a/packages/data-seeder/src/locations.ts
+++ b/packages/data-seeder/src/locations.ts
@@ -9,31 +9,29 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 import fetch from 'node-fetch'
-import * as _ from 'lodash'
 import { env } from './environment'
-import { TypeOf, z } from 'zod'
+import { z } from 'zod'
 import { raise } from './utils'
 import { fromZodError } from 'zod-validation-error'
 import { getUUID } from '@opencrvs/commons'
 import { createInitialisationClient } from './index'
 
-const LOCATION_TYPES = [
-  'ADMIN_STRUCTURE',
-  'HEALTH_FACILITY',
-  'CRVS_OFFICE'
-] as const
-
-const LocationSchema = z.array(
+const RawLocationSchema =
   z.object({
     id: z.string(),
     name: z.string(),
-    alias: z.string().optional(),
     partOf: z.string(),
-    locationType: z.enum(LOCATION_TYPES)
+    locationType: z.string()
   })
-)
 
-function validateAdminStructure(locations: TypeOf<typeof LocationSchema>) {
+const RawAdministrativeAreaSchema = RawLocationSchema.omit({ locationType: true })
+
+const CountryConfigLocationResponse = z.object({
+  locations: z.array(RawLocationSchema),
+  administrativeAreas: z.array(RawAdministrativeAreaSchema)
+})
+
+function validateAdminStructure(locations: z.output<typeof CountryConfigLocationResponse>['administrativeAreas']) {
   const locationsMap = new Map(
     locations.map((loc) => {
       return [loc.id, loc]
@@ -68,37 +66,38 @@ async function getLocations() {
     raise(`Expected to get the locations from ${url}`)
   }
 
-  const parsedLocations = LocationSchema.safeParse(await res.json())
-  if (!parsedLocations.success) {
+  const parsedResponse = CountryConfigLocationResponse.safeParse(await res.json())
+  if (!parsedResponse.success) {
     raise(
-      fromZodError(parsedLocations.error, {
+      fromZodError(parsedResponse.error, {
         prefix: `Error validating locations data returned from ${url}`
       })
     )
   }
 
-  const [administrativeAreas, locations] = _.partition(
-    parsedLocations.data,
-    ({ locationType }) => locationType === 'ADMIN_STRUCTURE'
-  )
+  const {administrativeAreas, locations} = parsedResponse.data
 
   const administrativeAreaMap = validateAdminStructure(administrativeAreas)
 
   const NULL_ADMINISTRATIVE_AREA_ID = '0'
-  locations.forEach((facilityOrOffice) => {
-    const administrativeAreaId = facilityOrOffice.partOf.split('/')[1]
+  locations.forEach((location) => {
+    const administrativeAreaId = location.partOf.split('/')[1]
     if (
       !administrativeAreaMap.get(administrativeAreaId) &&
       administrativeAreaId !== NULL_ADMINISTRATIVE_AREA_ID
     ) {
       raise(
-        `Parent location "${facilityOrOffice.partOf}" not found for ${facilityOrOffice.name}`
+        `Parent location "${location.partOf}" not found for ${location.name}`
       )
     }
   })
 
   const administrativeHierarchyIdMap = new Map(
-    parsedLocations.data.map(({ id }) => [id, getUUID()])
+    administrativeAreas.map(({ id }) => [id, getUUID()])
+  )
+
+  const locationIdMap = new Map(
+    locations.map(({ id }) => [id, getUUID()])
   )
 
   return {
@@ -111,7 +110,7 @@ async function getLocations() {
       validUntil: null
     })),
     locations: locations.map((loc) => ({
-      id: administrativeHierarchyIdMap.get(loc.id)!,
+      id: locationIdMap.get(loc.id)!,
       name: loc.name,
       administrativeAreaId:
         administrativeHierarchyIdMap.get(loc.partOf.split('/')[1]) || null,


### PR DESCRIPTION
The data-seeder now expects `GET /config/locations` to return a structured object instead of a flat array. Country configuration's locations endpoint needs to be updated accordingly.

**Before:**

```ts
Array<{
  id: string
  name: string
  alias?: string
  partOf: string
  locationType: 'ADMIN_STRUCTURE' | 'HEALTH_FACILITY' | 'CRVS_OFFICE'
}>
```

**After:**

```ts
{
  administrativeAreas: Array<{ id: string; name: string; partOf: string }>
  locations: Array<{
    id: string
    name: string
    partOf: string
    locationType: string
  }>
}
```

- `alias` has been removed and is no longer accepted.
- `locationType` in the `locations` array is now a free-form `string` — country configurations are no longer restricted to the three built-in values and may define custom location types.

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
