### PR TITLE
Sync FileInput local state with value prop so uploads persist on back-navigation

### DIFF
--- a/packages/client/src/tests/image-file.ts
+++ b/packages/client/src/tests/image-file.ts
@@ -1,0 +1,38 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+
+/**
+ * Creates a synthetic JPEG image `File` of the given dimensions, useful for
+ * exercising file-upload flows in Storybook interaction tests.
+ */
+export async function createImageFile(
+  name: string,
+  width: number,
+  height: number
+) {
+  return new Promise<File>((resolve, reject) => {
+    const canvas = document.createElement('canvas')
+    canvas.width = width
+    canvas.height = height
+    const ctx = canvas.getContext('2d')
+    if (ctx) {
+      ctx.fillStyle = '#000'
+      ctx.fillRect(0, 0, width, height)
+    }
+    canvas.toBlob((blob) => {
+      if (blob) {
+        resolve(new File([blob], name, { type: blob.type }))
+      } else {
+        reject(new Error('Could not create blob from canvas'))
+      }
+    }, 'image/jpeg')
+  })
+}

--- a/packages/client/src/v2-events/components/forms/File.interaction.stories.tsx
+++ b/packages/client/src/v2-events/components/forms/File.interaction.stories.tsx
@@ -17,6 +17,7 @@ import { userEvent } from '@storybook/testing-library'
 import { FieldType, MimeType, TestUserRole } from '@opencrvs/commons/client'
 import { FormFieldGenerator } from '@client/v2-events/components/forms/FormFieldGenerator'
 import { TRPCProvider } from '@client/v2-events/trpc'
+import { createImageFile } from '@client/tests/image-file'
 import { getTestValidatorContext } from '../../../../.storybook/decorators'
 import { FormFieldGeneratorPropsWithoutRef } from './FormFieldGenerator/FormFieldGenerator'
 
@@ -401,27 +402,6 @@ startxref
 
     window.fetch = originalFetch
   }
-}
-
-async function createImageFile(name: string, width: number, height: number) {
-  return new Promise<File>((resolve, reject) => {
-    const canvas = document.createElement('canvas')
-    canvas.width = width
-    canvas.height = height
-    const ctx = canvas.getContext('2d')
-    if (ctx) {
-      ctx.fillStyle = '#000'
-      ctx.fillRect(0, 0, width, height)
-    }
-    canvas.toBlob((blob) => {
-      if (blob) {
-        const file = new File([blob], name, { type: blob.type })
-        resolve(file)
-      } else {
-        reject(new Error('Could not create blob from canvas'))
-      }
-    }, 'image/jpeg')
-  })
 }
 
 export const FileInputButtonMaxImage: Story = {

--- a/packages/client/src/v2-events/components/forms/inputs/FileInput/FileInput.tsx
+++ b/packages/client/src/v2-events/components/forms/inputs/FileInput/FileInput.tsx
@@ -56,6 +56,15 @@ function FileInput({
   maxImageSize?: FileConfig['configuration']['maxImageSize']
 }) {
   const [file, setFile] = React.useState(value)
+
+  // Keep local state in sync with the value coming from the form store.
+  // On back-navigation the field re-mounts before Formik has re-initialised, so
+  // it first renders with an empty value and only receives the real value on a
+  // later render. Without this sync the uploaded file would never re-appear.
+  React.useEffect(() => {
+    setFile(value)
+  }, [value])
+
   const [modal, openModal] = useImageEditorModal({
     targetSize: maxImageSize?.targetSize
   })

--- a/packages/client/src/v2-events/features/events/actions/print-certificate/PrintCertificate.interaction.stories.tsx
+++ b/packages/client/src/v2-events/features/events/actions/print-certificate/PrintCertificate.interaction.stories.tsx
@@ -8,6 +8,9 @@
  *
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
+
+/* eslint-disable max-lines */
+
 import React from 'react'
 import type { Meta, StoryObj } from '@storybook/react'
 import { createTRPCMsw, httpLink } from '@vafanassieff/msw-trpc'
@@ -18,6 +21,7 @@ import { Outlet } from 'react-router-dom'
 import { http, HttpResponse } from 'msw'
 import {
   ActionType,
+  EventConfig,
   generateEventDocument,
   generateWorkqueues,
   getCurrentEventState,
@@ -29,7 +33,10 @@ import { ROUTES, routesConfig } from '@client/v2-events/routes'
 import { AppRouter } from '@client/v2-events/trpc'
 import { testDataGenerator } from '@client/tests/test-data-generators'
 import { mockOfflineData } from '@client/tests/mock-offline-data'
+import { localDraftStore } from '@client/v2-events/features/drafts/useDrafts'
 import { CERT_TEMPLATE_ID } from '../../useCertificateTemplateSelectorFieldConfig'
+import { useEventFormData } from '../../useEventFormData'
+import { useActionAnnotation } from '../../useActionAnnotation'
 import * as PrintCertificate from './index'
 
 const meta: Meta<typeof PrintCertificate.Review> = {
@@ -275,6 +282,195 @@ export const ContinuingAndGoingBack: Story = {
         await canvas.findByRole('button', { name: 'Yes, print certificate' })
       ).toBeInTheDocument()
     })
+  }
+}
+
+/**
+ * Regression test for the print-certificate file-upload bug.
+ *
+ * This event config is consists of a modified print action form, where the SOMEONE_ELSE
+ * collector has a page AFTER `collector` (collector.identity.verify) — so going Next then
+ * Back is genuine in-form navigation that re-mounts the collector page.
+ *
+ * Before the FileInput fix the uploaded affidavit vanished on Back even though
+ * the annotation store still held it; this drives that exact sequence and then
+ * opens the preview. Here, we are going to test the file persists after going back,
+ * and that clicking the link opens the preview as expected.
+ */
+const eventWithVisibleVerifyPage = {
+  ...tennisClubMembershipEvent,
+  actions: tennisClubMembershipEvent.actions.map((action) =>
+    action.type === ActionType.PRINT_CERTIFICATE
+      ? {
+          ...action,
+          printForm: {
+            ...action.printForm,
+            pages: action.printForm.pages.map((page) =>
+              page.id === 'collector.identity.verify'
+                ? (({ conditional, ...rest }) => rest)(page) // drop conditional on a copy to test back navigation doesn't lose uploaded file
+                : page
+            )
+          }
+        }
+      : action
+  )
+} as EventConfig
+
+async function createImageFile(name: string, width: number, height: number) {
+  return new Promise<File>((resolve, reject) => {
+    const c = document.createElement('canvas')
+    c.width = width
+    c.height = height
+    const ctx = c.getContext('2d')
+    if (ctx) {
+      ctx.fillStyle = '#000'
+      ctx.fillRect(0, 0, width, height)
+    }
+    c.toBlob((blob) => {
+      if (blob) {
+        resolve(new File([blob], name, { type: blob.type }))
+      } else {
+        reject(new Error('Could not create blob from canvas'))
+      }
+    }, 'image/jpeg')
+  })
+}
+
+export const UploadedFilePersistsOnBackNavigation: Story = {
+  // The annotation/form Zustand stores and the local draft are module-level
+  // singletons that survive between runs. Without resetting them, a re-run
+  // re-initialises the form from the previous run's data and the selects come
+  // back pre-populated, failing the play steps.
+  beforeEach: () => {
+    useActionAnnotation.getState().clear()
+    useEventFormData.getState().clear()
+    localDraftStore.getState().setDraft(null)
+  },
+  parameters: {
+    chromatic: { disableSnapshot: true },
+    test: {
+      // The optimistic upload fires a background POST /api/upload that has no
+      // handler here; the value is set optimistically regardless.
+      dangerouslyIgnoreUnhandledErrors: true
+    },
+    reactRouter: {
+      router: routesConfig,
+      initialPath: ROUTES.V2.EVENTS.PRINT_CERTIFICATE.PAGES.buildPath({
+        eventId: tennisClubMembershipEventDocument.id,
+        pageId: 'collector'
+      })
+    },
+    msw: {
+      handlers: {
+        upload: [
+          http.post('/api/upload', () => {
+            return HttpResponse.text('ok')
+          })
+        ],
+        events: [
+          tRPCMsw.event.config.get.query(() => {
+            return [eventWithVisibleVerifyPage]
+          }),
+          tRPCMsw.event.get.query(() => {
+            return tennisClubMembershipEventDocument
+          })
+        ]
+      }
+    }
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+
+    await step('Fill the certificate template and requester', async () => {
+      await userEvent.click(
+        await canvas.findByTestId('select__certificateTemplateId')
+      )
+      await userEvent.click(
+        await canvas.findByText(
+          'Tennis Club Membership Certificate certified copy'
+        )
+      )
+      await userEvent.click(
+        await canvas.findByTestId('select__collector____requesterId')
+      )
+      await userEvent.click(
+        await canvas.findByText('Print and issue someone else')
+      )
+    })
+
+    await step('Fill the required "someone else" details', async () => {
+      await userEvent.click(
+        await canvas.findByTestId('select__collector____OTHER____idType')
+      )
+      await userEvent.click(await canvas.findByText('No ID'))
+
+      await userEvent.type(
+        await canvas.findByTestId('text__collector____OTHER____firstName'),
+        'Nomen'
+      )
+      await userEvent.type(
+        await canvas.findByTestId('text__collector____OTHER____lastName'),
+        'Est Omen'
+      )
+      await userEvent.type(
+        await canvas.findByTestId(
+          'text__collector____OTHER____relationshipToMember'
+        ),
+        'Best friend'
+      )
+    })
+
+    await step('Upload the signed affidavit', async () => {
+      const input = canvasElement.querySelector(
+        'input[type="file"]'
+      ) as HTMLInputElement
+
+      // accepted types vary per config; clear accept so user-event doesn't drop it
+      input.accept = ''
+      await userEvent.upload(
+        input,
+        await createImageFile('signed-affidavit.jpg', 64, 64)
+      )
+
+      // Uploaded file preview link appears
+      await canvas.findByRole('button', { name: /signed affidavit/i })
+    })
+
+    await step('Continue to the next page', async () => {
+      await userEvent.click(
+        await canvas.findByRole('button', { name: 'Continue' })
+      )
+      // We are now on the second page
+      await canvas.findByText('Verify their identity')
+    })
+
+    await step('Go back to the collector page', async () => {
+      await userEvent.click(await canvas.findByRole('button', { name: 'Back' }))
+      await canvas.findByTestId('select__collector____requesterId')
+    })
+
+    await step(
+      'Uploaded affidavit is still present after back-navigation',
+      async () => {
+        // Regression: before the FileInput fix this link was gone.
+        await canvas.findByRole('button', { name: /signed affidavit/i })
+      }
+    )
+
+    await step(
+      'Clicking the upload link renders the image preview',
+      async () => {
+        await userEvent.click(
+          await canvas.findByRole('button', { name: /signed affidavit/i })
+        )
+        await waitFor(async () => {
+          await expect(
+            canvasElement.querySelector('#preview_image_field')
+          ).not.toBeNull()
+        })
+        await userEvent.click(await canvas.findByTestId('preview_close'))
+      }
+    )
   }
 }
 

--- a/packages/client/src/v2-events/features/events/actions/print-certificate/PrintCertificate.interaction.stories.tsx
+++ b/packages/client/src/v2-events/features/events/actions/print-certificate/PrintCertificate.interaction.stories.tsx
@@ -34,6 +34,7 @@ import { AppRouter } from '@client/v2-events/trpc'
 import { testDataGenerator } from '@client/tests/test-data-generators'
 import { mockOfflineData } from '@client/tests/mock-offline-data'
 import { localDraftStore } from '@client/v2-events/features/drafts/useDrafts'
+import { createImageFile } from '@client/tests/image-file'
 import { CERT_TEMPLATE_ID } from '../../useCertificateTemplateSelectorFieldConfig'
 import { useEventFormData } from '../../useEventFormData'
 import { useActionAnnotation } from '../../useActionAnnotation'
@@ -305,36 +306,18 @@ const eventWithVisibleVerifyPage = {
           ...action,
           printForm: {
             ...action.printForm,
-            pages: action.printForm.pages.map((page) =>
-              page.id === 'collector.identity.verify'
-                ? (({ conditional, ...rest }) => rest)(page) // drop conditional on a copy to test back navigation doesn't lose uploaded file
-                : page
-            )
+            pages: action.printForm.pages.map((page) => {
+              if (page.id === 'collector.identity.verify') {
+                const { conditional, ...rest } = page
+                return rest
+              }
+              return page
+            })
           }
         }
       : action
   )
 } as EventConfig
-
-async function createImageFile(name: string, width: number, height: number) {
-  return new Promise<File>((resolve, reject) => {
-    const c = document.createElement('canvas')
-    c.width = width
-    c.height = height
-    const ctx = c.getContext('2d')
-    if (ctx) {
-      ctx.fillStyle = '#000'
-      ctx.fillRect(0, 0, width, height)
-    }
-    c.toBlob((blob) => {
-      if (blob) {
-        resolve(new File([blob], name, { type: blob.type }))
-      } else {
-        reject(new Error('Could not create blob from canvas'))
-      }
-    }, 'image/jpeg')
-  })
-}
 
 export const UploadedFilePersistsOnBackNavigation: Story = {
   // The annotation/form Zustand stores and the local draft are module-level
@@ -353,6 +336,9 @@ export const UploadedFilePersistsOnBackNavigation: Story = {
       // handler here; the value is set optimistically regardless.
       dangerouslyIgnoreUnhandledErrors: true
     },
+    offline: {
+      configs: [eventWithVisibleVerifyPage]
+    },
     reactRouter: {
       router: routesConfig,
       initialPath: ROUTES.V2.EVENTS.PRINT_CERTIFICATE.PAGES.buildPath({
@@ -368,9 +354,6 @@ export const UploadedFilePersistsOnBackNavigation: Story = {
           })
         ],
         events: [
-          tRPCMsw.event.config.get.query(() => {
-            return [eventWithVisibleVerifyPage]
-          }),
           tRPCMsw.event.get.query(() => {
             return tennisClubMembershipEventDocument
           })


### PR DESCRIPTION
https://github.com/opencrvs/opencrvs-core/issues/12873

## Description

In the print certificate flow, uploading a file (e.g. `collector.OTHER.signedAffidavit`), navigating to the next page, then returning loses the uploaded file from the field — even though the value is still saved in the form store.

## Root cause

`FileInput` keeps the uploaded file in local React state seeded once via `useState(value)`. On back-navigation the field re-mounts **before** Formik re-initialises, so its first render receives an empty `value` and seeds local state to empty. When the real value arrives a render later, there was no effect syncing `value` → local state, so the uploader kept rendering from stale (empty) local state.

The form store and draft hold the file correctly the whole time — this is purely a display bug in `FileInput`.

## Fix

Sync local state to the `value` prop whenever it changes:

```js
React.useEffect(() => {
  setFile(value)
}, [value])
```

## Impact
Fixes file persistence on back-navigation for all flows using FieldType.FILE, not just print certificate.
Safe for the upload path — the optimistic setFile and the upload success callback already converge on the same value.

## Testing
Verified manually: upload → Continue → Previous now retains the uploaded file.

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
