### PR TITLE
fix: initialize redis before starting the server

### DIFF
--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -26,6 +26,7 @@ import * as Hapi from '@hapi/hapi'
 import { logger, validateFunc } from '@opencrvs/commons'
 import { readFileSync } from 'fs'
 
+import * as redis from '@gateway/utils/redis'
 import { badRequest, Boom, isBoom } from '@hapi/boom'
 import { RateLimitError } from './rate-limit'
 
@@ -122,12 +123,17 @@ export async function createServer() {
   }
 
   async function start() {
+    // Start redis before application server.
+    // We have had issues where redis was not ready when the server started which resulted in redis instance being undefined.
+
+    await redis.start()
     await app.start()
     app.log('info', `server started on port ${PORT}`)
   }
 
   async function stop() {
     await app.stop()
+    await redis.stop()
     app.log('info', 'server stopped')
   }
 


### PR DESCRIPTION
This got accidentally removed in 0dc9afb during cleanup.
