### PR TITLE
exclude query parameters in redirect URLs to prevent double login

### DIFF
--- a/packages/client/src/profile/profileReducer.ts
+++ b/packages/client/src/profile/profileReducer.ts
@@ -73,12 +73,11 @@ export const profileReducer: LoopReducer<
             Cmd.run(
               (getState: () => IStoreState) => {
                 if (shouldRedirectBack) {
-                  const baseUrl = window.location.origin
-                  const restUrl = window.location.href.replace(baseUrl, '')
+                  const redirectUrl = window.location.pathname
                   const params =
-                    restUrl === '/'
+                    redirectUrl === '/'
                       ? `?lang=${getState().i18n.language}`
-                      : `?lang=${getState().i18n.language}&redirectTo=${restUrl}`
+                      : `?lang=${getState().i18n.language}&redirectTo=${redirectUrl}`
                   window.location.assign(`/login${params}`)
                 } else {
                   window.location.assign(


### PR DESCRIPTION
## Description
https://github.com/opencrvs/opencrvs-core/issues/12884

# The Problem Flow

1. User at: `/events/xyz?backTo=/workqueue/draft`
2. Version detected or 401 error → redirected to login
3. User logs in + completes 2FA successfully
4. Login reducer tries to redirect back with the stored `redirectToURL`

---

## The Bug

In the reducer, when constructing the final URL after 2FA:

```typescript
const fullURL = redirectToURL
  ? `/register/${redirectToURL.replace(/^\//, '')}?token=${action.payload.token}&lang=...`
```

With `redirectToURL = /events/xyz?backTo=/workqueue/draft`, this created:

```
/register/events/xyz?backTo=/workqueue/draft?token=abc&lang=en
         ↑ first ?                          ↑ second ? (BUG!)
```

---

## Why the Double Login?

- Browser receives URL with two `?` characters
- The token parameter after the second `?` may be ignored or malformed
- Register app never receives the valid `token` parameter
- Without a token, user is not authenticated
- User gets redirected back to login page
- User has to login a second time

## How it is solved?

By excluding search query parameter.

N.B. In `packages/client/src/components/VersionMismatchModal.tsx > buildLoginUrl` function, we only consider redirecting to only `window.location.pathname`. So the change in this PR making sure a stable redirection behaviour from login page.

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
