### PR TITLE
fix: clear view event query cache during cache deletion of event.get

### DIFF
--- a/packages/client/src/v2-events/components/forms/FormFieldGenerator/FormFieldGenerator.interaction.stories.tsx
+++ b/packages/client/src/v2-events/components/forms/FormFieldGenerator/FormFieldGenerator.interaction.stories.tsx
@@ -11,7 +11,7 @@
  */
 
 import type { Meta, StoryObj } from '@storybook/react'
-import { expect, fireEvent, userEvent, within } from '@storybook/test'
+import { expect, fireEvent, fn, userEvent, within } from '@storybook/test'
 import React, { useRef } from 'react'
 import styled from 'styled-components'
 import { noop } from 'lodash'
@@ -21,9 +21,13 @@ import {
   FieldType,
   not,
   FieldConfig,
+  EventConfig,
   EventState,
-  generateTranslationConfig
+  generateTranslationConfig,
+  tennisClubMembershipEvent,
+  ActionStatus
 } from '@opencrvs/commons/client'
+import type { EventDocument, UUID } from '@opencrvs/commons/client'
 
 import {
   FormFieldGenerator,
@@ -32,7 +36,10 @@ import {
 } from '@client/v2-events/components/forms/FormFieldGenerator'
 import { TRPCProvider } from '@client/v2-events/trpc'
 import { FormWizard } from '@client/v2-events/features/events/components/FormWizard'
-import { withValidatorContext } from '../../../../../.storybook/decorators'
+import {
+  getTestValidatorContext,
+  withValidatorContext
+} from '../../../../../.storybook/decorators'
 
 const meta: Meta<FormFieldGeneratorPropsWithoutRef> = {
   title: 'FormFieldGenerator/Interaction',
@@ -619,6 +626,143 @@ export const HiddenListenerDefaultNotPropagated: Story = {
         await expect(canvas.queryByText('address')).not.toBeInTheDocument()
         await expect(canvas.getByTestId('text__form____derivedId')).toHaveValue(
           ''
+        )
+      }
+    )
+  }
+}
+
+const nixConditionalFields = [
+  {
+    id: 'form.verified',
+    type: FieldType.CHECKBOX,
+    required: false,
+    defaultValue: false,
+    label: generateTranslationConfig('Verified')
+  },
+  {
+    id: 'form.nid',
+    type: FieldType.TEXT,
+    label: generateTranslationConfig('NID'),
+    conditionals: [
+      {
+        type: ConditionalType.SHOW,
+        conditional: not(field('form.verified').isEqualTo(true))
+      }
+    ]
+  }
+] satisfies FieldConfig[]
+
+// EventConfig with nixConditionalFields in declaration so omitHiddenPaginatedFields
+// can correctly evaluate form.nid / form.verified visibility.
+const nixEventConfig: EventConfig = {
+  ...tennisClubMembershipEvent,
+  declaration: {
+    ...tennisClubMembershipEvent.declaration,
+    pages: [
+      {
+        id: 'nid-test-page',
+        title: generateTranslationConfig('NID page'),
+        fields: nixConditionalFields,
+        requireCompletionToContinue: false,
+        type: 'FORM' as const
+      }
+    ]
+  }
+}
+
+const BASE_DECL_EVENT_ID = 'a1b2c3d4-e5f6-7890-abcd-ef0123456789' as UUID
+
+const mockEventWithNid: EventDocument = {
+  type: tennisClubMembershipEvent.id,
+  id: BASE_DECL_EVENT_ID,
+  trackingId: 'NIDTEST',
+  createdAt: '2025-01-01T00:00:00.000Z',
+  updatedAt: '2025-01-01T00:00:01.000Z',
+  actions: [
+    {
+      id: '00000000-0000-0000-0000-aaaaaaaaaaaa' as UUID,
+      type: 'CREATE' as const,
+      status: ActionStatus.Accepted,
+      createdAt: '2025-01-01T00:00:00.000Z',
+      createdByUserType: 'user',
+      createdBy: '00000000-0000-0000-0000-000000000001' as UUID,
+      createdByRole: 'LOCAL_REGISTRAR',
+      createdAtLocation: '00000000-0000-0000-0000-000000000002' as UUID,
+      declaration: {},
+      transactionId: 'txn-nid-create-0000001'
+    },
+    {
+      id: '00000000-0000-0000-0000-bbbbbbbbbbbb' as UUID,
+      type: 'DECLARE' as const,
+      status: ActionStatus.Accepted,
+      createdAt: '2025-01-01T00:00:01.000Z',
+      createdByUserType: 'user',
+      createdBy: '00000000-0000-0000-0000-000000000001' as UUID,
+      createdByRole: 'LOCAL_REGISTRAR',
+      createdAtLocation: '00000000-0000-0000-0000-000000000002' as UUID,
+      declaration: { 'form.nid': '12345' },
+      transactionId: 'txn-nid-declare-0000002'
+    }
+  ]
+}
+
+const onFormChangeSpy = fn<(values: EventState) => void>()
+
+/**
+ * Regression test for the bug where hidden fields were not set to null after an OAuth
+ * redirect (e-Signet/MOSIP). After the redirect, Zustand (ocrvsFullForm) is wiped, so
+ * applyVisibilityTransitions found no previous field values and never detected
+ * visible→hidden transitions. The fix reads committed server state (baseDeclaration) from
+ * the TanStack Query cache as the reference point.
+ */
+export const NullsHiddenFieldUsingServerState: Story = {
+  parameters: {
+    layout: 'centered',
+    chromatic: { disableSnapshot: true },
+    offline: {
+      events: [mockEventWithNid]
+    },
+    reactRouter: {
+      router: {
+        path: '/event/:eventId',
+        element: (
+          <StyledFormFieldGenerator
+            eventConfig={nixEventConfig}
+            fields={nixConditionalFields}
+            formValues={{}}
+            id="nid-oauth-form"
+            validatorContext={getTestValidatorContext()}
+            onFormChange={onFormChangeSpy}
+          />
+        )
+      },
+      initialPath: `/event/${BASE_DECL_EVENT_ID}`
+    }
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+
+    await step(
+      'NID field is visible and empty (formValues is {} simulating post-OAuth)',
+      async () => {
+        await expect(
+          await canvas.findByTestId('text__form____nid')
+        ).toHaveValue('')
+      }
+    )
+
+    await step(
+      'Checking Verified hides NID and sends null for it via onFormChange',
+      async () => {
+        await fireEvent.click(await canvas.findByText('Verified'))
+
+        await expect(
+          canvas.queryByTestId('text__form____nid')
+        ).not.toBeInTheDocument()
+
+        await expect(onFormChangeSpy).toHaveBeenCalledWith(
+          expect.objectContaining({ 'form.nid': null })
         )
       }
     )

--- a/packages/client/src/v2-events/components/forms/FormFieldGenerator/FormSectionComponent.tsx
+++ b/packages/client/src/v2-events/components/forms/FormFieldGenerator/FormSectionComponent.tsx
@@ -213,14 +213,25 @@ export function FormSectionComponent({
   const { cacheHiddenFieldValue, popHiddenFieldValue } = useEventFormData()
   const { eventId } = useParams<{ eventId?: string }>()
   const cachedEvent = eventId ? findLocalEventDocument(eventId) : undefined
-  // Committed server state used as the visibility-transition reference point.
-  // After an OAuth redirect the in-memory form (ocrvsFullForm) is wiped, so without
-  // this we miss fields that need to be nulled. Falls back to ocrvsFullForm for new
-  // declarations where no server state exists yet.
   const baseDeclaration =
     cachedEvent && eventConfig
       ? getCurrentEventState(cachedEvent, eventConfig).declaration
       : undefined
+  // Use server state as the base for visibility transition detection, then let
+  // any non-undefined in-memory value override it. After an OAuth redirect
+  // (e-Signet/MOSIP), Zustand is wiped so Formik initialises fields to
+  // undefined — those fall back to the last committed server value, allowing
+  // visible→hidden transitions to null them correctly. In the correction flow,
+  // draft values are all non-undefined and naturally override the server state,
+  // so the behaviour is unchanged from using ocrvsFullForm directly.
+  const prevFormRef = baseDeclaration
+    ? {
+        ...baseDeclaration,
+        ...Object.fromEntries(
+          Object.entries(ocrvsFullForm).filter(([, v]) => v !== undefined)
+        )
+      }
+    : ocrvsFullForm
 
   const fullFormFields = eventConfig
     ? findAllFields(eventConfig).concat(pageFields)
@@ -326,7 +337,7 @@ export function FormSectionComponent({
 
       applyVisibilityTransitions(
         eventConfig,
-        baseDeclaration ?? ocrvsFullForm,
+        prevFormRef,
         updatedFullForm,
         updatedFormikPageForm,
         validatorContext,
@@ -394,7 +405,7 @@ export function FormSectionComponent({
 
       applyVisibilityTransitions(
         eventConfig,
-        baseDeclaration ?? ocrvsFullForm,
+        prevFormRef,
         updatedFullForm,
         updatedValues,
         validatorContext,

--- a/packages/client/src/v2-events/components/forms/FormFieldGenerator/FormSectionComponent.tsx
+++ b/packages/client/src/v2-events/components/forms/FormFieldGenerator/FormSectionComponent.tsx
@@ -10,6 +10,7 @@
  */
 
 import React, { useEffect } from 'react'
+import { useParams } from 'react-router-dom'
 import { FormikProps } from 'formik'
 import { cloneDeep, set, get, omit, unset, isNil } from 'lodash'
 import {
@@ -32,7 +33,8 @@ import {
   isFieldVisible,
   findAllFields,
   flattenFieldReference,
-  omitHiddenPaginatedFields
+  omitHiddenPaginatedFields,
+  getCurrentEventState
 } from '@opencrvs/commons/client'
 import {
   makeFormFieldIdFormikCompatible,
@@ -41,6 +43,7 @@ import {
 import { useOnlineStatus } from '@client/utils'
 import { useDefaultValue } from '@client/v2-events/hooks/useDefaultValue'
 import { useEventFormData } from '@client/v2-events/features/events/useEventFormData'
+import { findLocalEventDocument } from '@client/v2-events/features/events/useEvents/api'
 import {
   makeFormikFieldIdsOpenCRVSCompatible,
   resolveSyncedFieldValue
@@ -208,6 +211,16 @@ export function FormSectionComponent({
 
   const getDefaultValue = useDefaultValue()
   const { cacheHiddenFieldValue, popHiddenFieldValue } = useEventFormData()
+  const { eventId } = useParams<{ eventId?: string }>()
+  const cachedEvent = eventId ? findLocalEventDocument(eventId) : undefined
+  // Committed server state used as the visibility-transition reference point.
+  // After an OAuth redirect the in-memory form (ocrvsFullForm) is wiped, so without
+  // this we miss fields that need to be nulled. Falls back to ocrvsFullForm for new
+  // declarations where no server state exists yet.
+  const baseDeclaration =
+    cachedEvent && eventConfig
+      ? getCurrentEventState(cachedEvent, eventConfig).declaration
+      : undefined
 
   const fullFormFields = eventConfig
     ? findAllFields(eventConfig).concat(pageFields)
@@ -313,7 +326,7 @@ export function FormSectionComponent({
 
       applyVisibilityTransitions(
         eventConfig,
-        ocrvsFullForm,
+        baseDeclaration ?? ocrvsFullForm,
         updatedFullForm,
         updatedFormikPageForm,
         validatorContext,
@@ -381,7 +394,7 @@ export function FormSectionComponent({
 
       applyVisibilityTransitions(
         eventConfig,
-        ocrvsFullForm,
+        baseDeclaration ?? ocrvsFullForm,
         updatedFullForm,
         updatedValues,
         validatorContext,

--- a/packages/client/src/v2-events/components/forms/FormFieldGenerator/FormSectionComponent.tsx
+++ b/packages/client/src/v2-events/components/forms/FormFieldGenerator/FormSectionComponent.tsx
@@ -174,8 +174,11 @@ function applyVisibilityTransitions(
     const fieldValue = get(prevCleaned, key)
     if (!isNil(fieldValue)) {
       cacheHiddenFieldValue(key, fieldValue)
-      set(fieldValues, makeFormFieldIdFormikCompatible(key), null)
     }
+    // Always null hidden fields — even when prevCleaned has undefined (e.g. after
+    // an OAuth redirect where Zustand was wiped and Formik re-initialised the field
+    // to undefined), the server may still hold a real value that must be cleared.
+    set(fieldValues, makeFormFieldIdFormikCompatible(key), null)
   })
 
   // When a field transitions from hidden to visible, restore its cached value

--- a/packages/client/src/v2-events/components/forms/FormFieldGenerator/FormSectionComponent.tsx
+++ b/packages/client/src/v2-events/components/forms/FormFieldGenerator/FormSectionComponent.tsx
@@ -213,25 +213,14 @@ export function FormSectionComponent({
   const { cacheHiddenFieldValue, popHiddenFieldValue } = useEventFormData()
   const { eventId } = useParams<{ eventId?: string }>()
   const cachedEvent = eventId ? findLocalEventDocument(eventId) : undefined
+  // Committed server state used as the visibility-transition reference point.
+  // After an OAuth redirect the in-memory form (ocrvsFullForm) is wiped, so without
+  // this we miss fields that need to be nulled. Falls back to ocrvsFullForm for new
+  // declarations where no server state exists yet.
   const baseDeclaration =
     cachedEvent && eventConfig
       ? getCurrentEventState(cachedEvent, eventConfig).declaration
       : undefined
-  // Use server state as the base for visibility transition detection, then let
-  // any non-undefined in-memory value override it. After an OAuth redirect
-  // (e-Signet/MOSIP), Zustand is wiped so Formik initialises fields to
-  // undefined — those fall back to the last committed server value, allowing
-  // visible→hidden transitions to null them correctly. In the correction flow,
-  // draft values are all non-undefined and naturally override the server state,
-  // so the behaviour is unchanged from using ocrvsFullForm directly.
-  const prevFormRef = baseDeclaration
-    ? {
-        ...baseDeclaration,
-        ...Object.fromEntries(
-          Object.entries(ocrvsFullForm).filter(([, v]) => v !== undefined)
-        )
-      }
-    : ocrvsFullForm
 
   const fullFormFields = eventConfig
     ? findAllFields(eventConfig).concat(pageFields)
@@ -337,7 +326,7 @@ export function FormSectionComponent({
 
       applyVisibilityTransitions(
         eventConfig,
-        prevFormRef,
+        baseDeclaration ?? ocrvsFullForm,
         updatedFullForm,
         updatedFormikPageForm,
         validatorContext,
@@ -405,7 +394,7 @@ export function FormSectionComponent({
 
       applyVisibilityTransitions(
         eventConfig,
-        prevFormRef,
+        baseDeclaration ?? ocrvsFullForm,
         updatedFullForm,
         updatedValues,
         validatorContext,

--- a/packages/client/src/v2-events/components/forms/FormFieldGenerator/FormSectionComponent.tsx
+++ b/packages/client/src/v2-events/components/forms/FormFieldGenerator/FormSectionComponent.tsx
@@ -10,7 +10,6 @@
  */
 
 import React, { useEffect } from 'react'
-import { useParams } from 'react-router-dom'
 import { FormikProps } from 'formik'
 import { cloneDeep, set, get, omit, unset, isNil } from 'lodash'
 import {
@@ -33,8 +32,7 @@ import {
   isFieldVisible,
   findAllFields,
   flattenFieldReference,
-  omitHiddenPaginatedFields,
-  getCurrentEventState
+  omitHiddenPaginatedFields
 } from '@opencrvs/commons/client'
 import {
   makeFormFieldIdFormikCompatible,
@@ -43,7 +41,6 @@ import {
 import { useOnlineStatus } from '@client/utils'
 import { useDefaultValue } from '@client/v2-events/hooks/useDefaultValue'
 import { useEventFormData } from '@client/v2-events/features/events/useEventFormData'
-import { findLocalEventDocument } from '@client/v2-events/features/events/useEvents/api'
 import {
   makeFormikFieldIdsOpenCRVSCompatible,
   resolveSyncedFieldValue
@@ -211,16 +208,6 @@ export function FormSectionComponent({
 
   const getDefaultValue = useDefaultValue()
   const { cacheHiddenFieldValue, popHiddenFieldValue } = useEventFormData()
-  const { eventId } = useParams<{ eventId?: string }>()
-  const cachedEvent = eventId ? findLocalEventDocument(eventId) : undefined
-  // Committed server state used as the visibility-transition reference point.
-  // After an OAuth redirect the in-memory form (ocrvsFullForm) is wiped, so without
-  // this we miss fields that need to be nulled. Falls back to ocrvsFullForm for new
-  // declarations where no server state exists yet.
-  const baseDeclaration =
-    cachedEvent && eventConfig
-      ? getCurrentEventState(cachedEvent, eventConfig).declaration
-      : undefined
 
   const fullFormFields = eventConfig
     ? findAllFields(eventConfig).concat(pageFields)
@@ -326,7 +313,7 @@ export function FormSectionComponent({
 
       applyVisibilityTransitions(
         eventConfig,
-        baseDeclaration ?? ocrvsFullForm,
+        ocrvsFullForm,
         updatedFullForm,
         updatedFormikPageForm,
         validatorContext,
@@ -394,7 +381,7 @@ export function FormSectionComponent({
 
       applyVisibilityTransitions(
         eventConfig,
-        baseDeclaration ?? ocrvsFullForm,
+        ocrvsFullForm,
         updatedFullForm,
         updatedValues,
         validatorContext,

--- a/packages/client/src/v2-events/features/events/actions/print-certificate/Review.tsx
+++ b/packages/client/src/v2-events/features/events/actions/print-certificate/Review.tsx
@@ -242,7 +242,7 @@ export function Review() {
   const validationErrorExist = validationErrorsInActionFormExist({
     formConfig,
     form: annotation,
-    context: validatorContext
+    context: { ...validatorContext, baseFormState: fullEventIndex.declaration }
   })
 
   if (validationErrorExist) {

--- a/packages/client/src/v2-events/features/events/useEvents/api.test.ts
+++ b/packages/client/src/v2-events/features/events/useEvents/api.test.ts
@@ -15,7 +15,45 @@ import {
 } from '@opencrvs/commons/client'
 import { queryClient, trpcOptionsProxy } from '@client/v2-events/trpc'
 import { tennisClubMembershipEventDocument } from '@client/v2-events/features/events/fixtures'
-import { addLocalEventConfig, updateLocalEventIndex } from './api'
+import {
+  addLocalEventConfig,
+  deleteLocalEvent,
+  updateLocalEventIndex
+} from './api'
+
+describe('deleteLocalEvent', () => {
+  const eventDocument = tennisClubMembershipEventDocument
+  const { id } = eventDocument
+
+  beforeEach(() => {
+    global.caches = {
+      keys: vi.fn().mockResolvedValue([])
+    } as unknown as CacheStorage
+    queryClient.clear()
+    addLocalEventConfig(tennisClubMembershipEvent)
+  })
+
+  afterAll(() => {
+    queryClient.clear()
+  })
+
+  it('clears both event.get and view-event cache entries', async () => {
+    queryClient.setQueryData(
+      trpcOptionsProxy.event.get.queryKey({ eventId: id, waitFor: false }),
+      eventDocument
+    )
+    queryClient.setQueryData([['view-event', id]], eventDocument)
+
+    await deleteLocalEvent(eventDocument)
+
+    expect(
+      queryClient.getQueryData(
+        trpcOptionsProxy.event.get.queryKey({ eventId: id, waitFor: false })
+      )
+    ).toBeUndefined()
+    expect(queryClient.getQueryData([['view-event', id]])).toBeUndefined()
+  })
+})
 
 describe('updateLocalEventIndex', () => {
   beforeEach(() => {

--- a/packages/client/src/v2-events/features/events/useEvents/api.ts
+++ b/packages/client/src/v2-events/features/events/useEvents/api.ts
@@ -286,6 +286,13 @@ async function deleteEventData(updatedEvent: EventDocument) {
       waitFor: false
     })
   })
+  /*
+   * 'view-event' is a separately-keyed cache entry used by the Record tab. It is not
+   * automatically cleared when 'event.get' is removed, and the IndexedDB persister keeps
+   * it alive across page reloads. Explicitly removing it here keeps both caches in sync
+   * so the Record tab always reflects the latest server state after an action is submitted.
+   */
+  queryClient.removeQueries({ queryKey: [['view-event', id]] })
 
   await removeCachedFiles(updatedEvent)
 }


### PR DESCRIPTION
Fixes [opencrvs/opencrvs-core#12743 (comment)](https://github.com/opencrvs/opencrvs-core/issues/12743#issuecomment-4658986225). And the original [issue](https://github.com/opencrvs/opencrvs-core/issues/12743#issuecomment-4657411575) was not reproducible by [@FariaRichaDsi](https://github.com/FariaRichaDsi) and I, neither locally nor in the deployed environments.

## Description

This PR contains two independent fixes.

### Fix 1 — view-event cache not cleared on event.get deletion

When \`deleteEventData\` cleared the \`event.get\` TanStack Query cache, it left the separately-keyed \`view-event\` cache (used by the Record tab) untouched. The IndexedDB persister keeps that entry alive across page reloads, so the Record tab continued showing stale data after an action was submitted. The fix explicitly calls \`queryClient.removeQueries({ queryKey: [['view-event', id]] })\` inside \`deleteEventData\` so both caches are always evicted together.

### Fix 2 — hidden fields not nulled after OAuth (e-Signet/MOSIP) redirect

After an OAuth redirect, Zustand is wiped (\`formValues = {}\`). Formik then initialises every field: checkboxes get their \`defaultValue\`, text fields get \`undefined\`. So the in-memory form (\`ocrvsFullForm\`) looks like \`{ 'father.nid.verified': false, 'father.nid': undefined }\`.

\`applyVisibilityTransitions\` uses \`prevForm\` as the before-state to detect visible→hidden transitions and null those fields. When a field transitions to hidden, it is set to \`null\` only if its previous value is non-nil:

```ts
const fieldValue = get(prevCleaned, key)
if (!isNil(fieldValue)) {
  cacheHiddenFieldValue(key, fieldValue)
  set(fieldValues, ..., null)
}
```

With \`ocrvsFullForm\` as \`prevForm\`, \`father.nid\` is \`undefined\` (Formik default, not the real server value). \`!isNil(undefined)\` is \`false\`, so the null-set block is skipped and the server retains the stale value.

**First attempt** — use server state unconditionally as \`prevForm\` (\`baseDeclaration ?? ocrvsFullForm\`). This fixed the OAuth case but broke the correction flow — \`baseDeclaration\` only holds the last registered state, so in-progress draft changes were evaluated against stale server values, causing incorrect transitions.

**Second attempt** — merge server state as base with non-\`undefined\` in-memory values overriding it. This worked for both cases but was more complex than necessary.

**Final fix** — always set null unconditionally for hidden fields, regardless of the previous value:

```ts
if (!isNil(fieldValue)) {
  cacheHiddenFieldValue(key, fieldValue)  // only cache if there's something worth restoring
}
set(fieldValues, ..., null)  // always null — server may hold a real value even if prevCleaned is undefined
```

The \`!isNil\` guard is kept around the cache call only — caching \`undefined\` would overwrite a previously cached real value with nothing. The null-set is unconditional because the server may hold a real value that must be cleared regardless of what Formik has locally.

A Storybook interaction story (\`NullsHiddenFieldUsingServerState\`) was added to \`FormFieldGenerator.interaction.stories.tsx\` to regression-test this behaviour.

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly