### PR TITLE
fix(client): show offline message on Record page when event is uncached (#12922)

### DIFF
--- a/packages/client/src/v2-events/features/events/ReadOnlyView.stories.tsx
+++ b/packages/client/src/v2-events/features/events/ReadOnlyView.stories.tsx
@@ -24,9 +24,14 @@ import {
   tennisClubMembershipEvent,
   TestUserRole
 } from '@opencrvs/commons/client'
-import { AppRouter } from '@client/v2-events/trpc'
+import {
+  AppRouter,
+  queryClient,
+  trpcOptionsProxy
+} from '@client/v2-events/trpc'
 import { ROUTES, routesConfig } from '@client/v2-events/routes'
 import { testDataGenerator } from '@client/tests/test-data-generators'
+import { setNavigatorOnline } from '@client/tests/storybook-utils'
 import { ReadonlyViewIndex } from './ReadOnlyView'
 
 const generator = testDataGenerator()
@@ -188,5 +193,85 @@ export const ReadOnlyViewForUserWithReadPermission: Story = {
         ]
       }
     }
+  }
+}
+
+/**
+ * Regression test for opencrvs/opencrvs-core#12922:
+ *
+ * When the user opens the Record page for an event they have not previously
+ * downloaded while offline, React Query pauses the fetch indefinitely and the
+ * page used to show a spinner that never disappears. The fix renders an
+ * explicit offline message instead.
+ *
+ * To reproduce the user flow in storybook we pre-populate the local event
+ * index (so EventOverviewLayout can render) but remove the full event
+ * document from React Query's cache to simulate "never downloaded". Going
+ * offline then triggers the new message.
+ */
+export const ShowsOfflineMessageWhenRecordNotCached: Story = {
+  parameters: {
+    chromatic: { disableSnapshot: true },
+    reactRouter: {
+      router: routesConfig,
+      initialPath: ROUTES.V2.EVENTS.EVENT.RECORD.buildPath({
+        eventId: eventDocument.id
+      })
+    },
+    offline: {
+      events: [eventDocument]
+    },
+    msw: {
+      handlers: {
+        workqueues: [
+          tRPCMsw.workqueue.config.list.query(() => generateWorkqueues()),
+          tRPCMsw.workqueue.count.query((input) =>
+            input.reduce((acc, { slug }) => ({ ...acc, [slug]: 0 }), {})
+          )
+        ],
+        event: [
+          tRPCMsw.event.get.query(() => eventDocument),
+          tRPCMsw.event.search.query(() => ({
+            total: 1,
+            results: [
+              getCurrentEventState(eventDocument, tennisClubMembershipEvent)
+            ]
+          }))
+        ],
+        drafts: [tRPCMsw.event.draft.list.query(() => [])],
+        user: [
+          tRPCMsw.user.list.query(() => [
+            generator.user.localRegistrar().summary
+          ]),
+          tRPCMsw.user.get.query(() => generator.user.localRegistrar().v2)
+        ]
+      }
+    }
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    // The `offline.events` setup pre-caches the full event document for the
+    // Storybook user. Clear it to simulate a record that the user has never
+    // downloaded — the EventOverviewLayout still works because the local
+    // event index used by `searchEventById` is unaffected.
+    queryClient.removeQueries({
+      queryKey: trpcOptionsProxy.event.get.queryKey({
+        eventId: eventDocument.id,
+        waitFor: false
+      })
+    })
+    queryClient.removeQueries({ queryKey: [['view-event', eventDocument.id]] })
+
+    setNavigatorOnline(false)
+
+    // Without the fix this assertion times out — the page shows a spinner
+    // that never resolves because React Query pauses the fetch when offline.
+    await canvas.findByTestId('record-offline-message')
+    await expect(await canvas.findByText('No connection')).toBeVisible()
+
+    // Restore so the stubbed offline state does not leak into other stories
+    // rendered in the same preview iframe.
+    setNavigatorOnline(true)
   }
 }

--- a/packages/client/src/v2-events/features/events/ReadOnlyView.tsx
+++ b/packages/client/src/v2-events/features/events/ReadOnlyView.tsx
@@ -16,6 +16,8 @@ import {
   useTypedSearchParams
 } from 'react-router-typesafe-routes/dom'
 import { noop } from 'lodash'
+import { defineMessages, useIntl } from 'react-intl'
+import styled from 'styled-components'
 import {
   ActionType,
   applyDraftToEventIndex,
@@ -28,6 +30,7 @@ import {
   getAssignmentStatus,
   AssignmentStatus
 } from '@opencrvs/commons/client'
+import { Content, ContentSize } from '@opencrvs/components/lib/Content'
 import { getAnnotationForActionType } from '@client/v2-events/features/events/components/Action/utils'
 import { useEventConfiguration } from '@client/v2-events/features/events/useEventConfiguration'
 import { useEvents } from '@client/v2-events/features/events/useEvents/useEvents'
@@ -38,9 +41,30 @@ import { withSuspense } from '@client/v2-events/components/withSuspense'
 import { useDrafts } from '@client/v2-events/features/drafts/useDrafts'
 import { useValidatorContext } from '@client/v2-events/hooks/useValidatorContext'
 import { useAuthentication } from '@client/utils/userUtils'
+import { useOnlineStatus } from '@client/utils'
+import { queryClient, useTRPC } from '@client/v2-events/trpc'
 
 import { useCanAccessEventWithScopes } from '@client/v2-events/hooks/useCanAccessEventWithScopes'
 import { removeCachedFiles } from '../files/cache'
+
+const messages = defineMessages({
+  offlineTitle: {
+    id: 'v2.event.record.offline.title',
+    defaultMessage: 'No connection',
+    description: 'Title shown on the Record page when the user is offline'
+  },
+  offlineDescription: {
+    id: 'v2.event.record.offline.description',
+    defaultMessage:
+      'This record has not been downloaded yet so it cannot be opened offline. Please reconnect to the internet to view it.',
+    description:
+      'Message shown on the Record page when the user is offline and the record has not been cached locally'
+  }
+})
+
+const OfflineMessageWrapper = styled.div`
+  text-align: center;
+`
 
 function ReadonlyViewContent({ eventId }: { eventId: UUID }) {
   const events = useEvents()
@@ -133,6 +157,20 @@ function ReadonlyViewContent({ eventId }: { eventId: UUID }) {
   )
 }
 
+function OfflineRecordMessage() {
+  const intl = useIntl()
+  return (
+    <Content
+      size={ContentSize.SMALL}
+      title={intl.formatMessage(messages.offlineTitle)}
+    >
+      <OfflineMessageWrapper data-testid="record-offline-message">
+        {intl.formatMessage(messages.offlineDescription)}
+      </OfflineMessageWrapper>
+    </Content>
+  )
+}
+
 function ReadonlyView() {
   const { eventId } = useTypedParams(ROUTES.V2.EVENTS.EVENT.RECORD)
   const [{ backTo }] = useTypedSearchParams(ROUTES.V2.EVENTS.EVENT.RECORD)
@@ -140,10 +178,26 @@ function ReadonlyView() {
   const { canAccessEventWithScopes } = useCanAccessEventWithScopes(eventId, [
     'record.read'
   ])
+  const isOnline = useOnlineStatus()
+  const trpc = useTRPC()
 
   if (!canAccessEventWithScopes()) {
     navigate(ROUTES.V2.EVENTS.EVENT.buildPath({ eventId }, { backTo }))
     return null
+  }
+
+  // React Query pauses queries when the browser is offline, so the suspense
+  // boundary inside ReadonlyViewContent would hang on a spinner forever if
+  // the user opens a record they have not previously downloaded.
+  // Render a clear message instead — useOnlineStatus re-renders this when
+  // the connection returns, so the content loads automatically.
+  const isCachedAsView = queryClient.getQueryData([['view-event', eventId]])
+  const isCachedAsAssigned = queryClient.getQueryData(
+    trpc.event.get.queryKey({ eventId, waitFor: false })
+  )
+
+  if (!isOnline && !isCachedAsView && !isCachedAsAssigned) {
+    return <OfflineRecordMessage />
   }
 
   return <ReadonlyViewContent eventId={eventId} />


### PR DESCRIPTION
## Summary

- The Record page used to show an infinite spinner when the user opened it offline without having previously downloaded the event. `useGetOrDownloadEvent` triggers `useSuspenseQuery`, and React Query pauses queries when `navigator.onLine` is false — so the suspense boundary never resolves.
- `ReadonlyView` now detects offline + uncached and renders a clear "No connection" message instead. `useOnlineStatus` causes the view to re-render when the connection returns, so the record loads automatically once back online.

## Test plan

- [x] Added storybook interaction test `ShowsOfflineMessageWhenRecordNotCached` in `ReadOnlyView.stories.tsx` that:
  - Pre-caches the local event index (so `EventOverviewLayout` renders), but clears the full event document cache to simulate "never downloaded".
  - Triggers `setNavigatorOnline(false)`.
  - Asserts the offline message appears (instead of an infinite spinner).
- [ ] Manual: in dev, open a fresh record from the workqueue while online → go offline (DevTools Network) → click Record tab → expect "No connection" message; come back online → record loads automatically.
- [ ] Country config translations (`v2.event.record.offline.title`, `v2.event.record.offline.description`) added separately to `opencrvs-farajaland/src/translations/client.csv`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)