### PR TITLE
When user goes offline when downloading/assigning a record, switch to offline-icon

### DIFF
--- a/packages/client/src/v2-events/components/DownloadButton.tsx
+++ b/packages/client/src/v2-events/components/DownloadButton.tsx
@@ -120,6 +120,7 @@ export function DownloadButton({
           data-tip
           data-class="no-connection"
           data-for={`${id}_noConnection`}
+          data-testid="no-connection-icon"
         >
           <ConnectionError key={id} id={`${id}_noConnection`} />
         </div>
@@ -134,6 +135,7 @@ export function DownloadButton({
     return (
       <StatusIndicator
         className={className}
+        data-testid="download-loading-icon"
         id={`${id}-download-loading`}
         isLoading={true}
       >

--- a/packages/client/src/v2-events/components/DownloadButton.tsx
+++ b/packages/client/src/v2-events/components/DownloadButton.tsx
@@ -113,19 +113,6 @@ export function DownloadButton({
     event.id
   )
 
-  if (eventDocument.isFetching || isAssignMutationFetching) {
-    return (
-      <StatusIndicator
-        className={className}
-        id={`${id}-download-loading`}
-        isLoading={true}
-      >
-        <Spinner id={`action-loading-${id}`} size={24} />
-      </StatusIndicator>
-    )
-  }
-  const isFailed = eventDocument.isError
-
   if (!isOnline) {
     return (
       <NoConnectionViewContainer>
@@ -142,6 +129,19 @@ export function DownloadButton({
       </NoConnectionViewContainer>
     )
   }
+
+  if (eventDocument.isFetching || isAssignMutationFetching) {
+    return (
+      <StatusIndicator
+        className={className}
+        id={`${id}-download-loading`}
+        isLoading={true}
+      >
+        <Spinner id={`action-loading-${id}`} size={24} />
+      </StatusIndicator>
+    )
+  }
+  const isFailed = eventDocument.isError
 
   const isDownloadedToMe =
     assignmentStatus === AssignmentStatus.ASSIGNED_TO_SELF &&


### PR DESCRIPTION
## Description

Resolves: https://github.com/opencrvs/opencrvs-core/issues/12905
e2e test: https://github.com/opencrvs/opencrvs-farajaland/pull/2213

Priority given to offline icon, instead of loading-icon

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
