### PR TITLE
[OCRVS-12856-b] Fix: certificate texts clipped in death certified copy

### DIFF
--- a/packages/client/src/v2-events/features/events/actions/print-certificate/pdfUtils.test.ts
+++ b/packages/client/src/v2-events/features/events/actions/print-certificate/pdfUtils.test.ts
@@ -9,6 +9,8 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 
+/* eslint-disable max-lines */
+
 import { createIntl } from 'react-intl'
 import createFetchMock from 'vitest-fetch-mock'
 import { ContentSvg } from 'pdfmake/interfaces'

--- a/packages/client/src/v2-events/features/events/actions/print-certificate/pdfUtils.test.ts
+++ b/packages/client/src/v2-events/features/events/actions/print-certificate/pdfUtils.test.ts
@@ -239,6 +239,56 @@ describe('svgToPdfTemplate', () => {
       'href="data:image/png;base64,ALREADY_EMBEDDED"'
     )
   })
+
+  test('strips clip-path from text groups but keeps it on decorative groups', async () => {
+    fetch.mockClear()
+
+    const svgString = `<svg width="100" height="100" xmlns="http://www.w3.org/2000/svg"><g clip-path="url(#clipText)"><text x="10" y="20">Long value that would be clipped</text></g><g clip-path="url(#clipDecorative)"><path d="M0 0H10V10H0Z"/></g></svg>`
+
+    const result = await svgToPdfTemplate(svgString, {})
+    const [content] = result.definition.content as [ContentSvg]
+
+    // Text group is unclipped so PDFKit's wider metrics can't truncate it.
+    expect(content.svg).not.toContain('url(#clipText)')
+    // Decorative (no <text>) group keeps its clip so it stays bounded.
+    expect(content.svg).toContain('url(#clipDecorative)')
+  })
+
+  test('strips clip-path on a bare <text> element', async () => {
+    fetch.mockClear()
+
+    const svgString = `<svg width="100" height="100" xmlns="http://www.w3.org/2000/svg"><text clip-path="url(#clipText)" x="10" y="20">Value</text></svg>`
+
+    const result = await svgToPdfTemplate(svgString, {})
+    const [content] = result.definition.content as [ContentSvg]
+
+    expect(content.svg).not.toContain('url(#clipText)')
+    expect(content.svg).toContain('Value')
+  })
+
+  test('does not strip mask attributes', async () => {
+    fetch.mockClear()
+
+    const svgString = `<svg width="100" height="100" xmlns="http://www.w3.org/2000/svg"><g mask="url(#maskText)"><text x="10" y="20">Masked value</text></g></svg>`
+
+    const result = await svgToPdfTemplate(svgString, {})
+    const [content] = result.definition.content as [ContentSvg]
+
+    expect(content.svg).toContain('url(#maskText)')
+  })
+
+  test('strips clip-path from text inside [data-page] sections', async () => {
+    fetch.mockClear()
+
+    const svgString = `<svg width="200" height="400" xmlns="http://www.w3.org/2000/svg"><g data-page="1"><g clip-path="url(#clip1)"><text x="10" y="20">Page one value</text></g></g><g data-page="2"><g clip-path="url(#clip2)"><text x="10" y="20">Page two value</text></g></g></svg>`
+
+    const result = await svgToPdfTemplate(svgString, {})
+    const contents = result.definition.content as ContentSvg[]
+
+    expect(contents.length).toBe(2)
+    expect(contents[0].svg).not.toContain('url(#clip1)')
+    expect(contents[1].svg).not.toContain('url(#clip2)')
+  })
 })
 
 function expectRenderOutput(template: string, output: string) {

--- a/packages/client/src/v2-events/features/events/actions/print-certificate/pdfUtils.ts
+++ b/packages/client/src/v2-events/features/events/actions/print-certificate/pdfUtils.ts
@@ -724,6 +724,31 @@ async function downloadAndEmbedImages(svgString: string): Promise<string> {
   return serializer.serializeToString(svg)
 }
 
+/**
+ * Remove `clip-path` from elements that contain text, in-place, before the SVG
+ * is handed to pdfmake/svg-to-pdfkit for PDF rendering.
+ *
+ * The on-screen preview keeps these clips and renders correctly. In the PDF,
+ * svg-to-pdfkit measures the TTF glyphs with slightly different (wider) metrics
+ * than the browser's web-font engine (and maps font-weight="600" to Bold/700),
+ * so text that fits its clip box on screen overflows it by a few points and the
+ * trailing glyph(s) get truncated. svg-to-pdfkit exposes no option to disable
+ * clipping, so the only way to recover the text is to strip the attribute here.
+ *
+ * Only text-bearing elements are unclipped: decorative/background clips (e.g. the
+ * watermark `<g clip-path="url(#background)">`, which contains no <text>) are left
+ * intact so they stay bounded to the card. SVG <text> is single-line by spec, so
+ * unclipped values extend horizontally into the empty right margin — they never
+ * wrap or bleed into the field below.
+ */
+export function stripTextClipPaths(svgElement: Element): void {
+  svgElement.querySelectorAll('[clip-path]').forEach((el) => {
+    if (el.tagName.toLowerCase() === 'text' || el.querySelector('text')) {
+      el.removeAttribute('clip-path')
+    }
+  })
+}
+
 export async function svgToPdfTemplate(
   svg: string,
   certificateFonts: CertificateConfiguration
@@ -755,6 +780,11 @@ export async function svgToPdfTemplate(
     svgWithInlineImages,
     'image/svg+xml'
   ).documentElement
+
+  // Remove clip-paths from text so PDFKit's wider glyph metrics don't truncate
+  // values that fit on screen. Mutates svgElement in place, so both the
+  // multipage ($sections, cloned below) and single-page branches pick it up.
+  stripTextClipPaths(svgElement)
 
   const $sections = svgElement.querySelectorAll('[data-page]')
   const widthValue = svgElement.getAttribute('width')
@@ -811,7 +841,9 @@ export async function svgToPdfTemplate(
   } else {
     pdfTemplate.definition.content = [
       {
-        svg: svgWithInlineImages
+        // Serialize the parsed DOM (not svgWithInlineImages) so the in-place
+        // clip-path stripping above is reflected in the rendered SVG.
+        svg: new XMLSerializer().serializeToString(svgElement)
       },
       ...absolutelyPositionedHTMLs
     ]

--- a/packages/client/src/v2-events/features/events/actions/print-certificate/pdfUtils.ts
+++ b/packages/client/src/v2-events/features/events/actions/print-certificate/pdfUtils.ts
@@ -741,7 +741,7 @@ async function downloadAndEmbedImages(svgString: string): Promise<string> {
  * unclipped values extend horizontally into the empty right margin — they never
  * wrap or bleed into the field below.
  */
-export function stripTextClipPaths(svgElement: Element): void {
+function stripTextClipPaths(svgElement: Element): void {
   svgElement.querySelectorAll('[clip-path]').forEach((el) => {
     if (el.tagName.toLowerCase() === 'text' || el.querySelector('text')) {
       el.removeAttribute('clip-path')


### PR DESCRIPTION
## Summary

- PDF certificate printouts truncated text horizontally (e.g. the death certified-copy header lost `CÈS`; "Place of registration" lost `nd`). The browser preview of the same SVG was correct.
- Root cause: `svg-to-pdfkit` measures TTF glyphs slightly wider than the browser's web-font engine and maps `font-weight="600"` to Bold(700), which is wider still. Text that fits its `<clipPath>` box on screen overflows it by a few points in PDFKit, truncating trailing glyphs. `svg-to-pdfkit` exposes no option to disable clipping.
- Fix: strip `clip-path` from text-bearing elements inside `svgToPdfTemplate` (PDF path only) via a new `stripTextClipPaths` helper. Decorative/watermark clips (no `<text>` descendant) and `mask` attributes are left intact. The on-screen preview (`Review.tsx` `dangerouslySetInnerHTML`) never calls `svgToPdfTemplate` — it is pixel-identical after this change.
- No SVG template edits, no font files, no country-config changes — client-only.

## Test plan

- [ ] Generate the death "certified copy" PDF and confirm the header renders the full `…DE L'ACTE DE DÉCÈS` and field 10 renders the full `…Central, Farajaland`
- [ ] Spot-check birth certified-copy PDF for no layout regression
- [ ] Spot-check a tennis multipage certificate (uses `mask`, not `clip-path`, for field values — must be unchanged)
- [ ] Confirm the on-screen preview in the print-certificate review screen is visually unchanged
- [ ] Unit tests: 4 new tests cover text-group stripping, decorative-group preservation, mask preservation, and multipage `[data-page]` sections

### PDF Output
[pdf-after-4.pdf](https://github.com/user-attachments/files/28802253/pdf-after-4.pdf)
