### PR TITLE
fix: clear persisted react-query cache on version mismatch

### DIFF
--- a/packages/client/src/components/VersionMismatchModal.test.tsx
+++ b/packages/client/src/components/VersionMismatchModal.test.tsx
@@ -1,0 +1,50 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+import * as React from 'react'
+import { waitFor } from '@testing-library/react'
+import { getStorageUserDetailsSuccess } from '@client/profile/profileActions'
+import { storage } from '@client/storage'
+import {
+  createTestComponent,
+  createTestStore,
+  userDetails
+} from '@client/tests/util'
+import { VersionMismatchModal } from './VersionMismatchModal'
+
+describe('VersionMismatchModal', () => {
+  it('drops the persisted react-query cache of the current user on re-login', async () => {
+    const { store } = await createTestStore()
+    store.dispatch(getStorageUserDetailsSuccess(JSON.stringify(userDetails)))
+
+    const originalLocation = window.location
+    delete (window as { location?: Location }).location
+    window.location = { ...originalLocation, assign: vi.fn() }
+
+    const { component } = await createTestComponent(
+      <VersionMismatchModal show={true} />,
+      { store }
+    )
+
+    component.find('#login').hostNodes().simulate('click')
+
+    await waitFor(() => {
+      expect(storage.removeItem).toHaveBeenCalledWith(
+        `react-query-${userDetails.id}`
+      )
+    })
+    expect(storage.removeItem).toHaveBeenCalledWith(
+      `react-query-large-query-storage-${userDetails.id}`
+    )
+    expect(window.location.assign).toHaveBeenCalled()
+
+    window.location = originalLocation
+  })
+})

--- a/packages/client/src/components/VersionMismatchModal.tsx
+++ b/packages/client/src/components/VersionMismatchModal.tsx
@@ -18,6 +18,8 @@ import { storage } from '@client/storage'
 import { removeToken } from '@client/utils/authUtils'
 import { removeUserDetails } from '@client/utils/userUtils'
 import { messages as reloadModalMessages } from '@client/i18n/messages/views/reloadModal'
+import { getUserDetails } from '@client/profile/profileSelectors'
+import { removePersistedClient } from '@client/v2-events/trpc'
 
 const SCREEN_LOCK = 'screenLock'
 
@@ -35,6 +37,7 @@ export function VersionMismatchModal({ show }: { show: boolean }) {
   const appName = useSelector(
     (state: IStoreState) => state.offline.offlineData.config?.APPLICATION_NAME
   )
+  const userId = useSelector(getUserDetails)?.id
 
   const handleReLogin = async () => {
     // Unregister the SW before redirecting so it cannot intercept the
@@ -42,6 +45,11 @@ export function VersionMismatchModal({ show }: { show: boolean }) {
     if ('serviceWorker' in navigator) {
       const registration = await navigator.serviceWorker.getRegistration()
       await registration?.unregister()
+    }
+    // The new app version may expect a different shape for the persisted
+    // react-query data, so drop it and let the new version refetch.
+    if (userId) {
+      await removePersistedClient(userId)
     }
     await storage.removeItem(SCREEN_LOCK)
     await removeToken()

--- a/packages/client/src/v2-events/trpc.tsx
+++ b/packages/client/src/v2-events/trpc.tsx
@@ -92,9 +92,28 @@ function getQueryClient() {
   })
 }
 
+function getPersistedClientKeys(storageIdentifier: string) {
+  return {
+    client: `react-query-${storageIdentifier}`,
+    largeQueries: `react-query-large-query-storage-${storageIdentifier}`
+  }
+}
+
+/**
+ * Removes the persisted react-query client (including large query storage)
+ * for the given store identifier (the user id, see TRPCProvider usage).
+ */
+export async function removePersistedClient(storageIdentifier: string) {
+  const keys = getPersistedClientKeys(storageIdentifier)
+  await storage.removeItem(keys.client)
+  await storage.removeItem(keys.largeQueries)
+}
+
 function createIDBPersister(storageIdentifier: string) {
-  const fullStorageIdentifier = `react-query-${storageIdentifier}`
-  const largeQueryStorageIdentifier = `react-query-large-query-storage-${storageIdentifier}`
+  const {
+    client: fullStorageIdentifier,
+    largeQueries: largeQueryStorageIdentifier
+  } = getPersistedClientKeys(storageIdentifier)
 
   return {
     /** By default, client is persisted whenever a query/mutation occurs */
@@ -168,8 +187,7 @@ function createIDBPersister(storageIdentifier: string) {
       return client
     },
     removeClient: async () => {
-      await storage.removeItem(fullStorageIdentifier)
-      await storage.removeItem(largeQueryStorageIdentifier)
+      await removePersistedClient(storageIdentifier)
     }
   } satisfies Persister
 }


### PR DESCRIPTION
## Description

The issue https://github.com/opencrvs/opencrvs-core/issues/12895 was most likely caused due to the difference in shape of location data in cache across deployments. One remedy is to clear data when user is logged out for version mismatch. This still does not fix it for deployments where version does not change but shape does.

Side effect: When user sees the version mismatch modal and then logs in again, they will have to re-download all the assigned records again. (The records will still be assigned to them before downloading again) 

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
