### PR TITLE
Add toasts for user creation and updating

### DIFF
--- a/packages/client/src/v2-events/features/events/useToastAndRedirect.tsx
+++ b/packages/client/src/v2-events/features/events/useToastAndRedirect.tsx
@@ -44,6 +44,14 @@ function ToastWithIntl({
   )
 }
 
+/**
+ * Displays a toast using the application's standardized toast component.
+ *
+ * **Important:** Always use this function to create toasts instead of calling the `toast` library directly.
+ * This ensures consistent presentation and behavior for all notification toasts in the application.
+ *
+ * @param props - The properties for the toast, including the message, type, ID, and any interpolation options.
+ */
 export function showToast(props: ToastProps) {
   toast.custom(<ToastWithIntl {...props} />, { id: props.toastId })
 }

--- a/packages/client/src/v2-events/features/events/useToastAndRedirect.tsx
+++ b/packages/client/src/v2-events/features/events/useToastAndRedirect.tsx
@@ -47,9 +47,6 @@ function ToastWithIntl({
 /**
  * Displays a toast using the application's standardized toast component.
  *
- * **Important:** Always use this function to create toasts instead of calling the `toast` library directly.
- * This ensures consistent presentation and behavior for all notification toasts in the application.
- *
  * @param props - The properties for the toast, including the message, type, ID, and any interpolation options.
  */
 export function showToast(props: ToastProps) {

--- a/packages/client/src/views/SysAdmin/Team/user/userEditor/UserEditor.interaction.stories.tsx
+++ b/packages/client/src/views/SysAdmin/Team/user/userEditor/UserEditor.interaction.stories.tsx
@@ -13,6 +13,7 @@ import { within, expect, fn, waitFor } from '@storybook/test'
 import { userEvent } from '@storybook/testing-library'
 import { createTRPCMsw, httpLink } from '@vafanassieff/msw-trpc'
 import superjson from 'superjson'
+import { TRPCError } from '@trpc/server'
 import {
   DocumentPath,
   encodeScope,
@@ -1806,6 +1807,159 @@ export const InProgressEditsPreservedForSameUserThenClearedAfterSwitch: StoryObj
           expect(
             canvasElement.querySelector('[data-testid="row-value-email"]')
           ).not.toHaveTextContent(editedEmail)
+        )
+      }
+    )
+  }
+}
+
+export const CreateUserShowsSuccessToast: StoryObj = {
+  parameters: {
+    chromatic: { disableSnapshot: true },
+    reactRouter: {
+      router: routesConfig,
+      initialPath: ROUTES.V2.SETTINGS.USER.REVIEW.buildPath({
+        userId: createTemporaryId()
+      })
+    },
+    msw: {
+      handlers: {
+        userRoles: [tRPCMsw.user.roles.list.query(() => mockRoles)],
+        createUser: [tRPCMsw.user.create.mutation(() => mockUser)]
+      }
+    }
+  },
+  beforeEach: () => {
+    useUserFormState.getState().setUserForm({
+      primaryOfficeId: mockUser.primaryOfficeId,
+      role: TestUserRole.enum.REGISTRATION_AGENT,
+      name: { firstname: 'Test', surname: 'User' },
+      phoneNumber: '01712345678',
+      email: 'test@opencrvs.org'
+    })
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+
+    await step('Submit the create form', async () => {
+      await userEvent.click(
+        await canvas.findByRole('button', { name: /create user/i })
+      )
+    })
+
+    await step('Success toast "New user created" appears', async () => {
+      // Toasts render in a portal outside canvasElement — query document.body.
+      await waitFor(() =>
+        expect(
+          within(document.body).getByText('New user created')
+        ).toBeInTheDocument()
+      )
+    })
+  }
+}
+
+export const UpdateUserShowsSuccessToast: StoryObj = {
+  parameters: {
+    chromatic: { disableSnapshot: true },
+    reactRouter: {
+      router: routesConfig,
+      initialPath: ROUTES.V2.SETTINGS.USER.REVIEW.buildPath({
+        userId: mockUser.id
+      })
+    },
+    msw: {
+      handlers: {
+        userRoles: [tRPCMsw.user.roles.list.query(() => mockRoles)],
+        user: [tRPCMsw.user.get.query(() => mockUser)],
+        updateUser: [tRPCMsw.user.update.mutation(() => mockUser)]
+      }
+    }
+  },
+  beforeEach: () => {
+    useUserFormState.getState().setUserForm(
+      {
+        primaryOfficeId: mockUser.primaryOfficeId,
+        role: TestUserRole.enum.REGISTRATION_AGENT,
+        name: {
+          firstname: mockUser.name.firstname,
+          surname: mockUser.name.surname
+        },
+        phoneNumber: mockUser.mobile,
+        email: mockUser.email
+      },
+      mockUser.id
+    )
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+
+    await step('Submit the update form', async () => {
+      await userEvent.click(
+        await canvas.findByRole('button', { name: /confirm/i })
+      )
+    })
+
+    await step(
+      'Success toast "User details have been updated" appears',
+      async () => {
+        await waitFor(() =>
+          expect(
+            within(document.body).getByText('User details have been updated')
+          ).toBeInTheDocument()
+        )
+      }
+    )
+  }
+}
+
+export const CreateUserShowsErrorToastOnUnknownFailure: StoryObj = {
+  parameters: {
+    chromatic: { disableSnapshot: true },
+    reactRouter: {
+      router: routesConfig,
+      initialPath: ROUTES.V2.SETTINGS.USER.REVIEW.buildPath({
+        userId: createTemporaryId()
+      })
+    },
+    msw: {
+      handlers: {
+        userRoles: [tRPCMsw.user.roles.list.query(() => mockRoles)],
+        createUser: [
+          tRPCMsw.user.create.mutation(() => {
+            throw new TRPCError({
+              code: 'CONFLICT',
+              message: 'UNHANDLED_CONFLICT'
+            })
+          })
+        ]
+      }
+    }
+  },
+  beforeEach: () => {
+    useUserFormState.getState().setUserForm({
+      primaryOfficeId: mockUser.primaryOfficeId,
+      role: TestUserRole.enum.REGISTRATION_AGENT,
+      name: { firstname: 'Test', surname: 'User' },
+      phoneNumber: '01712345678',
+      email: 'test@opencrvs.org'
+    })
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+
+    await step('Submit the create form', async () => {
+      await userEvent.click(
+        await canvas.findByRole('button', { name: /create user/i })
+      )
+    })
+
+    await step(
+      'Generic error toast "Sorry! Something went wrong" appears',
+      async () => {
+        await waitFor(() =>
+          expect(
+            within(document.body).getByText('Sorry! Something went wrong')
+          ).toBeInTheDocument()
         )
       }
     )

--- a/packages/client/src/views/SysAdmin/Team/user/userEditor/UserEditor.tsx
+++ b/packages/client/src/views/SysAdmin/Team/user/userEditor/UserEditor.tsx
@@ -52,6 +52,8 @@ import { withSuspense } from '@client/v2-events/components/withSuspense'
 import { serializeSearchParams } from '@client/v2-events/features/events/Search/utils'
 import { usePermissions } from '@client/hooks/useAuthorization'
 import toast from 'react-hot-toast'
+import { showToast } from '@client/v2-events/features/events/useToastAndRedirect'
+import { messages as notificationMessages } from '@client/i18n/messages/views/notifications'
 import { useUserEditConfig } from '@client/hooks/useUserEditConfig'
 import { useUserFormState } from './useUserFormState'
 
@@ -335,6 +337,11 @@ const ReviewUserComponent = () => {
     updateUserMutation.mutate(payload, {
       onSuccess: (data) => {
         clear()
+        showToast({
+          message: notificationMessages.userFormUpdateSuccess,
+          toastType: 'success',
+          toastId: 'user-update-success'
+        })
         navigate(ROUTES.V2.SETTINGS.USER.VIEW.buildPath({ userId: data.id }))
       },
       onError: handleMutationError
@@ -403,6 +410,12 @@ const ReviewUserComponent = () => {
         return
       }
     }
+
+    showToast({
+      message: notificationMessages.userFormFail,
+      toastType: 'error',
+      toastId: 'user-form-error'
+    })
   }
 
   const handleClose = useCloseUserForm({
@@ -558,6 +571,11 @@ const ReviewUserComponent = () => {
               createUserMutation.mutate(payload, {
                 onSuccess: () => {
                   clear()
+                  showToast({
+                    message: notificationMessages.userFormSuccess,
+                    toastType: 'success',
+                    toastId: 'user-create-success'
+                  })
                   navigate(
                     `${routes.TEAM_USER_LIST}?locationId=${payload.primaryOfficeId}`
                   )


### PR DESCRIPTION
## Description

Resolves: https://github.com/opencrvs/opencrvs-core/issues/12537
E2e test: https://github.com/opencrvs/opencrvs-farajaland/pull/2216

Add success and error toasts for user creation and updating

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
