### PR TITLE
fix: Trim whitespaces from image tag inputs to prevent invalid Docker reference errors

### DIFF
--- a/charts/opencrvs-services/templates/_image-registry-helper.tpl
+++ b/charts/opencrvs-services/templates/_image-registry-helper.tpl
@@ -49,7 +49,7 @@ ghcr.io/opencrvs/ocrvs-auth:v1.9.11
 {{- $root := .root -}}
 {{- $svc := .service -}}
 
-{{- $rawTag := $svc.image.tag | default $root.Values.platform.tag | default $root.Values.image.tag -}}
+{{- $rawTag := $svc.image.tag | default $root.Values.platform.tag | default $root.Values.image.tag | trim -}}
 {{- $tag := kindIs "float64" $rawTag | ternary ($rawTag | int64 | toString) ($rawTag | toString) -}}
 {{- $repository := $svc.image.repository | default $root.Values.platform.repository -}}
 {{- $name := required "service image.name is required" $svc.image.name -}}


### PR DESCRIPTION


## Description

Related issue: https://github.com/opencrvs/opencrvs-core/issues/11879

Trim whitespaces from image tag inputs to prevent invalid Docker reference errors

## Testing

Connect to e2e cluster

Dump existing OpenCRVS configuration

Check existing namespaces:
```
k get ns
```
Get configuration for one of the namespaces:
```
helm get values -n opencrvs-ocrvs-11879 opencrvs > opencrvs.yaml 
```
Switch to branch ocrvs-11879 in opencrvs-core:
```
git checkout ocrvs-11879
```
Run helm upgrade:
```
helm upgrade -f opencrvs.yaml --install opencrvs charts/opencrvs-services/ --set platform.tag=" 378173f"
```
Check results:
<img width="695" height="331" alt="image" src="https://github.com/user-attachments/assets/071c6e9b-971c-4e9f-9165-d766f939de6d" />

<img width="993" height="402" alt="image" src="https://github.com/user-attachments/assets/177000c6-e708-4cac-a2db-98fbdd4822d8" />


## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
