### PR TITLE
fix: MOSIP hooks lost while managing release-v2.0.0 branch

### DIFF
--- a/charts/opencrvs-mosip/templates/certs.yaml
+++ b/charts/opencrvs-mosip/templates/certs.yaml
@@ -6,6 +6,8 @@ metadata:
   name: mosip-certs
   annotations:
     "helm.sh/resource-policy": keep
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "0"
 type: Opaque
 data:
   esignet-jwk.txt: {{ .Files.Get "example-certs/esignet-jwk.txt" | b64enc | quote }}


### PR DESCRIPTION
## Description

This change is responsible for creating secrets ahead of container creation to avoid container configuration errors

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
