### PR TITLE
fix(ocrvs-12880): cache locations to prevent thundering herd on config service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements
 
 - Team page now shows a user-friendly "Too many requests" message when the `searchUsers` rate limit (20 req/min) is hit, instead of the generic query error. [#12990](https://github.com/opencrvs/opencrvs-core/issues/12990)
+- Gateway locations endpoint now serves responses from an in-process cache backed by Redis, reducing memory allocations under concurrent load. Cached payloads are gzip-compressed so write buffers to Traefik are proportionally smaller during request spikes. [#12880](https://github.com/opencrvs/opencrvs-core/issues/12880)
 
 ## 1.9.14
 

--- a/packages/Dockerfile.base
+++ b/packages/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM node:22-slim
+FROM node:22.22.3-slim
 
 RUN apt-get update && apt-get upgrade -y
 

--- a/packages/data-seeder/src/locations.ts
+++ b/packages/data-seeder/src/locations.ts
@@ -232,7 +232,8 @@ export async function seedLocations(token: string) {
 function getLocationsByType(type: string) {
   return fetch(`${env.GATEWAY_HOST}/locations?type=${type}&_count=0`, {
     headers: {
-      'Content-Type': 'application/fhir+json'
+      'Content-Type': 'application/fhir+json',
+      'Cache-Control': 'no-store'
     }
   })
 }

--- a/packages/gateway/src/config/proxies.ts
+++ b/packages/gateway/src/config/proxies.ts
@@ -18,6 +18,7 @@ import {
   fetchAndCache,
   getCachedLocations
 } from '@gateway/utils/locations-cache'
+import { logger } from '@opencrvs/commons'
 import z from 'zod'
 import { promisify } from 'util'
 import { gunzip as _gunzip } from 'zlib'
@@ -47,12 +48,21 @@ const getLocationsHandler = async (req: Request, h: ResponseToolkit) => {
   const acceptsGzip: boolean =
     req.headers['accept-encoding']?.includes('gzip') ?? false
 
-  const compressed =
-    (await getCachedLocations(query)) ??
-    (await fetchAndCache(query, async () => {
-      const res = await fetch(`${APPLICATION_CONFIG_URL}locations${query}`)
-      return res.text()
-    }))
+  let compressed = await getCachedLocations(query)
+
+  if (!compressed) {
+    try {
+      compressed = await fetchAndCache(query, async () => {
+        const res = await fetch(`${APPLICATION_CONFIG_URL}locations${query}`)
+        if (!res.ok)
+          throw new Error(`upstream locations returned ${res.status}`)
+        return res.text()
+      })
+    } catch (e) {
+      logger.error(`Locations fetch failed: ${e}`)
+      return h.response({ statusCode: 502, error: 'Bad Gateway' }).code(502)
+    }
+  }
 
   if (acceptsGzip) {
     return h
@@ -62,11 +72,18 @@ const getLocationsHandler = async (req: Request, h: ResponseToolkit) => {
       .header('Vary', 'Accept-Encoding')
   }
 
-  const body = await gunzip(compressed)
-  return h
-    .response(body)
-    .type('application/json')
-    .header('Vary', 'Accept-Encoding')
+  try {
+    const body = await gunzip(compressed)
+    return h
+      .response(body)
+      .type('application/json')
+      .header('Vary', 'Accept-Encoding')
+  } catch (e) {
+    logger.error(`Locations gunzip failed for query=${query}: ${e}`)
+    return h
+      .response({ statusCode: 500, error: 'Internal Server Error' })
+      .code(500)
+  }
 }
 
 export const catchAllProxy = {

--- a/packages/gateway/src/config/proxies.ts
+++ b/packages/gateway/src/config/proxies.ts
@@ -13,8 +13,13 @@ import { APPLICATION_CONFIG_URL, AUTH_URL } from '@gateway/constants'
 import fetch from '@gateway/fetch'
 import { rateLimitedRoute } from '@gateway/rate-limit'
 import { api } from '@gateway/v2-events/events/service'
+import {
+  bustLocationsCache,
+  fetchAndCache,
+  getCachedLocations
+} from '@gateway/utils/locations-cache'
 import z from 'zod'
-import { ServerRoute } from '@hapi/hapi'
+import { ServerRoute, ResponseToolkit } from '@hapi/hapi'
 
 const LegacyLocationUpdate = z.object({
   name: z.string().optional(),
@@ -32,6 +37,18 @@ const LegacyLocationUpdate = z.object({
     )
     .optional()
 })
+
+const getLocationsHandler = async (query: string, h: ResponseToolkit) => {
+  const cached = await getCachedLocations(query)
+  if (cached) return h.response(cached).type('application/json')
+
+  const body = await fetchAndCache(query, async () => {
+    const res = await fetch(`${APPLICATION_CONFIG_URL}locations${query}`)
+    return res.text()
+  })
+
+  return h.response(body).type('application/json')
+}
 
 export const catchAllProxy = {
   auth: {
@@ -54,11 +71,15 @@ export const catchAllProxy = {
   location: {
     method: '*',
     path: '/location',
-    handler: (req, h) =>
-      h.proxy({
+    handler: async (req, h) => {
+      if (req.method === 'get') return getLocationsHandler(req.url.search, h)
+
+      void bustLocationsCache()
+      return h.proxy({
         uri: `${APPLICATION_CONFIG_URL}locations${req.url.search}`,
         passThrough: true
-      }),
+      })
+    },
     options: {
       auth: false,
       payload: {
@@ -87,11 +108,7 @@ export const catchAllProxy = {
   getLocations: {
     method: 'GET',
     path: '/locations',
-    handler: (req, h) =>
-      h.proxy({
-        uri: `${APPLICATION_CONFIG_URL}locations${req.url.search}`,
-        passThrough: true
-      }),
+    handler: (req, h) => getLocationsHandler(req.url.search, h),
     options: {
       auth: false
     }
@@ -132,6 +149,8 @@ export const catchAllProxy = {
         }
       })
 
+      await bustLocationsCache()
+
       return h.response(response.body).code(response.status)
     },
     options: {
@@ -164,6 +183,8 @@ export const catchAllProxy = {
           }
         }
       })
+
+      await bustLocationsCache()
 
       return h.response({}).code(response.status)
     },

--- a/packages/gateway/src/config/proxies.ts
+++ b/packages/gateway/src/config/proxies.ts
@@ -48,7 +48,18 @@ const getLocationsHandler = async (req: Request, h: ResponseToolkit) => {
   const acceptsGzip: boolean =
     req.headers['accept-encoding']?.includes('gzip') ?? false
 
-  let compressed = await getCachedLocations(query)
+  const cacheControl = req.headers['cache-control'] ?? ''
+  const noStore = cacheControl.includes('no-store')
+  const noCache = cacheControl.includes('no-cache')
+
+  if (!query.includes('_count=0') || noStore) {
+    return h.proxy({
+      uri: `${APPLICATION_CONFIG_URL}locations${query}`,
+      passThrough: true
+    })
+  }
+
+  let compressed = noCache ? null : await getCachedLocations(query)
 
   if (!compressed) {
     try {

--- a/packages/gateway/src/config/proxies.ts
+++ b/packages/gateway/src/config/proxies.ts
@@ -19,7 +19,11 @@ import {
   getCachedLocations
 } from '@gateway/utils/locations-cache'
 import z from 'zod'
-import { ServerRoute, ResponseToolkit } from '@hapi/hapi'
+import { promisify } from 'util'
+import { gunzip as _gunzip } from 'zlib'
+import { ServerRoute, ResponseToolkit, Request } from '@hapi/hapi'
+
+const gunzip = promisify(_gunzip)
 
 const LegacyLocationUpdate = z.object({
   name: z.string().optional(),
@@ -38,16 +42,31 @@ const LegacyLocationUpdate = z.object({
     .optional()
 })
 
-const getLocationsHandler = async (query: string, h: ResponseToolkit) => {
-  const cached = await getCachedLocations(query)
-  if (cached) return h.response(cached).type('application/json')
+const getLocationsHandler = async (req: Request, h: ResponseToolkit) => {
+  const query = req.url.search
+  const acceptsGzip: boolean =
+    req.headers['accept-encoding']?.includes('gzip') ?? false
 
-  const body = await fetchAndCache(query, async () => {
-    const res = await fetch(`${APPLICATION_CONFIG_URL}locations${query}`)
-    return res.text()
-  })
+  const compressed =
+    (await getCachedLocations(query)) ??
+    (await fetchAndCache(query, async () => {
+      const res = await fetch(`${APPLICATION_CONFIG_URL}locations${query}`)
+      return res.text()
+    }))
 
-  return h.response(body).type('application/json')
+  if (acceptsGzip) {
+    return h
+      .response(compressed)
+      .type('application/json')
+      .header('Content-Encoding', 'gzip')
+      .header('Vary', 'Accept-Encoding')
+  }
+
+  const body = await gunzip(compressed)
+  return h
+    .response(body)
+    .type('application/json')
+    .header('Vary', 'Accept-Encoding')
 }
 
 export const catchAllProxy = {
@@ -72,7 +91,7 @@ export const catchAllProxy = {
     method: '*',
     path: '/location',
     handler: async (req, h) => {
-      if (req.method === 'get') return getLocationsHandler(req.url.search, h)
+      if (req.method === 'get') return getLocationsHandler(req, h)
 
       void bustLocationsCache()
       return h.proxy({
@@ -108,7 +127,7 @@ export const catchAllProxy = {
   getLocations: {
     method: 'GET',
     path: '/locations',
-    handler: (req, h) => getLocationsHandler(req.url.search, h),
+    handler: (req, h) => getLocationsHandler(req, h),
     options: {
       auth: false
     }

--- a/packages/gateway/src/utils/locations-cache.ts
+++ b/packages/gateway/src/utils/locations-cache.ts
@@ -37,24 +37,35 @@ export const getCachedLocations = async (
   const mem = memCache.get(query)
   if (mem && Date.now() < mem.expiresAt) return mem.compressed
 
-  const stored = await redis.get(`${KEY_PREFIX}${query}`)
-  if (stored) {
-    const compressed = Buffer.from(stored, 'base64')
-    memCache.set(query, { compressed, expiresAt: Date.now() + MEM_TTL_MS })
-    return compressed
+  try {
+    const stored = await redis.get(`${KEY_PREFIX}${query}`)
+    if (stored) {
+      const compressed = Buffer.from(stored, 'base64')
+      memCache.set(query, { compressed, expiresAt: Date.now() + MEM_TTL_MS })
+      return compressed
+    }
+  } catch (e) {
+    logger.warn(`Locations Redis GET failed, falling through to upstream: ${e}`)
   }
+
   return null
 }
 
 const setCachedLocations = (query: string, compressed: Buffer) =>
-  redis.set(`${KEY_PREFIX}${query}`, compressed.toString('base64'), { EX: TTL })
+  redis
+    .set(`${KEY_PREFIX}${query}`, compressed.toString('base64'), { EX: TTL })
+    .catch((e) => logger.warn(`Locations Redis SET failed: ${e}`))
 
 export const bustLocationsCache = async () => {
   memCache.clear()
-  const keys = await redis.keys(`${KEY_PREFIX}*`)
-  if (keys.length) {
-    await redis.del(keys)
-    logger.info(`Locations cache busted: ${keys.length} keys cleared`)
+  try {
+    const keys = await redis.keys(`${KEY_PREFIX}*`)
+    if (keys.length) {
+      await redis.del(keys)
+      logger.info(`Locations cache busted: ${keys.length} keys cleared`)
+    }
+  } catch (e) {
+    logger.warn(`Locations Redis bust failed: ${e}`)
   }
 }
 

--- a/packages/gateway/src/utils/locations-cache.ts
+++ b/packages/gateway/src/utils/locations-cache.ts
@@ -9,33 +9,45 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 import { logger } from '@opencrvs/commons'
+import { promisify } from 'util'
+import { gzip as _gzip } from 'zlib'
 import { redis } from './redis'
+
+const gzip = promisify(_gzip)
 
 const TTL = 60 * 60 * 24 // 24 hours
 const MEM_TTL_MS = 60 * 1000 // 1 minute
 const KEY_PREFIX = 'locations:'
+
 // Deduplicates concurrent upstream fetches during cold-cache window. Without this,
 // N simultaneous misses on the same query each trigger a separate fetch. Once the
 // cache warms, this map is bypassed entirely.
-const inflight = new Map<string, Promise<string>>()
+const inflight = new Map<string, Promise<Buffer>>()
 
 // Redis GET allocates a new string per call. Under high concurrency, N requests
 // against a warm Redis cache = N strings in memory simultaneously. memCache keeps
-// one shared copy per query, reducing allocations to one per TTL window.
-type MemEntry = { body: string; expiresAt: number }
+// one shared compressed Buffer per query, reducing allocations to one per TTL window.
+// Stored compressed so write buffers to Traefik are smaller under high concurrency.
+type MemEntry = { compressed: Buffer; expiresAt: number }
 const memCache = new Map<string, MemEntry>()
 
-export const getCachedLocations = async (query: string) => {
+export const getCachedLocations = async (
+  query: string
+): Promise<Buffer | null> => {
   const mem = memCache.get(query)
-  if (mem && Date.now() < mem.expiresAt) return mem.body
+  if (mem && Date.now() < mem.expiresAt) return mem.compressed
 
-  const body = await redis.get(`${KEY_PREFIX}${query}`)
-  if (body) memCache.set(query, { body, expiresAt: Date.now() + MEM_TTL_MS })
-  return body
+  const stored = await redis.get(`${KEY_PREFIX}${query}`)
+  if (stored) {
+    const compressed = Buffer.from(stored, 'base64')
+    memCache.set(query, { compressed, expiresAt: Date.now() + MEM_TTL_MS })
+    return compressed
+  }
+  return null
 }
 
-export const setCachedLocations = (query: string, body: string) =>
-  redis.set(`${KEY_PREFIX}${query}`, body, { EX: TTL })
+export const setCachedLocations = (query: string, compressed: Buffer) =>
+  redis.set(`${KEY_PREFIX}${query}`, compressed.toString('base64'), { EX: TTL })
 
 export const bustLocationsCache = async () => {
   memCache.clear()
@@ -49,15 +61,16 @@ export const bustLocationsCache = async () => {
 export const fetchAndCache = (
   query: string,
   fetcher: () => Promise<string>
-): Promise<string> => {
+): Promise<Buffer> => {
   const existing = inflight.get(query)
   if (existing) return existing
 
   const promise = fetcher()
-    .then((body) => {
-      memCache.set(query, { body, expiresAt: Date.now() + MEM_TTL_MS })
-      setCachedLocations(query, body)
-      return body
+    .then(async (body) => {
+      const compressed = await gzip(body)
+      memCache.set(query, { compressed, expiresAt: Date.now() + MEM_TTL_MS })
+      setCachedLocations(query, compressed)
+      return compressed
     })
     .finally(() => inflight.delete(query))
 

--- a/packages/gateway/src/utils/locations-cache.ts
+++ b/packages/gateway/src/utils/locations-cache.ts
@@ -1,0 +1,44 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+import { redis } from './redis'
+
+const TTL = 60 * 60 * 24 // 24 hours
+const KEY_PREFIX = 'locations:'
+const inflight = new Map<string, Promise<string>>()
+
+export const getCachedLocations = (query: string) =>
+  redis.get(`${KEY_PREFIX}${query}`)
+
+export const setCachedLocations = (query: string, body: string) =>
+  redis.set(`${KEY_PREFIX}${query}`, body, { EX: TTL })
+
+export const bustLocationsCache = async () => {
+  const keys = await redis.keys(`${KEY_PREFIX}*`)
+  if (keys.length) await redis.del(keys)
+}
+
+export const fetchAndCache = (
+  query: string,
+  fetcher: () => Promise<string>
+): Promise<string> => {
+  const existing = inflight.get(query)
+  if (existing) return existing
+
+  const promise = fetcher()
+    .then((body) => {
+      setCachedLocations(query, body)
+      return body
+    })
+    .finally(() => inflight.delete(query))
+
+  inflight.set(query, promise)
+  return promise
+}

--- a/packages/gateway/src/utils/locations-cache.ts
+++ b/packages/gateway/src/utils/locations-cache.ts
@@ -46,7 +46,7 @@ export const getCachedLocations = async (
   return null
 }
 
-export const setCachedLocations = (query: string, compressed: Buffer) =>
+const setCachedLocations = (query: string, compressed: Buffer) =>
   redis.set(`${KEY_PREFIX}${query}`, compressed.toString('base64'), { EX: TTL })
 
 export const bustLocationsCache = async () => {

--- a/packages/gateway/src/utils/locations-cache.ts
+++ b/packages/gateway/src/utils/locations-cache.ts
@@ -12,16 +12,33 @@ import { logger } from '@opencrvs/commons'
 import { redis } from './redis'
 
 const TTL = 60 * 60 * 24 // 24 hours
+const MEM_TTL_MS = 60 * 1000 // 1 minute
 const KEY_PREFIX = 'locations:'
+// Deduplicates concurrent upstream fetches during cold-cache window. Without this,
+// N simultaneous misses on the same query each trigger a separate fetch. Once the
+// cache warms, this map is bypassed entirely.
 const inflight = new Map<string, Promise<string>>()
 
-export const getCachedLocations = (query: string) =>
-  redis.get(`${KEY_PREFIX}${query}`)
+// Redis GET allocates a new string per call. Under high concurrency, N requests
+// against a warm Redis cache = N strings in memory simultaneously. memCache keeps
+// one shared copy per query, reducing allocations to one per TTL window.
+type MemEntry = { body: string; expiresAt: number }
+const memCache = new Map<string, MemEntry>()
+
+export const getCachedLocations = async (query: string) => {
+  const mem = memCache.get(query)
+  if (mem && Date.now() < mem.expiresAt) return mem.body
+
+  const body = await redis.get(`${KEY_PREFIX}${query}`)
+  if (body) memCache.set(query, { body, expiresAt: Date.now() + MEM_TTL_MS })
+  return body
+}
 
 export const setCachedLocations = (query: string, body: string) =>
   redis.set(`${KEY_PREFIX}${query}`, body, { EX: TTL })
 
 export const bustLocationsCache = async () => {
+  memCache.clear()
   const keys = await redis.keys(`${KEY_PREFIX}*`)
   if (keys.length) {
     await redis.del(keys)
@@ -38,6 +55,7 @@ export const fetchAndCache = (
 
   const promise = fetcher()
     .then((body) => {
+      memCache.set(query, { body, expiresAt: Date.now() + MEM_TTL_MS })
       setCachedLocations(query, body)
       return body
     })

--- a/packages/gateway/src/utils/locations-cache.ts
+++ b/packages/gateway/src/utils/locations-cache.ts
@@ -8,6 +8,7 @@
  *
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
+import { logger } from '@opencrvs/commons'
 import { redis } from './redis'
 
 const TTL = 60 * 60 * 24 // 24 hours
@@ -22,7 +23,10 @@ export const setCachedLocations = (query: string, body: string) =>
 
 export const bustLocationsCache = async () => {
   const keys = await redis.keys(`${KEY_PREFIX}*`)
-  if (keys.length) await redis.del(keys)
+  if (keys.length) {
+    await redis.del(keys)
+    logger.info(`Locations cache busted: ${keys.length} keys cleared`)
+  }
 }
 
 export const fetchAndCache = (


### PR DESCRIPTION
## Test environment
https://register.farajaland-dev.opencrvs.dev  running v1.9.15 (pre-release) with the following data pre-loaded:
  - 40 provinces
  - 80,000 districts
  - 10,000 CRVS offices
  - 10,000 health facilities
  - 100,040 total
  
## Test scenario
GET /location?type=\<ADMIN_STRUCTURE | HEALTH_FACILITY | CRVS_OFFICE\>&_count=0

All hit simultaneously via parallel `hey` processes.

The system was unusable at it's current state due to the hearth service buckling even with just ~5 concurrent requests. 

## The solution

<img width="860" height="1019" alt="image" src="https://github.com/user-attachments/assets/4d202b8d-289e-4495-9b0b-768484a388ed" />

## Metrics after the introduction of the caching layer

<img width="796" height="412" alt="Screenshot from 2026-06-16 14-32-18" src="https://github.com/user-attachments/assets/1dbec32b-a08c-4a52-b83b-d9158e31d544" />
<img width="796" height="412" alt="Screenshot from 2026-06-16 16-51-16" src="https://github.com/user-attachments/assets/5191b8a4-fd41-425b-be59-f47aaa2260fb" />
<img width="796" height="412" alt="Screenshot from 2026-06-16 14-32-30" src="https://github.com/user-attachments/assets/e4aace74-d0b1-4b78-8b56-ac44de982073" />
<img width="796" height="412" alt="Screenshot from 2026-06-16 14-32-40" src="https://github.com/user-attachments/assets/54ffd7ff-47fb-47a5-8b5e-ec4a27e2c86c" />

