### PR TITLE
fix: Change order to trim spaces

### DIFF
--- a/charts/opencrvs-services/templates/_image-registry-helper.tpl
+++ b/charts/opencrvs-services/templates/_image-registry-helper.tpl
@@ -49,8 +49,8 @@ ghcr.io/opencrvs/ocrvs-auth:v1.9.11
 {{- $root := .root -}}
 {{- $svc := .service -}}
 
-{{- $rawTag := $svc.image.tag | default $root.Values.platform.tag | default $root.Values.image.tag | trim -}}
-{{- $tag := kindIs "float64" $rawTag | ternary ($rawTag | int64 | toString) ($rawTag | toString) -}}
+{{- $rawTag := $svc.image.tag | default $root.Values.platform.tag | default $root.Values.image.tag -}}
+{{- $tag := kindIs "float64" $rawTag | ternary ($rawTag | int64 | toString) ($rawTag | toString) | trim -}}
 {{- $repository := $svc.image.repository | default $root.Values.platform.repository -}}
 {{- $name := required "service image.name is required" $svc.image.name -}}
 


### PR DESCRIPTION
## Description

Trim string tag instead of trimming raw tag

## Testing

1. Dump existing configuration
   ```
   helm get values opencrvs > opencrvs.yaml 
   ```
2. Update countryconfig.image.tag to `1599409`
3. Deploy `helm upgrade -f opencrvs.yaml opencrvs charts/opencrvs-services/`

<img width="744" height="299" alt="image" src="https://github.com/user-attachments/assets/ce9eda64-bc01-4a3f-967b-8eb354741802" />

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
