### PR TITLE
show offline-aware fallback for v2-events suspense boundaries

### DIFF
--- a/packages/client/src/v2-events/components/SuspenseLoadingFallback.tsx
+++ b/packages/client/src/v2-events/components/SuspenseLoadingFallback.tsx
@@ -1,0 +1,96 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+import React from 'react'
+import styled from 'styled-components'
+import { defineMessages, useIntl } from 'react-intl'
+import { Spinner } from '@opencrvs/components'
+import { ConnectionError } from '@opencrvs/components/lib/icons'
+import { useOnlineStatus } from '@client/utils'
+
+const messages = defineMessages({
+  offlineTitle: {
+    id: 'v2.suspense.offline.title',
+    defaultMessage: 'No connection',
+    description: 'Title shown on a loading screen when the user is offline'
+  },
+  offlineDescription: {
+    id: 'v2.suspense.offline.description',
+    defaultMessage:
+      'This content has not been downloaded yet, so it cannot be shown offline. It will load automatically once you are back online.',
+    description:
+      'Message shown when a screen cannot load because the user is offline and the data has not been cached locally'
+  }
+})
+
+const FullSizeWrapper = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`
+
+const OfflineWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  max-width: 360px;
+  padding: 24px;
+`
+const OfflineTitle = styled.h2`
+  ${({ theme }) => theme.fonts.h2};
+  color: ${({ theme }) => theme.colors.copy};
+  margin: 16px 0 8px;
+`
+const OfflineDescription = styled.p`
+  ${({ theme }) => theme.fonts.reg16};
+  color: ${({ theme }) => theme.colors.grey500};
+  margin: 0;
+`
+
+/**
+ * Suspense fallback used across the v2-events app.
+ *
+ * React Query pauses queries while the browser is offline, so a
+ * `useSuspenseQuery` for data that has not been cached yet would otherwise
+ * suspend forever and leave this fallback spinning indefinitely. When offline
+ * we show a clear message instead; `useOnlineStatus` re-renders this when the
+ * connection returns, the paused query resumes, and the content loads
+ * automatically. Cached data resolves synchronously and never reaches this
+ * fallback, so offline-first behaviour is preserved.
+ */
+export function SuspenseLoadingFallback({ id }: { id?: string }) {
+  const isOnline = useOnlineStatus()
+  const intl = useIntl()
+
+  if (!isOnline) {
+    return (
+      <FullSizeWrapper>
+        <OfflineWrapper id="suspense-offline-message">
+          <ConnectionError />
+          <OfflineTitle>
+            {intl.formatMessage(messages.offlineTitle)}
+          </OfflineTitle>
+          <OfflineDescription>
+            {intl.formatMessage(messages.offlineDescription)}
+          </OfflineDescription>
+        </OfflineWrapper>
+      </FullSizeWrapper>
+    )
+  }
+
+  return (
+    <FullSizeWrapper>
+      <Spinner id={id ?? 'page-spinner'} />
+    </FullSizeWrapper>
+  )
+}

--- a/packages/client/src/v2-events/components/withSuspense.tsx
+++ b/packages/client/src/v2-events/components/withSuspense.tsx
@@ -10,32 +10,19 @@
  */
 
 import React from 'react'
-import styled from 'styled-components'
-import { Spinner } from '@opencrvs/components'
+import { SuspenseLoadingFallback } from './SuspenseLoadingFallback'
 
 /**
- * HOC to wrap a component in a suspense boundary with a spinner fallback.
+ * HOC to wrap a component in a suspense boundary with an offline-aware
+ * loading fallback. See {@link SuspenseLoadingFallback} for why the fallback
+ * is offline-aware.
  */
-
-const FullSizeWrapper = styled.div`
-  width: 100%;
-  height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-`
 
 export function withSuspense<P extends object>(
   Component: React.ComponentType<P>
 ) {
   return (props: P) => (
-    <React.Suspense
-      fallback={
-        <FullSizeWrapper>
-          <Spinner id={`page-spinner-${Date.now()}`} />
-        </FullSizeWrapper>
-      }
-    >
+    <React.Suspense fallback={<SuspenseLoadingFallback />}>
       <Component {...props} />
     </React.Suspense>
   )

--- a/packages/client/src/v2-events/features/events/EventSelection.tsx
+++ b/packages/client/src/v2-events/features/events/EventSelection.tsx
@@ -14,7 +14,6 @@ import { defineMessages, useIntl } from 'react-intl'
 import { useNavigate } from 'react-router-dom'
 import { useTypedSearchParams } from 'react-router-typesafe-routes/dom'
 import { useSelector } from 'react-redux'
-import { Spinner } from '@opencrvs/components'
 import { AppBar } from '@opencrvs/components/lib/AppBar'
 import { Button } from '@opencrvs/components/lib/Button'
 import { Content, ContentSize } from '@opencrvs/components/lib/Content'
@@ -24,6 +23,7 @@ import { Icon } from '@opencrvs/components/lib/Icon'
 import { RadioGroup, RadioSize } from '@opencrvs/components/lib/Radio'
 import { Stack } from '@opencrvs/components/lib/Stack'
 import { canUserCreateEvent } from '@opencrvs/commons/client'
+import { SuspenseLoadingFallback } from '@client/v2-events/components/SuspenseLoadingFallback'
 import { ROUTES } from '@client/v2-events/routes'
 import { createTemporaryId } from '@client/v2-events/utils'
 import { getScope, getUserDetails } from '@client/profile/profileSelectors'
@@ -196,7 +196,9 @@ export function EventSelection() {
         size={ContentSize.SMALL}
         title={intl.formatMessage(messages.registerNewEventHeading)}
       >
-        <React.Suspense fallback={<Spinner id="event-selector-spinner" />}>
+        <React.Suspense
+          fallback={<SuspenseLoadingFallback id="event-selector-spinner" />}
+        >
           <EventSelector />
         </React.Suspense>
       </Content>

--- a/packages/client/src/v2-events/features/events/actions/dedup/ReviewDuplicate.tsx
+++ b/packages/client/src/v2-events/features/events/actions/dedup/ReviewDuplicate.tsx
@@ -22,7 +22,7 @@ import {
   getCurrentEventState,
   getDeclaration
 } from '@opencrvs/commons/client'
-import { FormTabs, Frame, Icon, IFormTabs, Spinner } from '@opencrvs/components'
+import { FormTabs, Frame, Icon, IFormTabs } from '@opencrvs/components'
 import { Duplicate } from '@opencrvs/components/lib/icons'
 import { useEventConfiguration } from '@client/v2-events/features/events/useEventConfiguration'
 import { useEvents } from '@client/v2-events/features/events/useEvents/useEvents'
@@ -30,6 +30,7 @@ import { ROUTES } from '@client/v2-events/routes'
 import { Review as ReviewComponent } from '@client/v2-events/features/events/components/Review'
 import { useIntlFormatMessageWithFlattenedParams } from '@client/v2-events/messages/utils'
 import { withSuspense } from '@client/v2-events/components/withSuspense'
+import { SuspenseLoadingFallback } from '@client/v2-events/components/SuspenseLoadingFallback'
 import { FormHeader } from '@client/v2-events/layouts/form/FormHeader'
 import { findLocalEventDocument } from '../../useEvents/api'
 import { useValidatorContext } from '../../../../hooks/useValidatorContext'
@@ -217,7 +218,9 @@ function ReviewDuplicate() {
         />
       </TopBar>
       {selectedTab === event.trackingId ? (
-        <React.Suspense fallback={<Spinner id="event-form-spinner" />}>
+        <React.Suspense
+          fallback={<SuspenseLoadingFallback id="event-form-spinner" />}
+        >
           <ReviewComponent.Body
             readonlyMode
             banner={<DuplicateForm eventIndex={eventState} />}

--- a/packages/client/src/v2-events/features/workqueues/Workqueue.interaction.stories.tsx
+++ b/packages/client/src/v2-events/features/workqueues/Workqueue.interaction.stories.tsx
@@ -601,6 +601,87 @@ export const DraftPaginationOffline: Story = {
   }
 }
 
+/**
+ * Regression test for the offline-aware Suspense fallback (SuspenseLoadingFallback).
+ *
+ * Scenario: the workqueue route starts loading, the spinner shows, and the
+ * network drops *mid-load* (before the list query resolves). The fallback must
+ * swap the spinner for the "No connection" message instead of spinning forever,
+ * and return to the spinner once back online.
+ *
+ * The list query (`event.search`) never resolves, so the workqueue content stays
+ * in its Suspense (loading) state for the whole test while we toggle connectivity.
+ */
+export const WorkqueueGoesOfflineWhileLoading: Story = {
+  parameters: {
+    userRole: TestUserRole.enum.LOCAL_REGISTRAR,
+    reactRouter: {
+      router: routesConfig,
+      initialPath: ROUTES.V2.WORKQUEUES.WORKQUEUE.buildPath({ slug: 'recent' })
+    },
+    chromatic: { disableSnapshot: true },
+    msw: {
+      handlers: {
+        workqueues: [
+          tRPCMsw.workqueue.config.list.query(() => {
+            return generateWorkqueues('recent')
+          }),
+          tRPCMsw.workqueue.count.query((input) => {
+            return input.reduce((acc, { slug }) => {
+              return { ...acc, [slug]: queryData.length }
+            }, {})
+          })
+        ],
+        event: [
+          // Never resolves: keeps the workqueue content query pending so the
+          // Suspense fallback stays mounted while we toggle connectivity.
+          tRPCMsw.event.search.query(
+            async () => new Promise<never>(() => undefined)
+          )
+        ]
+      }
+    }
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+
+    await step(
+      'Loading spinner appears while the list query is in flight',
+      async () => {
+        await canvas.findAllByTestId('spinner')
+        await expect(
+          canvasElement.querySelector('#suspense-offline-message')
+        ).not.toBeInTheDocument()
+      }
+    )
+
+    await step(
+      'Network drops mid-load → offline message replaces the spinner',
+      async () => {
+        setNavigatorOnline(false)
+
+        await canvas.findAllByText('No connection')
+        await expect(
+          canvasElement.querySelector('#page-spinner')
+        ).not.toBeInTheDocument()
+      }
+    )
+
+    await step('Back online → returns to the loading spinner', async () => {
+      setNavigatorOnline(true)
+
+      await canvas.findAllByTestId('spinner')
+      await expect(
+        canvasElement.querySelector('#suspense-offline-message')
+      ).not.toBeInTheDocument()
+    })
+
+    // Restore online status so the stubbed offline state does not leak into
+    // stories rendered after this one in the same preview iframe
+    setNavigatorOnline(true)
+  }
+}
+
 // ---------------------------------------------------------------------------
 // WorkqueueAutoRefreshOnCountChange
 //

--- a/packages/client/src/v2-events/layouts/form/index.tsx
+++ b/packages/client/src/v2-events/layouts/form/index.tsx
@@ -12,10 +12,11 @@
 import React from 'react'
 import { useTypedParams } from 'react-router-typesafe-routes/dom'
 import { useIntl } from 'react-intl'
-import { Frame, Spinner } from '@opencrvs/components'
+import { Frame } from '@opencrvs/components'
 import { DeclarationIcon } from '@opencrvs/components/lib/icons'
 import { useEventConfiguration } from '@client/v2-events/features/events/useEventConfiguration'
 import { useEvents } from '@client/v2-events/features/events/useEvents/useEvents'
+import { SuspenseLoadingFallback } from '@client/v2-events/components/SuspenseLoadingFallback'
 import { FormHeader } from './FormHeader'
 import { AllowedRouteWithEventId } from './utils'
 
@@ -57,7 +58,9 @@ export function FormLayout({
       }
       skipToContentText="Skip to form"
     >
-      <React.Suspense fallback={<Spinner id="event-form-spinner" />}>
+      <React.Suspense
+        fallback={<SuspenseLoadingFallback id="event-form-spinner" />}
+      >
         {children}
       </React.Suspense>
     </Frame>


### PR DESCRIPTION
# fix: show offline message instead of infinite loader when offline
https://github.com/opencrvs/opencrvs-core/issues/12899
opencrvs-core: https://github.com/opencrvs/opencrvs-core/pull/12964
opencrvs-countryconfig: https://github.com/opencrvs/opencrvs-countryconfig/pull/1456
opencrvs-farajaland: https://github.com/opencrvs/opencrvs-farajaland/pull/2227

## Summary

Loading screens in the v2-events app hung on an infinite spinner whenever the device went offline and the requested data hadn't been downloaded yet. This PR makes every Suspense loading boundary **offline-aware**: instead of spinning forever, it shows a clear "No connection" message and automatically loads the content once the connection returns.

## Problem

React Query is configured with the default `networkMode: 'online'`. When the browser is offline, queries don't fail — they enter `fetchStatus: 'paused'` while staying `pending`. As a result, any `useSuspenseQuery` for data that **isn't already cached** suspends indefinitely, and the Suspense fallback (a bare `<Spinner />`) spins forever with no error and no recovery path until connectivity is restored.

**Steps to reproduce**
1. Log in (3G), enter PIN.
2. Switch network from online to offline.
3. Navigate to a screen whose data hasn't been cached (e.g. a search for a new term).

**Actual:** spinner loads infinitely.
**Expected:** a message that the device is offline; content loads automatically when back online.

This is the same root cause already documented and handled per-screen in `ReadOnlyView.tsx`; this PR generalizes that handling to all Suspense boundaries.

## Solution

A single shared, offline-aware Suspense fallback, reused everywhere:

- **New** `packages/client/src/v2-events/components/SuspenseLoadingFallback.tsx`
  - Uses the existing `useOnlineStatus()` hook (`packages/client/src/utils.ts`).
  - **Online:** renders the existing centered `<Spinner />` (unchanged UX; accepts an optional `id` prop to preserve the previous spinner ids).
  - **Offline:** renders a centered "No connection" message (`ConnectionError` icon + title + description) explaining the content will load automatically on reconnect.
- Wired into the loading boundaries:
  - `withSuspense.tsx` — the global HOC that wraps every route/component.
  - `features/events/EventSelection.tsx`
  - `layouts/form/index.tsx`
  - `features/events/actions/dedup/ReviewDuplicate.tsx`

## Why this preserves offline-first

The app's offline-first behavior is untouched:
- **Cached reads** resolve synchronously and never reach the fallback — so the offline message only appears for not-yet-downloaded data.
- **Queued mutations** sync via `onlineManager` + `resumePausedMutations()`, which are independent of query `networkMode` and of the Suspense fallback UI.

Earlier alternatives (a global "you're offline" gate at the app root, or a bootstrap-request timeout) were rejected because they would disable offline-first; the fix lives at the Suspense boundary instead.

## Changes

| File | Change |
|------|--------|
| `v2-events/components/SuspenseLoadingFallback.tsx` | **New** — shared offline-aware fallback |
| `v2-events/components/withSuspense.tsx` | Use the shared fallback (global coverage) |
| `v2-events/features/events/EventSelection.tsx` | Use the shared fallback |
| `v2-events/layouts/form/index.tsx` | Use the shared fallback |
| `v2-events/features/events/actions/dedup/ReviewDuplicate.tsx` | Use the shared fallback |

## Testing

Verified end-to-end against the local stack (login `k.mweene`, browser context toggled offline/online):

- ✅ **Offline + uncached** (novel global search): shows the "No connection" message in ~1s instead of an infinite spinner.
- ✅ **Auto-recovery:** reconnecting clears the message and resolves the query — no manual reload.
- ✅ **Offline-first preserved:** while offline, a cached workqueue still renders fully with no offline message.
- ✅ **Online unchanged:** normal loads still show the spinner briefly.
- ✅ `yarn test:compilation` (tsc) and ESLint on all changed files pass.

## Notes / out of scope

- `ReadOnlyView.tsx` keeps its existing record-specific offline guard (harmless overlap, more tailored copy).
- The legacy v1 `UserEditor.tsx` Suspense boundary is outside the offline v2-events flow and is not changed.
- New i18n strings: `v2.suspense.offline.title`, `v2.suspense.offline.description`.

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
