### PR TITLE
fix: Drop not used fields from Elasticsearch index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,7 @@ HTTP input now accepts `field('..')` references in the HTTP body definition.
 - Fixed vulnerabilities on CSP HTTP Header for login page [#12094](https://github.com/opencrvs/opencrvs-core/issues/12094)
 - Merged Helm charts as part of Monorepo [#12679](https://github.com/opencrvs/opencrvs-core/issues/12679)
 - Change nginx log format to json for client and login containers [#10202](https://github.com/opencrvs/opencrvs-core/issues/10202)
+- Reduce the amount of data sent to Elasticsearch by dropping unused and duplicate fields during Filebeat processing [#11232](https://github.com/opencrvs/opencrvs-core/issues/11232)
 
 ## 1.9.14
 

--- a/charts/dependencies/files/beats/filebeat.yml
+++ b/charts/dependencies/files/beats/filebeat.yml
@@ -126,7 +126,37 @@ processors:
             }
           }
         } 
-
+  - drop_fields:
+      fields:
+        - agent
+        - ecs
+        - input
+        - host.ip
+        - host.mac
+        - host.os
+        - host.architecture
+        - host.containerized
+        - log.file.device_id
+        - log.file.inode
+        - log.file.fingerprint
+        - log.offset
+        - kubernetes.node.uid
+        - kubernetes.namespace_uid
+        - kubernetes.namespace_labels
+        - kubernetes.node.labels
+        - kubernetes.pod.uid
+        - container.id
+        - stream
+        - event.timezone
+        - pid
+        - req.remotePort
+        - container.runtime
+        - time
+        - kubernetes.node.name
+        - kubernetes.container.name
+        - kubernetes.labels.pod-template-hash
+        - level
+      ignore_missing: true
 #========================== Elasticsearch output ===============================
 output.elasticsearch:
   hosts: ['${ELASTICSEARCH_HOST}']


### PR DESCRIPTION
## Description

Related issue: https://github.com/opencrvs/opencrvs-core/issues/11232

Filebeat currently forwards a number of metadata fields that are not used for log analysis or troubleshooting. These fields increase Elasticsearch index size and storage requirements without providing significant value.

This PR reduces the amount of data sent to Elasticsearch by dropping unused and duplicate fields during Filebeat processing. This helps decrease index size, reduce storage consumption, and improve overall efficiency while preserving the fields required for log search, filtering, and debugging.

Reducing index size will help countries and our development team increase index retention period in the future releases and reduce disk usage.

## Tesing

Example original index entry:
- Number of fields: 100
- Entry size: 3.8K
[countryconfig-index-record-before.json](https://github.com/user-attachments/files/29005326/countryconfig-index-record-before.json)

Example index entry after dropping fields:
- Number of fields: 30
- Entry size: 1.6K
[countryconfig-index-record-after.json](https://github.com/user-attachments/files/29005323/countryconfig-index-record-after.json)

```
NB01NSTL012:opencrvs-core vmudryi$ ls -lh countryconfig-index-record-*
-rw-r--r--@ 1 vmudryi  staff   1.6K Jun 16 17:24 countryconfig-index-record-after.json
-rw-r--r--@ 1 vmudryi  staff   3.8K Jun 16 17:04 countryconfig-index-record-before.json
```

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
