### PR TITLE
Remove mark-as-duplicate checkbox from reject modal

### DIFF
--- a/packages/client/src/i18n/messages/views/reject.ts
+++ b/packages/client/src/i18n/messages/views/reject.ts
@@ -22,7 +22,6 @@ interface IRejectMessages
   rejectionReasonOther: MessageDescriptor
   rejectionCommentForHealthWorkerLabel: MessageDescriptor
   rejectionFormInstruction: MessageDescriptor
-  markAsDuplicate: MessageDescriptor
   rejectionReasonLabel: MessageDescriptor
 }
 
@@ -56,11 +55,6 @@ const messagesToDefine: IRejectMessages = {
   rejectionReasonDuplicate: {
     id: 'review.rejection.form.reasons.duplicate',
     defaultMessage: 'Duplicate declaration',
-    description: 'Label for rejection option duplicate'
-  },
-  markAsDuplicate: {
-    id: 'review.rejection.form.reasons.markDuplicate',
-    defaultMessage: 'Mark as a duplicate',
     description: 'Label for rejection option duplicate'
   },
   rejectionReasonMisspelling: {

--- a/packages/client/src/v2-events/features/events/actions/reject/useRejectionModal.tsx
+++ b/packages/client/src/v2-events/features/events/actions/reject/useRejectionModal.tsx
@@ -14,18 +14,10 @@ import { v4 as uuid } from 'uuid'
 import { UUID, getActionConfig, ActionType } from '@opencrvs/commons/client'
 import { useEvents } from '@client/v2-events/features/events/useEvents/useEvents'
 import { useModal } from '@client/v2-events/hooks/useModal'
-import {
-  REJECT_ACTIONS,
-  RejectionState,
-  Review as ReviewComponent
-} from '@client/v2-events/features/events/components/Review'
+import { Review as ReviewComponent } from '@client/v2-events/features/events/components/Review'
 import { useEventConfiguration } from '@client/v2-events/features/events/useEventConfiguration'
 
-export function useRejectionModal(
-  eventId: UUID,
-  eventType: string,
-  allowArchive = true
-) {
+export function useRejectionModal(eventId: UUID, eventType: string) {
   const [modal, openModal] = useModal()
   const events = useEvents()
   const { eventConfiguration } = useEventConfiguration(eventType)
@@ -37,37 +29,21 @@ export function useRejectionModal(
   const supportingCopy = rejectActionConfig?.supportingCopy
 
   async function handleRejection(onClose: () => void) {
-    const confirmedRejection = await openModal<RejectionState | null>(
-      (close) => (
-        <ReviewComponent.ActionModal.Reject
-          allowArchive={allowArchive}
-          close={close}
-          supportingCopy={supportingCopy}
-        />
-      )
-    )
+    const confirmedRejection = await openModal<string | null>((close) => (
+      <ReviewComponent.ActionModal.Reject
+        close={close}
+        supportingCopy={supportingCopy}
+      />
+    ))
+
     if (confirmedRejection) {
-      const { rejectAction, message } = confirmedRejection
-
-      if (rejectAction === REJECT_ACTIONS.SEND_FOR_UPDATE) {
-        events.actions.reject.mutate({
-          eventId,
-          declaration: {},
-          transactionId: uuid(),
-          annotation: {},
-          content: { reason: message }
-        })
-      }
-
-      if (rejectAction === REJECT_ACTIONS.ARCHIVE) {
-        events.actions.archive.mutate({
-          eventId,
-          declaration: {},
-          transactionId: uuid(),
-          annotation: {},
-          content: { reason: message }
-        })
-      }
+      events.actions.reject.mutate({
+        eventId,
+        declaration: {},
+        transactionId: uuid(),
+        annotation: {},
+        content: { reason: confirmedRejection }
+      })
 
       onClose()
       return

--- a/packages/client/src/v2-events/features/events/actions/reject/useRejectionModal.tsx
+++ b/packages/client/src/v2-events/features/events/actions/reject/useRejectionModal.tsx
@@ -47,7 +47,7 @@ export function useRejectionModal(
       )
     )
     if (confirmedRejection) {
-      const { rejectAction, message, isDuplicate } = confirmedRejection
+      const { rejectAction, message } = confirmedRejection
 
       if (rejectAction === REJECT_ACTIONS.SEND_FOR_UPDATE) {
         events.actions.reject.mutate({
@@ -60,22 +60,13 @@ export function useRejectionModal(
       }
 
       if (rejectAction === REJECT_ACTIONS.ARCHIVE) {
-        if (isDuplicate) {
-          events.customActions.archiveOnDuplicate.mutate({
-            eventId,
-            declaration: {},
-            transactionId: uuid(),
-            content: { reason: message }
-          })
-        } else {
-          events.actions.archive.mutate({
-            eventId,
-            declaration: {},
-            transactionId: uuid(),
-            annotation: {},
-            content: { reason: message }
-          })
-        }
+        events.actions.archive.mutate({
+          eventId,
+          declaration: {},
+          transactionId: uuid(),
+          annotation: {},
+          content: { reason: message }
+        })
       }
 
       onClose()

--- a/packages/client/src/v2-events/features/events/components/Review.stories.tsx
+++ b/packages/client/src/v2-events/features/events/components/Review.stories.tsx
@@ -32,7 +32,7 @@ import {
   getTestValidatorContext,
   withValidatorContext
 } from '../../../../../.storybook/decorators'
-import { RejectionState, Review } from './Review'
+import { Review } from './Review'
 
 /* eslint-disable max-lines */
 const mockDeclaration = {
@@ -184,7 +184,7 @@ export const ReviewWithValidationErrors: Story = {
     const [modal, openModal] = useModal()
 
     async function handleRejection() {
-      await openModal<RejectionState | null>((close) => (
+      await openModal<string | null>((close) => (
         <Review.ActionModal.Reject close={close} />
       ))
     }

--- a/packages/client/src/v2-events/features/events/components/Review.tsx
+++ b/packages/client/src/v2-events/features/events/components/Review.tsx
@@ -778,12 +778,11 @@ function RejectActionModal({
     <ResponsiveModal
       showHeaderBorder
       actions={actions}
-      contentHeight={270}
       handleClose={() => close(null)}
       id="reject-modal"
       show={true}
       title={intl.formatMessage(reviewMessages.rejectModalTitle)}
-      width={918}
+      width={700}
     >
       <Stack alignItems="left" direction="column">
         <Text color="grey500" element="p" variant="reg16">

--- a/packages/client/src/v2-events/features/events/components/Review.tsx
+++ b/packages/client/src/v2-events/features/events/components/Review.tsx
@@ -18,7 +18,6 @@ import { CountryLogo } from '@opencrvs/components/lib/icons'
 import {
   Accordion,
   Button,
-  Checkbox,
   Link,
   ListReview,
   ResponsiveModal,
@@ -189,11 +188,6 @@ const reviewMessages = defineMessages({
     id: 'rejectModal.title',
     defaultMessage: 'Reason for rejection?',
     description: 'The title for reject modal'
-  },
-  rejectModalMarkAsDuplicate: {
-    id: 'rejectModal.markAsDuplicate',
-    defaultMessage: 'Mark as a duplicate',
-    description: 'The label for mark as duplicate checkbox of reject modal'
   },
   annotationsTitle: {
     id: 'review.annotations.title',
@@ -717,7 +711,6 @@ export const REJECT_ACTIONS = {
 export interface RejectionState {
   rejectAction: keyof typeof REJECT_ACTIONS
   message: string
-  isDuplicate: boolean
 }
 
 function RejectActionModal({
@@ -731,8 +724,7 @@ function RejectActionModal({
 }) {
   const [state, setState] = useState<RejectionState>({
     rejectAction: REJECT_ACTIONS.ARCHIVE,
-    message: '',
-    isDuplicate: false
+    message: ''
   })
 
   const intl = useIntl()
@@ -768,7 +760,7 @@ function RejectActionModal({
       : []),
     <Button
       key="confirm_reject_with_update"
-      disabled={!state.message || state.isDuplicate}
+      disabled={!state.message}
       id="confirm_reject_with_update"
       type="negative"
       onClick={() => {
@@ -803,15 +795,6 @@ function RejectActionModal({
           value={state.message}
           onChange={(e) =>
             setState((prev) => ({ ...prev, message: e.target.value }))
-          }
-        />
-        <Checkbox
-          label={intl.formatMessage(reviewMessages.rejectModalMarkAsDuplicate)}
-          name={'markDuplicate'}
-          selected={state.isDuplicate}
-          value={''}
-          onChange={() =>
-            setState((prev) => ({ ...prev, isDuplicate: !prev.isDuplicate }))
           }
         />
       </Stack>

--- a/packages/client/src/v2-events/features/events/components/Review.tsx
+++ b/packages/client/src/v2-events/features/events/components/Review.tsx
@@ -703,30 +703,18 @@ function AcceptActionModal({
   )
 }
 
-export const REJECT_ACTIONS = {
-  ARCHIVE: 'ARCHIVE',
-  SEND_FOR_UPDATE: 'SEND_FOR_UPDATE'
-} as const
-
 export interface RejectionState {
-  rejectAction: keyof typeof REJECT_ACTIONS
   message: string
 }
 
 function RejectActionModal({
   close,
-  allowArchive = true,
   supportingCopy
 }: {
-  close: (result: RejectionState | null) => void
-  allowArchive?: boolean
+  close: (result: string | null) => void
   supportingCopy?: MessageDescriptor
 }) {
-  const [state, setState] = useState<RejectionState>({
-    rejectAction: REJECT_ACTIONS.ARCHIVE,
-    message: ''
-  })
-
+  const [message, setMessage] = useState<string>('')
   const intl = useIntl()
 
   const actions = [
@@ -740,34 +728,13 @@ function RejectActionModal({
     >
       {intl.formatMessage(buttonMessages.cancel)}
     </Button>,
-    ...(allowArchive
-      ? [
-          <Button
-            key="confirm_reject_with_archive"
-            disabled={!state.message}
-            id="confirm_reject_with_archive"
-            type="secondaryNegative"
-            onClick={() => {
-              close({
-                ...state,
-                rejectAction: REJECT_ACTIONS.ARCHIVE
-              })
-            }}
-          >
-            {intl.formatMessage(reviewMessages.rejectModalArchive)}
-          </Button>
-        ]
-      : []),
     <Button
       key="confirm_reject_with_update"
-      disabled={!state.message}
+      disabled={!message}
       id="confirm_reject_with_update"
       type="negative"
       onClick={() => {
-        close({
-          ...state,
-          rejectAction: REJECT_ACTIONS.SEND_FOR_UPDATE
-        })
+        close(message)
       }}
     >
       {intl.formatMessage(reviewMessages.rejectModalSendForUpdate)}
@@ -791,10 +758,8 @@ function RejectActionModal({
         <TextArea
           data-testid="reject-reason"
           required={true}
-          value={state.message}
-          onChange={(e) =>
-            setState((prev) => ({ ...prev, message: e.target.value }))
-          }
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
         />
       </Stack>
     </ResponsiveModal>

--- a/packages/client/src/v2-events/features/events/components/Review.tsx
+++ b/packages/client/src/v2-events/features/events/components/Review.tsx
@@ -174,11 +174,6 @@ const reviewMessages = defineMessages({
     defaultMessage: 'Government',
     description: 'Header title that shows govt name'
   },
-  rejectModalArchive: {
-    id: 'rejectModal.archive',
-    defaultMessage: 'Archive',
-    description: 'The label for archive button of reject modal'
-  },
   rejectModalSendForUpdate: {
     id: 'rejectModal.sendForUpdate',
     defaultMessage: 'Send For Update',
@@ -701,10 +696,6 @@ function AcceptActionModal({
       </Stack>
     </ResponsiveModal>
   )
-}
-
-export interface RejectionState {
-  message: string
 }
 
 function RejectActionModal({

--- a/packages/client/src/v2-events/features/workqueues/Actions/useEventActionsOnClick.tsx
+++ b/packages/client/src/v2-events/features/workqueues/Actions/useEventActionsOnClick.tsx
@@ -53,8 +53,7 @@ export function useEventActionsOnClick(event: EventIndex) {
   const { eventConfiguration } = useEventConfiguration(event.type)
   const { handleRejection, rejectionModal } = useRejectionModal(
     event.id,
-    event.type,
-    false
+    event.type
   )
   const { onQuickAction, quickActionModal } = useQuickActionModal(
     eventConfiguration,


### PR DESCRIPTION
## Description

This was a request by Jon!

Also cleanup unused archive functionality from reject modal code.

After:
<img width="1184" height="841" alt="Screenshot 2026-06-17 at 14 54 39" src="https://github.com/user-attachments/assets/6ca607d8-e470-49be-a6ab-14c3627fe67c" />

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
