### PR TITLE
feat: better UX when rate limit is hit in team page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.9.15 Release Candidate
 
+### Improvements
+
+- Team page now shows a user-friendly "Too many requests" message when the `searchUsers` rate limit (20 req/min) is hit, instead of the generic query error. [#12990](https://github.com/opencrvs/opencrvs-core/issues/12990)
+
 ## 1.9.14
 
 ### New features

--- a/packages/client/src/i18n/messages/constants.ts
+++ b/packages/client/src/i18n/messages/constants.ts
@@ -164,6 +164,7 @@ interface IConstantsMessages
   duplicateOf: MessageDescriptor
   matchedTo: MessageDescriptor
   humanName: MessageDescriptor
+  retryInSeconds: MessageDescriptor
 }
 const messagesToDefine: IConstantsMessages = {
   action: {
@@ -984,6 +985,12 @@ const messagesToDefine: IConstantsMessages = {
     defaultMessage: `{firstName} {middleName} {lastName}`,
     description: 'A localized order of the full name',
     id: 'constants.humanName'
+  },
+  retryInSeconds: {
+    defaultMessage: 'Retry in {seconds}s',
+    description:
+      'Button label showing remaining seconds before retry is allowed',
+    id: 'constants.retryInSeconds'
   }
 }
 export const constantsMessages: Record<

--- a/packages/client/src/i18n/messages/errors.ts
+++ b/packages/client/src/i18n/messages/errors.ts
@@ -26,6 +26,7 @@ interface IErrorMessages
   registrationQueryError: MessageDescriptor
   unauthorized: MessageDescriptor
   userQueryError: MessageDescriptor
+  userQueryRateLimitError: MessageDescriptor
   loadingDeclarations: MessageDescriptor
   noDeclaration: MessageDescriptor
   waitingForConnection: MessageDescriptor
@@ -108,6 +109,12 @@ const messagesToDefine: IErrorMessages = {
     defaultMessage: 'An error occurred while loading system users',
     description: 'The text when error ocurred loading system users',
     id: 'system.user.queryError'
+  },
+  userQueryRateLimitError: {
+    defaultMessage: 'Too many requests. Please wait before retrying.',
+    description:
+      'Error text shown when the user list query is rate limited (HTTP 429)',
+    id: 'system.user.queryRateLimitError'
   },
   loadingDeclarations: {
     defaultMessage: 'Loading declarations...',

--- a/packages/client/src/views/SysAdmin/Team/user/UserList.tsx
+++ b/packages/client/src/views/SysAdmin/Team/user/UserList.tsx
@@ -9,6 +9,7 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 import { Query } from '@client/components/Query'
+import { ApolloError } from '@apollo/client'
 import {
   buttonMessages,
   constantsMessages,
@@ -55,7 +56,7 @@ import { userMutations } from '@client/user/mutations'
 import { Pagination } from '@opencrvs/components/lib/Pagination'
 import { Icon } from '@opencrvs/components/lib/Icon'
 import { ListUser } from '@opencrvs/components/lib/ListUser'
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import {
   withOnlineStatus,
   LoadingIndicator
@@ -207,6 +208,38 @@ export const Status = (statusProps: IStatusProps) => {
         <Pill type="pending" label={intl.formatMessage(messages.pending)} />
       )
   }
+}
+
+const RATE_LIMIT_RETRY_SECONDS = 60
+
+function isRateLimitError(error: ApolloError): boolean {
+  return error.graphQLErrors?.some(
+    (e) => e.extensions?.code === 'RATE_LIMIT_EXCEEDED'
+  )
+}
+
+function RateLimitErrorPanel({ refetch }: { refetch: () => void }) {
+  const intl = useIntl()
+  const [countdown, setCountdown] = useState(RATE_LIMIT_RETRY_SECONDS)
+
+  useEffect(() => {
+    if (countdown <= 0) return
+    const timer = setTimeout(() => setCountdown((c) => c - 1), 1000)
+    return () => clearTimeout(timer)
+  }, [countdown])
+
+  return (
+    <ErrorText id="user_loading_error">
+      <>{intl.formatMessage(errorMessages.userQueryRateLimitError)}</>
+      <LinkButtonModified disabled={countdown > 0} onClick={() => refetch()}>
+        {countdown > 0
+          ? intl.formatMessage(constantsMessages.retryInSeconds, {
+              seconds: countdown
+            })
+          : intl.formatMessage(constantsMessages.refresh)}
+      </LinkButtonModified>
+    </ErrorText>
+  )
 }
 
 function UserListComponent(props: IProps) {
@@ -811,7 +844,7 @@ function UserListComponent(props: IProps) {
           }}
           fetchPolicy={'cache-and-network'}
         >
-          {({ data, loading, error }) => {
+          {({ data, loading, error, refetch }) => {
             return (
               <Content
                 title={
@@ -825,14 +858,18 @@ function UserListComponent(props: IProps) {
                 topActionButtons={LocationButton(locationId)}
               >
                 {error ? (
-                  <ErrorText id="user_loading_error">
-                    <>{intl.formatMessage(errorMessages.userQueryError)}</>
-                    <LinkButtonModified
-                      onClick={() => window.location.reload()}
-                    >
-                      {intl.formatMessage(constantsMessages.refresh)}
-                    </LinkButtonModified>
-                  </ErrorText>
+                  isRateLimitError(error) ? (
+                    <RateLimitErrorPanel refetch={refetch} />
+                  ) : (
+                    <ErrorText id="user_loading_error">
+                      <>{intl.formatMessage(errorMessages.userQueryError)}</>
+                      <LinkButtonModified
+                        onClick={() => window.location.reload()}
+                      >
+                        {intl.formatMessage(constantsMessages.refresh)}
+                      </LinkButtonModified>
+                    </ErrorText>
+                  )
                 ) : loading ? (
                   <Loading>
                     <LoadingIndicator loading={true} />


### PR DESCRIPTION
https://github.com/opencrvs/opencrvs-countryconfig/pull/1459

## Before
<img width="1648" height="925" alt="rate-limit-error" src="https://github.com/user-attachments/assets/35dfe893-1bae-4191-846d-2a32a526e6f0" />

## After
<img width="1648" height="925" alt="rate-limit-handled" src="https://github.com/user-attachments/assets/0b3c16e2-5c1e-4437-bb32-4fd631040590" />

<img width="1835" height="955" alt="image" src="https://github.com/user-attachments/assets/13297ff2-832c-4aec-9198-e7f34c314e07" />

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
