### PR TITLE
Fix issue with allowed actions on archived, rejected records.

### DIFF
--- a/packages/commons/src/events/state/__snapshots__/availableActions.test.ts.snap
+++ b/packages/commons/src/events/state/__snapshots__/availableActions.test.ts.snap
@@ -12,12 +12,10 @@ exports[`getAvailableActionsForEvent() returns the correct actions for "REGISTER
 ]
 `;
 
-exports[`getAvailableActionsForEvent() should not allow ARCHIVE for "ARCHIVED" status with rejected flag 1`] = `
+exports[`getAvailableActionsForEvent() should not allow ARCHIVE or EDIT for "ARCHIVED" status with rejected flag 1`] = `
 [
   "READ",
-  "NOTIFY",
   "CUSTOM",
-  "EDIT",
 ]
 `;
 

--- a/packages/commons/src/events/state/__snapshots__/availableActions.test.ts.snap
+++ b/packages/commons/src/events/state/__snapshots__/availableActions.test.ts.snap
@@ -12,6 +12,15 @@ exports[`getAvailableActionsForEvent() returns the correct actions for "REGISTER
 ]
 `;
 
+exports[`getAvailableActionsForEvent() should not allow ARCHIVE for "ARCHIVED" status with rejected flag 1`] = `
+[
+  "READ",
+  "NOTIFY",
+  "CUSTOM",
+  "EDIT",
+]
+`;
+
 exports[`getAvailableActionsForEvent() should return the correct actions for "ARCHIVED" status with no flags 1`] = `
 [
   "READ",

--- a/packages/commons/src/events/state/availableActions.test.ts
+++ b/packages/commons/src/events/state/availableActions.test.ts
@@ -34,13 +34,14 @@ describe('getAvailableActionsForEvent()', () => {
     })
   }
 
-  it(`should not allow ARCHIVE for "${EventStatus.enum.ARCHIVED}" status with ${InherentFlags.REJECTED} flag`, () => {
+  it(`should not allow ARCHIVE or EDIT for "${EventStatus.enum.ARCHIVED}" status with ${InherentFlags.REJECTED} flag`, () => {
     const actions = getAvailableActionsForEvent({
       status: EventStatus.enum.ARCHIVED,
       flags: [InherentFlags.REJECTED]
     } as EventIndex)
 
     expect(actions).not.toContain(ActionType.ARCHIVE)
+    expect(actions).not.toContain(ActionType.EDIT)
     expect(actions).toMatchSnapshot()
   })
 

--- a/packages/commons/src/events/state/availableActions.test.ts
+++ b/packages/commons/src/events/state/availableActions.test.ts
@@ -8,6 +8,7 @@
  *
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
+import { ActionType } from '../ActionType'
 import { EventIndex } from '../EventIndex'
 import { EventStatus } from '../EventMetadata'
 import { InherentFlags } from '../Flag'
@@ -32,6 +33,16 @@ describe('getAvailableActionsForEvent()', () => {
       ).toMatchSnapshot()
     })
   }
+
+  it(`should not allow ARCHIVE for "${EventStatus.enum.ARCHIVED}" status with ${InherentFlags.REJECTED} flag`, () => {
+    const actions = getAvailableActionsForEvent({
+      status: EventStatus.enum.ARCHIVED,
+      flags: [InherentFlags.REJECTED]
+    } as EventIndex)
+
+    expect(actions).not.toContain(ActionType.ARCHIVE)
+    expect(actions).toMatchSnapshot()
+  })
 
   it(`should return the correct actions for "${EventStatus.enum.REGISTERED}" status with ${InherentFlags.CORRECTION_REQUESTED} flag`, () => {
     expect(

--- a/packages/commons/src/events/state/availableActions.ts
+++ b/packages/commons/src/events/state/availableActions.ts
@@ -113,12 +113,23 @@ export function filterActionsByFlags(
 }
 
 /**
- * Bases available actions on previous status without the REJECTED flag if the current flags contain REJECTED.
- * 1. This is to ensure that the user can still perform actions on the event after rejection.
- * 2. In 1.9 we allow rejecting event in rejected state. No filtering of previous actions needed.
- * (NOTIFIED & DECLARED) + REJECTED are an exception to this as we want to allow all the
- * actions available to CREATED minus DELETE plus ARCHIVE
+ * A rejected record has a specific set of core actions that are available to it.
+ *
+ * This expansion only applies while the record is still active. Once it has
+ * been archived it must behave like any other archived record: it cannot be
+ * edited or archived again, so we fall through to the status-based actions.
+ *
+ * At some point we will refactor 'Rejected' to be a countryconfig flag, at
+ * which point we can remove this special case.
  */
+const REJECTED_ACTIONS: DisplayableAction[] = [
+  ActionType.READ,
+  ActionType.NOTIFY,
+  ActionType.CUSTOM,
+  ActionType.EDIT,
+  ActionType.ARCHIVE
+]
+
 function getAvailableActionsWithoutFlagFilters(
   status: EventStatus,
   flags: Flag[]
@@ -128,21 +139,11 @@ function getAvailableActionsWithoutFlagFilters(
     return [ActionType.NOTIFY, ActionType.DECLARE, ActionType.REGISTER]
   }
 
-  // At some point we will refactor 'Rejected' to be a countryconfig flag, at which point we can remove this silly logic.
-  if (flags.includes(InherentFlags.REJECTED)) {
-    const rejectedActions = [
-      ActionType.READ,
-      ActionType.NOTIFY,
-      ActionType.CUSTOM,
-      ActionType.EDIT
-    ]
-
-    if (status !== EventStatus.enum.ARCHIVED) {
-      return [...rejectedActions, ActionType.ARCHIVE]
-    } else {
-      // Archived records cannot be archived again.
-      return rejectedActions
-    }
+  if (
+    flags.includes(InherentFlags.REJECTED) &&
+    status !== EventStatus.enum.ARCHIVED
+  ) {
+    return REJECTED_ACTIONS
   }
 
   return AVAILABLE_ACTIONS_BY_EVENT_STATUS[status]

--- a/packages/commons/src/events/state/availableActions.ts
+++ b/packages/commons/src/events/state/availableActions.ts
@@ -130,13 +130,19 @@ function getAvailableActionsWithoutFlagFilters(
 
   // At some point we will refactor 'Rejected' to be a countryconfig flag, at which point we can remove this silly logic.
   if (flags.includes(InherentFlags.REJECTED)) {
-    return [
+    const rejectedActions = [
       ActionType.READ,
       ActionType.NOTIFY,
       ActionType.CUSTOM,
-      ActionType.EDIT,
-      ActionType.ARCHIVE
+      ActionType.EDIT
     ]
+
+    if (status !== EventStatus.enum.ARCHIVED) {
+      return [...rejectedActions, ActionType.ARCHIVE]
+    } else {
+      // Archived records cannot be archived again.
+      return rejectedActions
+    }
   }
 
   return AVAILABLE_ACTIONS_BY_EVENT_STATUS[status]

--- a/packages/commons/src/events/state/availableActions.ts
+++ b/packages/commons/src/events/state/availableActions.ts
@@ -115,7 +115,7 @@ export function filterActionsByFlags(
 /**
  * A rejected record has a specific set of core actions that are available to it.
  *
- * This expansion only applies while the record is still active. Once it has
+ * This list of actions only applies while the record is still active. Once it has
  * been archived it must behave like any other archived record: it cannot be
  * edited or archived again, so we fall through to the status-based actions.
  *


### PR DESCRIPTION
## Description

Resolves https://github.com/opencrvs/opencrvs-core/issues/12999
And comment https://github.com/opencrvs/opencrvs-core/issues/12853#issuecomment-4748915367

Fix issue where rejected, archived records displayed incorrect actions.

We now use logic on `AVAILABLE_ACTIONS_BY_EVENT_STATUS`: `[EventStatus.enum.ARCHIVED]: [ActionType.READ, ActionType.CUSTOM]` for archived actions, even if rejected.

Refactor logic for available actions for rejected records

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
