### PR TITLE
Ensure `event.search` is initiated on workqueue change

### DIFF
--- a/packages/client/src/v2-events/features/workqueues/Workqueue.interaction.stories.tsx
+++ b/packages/client/src/v2-events/features/workqueues/Workqueue.interaction.stories.tsx
@@ -961,3 +961,127 @@ export const WorkqueueAutoRefreshOnCountChange: Story = {
     })
   }
 }
+
+let switchDataChanged = false
+let switchSearchCalls = 0
+
+const switchInitialCount = 2
+const switchUpdatedCount = 3
+
+const switchInitialEvents = queryData.slice(0, switchInitialCount)
+const switchUpdatedEvents = [
+  eventQueryDataGenerator(undefined, 8888),
+  ...switchInitialEvents
+]
+
+const switchWorkqueues = [
+  ...generateWorkqueues('recent'),
+  ...generateWorkqueues('sent-for-review')
+]
+
+// The sidebar only renders workqueues whose slug is in the user's `workqueue`
+// scope ids (see useCountryConfigWorkqueueConfigurations). Grant both slugs so
+// they both appear and can be switched between. The FIELD_AGENT role is used
+// because that is the preview branch that honours a custom `token` parameter.
+const switchToken = buildFakeStorybookToken([
+  encodeScope({
+    type: 'workqueue',
+    options: { ids: ['recent', 'sent-for-review'] }
+  }),
+  encodeScope({ type: 'record.read' }),
+  encodeScope({ type: 'record.search' })
+])
+
+export const RefetchesOnWorkqueueSwitch: Story = {
+  beforeEach: () => {
+    switchDataChanged = false
+    switchSearchCalls = 0
+  },
+  parameters: {
+    userRole: TestUserRole.enum.FIELD_AGENT,
+    token: switchToken,
+    reactRouter: {
+      router: routesConfig,
+      initialPath: ROUTES.V2.WORKQUEUES.WORKQUEUE.buildPath({ slug: 'recent' })
+    },
+    chromatic: { disableSnapshot: true },
+    msw: {
+      handlers: {
+        workqueues: [
+          tRPCMsw.workqueue.config.list.query(() => switchWorkqueues),
+          tRPCMsw.workqueue.count.query((input) => {
+            const count = switchDataChanged
+              ? switchUpdatedCount
+              : switchInitialCount
+            return input.reduce(
+              (acc, { slug }) => ({ ...acc, [slug]: count }),
+              {} as Record<string, number>
+            )
+          })
+        ],
+        event: [
+          tRPCMsw.event.search.query(() => {
+            switchSearchCalls++
+            return {
+              results: switchDataChanged
+                ? switchUpdatedEvents
+                : switchInitialEvents,
+              total: switchDataChanged ? switchUpdatedCount : switchInitialCount
+            }
+          })
+        ]
+      }
+    }
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+
+    await step('Initial workqueue (recent) renders 2 events', async () => {
+      await canvas.findByText('Farajaland CRVS', {}, { timeout: 5000 })
+      await waitFor(async () => {
+        const rows = canvasElement.querySelectorAll('div[id^="row_"]')
+        await expect(rows).toHaveLength(switchInitialCount)
+      })
+    })
+
+    await step(
+      'Switching to another workqueue initiates a fresh search',
+      async () => {
+        const callsBefore = switchSearchCalls
+        await userEvent.click(
+          await canvas.findByTestId('navigation_workqueue_sent-for-review')
+        )
+        await waitFor(async () => {
+          await expect(switchSearchCalls).toBeGreaterThan(callsBefore)
+        })
+      }
+    )
+
+    await step(
+      'Switching back refetches and renders fresh data without waiting for the poll',
+      async () => {
+        // Server data changes while we are viewing the other workqueue.
+        switchDataChanged = true
+        const callsBefore = switchSearchCalls
+
+        await userEvent.click(
+          await canvas.findByTestId('navigation_workqueue_recent')
+        )
+
+        // The switch itself must initiate a new search ...
+        await waitFor(async () => {
+          await expect(switchSearchCalls).toBeGreaterThan(callsBefore)
+        })
+
+        // ... and the list must immediately reflect the fresh data.
+        await waitFor(
+          async () => {
+            const rows = canvasElement.querySelectorAll('div[id^="row_"]')
+            await expect(rows).toHaveLength(switchUpdatedCount)
+          },
+          { timeout: 5000 }
+        )
+      }
+    )
+  }
+}

--- a/packages/client/src/v2-events/features/workqueues/Workqueue.tsx
+++ b/packages/client/src/v2-events/features/workqueues/Workqueue.tsx
@@ -102,7 +102,12 @@ function WorkqueueContent() {
   if (workqueueSlug === CoreWorkqueues.DRAFT) {
     return <Draft />
   }
-  return <ConfigurableWorkqueue workqueueSlug={workqueueSlug} />
+  /*
+   * Key by slug so switching workqueues remounts the data component and the search query.
+   */
+  return (
+    <ConfigurableWorkqueue key={workqueueSlug} workqueueSlug={workqueueSlug} />
+  )
 }
 
 export function WorkqueueContainer() {


### PR DESCRIPTION
## Description

Resolves https://github.com/opencrvs/opencrvs-core/issues/11703

By keying the component to `workqueueSlug`, we ensure that the `event.search` query is always sent when a user switches workqueue.

This was tested by Taohid before merging: https://github.com/opencrvs/opencrvs-core/issues/11703#issuecomment-4766634652

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
