### PR TITLE
Remove margin from hidden input fields

### DIFF
--- a/packages/client/src/v2-events/components/forms/FormFieldGenerator/FormSectionComponent.tsx
+++ b/packages/client/src/v2-events/components/forms/FormFieldGenerator/FormSectionComponent.tsx
@@ -32,7 +32,8 @@ import {
   isFieldVisible,
   findAllFields,
   flattenFieldReference,
-  omitHiddenPaginatedFields
+  omitHiddenPaginatedFields,
+  HiddenFieldTypes
 } from '@opencrvs/commons/client'
 import {
   makeFormFieldIdFormikCompatible,
@@ -489,7 +490,9 @@ export function FormSectionComponent({
         return (
           <FormItem
             key={formikFieldId}
-            ignoreBottomMargin={field.type === FieldType.PAGE_HEADER}
+            ignoreBottomMargin={HiddenFieldTypes.some(
+              (type) => type === field.type
+            )}
           >
             <GeneratedInputField
               allKnownFields={fullFormFields}

--- a/packages/client/src/v2-events/features/events/registered-fields/PageHeader.tsx
+++ b/packages/client/src/v2-events/features/events/registered-fields/PageHeader.tsx
@@ -10,10 +10,15 @@
  */
 
 import React from 'react'
+import styled from 'styled-components'
 import { SubHeader } from '@opencrvs/components'
 
+const StyledSubHeader = styled(SubHeader)`
+  padding-bottom: 0;
+`
+
 function PageHeaderInput({ children }: { children: React.ReactNode }) {
-  return <SubHeader>{children}</SubHeader>
+  return <StyledSubHeader>{children}</StyledSubHeader>
 }
 
 export const PageHeader = {

--- a/packages/commons/src/events/FieldType.ts
+++ b/packages/commons/src/events/FieldType.ts
@@ -112,3 +112,9 @@ export const FieldTypesToHideInReview = [
   FieldType.ALPHA_PRINT_BUTTON,
   FieldType.ALPHA_HIDDEN
 ]
+
+export const HiddenFieldTypes = [
+  FieldType.HTTP,
+  FieldType.QUERY_PARAM_READER,
+  FieldType.ALPHA_HIDDEN
+]


### PR DESCRIPTION
## Description

Hidden field types were causing margin on form page. Remove the margin.

Before:
<img width="550" alt="Screenshot 2026-06-22 at 13 47 36" src="https://github.com/user-attachments/assets/225ea9dc-3fa5-4912-b8b5-0aacaac678f8" />


After:
<img width="550" alt="Screenshot 2026-06-22 at 13 47 50" src="https://github.com/user-attachments/assets/663ec64d-bfb2-4e78-ac27-cd5c4230f905" />


## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
