### PR TITLE
fix: force reload on reconnect when app goes offline mid-initialisation to prevent install hang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,7 @@ HTTP input now accepts `field('..')` references in the HTTP body definition.
 - Merged Helm charts as part of Monorepo [#12679](https://github.com/opencrvs/opencrvs-core/issues/12679)
 - Change nginx log format to json for client and login containers [#10202](https://github.com/opencrvs/opencrvs-core/issues/10202)
 - Reduce the amount of data sent to Elasticsearch by dropping unused and duplicate fields during Filebeat processing [#11232](https://github.com/opencrvs/opencrvs-core/issues/11232)
+- The app now recovers automatically when the network changes (e.g. Ethernet → WiFi) or become online -> offline -> online again during app initialisation is halfway. If connectivity drops while the app is still loading and is then restored, the app reloads itself to finish loading, instead of getting stuck on the "Installing application…" screen and requiring a manual refresh. [#12898](https://github.com/opencrvs/opencrvs-core/issues/12898)
 
 ## 1.9.15 Release Candidate
 

--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -115,6 +115,7 @@ Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencr
         <p>Installing application...</p>
       </div>
     </div>
+    <script src="/connectivity-recovery.js"></script>
     <script type="module" src="/src/index.tsx"></script>
   </body>
 </html>

--- a/packages/client/public/connectivity-recovery.js
+++ b/packages/client/public/connectivity-recovery.js
@@ -1,0 +1,65 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+
+/*
+ * Connectivity recovery during initial app load (#12898).
+ *
+ * Loaded as a classic script BEFORE the app bundle, so its listeners attach
+ * before the bundle downloads — catching network switches that happen while the
+ * bundle / service-worker assets are still loading. Such a switch can abort the
+ * service worker precache (leaving the app stuck on "Installing application…")
+ * or interrupt the bundle fetch; browsers don't auto-retry either, only a reload
+ * does. So if we go offline while still loading and then come back online, force
+ * one reload. Once the app has rendered we unsubscribe, so a blip in an active
+ * session never reloads.
+ */
+;(function () {
+  function appLoaded() {
+    // React replaces #root's contents on first render, removing this placeholder.
+    const noRootAppProgress = !document.getElementById('root-app-progress')
+    const noAppSpinner = !document.getElementById('appSpinner')
+    return noRootAppProgress && noAppSpinner
+  }
+
+  var wentOfflineWhileLoading = !navigator.onLine
+
+  function onOffline() {
+    if (!appLoaded()) {
+      wentOfflineWhileLoading = true
+    }
+  }
+
+  function onOnline() {
+    if (!appLoaded() && wentOfflineWhileLoading) {
+      window.location.reload()
+    }
+  }
+
+  function unsubscribe() {
+    window.removeEventListener('offline', onOffline)
+    window.removeEventListener('online', onOnline)
+  }
+
+  window.addEventListener('offline', onOffline)
+  window.addEventListener('online', onOnline)
+
+  // Unsubscribe as soon as the app has rendered.
+  var root = document.getElementById('root')
+  if (root && 'MutationObserver' in window) {
+    var observer = new MutationObserver(function () {
+      if (appLoaded()) {
+        observer.disconnect()
+        unsubscribe()
+      }
+    })
+    observer.observe(root, { childList: true, subtree: true })
+  }
+})()


### PR DESCRIPTION
https://github.com/opencrvs/opencrvs-core/issues/12898#issuecomment-4765455624
# Fix: app hangs on "Installing application…" after a network switch during logi

## Problem

When a user switches networks (e.g. Ethernet → WiFi) **during the initial load
of the client app at login**, the app gets stuck on the "Installing
application…" screen for a long time. A "You are back online" toast appears, but
the app does not progress. Manually refreshing the page fixes it — the app then
finishes loading and navigates to the PIN-entry screen.

### Steps to reproduce
1. Connect via Ethernet, enter username & password, then the 2FA code.
2. After 2FA, the client app loads and shows "Installing application…".
3. Switch from Ethernet to WiFi while the app is still loading.
4. **Actual:** the app stalls on the install screen; only a manual refresh recovers it.
5. **Expected:** the app finishes loading promptly after reconnecting.

## Root cause

The client (`packages/client`) is an offline-first Workbox PWA. On first load it
shows the static "Installing application…" placeholder (`index.html`) and only
renders React **after the service worker is active** (`navigator.serviceWorker.ready`
gate in `index.tsx`). The service worker precaches up to 10 MB of assets during
its `install` event.

A network switch during this window can:
1. **Abort the Workbox precache** — any in-flight precache fetch fails, the
   `install` step rejects, and the new service worker is **discarded and never
   activates**, so `serviceWorker.ready` never resolves and React never renders; and/or
2. **Interrupt the app bundle download itself** (or a dynamic chunk), so the app's
   own JS never finishes executing.

Browsers do **not** automatically retry a failed service-worker install or a
failed bundle fetch — only a page reload does. That's why a manual refresh is the
only thing that recovers the app today.

Crucially, any connectivity handling placed inside the app bundle (`index.tsx`)
can only help *after* that bundle has downloaded and executed — so it cannot cover
case (2) or the bundle-download window at all.

## Solution

Add a tiny **external, classic (non-module) script** —
`packages/client/public/connectivity-recovery.js` — loaded **before** the app
bundle in `index.html`. Because a classic `<script src>` executes before deferred
module scripts, its `online`/`offline` listeners attach **before the app bundle
downloads**, so it covers all three cases above.

Behaviour:
- Detects whether the app has finished loading by checking for the
  `#root-app-progress` placeholder element. React removes it on first render, so
  its presence means the app has not loaded yet.
- If connectivity is lost while still loading and then returns, it triggers a
  single `window.location.reload()` — reproducing the known-good manual-refresh
  recovery automatically, on the now-stable connection.
- A `MutationObserver` unsubscribes the listeners as soon as the app renders, so a
  network blip during an **active session never causes a reload**.

`index.tsx` is reverted to its original form (it only keeps the existing
"back online" toast); all init-time connectivity recovery now lives in the external
script.

### Why an external file (not an inline script)
The client is served with a strict Content-Security-Policy whose `script-src` does
**not** include `'unsafe-inline'`, so a literal inline `<script>` would be blocked.
An external same-origin file is allowed by `script-src 'self'`, requires no CSP
changes, and is precached by the service worker (so it loads instantly/offline on
subsequent visits).

## Changes
- `packages/client/public/connectivity-recovery.js` — new early connectivity-recovery script.
- `packages/client/index.html` — load it immediately before the module bundle.
- `packages/client/src/index.tsx` — remove the inline connectivity logic (reverted to toast-only).

## Testing
> The service worker only registers in a production build, so test against a
> production-like build/serve.

- [ ] **Main repro:** Ethernet → log in → 2FA → "Installing application…"; switch
      Ethernet→WiFi while loading → app auto-reloads once and reaches the PIN page,
      no manual refresh.
- [ ] **Bundle-loading window:** DevTools → Network → Slow 3G; start a fresh load,
      toggle **Offline** while the bundle/chunks are downloading, then back
      **Online** → app auto-reloads and completes.
- [ ] **Loaded-session regression:** once on the PIN page (or beyond), toggle
      Offline→Online → **no reload**; only the existing "You are back online" toast
      appears (confirms the listeners unsubscribed).
- [ ] **Happy path:** a clean login on a stable connection reaches the PIN page as before.

## Risk
Low. One small additive file plus a single HTML script tag; `index.tsx` is reverted
toward its original form. Recovery is strictly gated to the pre-render window, so
loaded sessions are unaffected. No CSP/nginx changes required.

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
