### PR TITLE
fix: Block access to locations outside the user's jurisdiction

### DIFF
--- a/packages/client/src/views/SysAdmin/Team/user/UserList.tsx
+++ b/packages/client/src/views/SysAdmin/Team/user/UserList.tsx
@@ -773,6 +773,11 @@ function UserListComponent({ userDetails }: UserListProps) {
     return <Navigate to={routes.HOME} />
   }
 
+  // Block access to a location outside the user's jurisdiction
+  if (!parsedId.success || !canAccessOffice({ id: parsedId.data })) {
+    return <Navigate to={routes.HOME} replace />
+  }
+
   return (
     <>
       {isOnline ? (


### PR DESCRIPTION
## Description

Before: When user's location is updated, user could still see the old team page (without any users)

After: If user is on any location outside their jurisdiction, they'll be redirected to home.
[Screencast from 2026-06-23 19-47-57.webm](https://github.com/user-attachments/assets/b41561c3-462b-44a3-9740-085f8527c1b8)
 

Clearly describe what has been changed. Include relevant context or background.
Explain how the issue was fixed (if applicable) and the root cause.

Link this pull request to the GitHub issue (and optionally name the branch `ocrvs-<issue #>`)

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
