### PR TITLE
fix(events): handle undefined value of administrative id of user

### DIFF
--- a/packages/commons/src/events/locations.test.ts
+++ b/packages/commons/src/events/locations.test.ts
@@ -14,11 +14,13 @@ import { SystemContext, UserContext } from '../users/User'
 import {
   AdministrativeArea,
   canAccessEventWithScope,
+  canAccessOtherUserWithScopes,
   EventIndexWithAdministrativeHierarchy,
   getLocationHierarchy,
-  Location
+  Location,
+  UserWithResolvedHierarchy
 } from './locations'
-import { RecordScopeV2 } from 'src/scopes'
+import { RecordScopeV2, UserScopeV2 } from 'src/scopes'
 import { UUID } from 'src/uuid'
 
 describe('canAccessEventWithScope()', () => {
@@ -317,6 +319,80 @@ describe('canAccessEventWithScope()', () => {
         ).toBe(true)
       }
     )
+  })
+})
+
+describe('canAccessOtherUserWithScopes()', () => {
+  const rng = createPrng(11111)
+  const adminAreaUuid = generateUuid(rng)
+  const officeUuid = generateUuid(rng)
+  const otherOfficeUuid = generateUuid(rng)
+
+  // The user being viewed lives in a different administrative area
+  const targetUser: UserWithResolvedHierarchy = {
+    role: TestUserRole.enum.FIELD_AGENT,
+    administrativeHierarchy: [adminAreaUuid, otherOfficeUuid],
+    primaryOfficeId: otherOfficeUuid
+  }
+
+  const scopeWithAdminAreaAccess: UserScopeV2 = {
+    type: 'user.read',
+    options: { accessLevel: 'administrativeArea' }
+  }
+
+  it('grants access when calling user has administrativeAreaId: null (root jurisdiction)', () => {
+    const callingUser: UserContext = {
+      type: 'user',
+      id: generateUuid(rng),
+      primaryOfficeId: officeUuid,
+      administrativeAreaId: null,
+      role: TestUserRole.enum.LOCAL_SYSTEM_ADMIN
+    }
+
+    expect(
+      canAccessOtherUserWithScopes({
+        scopes: [scopeWithAdminAreaAccess],
+        userToAccess: targetUser,
+        user: callingUser
+      })
+    ).toBe(true)
+  })
+
+  it('grants access when calling user has administrativeAreaId: undefined (root jurisdiction)', () => {
+    const callingUser: UserContext = {
+      type: 'user',
+      id: generateUuid(rng),
+      primaryOfficeId: officeUuid,
+      administrativeAreaId: undefined,
+      role: TestUserRole.enum.LOCAL_SYSTEM_ADMIN
+    }
+
+    expect(
+      canAccessOtherUserWithScopes({
+        scopes: [scopeWithAdminAreaAccess],
+        userToAccess: targetUser,
+        user: callingUser
+      })
+    ).toBe(true)
+  })
+
+  it('denies access when calling user has an administrativeAreaId not in the target hierarchy', () => {
+    const unrelatedAreaId = generateUuid(rng)
+    const callingUser: UserContext = {
+      type: 'user',
+      id: generateUuid(rng),
+      primaryOfficeId: officeUuid,
+      administrativeAreaId: unrelatedAreaId,
+      role: TestUserRole.enum.LOCAL_SYSTEM_ADMIN
+    }
+
+    expect(
+      canAccessOtherUserWithScopes({
+        scopes: [scopeWithAdminAreaAccess],
+        userToAccess: targetUser,
+        user: callingUser
+      })
+    ).toBe(false)
   })
 })
 

--- a/packages/commons/src/events/locations.ts
+++ b/packages/commons/src/events/locations.ts
@@ -276,7 +276,7 @@ export function canAccessUserWithScope({
   const hasAdministrativeAreaInHierarchy =
     userToAccess.administrativeHierarchy.some(
       (id) => user.administrativeAreaId === id
-    ) || user.administrativeAreaId === null // user with null administrative area has access to all administrative areas
+    ) || !user.administrativeAreaId // user with no administrative area has access to all administrative areas
 
   if (
     opts?.accessLevel === JurisdictionFilter.enum.administrativeArea &&


### PR DESCRIPTION
Fixes https://github.com/opencrvs/opencrvs-core/issues/12585#issuecomment-4796477862

## Description

Fixes the "Sorry, we couldn't load the content for this page" error thrown when a National Administrator changes a user's primary office to an HQ office or embassy office, and then a user with `user.read` scope tries to view that user's profile.

**Root cause:** `canAccessUserWithScope` in `packages/commons/src/events/locations.ts` checked `user.administrativeAreaId === null` to grant root/universal jurisdiction. However, when a CRVS office has no administrative area in the database (`NULL`), the mapping layer in `packages/events/src/service/users/utils.ts` converts it to `undefined` via `?? undefined`. `undefined === null` is `false`, so the jurisdiction check incorrectly denied access and the authorization middleware threw `NOT_FOUND`.

This is the same class of bug that PR #13050 fixed in `matchesJurisdictionFilter` — that fix covered the event-access path; this one covers the user-access path.

**Change:** `user.administrativeAreaId === null` → `!user.administrativeAreaId` (handles both `null` and `undefined`)

**Fixes:** #12585 (HQ office and embassy office cases confirmed fixed)

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [x] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
