### PR TITLE
bump mosip-api tags to version 2.0.0

### DIFF
--- a/charts/opencrvs-mosip/values.yaml
+++ b/charts/opencrvs-mosip/values.yaml
@@ -5,7 +5,7 @@ mosip_mock:
   enabled: true
   image:
     repository: ghcr.io/opencrvs/mosip-mock
-    tag: 2.0.0-rc.11
+    tag: 2.0.0
   env:
     FOO: bar
     SENDER_EMAIL_ADDRESS: 'test@opencrvs.org'
@@ -21,7 +21,7 @@ esignet_mock:
   enabled: true
   image:
     repository: ghcr.io/opencrvs/esignet-mock
-    tag: 2.0.0-rc.11
+    tag: 2.0.0
   env:
     OIDP_CLIENT_PRIVATE_KEY_PATH: /certs/esignet-jwk.txt
 
@@ -29,7 +29,7 @@ mosip_api:
   enabled: true
   image:
     repository: ghcr.io/opencrvs/mosip-api
-    tag: 2.0.0-rc.11
+    tag: 2.0.0
   env:
     LOCALE: en
     OIDP_CLIENT_PRIVATE_KEY_PATH: /certs/esignet-jwk.txt


### PR DESCRIPTION
## Description

Released mosip-api@2.0.0 today

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
