### PR TITLE
fix postgres db type & schema generation

### DIFF
--- a/packages/events/src/router/event/event.audit-log.test.ts
+++ b/packages/events/src/router/event/event.audit-log.test.ts
@@ -202,9 +202,9 @@ describe('audit log', () => {
   })
 
   describe('integrations.create', () => {
-    test('writes an audit log entry when a system client creates an integration', async () => {
-      const systemId = TEST_SYSTEM_ID
-      const client = createSystemTestClient(systemId, [
+    test('writes an audit log entry when a user creates an integration', async () => {
+      const { user } = await setupTestCase()
+      const client = createTestClient(user, [
         encodeScope({ type: 'integration.create' })
       ])
 
@@ -217,7 +217,7 @@ describe('audit log', () => {
       const logs = await db
         .selectFrom('auditLog')
         .selectAll()
-        .where('clientId', '=', systemId)
+        .where('clientId', '=', user.id)
         .execute()
 
       expect(logs).toHaveLength(1)
@@ -232,8 +232,8 @@ describe('audit log', () => {
     })
 
     test('does not include credentials in audit log response summary', async () => {
-      const systemId = TEST_SYSTEM_ID
-      const client = createSystemTestClient(systemId, [
+      const { user } = await setupTestCase()
+      const client = createTestClient(user, [
         encodeScope({ type: 'integration.create' })
       ])
 
@@ -246,7 +246,7 @@ describe('audit log', () => {
       const logs = await db
         .selectFrom('auditLog')
         .selectAll()
-        .where('clientId', '=', systemId)
+        .where('clientId', '=', user.id)
         .execute()
 
       expect(logs[0].responseSummary).not.toHaveProperty('shaSecret')

--- a/packages/events/src/router/integrations/integrations.test.ts
+++ b/packages/events/src/router/integrations/integrations.test.ts
@@ -9,18 +9,17 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 
-import { getUUID, UUID, encodeScope } from '@opencrvs/commons'
+import { UUID, encodeScope } from '@opencrvs/commons'
 import { getClient } from '@events/storage/postgres/events'
-import { createSystemTestClient } from '@events/tests/utils'
+import { createTestClient, setupTestCase } from '@events/tests/utils'
 
-const SYSTEM_ID = getUUID()
 const scope = encodeScope({ type: 'integration.create' })
 
 describe('integrations', () => {
   describe('integrations.create', () => {
     test('creates a system client and returns credentials', async () => {
-      const systemId = SYSTEM_ID
-      const client = createSystemTestClient(systemId, [scope])
+      const { user } = await setupTestCase()
+      const client = createTestClient(user, [scope])
 
       const result = await client.integrations.create({
         name: 'My Test Integration',
@@ -36,8 +35,8 @@ describe('integrations', () => {
     })
 
     test('inserts a row into system_clients table', async () => {
-      const systemId = SYSTEM_ID
-      const client = createSystemTestClient(systemId, [scope])
+      const { user } = await setupTestCase()
+      const client = createTestClient(user, [scope])
 
       const result = await client.integrations.create({
         name: 'DB Check Integration',
@@ -61,8 +60,8 @@ describe('integrations', () => {
     })
 
     test('writes an audit log entry', async () => {
-      const systemId = SYSTEM_ID
-      const client = createSystemTestClient(systemId, [scope])
+      const { user } = await setupTestCase()
+      const client = createTestClient(user, [scope])
 
       const result = await client.integrations.create({
         name: 'Audit Integration',
@@ -73,7 +72,7 @@ describe('integrations', () => {
       const logs = await db
         .selectFrom('auditLog')
         .selectAll()
-        .where('clientId', '=', systemId)
+        .where('clientId', '=', user.id)
         .where('operation', '=', 'integrations.create')
         .execute()
 
@@ -93,8 +92,8 @@ describe('integrations', () => {
 
   describe('integrations.list', () => {
     test('returns empty array when no clients exist', async () => {
-      const systemId = SYSTEM_ID
-      const client = createSystemTestClient(systemId, [scope])
+      const { user } = await setupTestCase()
+      const client = createTestClient(user, [scope])
 
       const result = await client.integrations.list()
 
@@ -102,8 +101,8 @@ describe('integrations', () => {
     })
 
     test('lists created integration clients', async () => {
-      const systemId = SYSTEM_ID
-      const client = createSystemTestClient(systemId, [scope])
+      const { user } = await setupTestCase()
+      const client = createTestClient(user, [scope])
 
       await client.integrations.create({
         name: 'Integration A',
@@ -131,8 +130,8 @@ describe('integrations', () => {
     })
 
     test('filters by status', async () => {
-      const systemId = SYSTEM_ID
-      const client = createSystemTestClient(systemId, [scope])
+      const { user } = await setupTestCase()
+      const client = createTestClient(user, [scope])
 
       await client.integrations.create({
         name: 'Active Integration',
@@ -166,8 +165,8 @@ describe('integrations', () => {
 
   describe('integrations.authenticate', () => {
     test('authenticates a system client and returns system details', async () => {
-      const systemId = SYSTEM_ID
-      const client = createSystemTestClient(systemId, [scope])
+      const { user } = await setupTestCase()
+      const client = createTestClient(user, [scope])
 
       const created = await client.integrations.create({
         name: 'Auth Integration',

--- a/packages/events/src/storage/postgres/events/schema/app/AppSchema.ts
+++ b/packages/events/src/storage/postgres/events/schema/app/AppSchema.ts
@@ -3,13 +3,13 @@
 
 import type { default as AnnouncementsTable } from './Announcements'
 import type { default as EventActionDraftsTable } from './EventActionDrafts'
+import type { default as AdministrativeAreasTable } from './AdministrativeAreas'
+import type { default as EventActionsTable } from './EventActions'
+import type { default as AuditLogTable } from './AuditLog'
 import type { default as SystemInitialisationTable } from './SystemInitialisation'
 import type { default as LocationsTable } from './Locations'
 import type { default as UserCredentialsTable } from './UserCredentials'
 import type { default as SystemClientsTable } from './SystemClients'
-import type { default as AdministrativeAreasTable } from './AdministrativeAreas'
-import type { default as EventActionsTable } from './EventActions'
-import type { default as AuditLogTable } from './AuditLog'
 import type { default as UsersTable } from './Users'
 import type { default as EventsTable } from './Events'
 
@@ -18,6 +18,12 @@ export default interface AppSchema {
 
   eventActionDrafts: EventActionDraftsTable
 
+  administrativeAreas: AdministrativeAreasTable
+
+  eventActions: EventActionsTable
+
+  auditLog: AuditLogTable
+
   systemInitialisation: SystemInitialisationTable
 
   locations: LocationsTable
@@ -25,12 +31,6 @@ export default interface AppSchema {
   userCredentials: UserCredentialsTable
 
   systemClients: SystemClientsTable
-
-  administrativeAreas: AdministrativeAreasTable
-
-  eventActions: EventActionsTable
-
-  auditLog: AuditLogTable
 
   users: UsersTable
 

--- a/packages/events/src/tests/postgres-migrations.sql
+++ b/packages/events/src/tests/postgres-migrations.sql
@@ -4,7 +4,7 @@
 
 
 -- Dumped from database version 17.6 (Debian 17.6-1.pgdg13+1)
--- Dumped by pg_dump version 17.6 (Debian 17.6-1.pgdg13+1)
+-- Dumped by pg_dump version 17.6 (Debian 17.6-2.pgdg13+1)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -26,6 +26,34 @@ CREATE SCHEMA app;
 
 
 ALTER SCHEMA app OWNER TO events_migrator;
+
+--
+-- Name: pg_trgm; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION pg_trgm; Type: COMMENT; Schema: -; Owner: 
+--
+
+COMMENT ON EXTENSION pg_trgm IS 'text similarity measurement and index searching based on trigrams';
+
+
+--
+-- Name: pgcrypto; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION pgcrypto; Type: COMMENT; Schema: -; Owner: 
+--
+
+COMMENT ON EXTENSION pgcrypto IS 'cryptographic functions';
+
 
 --
 -- Name: action_status; Type: TYPE; Schema: app; Owner: events_migrator
@@ -337,7 +365,7 @@ CREATE TABLE app.system_clients (
     legacy_id text,
     name text NOT NULL,
     scopes jsonb DEFAULT '[]'::jsonb NOT NULL,
-    created_by text NOT NULL,
+    created_by uuid NOT NULL,
     secret_hash text NOT NULL,
     salt text NOT NULL,
     sha_secret text NOT NULL,
@@ -762,6 +790,14 @@ ALTER TABLE ONLY app.event_actions
 
 ALTER TABLE ONLY app.event_actions
     ADD CONSTRAINT event_actions_original_action_id_fkey FOREIGN KEY (original_action_id) REFERENCES app.event_actions(id);
+
+
+--
+-- Name: system_clients fk_system_clients_created_by; Type: FK CONSTRAINT; Schema: app; Owner: events_migrator
+--
+
+ALTER TABLE ONLY app.system_clients
+    ADD CONSTRAINT fk_system_clients_created_by FOREIGN KEY (created_by) REFERENCES app.users(id);
 
 
 --


### PR DESCRIPTION
## Description

Fixes #10966.

Two developer tooling commands in `packages/events` were broken:

**`yarn generate-db-schema`** was failing with `permission denied for schema analytics` — `pg_dump` was trying to lock tables across both `app` and `analytics` schemas, but `events_migrator` does not have access to `analytics`. Fixed by adding `--exclude-schema=analytics --exclude-schema=reference_data` to the `pg_dump` invocation in `src/tests/generate-db-schema.sh`.

**`yarn generate-db-types`** was generating types for the analytics DB as well as the app schema. Fixed by scoping kanel to `schemas: ['app']` in `.kanelrc.js`.

The updated output files (`postgres-migrations.sql`, `AppSchema.ts`) reflect the first clean run of both commands:

- `postgres-migrations.sql` now captures two extensions (`pg_trgm`, `pgcrypto`) that were always present in the DB but missing from the snapshot because the dump was previously failing. It also picks up a `system_clients.created_by` column type change (`text` → `uuid`) and its corresponding FK constraint — both from existing migrations that were not captured before.
- `AppSchema.ts` has a cosmetic reordering of table entries (kanel reflects the DB declaration order).

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
