### PR TITLE
feat: independent configuration of NOTIFY action config

### DIFF
--- a/ACTIONS.md
+++ b/ACTIONS.md
@@ -10,7 +10,7 @@ Core actions, as the name suggests, are defined within the core and are availabl
 - `READ`
 - `ASSIGN` & `UNASSIGN`
 - `DELETE`
-- `NOTIFY`
+- `NOTIFY`\*
 - `DECLARE`\*, `VALIDATE`\* & `REGISTER`\*
 - `REJECT`\*
 - `ARCHIVE`
@@ -43,6 +43,8 @@ All custom actions are configurable.
 All custom actions and certain core actions are configurable.
 
 Actions are configured on a per–event-type basis, meaning different event types do not share action configurations.
+
+> [!NOTE] > `NOTIFY` has a special fallback behaviour: if no `NOTIFY` action config is defined, it inherits the `DECLARE` action config (label, flags, icon, conditionals). When a `NOTIFY` config is present, it is used independently — flag operations on `NOTIFY` do not affect `DECLARE` and vice versa. The `review` field on `NOTIFY` config is optional; when omitted, the `DECLARE` review page is used.
 
 Below we describe two configuration options: flag configurations and action conditionals. It is important to note that additional configuration options are available and that many core actions have configuration options specific to their action type.
 

--- a/packages/client/src/v2-events/features/events/actions/correct/utils.ts
+++ b/packages/client/src/v2-events/features/events/actions/correct/utils.ts
@@ -143,9 +143,9 @@ export function getAnnotationComparisonForField(
 }
 
 function getReviewForm(configuration: EventConfig) {
-  return configuration.actions.flatMap((action) =>
-    'review' in action && action.review != null ? [action.review] : []
-  )
+  return configuration.actions
+    .filter((action) => 'review' in action)
+    .map((action) => action.review)
 }
 
 export function getReviewFormFields(configuration: EventConfig) {

--- a/packages/client/src/v2-events/features/events/actions/correct/utils.ts
+++ b/packages/client/src/v2-events/features/events/actions/correct/utils.ts
@@ -143,9 +143,9 @@ export function getAnnotationComparisonForField(
 }
 
 function getReviewForm(configuration: EventConfig) {
-  return configuration.actions
-    .filter((action) => 'review' in action)
-    .map((action) => action.review)
+  return configuration.actions.flatMap((action) =>
+    'review' in action && action.review != null ? [action.review] : []
+  )
 }
 
 export function getReviewFormFields(configuration: EventConfig) {

--- a/packages/client/src/v2-events/features/events/actions/declare/DeclareActionMenu.tsx
+++ b/packages/client/src/v2-events/features/events/actions/declare/DeclareActionMenu.tsx
@@ -19,7 +19,8 @@ import {
   getCurrentEventState,
   getActionReview,
   getAvailableActionsForEvent,
-  getActionConfig
+  getActionConfig,
+  isValidIcon
 } from '@opencrvs/commons/client'
 import { PrimaryButton } from '@opencrvs/components/lib/buttons'
 import { DropdownMenu } from '@opencrvs/components/lib/Dropdown'
@@ -81,6 +82,11 @@ function useDeclarationActions(event: EventDocument) {
     actionType: ActionType.DECLARE
   })
 
+  const notifyActionConfig = getActionConfig({
+    eventConfiguration,
+    actionType: ActionType.NOTIFY
+  })
+
   const dialogCopy =
     actionConfig && 'dialogCopy' in actionConfig
       ? actionConfig.dialogCopy
@@ -89,7 +95,7 @@ function useDeclarationActions(event: EventDocument) {
   const actions = {
     [ActionType.NOTIFY]: {
       mutate: events.actions.notify.mutate,
-      supportingCopy: dialogCopy?.notify,
+      supportingCopy: notifyActionConfig?.supportingCopy ?? dialogCopy?.notify,
       title: {
         id: 'review.declare.incomplete.confirmModal.title',
         defaultMessage: 'Notify the {event}?',
@@ -193,7 +199,9 @@ function useDeclarationActions(event: EventDocument) {
         disabled: hasValidationErrors
       },
       {
-        icon: actionIcons[ActionType.DECLARE],
+        icon: isValidIcon(notifyActionConfig?.icon)
+          ? notifyActionConfig.icon
+          : actionIcons[ActionType.DECLARE],
         label: actionLabels[ActionType.NOTIFY],
         onClick: async () => handleDeclaration(ActionType.NOTIFY),
         hidden:

--- a/packages/client/src/v2-events/features/events/actions/declare/Notify.interaction.stories.tsx
+++ b/packages/client/src/v2-events/features/events/actions/declare/Notify.interaction.stories.tsx
@@ -1,0 +1,177 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+
+import type { Meta, StoryObj } from '@storybook/react'
+import { createTRPCMsw, httpLink } from '@vafanassieff/msw-trpc'
+import superjson from 'superjson'
+import { userEvent, within, expect, waitFor } from '@storybook/test'
+import {
+  ActionType,
+  tennisClubMembershipEvent,
+  generateEventDocument,
+  getCurrentEventState
+} from '@opencrvs/commons/client'
+import { ROUTES, routesConfig } from '@client/v2-events/routes'
+import { useEventFormData } from '@client/v2-events/features/events/useEventFormData'
+import { AppRouter } from '@client/v2-events/trpc'
+import { testDataGenerator } from '@client/tests/test-data-generators'
+import { createDeclarationTrpcMsw } from '@client/tests/v2-events/declaration.utils'
+import { ReviewIndex } from './Review'
+
+const generator = testDataGenerator()
+const tRPCMsw = createTRPCMsw<AppRouter>({
+  links: [httpLink({ url: '/api/events' })],
+  transformer: { input: superjson, output: superjson }
+})
+
+/*
+ * A variation of the tennis club membership event that has a dedicated NOTIFY
+ * action config with its own supportingCopy and label — separate from DECLARE.
+ * Used to verify that NotifyActionConfig is picked up independently.
+ */
+const eventConfigWithNotifyConfig = {
+  ...tennisClubMembershipEvent,
+  actions: tennisClubMembershipEvent.actions.map((action) => {
+    if (action.type === ActionType.NOTIFY) {
+      return {
+        ...action,
+        label: {
+          id: 'event.tennis-club-membership.action.notify.label',
+          defaultMessage: 'Notify health worker',
+          description: 'Label for the notify action'
+        },
+        supportingCopy: {
+          id: 'event.tennis-club-membership.action.notify.supportingCopy',
+          defaultMessage:
+            'This will notify the health worker responsible for this record.',
+          description: 'Supporting copy shown in the notify confirmation dialog'
+        },
+        flags: [{ id: 'health-worker-notified', operation: 'add' as const }]
+      }
+    }
+    return action
+  })
+}
+
+const createdEventDocument = generateEventDocument({
+  configuration: eventConfigWithNotifyConfig,
+  actions: [{ type: ActionType.CREATE }]
+})
+
+const declarationTrpcMsw = createDeclarationTrpcMsw(
+  tRPCMsw,
+  createdEventDocument
+)
+
+const mockUser = generator.user.fieldAgent().summary
+const mockUserFull = generator.user.fieldAgent().v2
+
+const meta: Meta<typeof ReviewIndex> = {
+  title: 'Declare/Notify config',
+  parameters: {
+    offline: {
+      events: [createdEventDocument],
+      configs: [eventConfigWithNotifyConfig]
+    }
+  },
+  beforeEach: () => {
+    useEventFormData.setState({ formValues: {} })
+  }
+}
+
+export default meta
+type Story = StoryObj<typeof ReviewIndex>
+
+const msw = {
+  handlers: {
+    drafts: declarationTrpcMsw.drafts.handlers,
+    events: [
+      tRPCMsw.event.search.query(() => ({
+        results: [
+          getCurrentEventState(
+            createdEventDocument,
+            eventConfigWithNotifyConfig
+          )
+        ],
+        total: 1
+      })),
+      ...declarationTrpcMsw.events.handlers
+    ],
+    user: [
+      tRPCMsw.user.list.query(() => [mockUser]),
+      tRPCMsw.user.get.query(() => mockUserFull)
+    ]
+  }
+}
+
+/*
+ * Verifies that when a NOTIFY action config is present:
+ * - The NOTIFY-specific supportingCopy appears in the confirmation dialog
+ * - The notify mutation is called (not declare)
+ */
+export const NotifyConfigSupportingCopyIsShownInDialog: Story = {
+  loaders: [
+    () => {
+      declarationTrpcMsw.events.reset()
+      declarationTrpcMsw.drafts.reset()
+    },
+    async () => {
+      window.localStorage.setItem('opencrvs', generator.user.token.fieldAgent)
+      await new Promise((resolve) => setTimeout(resolve, 50))
+    }
+  ],
+  parameters: {
+    reactRouter: {
+      router: routesConfig,
+      initialPath: ROUTES.V2.EVENTS.DECLARE.REVIEW.buildPath({
+        eventId: createdEventDocument.id
+      })
+    },
+    chromatic: { disableSnapshot: true },
+    msw
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+
+    await step('Field agent opens action menu and clicks Notify', async () => {
+      await userEvent.click(
+        await canvas.findByRole('button', { name: 'Action' })
+      )
+      await userEvent.click(await canvas.findByText('Notify'))
+    })
+
+    await step(
+      'Confirmation dialog shows NOTIFY-specific supporting copy',
+      async () => {
+        await expect(
+          await canvas.findByText(
+            'This will notify the health worker responsible for this record.'
+          )
+        ).toBeInTheDocument()
+      }
+    )
+
+    await step('Confirm notify action', async () => {
+      await userEvent.click(
+        await canvas.findByRole('button', { name: 'Notify' })
+      )
+    })
+
+    await step('Notify mutation was called, not declare', async () => {
+      await waitFor(async () => {
+        await expect(declarationTrpcMsw.events.getSpyCalls()).toMatchObject({
+          'event.actions.notify.request': true,
+          'event.actions.declare.request': false
+        })
+      })
+    })
+  }
+}

--- a/packages/commons/src/events/ActionConfig.ts
+++ b/packages/commons/src/events/ActionConfig.ts
@@ -69,7 +69,7 @@ const ReadActionConfig = ActionConfigBase.extend(
   }).shape
 )
 
-const NotifyConfig = DeclarationActionBase.extend(
+const NotifyConfig = ActionConfigBase.extend(
   z.object({
     type: z.literal(ActionType.NOTIFY)
   }).shape

--- a/packages/commons/src/events/ActionConfig.ts
+++ b/packages/commons/src/events/ActionConfig.ts
@@ -69,9 +69,12 @@ const ReadActionConfig = ActionConfigBase.extend(
   }).shape
 )
 
-const NotifyConfig = ActionConfigBase.extend(
+const NotifyConfig = DeclarationActionBase.extend(
   z.object({
-    type: z.literal(ActionType.NOTIFY)
+    type: z.literal(ActionType.NOTIFY),
+    review: DeclarationReviewConfig.describe(
+      'Configuration of the review page fields.'
+    ).optional()
   }).shape
 )
 

--- a/packages/commons/src/events/ActionConfig.ts
+++ b/packages/commons/src/events/ActionConfig.ts
@@ -69,6 +69,12 @@ const ReadActionConfig = ActionConfigBase.extend(
   }).shape
 )
 
+const NotifyConfig = ActionConfigBase.extend(
+  z.object({
+    type: z.literal(ActionType.NOTIFY)
+  }).shape
+)
+
 const DeclareConfig = DeclarationActionBase.extend(
   z.object({
     type: z.literal(ActionType.DECLARE),
@@ -171,10 +177,15 @@ export const ActionConfig = z
       description:
         'Configuration for the read action — defines the record-tab content displayed on the event overview page.'
     }),
+    NotifyConfig.meta({
+      id: 'NotifyActionConfig',
+      description:
+        'Configuration for the notify action. When present, NOTIFY uses this config independently from DECLARE. When absent, NOTIFY falls back to the DeclareActionConfig.'
+    }),
     DeclareConfig.meta({
       id: 'DeclareActionConfig',
       description:
-        'Configuration for the declare action. Includes review-page fields. Shared with the notify action (ActionType.NOTIFY).'
+        'Configuration for the declare action. Includes review-page fields. NOTIFY falls back to this config when no dedicated NotifyActionConfig is provided.'
     }),
     RejectConfig.meta({
       id: 'RejectActionConfig',
@@ -196,8 +207,7 @@ export const ActionConfig = z
     }),
     EditActionConfig.meta({
       id: 'EditActionConfig',
-      description:
-        'Configuration for editing a record before registration.'
+      description: 'Configuration for editing a record before registration.'
     }),
     ArchiveConfig.meta({
       id: 'ArchiveActionConfig',
@@ -225,8 +235,8 @@ export const actionConfigTypes: Set<ActionConfigTypes> = new Set(
  *
  * These are not the same as the broader workflow `action.type` values.
  * `ActionConfigTypes` includes only the action kinds that can be defined
- * in the country configuration (e.g. DECLARE, VALIDATE, CUSTOM), and
- * excludes workflow-only types such as CREATE or NOTIFY.
+ * in the country configuration (e.g. NOTIFY, DECLARE, VALIDATE, CUSTOM), and
+ * excludes workflow-only types such as CREATE.
  */
 export type ActionConfigTypes = ActionConfig['type']
 

--- a/packages/commons/src/events/ActionConfig.ts
+++ b/packages/commons/src/events/ActionConfig.ts
@@ -71,10 +71,7 @@ const ReadActionConfig = ActionConfigBase.extend(
 
 const NotifyConfig = DeclarationActionBase.extend(
   z.object({
-    type: z.literal(ActionType.NOTIFY),
-    review: DeclarationReviewConfig.describe(
-      'Configuration of the review page fields.'
-    ).optional()
+    type: z.literal(ActionType.NOTIFY)
   }).shape
 )
 

--- a/packages/commons/src/events/state/flags.test.ts
+++ b/packages/commons/src/events/state/flags.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 /*
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -547,6 +548,91 @@ describe('getEventFlags() – rejected flag', () => {
   })
 })
 
+describe('resolveEventCustomFlags() – NOTIFY config isolation', () => {
+  const configWithNotify: DeepPartial<EventConfig> = {
+    actions: [
+      {
+        type: ActionType.NOTIFY,
+        flags: [{ id: 'notify-only-flag', operation: 'add' }]
+      },
+      {
+        type: ActionType.DECLARE,
+        flags: [{ id: 'declare-only-flag', operation: 'add' }]
+      }
+    ],
+    declaration: {
+      label: { id: '', defaultMessage: '', description: '' },
+      pages: []
+    }
+  }
+
+  const configWithoutNotify: DeepPartial<EventConfig> = {
+    actions: [
+      {
+        type: ActionType.DECLARE,
+        flags: [{ id: 'declare-only-flag', operation: 'add' }]
+      }
+    ],
+    declaration: {
+      label: { id: '', defaultMessage: '', description: '' },
+      pages: []
+    }
+  }
+
+  test('NOTIFY action uses NOTIFY flags when NOTIFY config is present', () => {
+    const event: DeepPartial<EventDocument> = {
+      actions: [
+        {
+          type: ActionType.NOTIFY,
+          declaration: {},
+          createdAt: formatISO(now),
+          status: ActionStatus.Accepted
+        }
+      ]
+    }
+
+    // @ts-expect-error - allow partial actions and event config
+    const flags = resolveEventCustomFlags(event, configWithNotify)
+    expect(flags).toContain('notify-only-flag')
+    expect(flags).not.toContain('declare-only-flag')
+  })
+
+  test('DECLARE action uses DECLARE flags when NOTIFY config is also present', () => {
+    const event: DeepPartial<EventDocument> = {
+      actions: [
+        {
+          type: ActionType.DECLARE,
+          declaration: {},
+          createdAt: formatISO(now),
+          status: ActionStatus.Accepted
+        }
+      ]
+    }
+
+    // @ts-expect-error - allow partial actions and event config
+    const flags = resolveEventCustomFlags(event, configWithNotify)
+    expect(flags).toContain('declare-only-flag')
+    expect(flags).not.toContain('notify-only-flag')
+  })
+
+  test('NOTIFY action falls back to DECLARE flags when no NOTIFY config is present', () => {
+    const event: DeepPartial<EventDocument> = {
+      actions: [
+        {
+          type: ActionType.NOTIFY,
+          declaration: {},
+          createdAt: formatISO(now),
+          status: ActionStatus.Accepted
+        }
+      ]
+    }
+
+    // @ts-expect-error - allow partial actions and event config
+    const flags = resolveEventCustomFlags(event, configWithoutNotify)
+    expect(flags).toContain('declare-only-flag')
+  })
+})
+
 describe('getEventFlags() – any inherent flag is clearable by action config', () => {
   test('INCOMPLETE is present for a notified record', () => {
     const event: DeepPartial<EventDocument> = {
@@ -561,7 +647,9 @@ describe('getEventFlags() – any inherent flag is clearable by action config', 
     }
 
     // @ts-expect-error - allow partial event document and event config
-    expect(getEventFlags(event, eventConfig)).toContain(InherentFlags.INCOMPLETE)
+    expect(getEventFlags(event, eventConfig)).toContain(
+      InherentFlags.INCOMPLETE
+    )
   })
 
   test('INCOMPLETE is cleared by a custom action whose config removes it', () => {

--- a/packages/commons/src/events/utils.test.ts
+++ b/packages/commons/src/events/utils.test.ts
@@ -15,9 +15,11 @@ import { UUID } from '../uuid'
 import { cloneDeep, difference } from 'lodash'
 import { Action, ActionDocument, ActionStatus } from './ActionDocument'
 import { EventDocument } from './EventDocument'
+import { EventConfig } from './EventConfig'
 import { ActionType } from './ActionType'
 import {
   findLastAssignmentAction,
+  getActionConfig,
   getCompleteActionAnnotation,
   getCompleteActionContent,
   getDeclaration,
@@ -931,6 +933,64 @@ describe('getCompleteActionContent', () => {
 
     const result = getCompleteActionContent(baseEvent, action)
 
+    expect(result).toBeUndefined()
+  })
+})
+
+describe('getActionConfig() – NOTIFY fallback and isolation', () => {
+  const configWithoutNotify = {
+    actions: [
+      {
+        type: ActionType.DECLARE,
+        label: { id: 'declare', defaultMessage: 'Declare', description: '' }
+      }
+    ]
+  }
+
+  const configWithNotify = {
+    actions: [
+      {
+        type: ActionType.NOTIFY,
+        label: { id: 'notify', defaultMessage: 'Notify', description: '' }
+      },
+      {
+        type: ActionType.DECLARE,
+        label: { id: 'declare', defaultMessage: 'Declare', description: '' }
+      }
+    ]
+  }
+
+  const configWithoutEither = { actions: [] }
+
+  it('falls back to DECLARE config when no NOTIFY config is present', () => {
+    const result = getActionConfig({
+      eventConfiguration: configWithoutNotify as unknown as EventConfig,
+      actionType: ActionType.NOTIFY
+    })
+    expect(result?.type).toBe(ActionType.DECLARE)
+  })
+
+  it('returns NOTIFY config when present', () => {
+    const result = getActionConfig({
+      eventConfiguration: configWithNotify as unknown as EventConfig,
+      actionType: ActionType.NOTIFY
+    })
+    expect(result?.type).toBe(ActionType.NOTIFY)
+  })
+
+  it('returns DECLARE config independently when NOTIFY config is also present', () => {
+    const result = getActionConfig({
+      eventConfiguration: configWithNotify as unknown as EventConfig,
+      actionType: ActionType.DECLARE
+    })
+    expect(result?.type).toBe(ActionType.DECLARE)
+  })
+
+  it('returns undefined when neither NOTIFY nor DECLARE config exists', () => {
+    const result = getActionConfig({
+      eventConfiguration: configWithoutEither as unknown as EventConfig,
+      actionType: ActionType.NOTIFY
+    })
     expect(result).toBeUndefined()
   })
 })

--- a/packages/commons/src/events/utils.ts
+++ b/packages/commons/src/events/utils.ts
@@ -169,7 +169,7 @@ export const getActionAnnotationFields = (actionConfig: ActionConfig) => {
     return actionConfig.form
   }
 
-  if ('review' in actionConfig) {
+  if ('review' in actionConfig && actionConfig.review != null) {
     return actionConfig.review.fields
   }
 

--- a/packages/commons/src/events/utils.ts
+++ b/packages/commons/src/events/utils.ts
@@ -102,15 +102,18 @@ export function getActionConfig({
   actionType: DisplayableAction
   customActionType?: string
 }): ActionConfig | undefined {
+  // Notify uses its own config when present, otherwise falls back to declare
+  if (actionType === ActionType.NOTIFY) {
+    return (
+      eventConfiguration.actions.find((a) => a.type === ActionType.NOTIFY) ??
+      eventConfiguration.actions.find((a) => a.type === ActionType.DECLARE)
+    )
+  }
+
   return eventConfiguration.actions.find((a) => {
     // We can have multiple custom actions configured, we specify the custom action with 'customActionType'
     if (a.type === ActionType.CUSTOM && customActionType) {
       return a.customActionType === customActionType
-    }
-
-    // Notify uses the declare action config
-    if (actionType === ActionType.NOTIFY) {
-      return a.type === ActionType.DECLARE
     }
 
     // For correction approval/rejection, we use the correction request action config

--- a/packages/commons/src/fixtures/tennis-club-membership-event.ts
+++ b/packages/commons/src/fixtures/tennis-club-membership-event.ts
@@ -78,6 +78,21 @@ export const tennisClubMembershipEvent = defineConfig({
       review: TENNIS_CLUB_DECLARATION_REVIEW
     },
     {
+      type: ActionType.NOTIFY,
+      label: {
+        defaultMessage: 'Notify health worker',
+        description:
+          'This is shown as the action name anywhere the user can trigger the action from',
+        id: 'event.tennis-club-membership.action.notify.label'
+      },
+      flags: [
+        {
+          id: 'health-worker-notified',
+          operation: 'add' as const
+        }
+      ]
+    },
+    {
       type: ActionType.REJECT,
       label: {
         defaultMessage: 'Reject',
@@ -335,6 +350,17 @@ export const tennisClubMembershipEvent = defineConfig({
         defaultMessage: 'Escalated',
         description:
           'This is the label to show in audit history for the escalate action'
+      }
+    }
+  ],
+  flags: [
+    {
+      id: 'health-worker-notified',
+      requiresAction: false,
+      label: {
+        id: 'event.tennis-club-membership.flag.health-worker-notified.label',
+        defaultMessage: 'Health worker notified',
+        description: 'Label for the health-worker-notified flag'
       }
     }
   ],

--- a/packages/events/src/router/event/__snapshots__/event.search.test.ts.snap
+++ b/packages/events/src/router/event/__snapshots__/event.search.test.ts.snap
@@ -873,6 +873,7 @@ exports[`User with "location" scope only sees events created by system user to t
   },
   "flags": [
     "incomplete",
+    "health-worker-notified",
   ],
   "id": "[sanitized]",
   "legalStatuses": {},


### PR DESCRIPTION
Farajaland PR: https://github.com/opencrvs/opencrvs-farajaland/pull/2246

## Description

`ActionType.NOTIFY` previously shared the `ActionType.DECLARE` action config — there was no way to configure label, flags, icon, or conditionals for NOTIFY independently.

**What this PR addresses (all acceptance criteria):**

- **Schema** — `NotifyConfig` added to the `ActionConfig` discriminated union. Supports `label`, `flags`, `icon`, `conditionals`.
- **Runtime fallback** — `getActionConfig()` returns the dedicated NOTIFY config when present; when absent, it falls back to the DECLARE config exactly as before. Backwards compatible by construction.
- **Flag isolation** — `resolveEventCustomFlags` calls `getActionConfig` per action, so flag operations on NOTIFY no longer bleed into DECLARE and vice versa when a dedicated NOTIFY config is present.
- **Client** — `DeclareActionMenu` picks up NOTIFY-specific `supportingCopy` and `icon` from the NOTIFY config when present, falling back to `dialogCopy.notify` from the DECLARE config.
- **Docs** — `ACTIONS.md` updated: NOTIFY is now listed as independently configurable with the fallback behaviour documented.
- **Tests** — `getActionConfig` fallback/isolation tests added to `utils.test.ts`; flag isolation tests added to `flags.test.ts`.
- **Storybook** — `Notify.interaction.stories.tsx` verifies that NOTIFY-specific `supportingCopy` appears in the confirmation dialog and the notify (not declare) mutation is called.

**What is NOT addressed (explicitly out of scope per the issue):**

- Action-specific small form configs for NOTIFY/DECLARE — tracked separately in #11305. For now NOTIFY continues to use the DECLARE action's big form, as stated in the issue.

**Design decisions made during this PR:**

- **`review` not included on `NotifyConfig`** — the declare review page is shared by NOTIFY, DECLARE, and REGISTER. Giving NOTIFY its own review config creates an ambiguity: when a user has all three scopes, there is no rule for which review form to show. Keeping review on DECLARE only avoids this. A dedicated NOTIFY review page (separate route) would be the clean long-term solution if needed.
- **`deduplication` not included on `NotifyConfig`** — the `detectDuplicate` middleware is hardcoded to run only for `ActionType.REGISTER`. Exposing a `deduplication` field on NOTIFY config would be accepted by the schema but silently ignored at runtime. `NotifyConfig` therefore extends `ActionConfigBase` (no dedup) rather than `DeclarationActionBase`. Dedup support for NOTIFY can be added as a separate effort when the middleware is extended.

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly