### PR TITLE
fix: Release versioning

### DIFF
--- a/.github/workflows/init-release.yml
+++ b/.github/workflows/init-release.yml
@@ -97,6 +97,23 @@ jobs:
           # Bump all workspace package.json files and the root in one command.
           npx lerna exec 'yarn version --new-version ${{ inputs.version }} --no-git-tag-version'
           yarn version --new-version ${{ inputs.version }} --no-git-tag-version
+          # Bump helm chart version without creating a git tag.
+          find charts/ -name Chart.yaml -exec yq -i ".version = \"v$VERSION\"" {} \;
+          find charts/ -name Chart.yaml -exec yq -i ".appVersion = \"v$VERSION\"" {} \;
+          # Bump version in default values.yaml for opencrvs-services
+          # TODO: yq is not relaiable for this case, check if we can use ruamel.yaml (python) library
+          sed -i.bak -E '
+          /^platform:/,/^[^[:space:]]/ {
+            s/^([[:space:]]*tag:[[:space:]]*).*/\1'"$VERSION"'/
+          }
+          /^countryconfig:/,/^[^[:space:]]/ {
+            /^[[:space:]]*image:/,/^[[:space:]]{2}[a-zA-Z0-9_-]+:/ {
+              s/^([[:space:]]*tag:[[:space:]]*).*/\1'"$VERSION"'/
+            }
+          }
+          ' charts/opencrvs-services/values.yaml
+          rm charts/opencrvs-services/values.yaml.bak
+
           git add .
           git commit -m "chore: update version to ${{ inputs.version }}"
 


### PR DESCRIPTION
## Description

Goal of this PR is to introduce automated release management to helm charts versions


## Testing

Manually tested on localhost:

<img width="652" height="338" alt="image" src="https://github.com/user-attachments/assets/52222c7a-4fde-46ab-b588-04eea9bd414b" />


## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
