### PR TITLE
Add AI task critique workflow using opencode

### DIFF
--- a/.github/workflows/ai-critique-issue.yml
+++ b/.github/workflows/ai-critique-issue.yml
@@ -1,0 +1,50 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# OpenCRVS is also distributed under the terms of the Civil Registration
+# & Healthcare Disclaimer located at http://opencrvs.org/license.
+#
+# Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+
+name: AI Task Critique
+on:
+  issues:
+    types: [opened]
+  issue_comment:
+    types: [created]
+
+jobs:
+  critique:
+    if: |
+      (github.event.issue.user.login == 'rikukissa' || github.event.issue.user.login == 'naftis') &&
+      (github.event_name != 'issue_comment' || github.event.comment.user.login != 'github-actions[bot]')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - uses: anomalyco/opencode/github@latest
+        env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_ZEN_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          model: zen/deepseek-v4-flash
+          use_github_token: true
+          prompt: |
+            Read the issue title, description, and all comments using the `read` tool.
+
+            Critique the completeness of this task using the "grilling" technique:
+
+            - Interview the issue author relentlessly about every aspect of their plan until a shared understanding is reached.
+            - Walk down each branch of the design tree, resolving dependencies between decisions one-by-one.
+            - For each question, provide your recommended answer.
+            - Ask questions ONE AT A TIME — wait for feedback before continuing. Asking multiple questions at once is bewildering.
+            - If a question can be answered by exploring the codebase, explore the codebase instead.
+
+            Post your first question as a comment on the issue. If the conversation has clarified important details, update the issue description to reflect the refined understanding.


### PR DESCRIPTION
## Summary

Replaces the previous GitHub Agentic Workflow approach with a standard GitHub Actions workflow using the `anomalyco/opencode/github` action and **DeepSeek V4 Flash** via **OpenCode Zen**.

## How it works

Triggers on issue creation and comments, but only for issues authored by @rikukissa or @naftis. The opencode agent reads the full issue context (title, description, all comments) and applies the **grilling technique** — one question at a time — until the task is well-defined.

### Events

| Event | Behavior |
|---|---|
| `issues: opened` | Agent reads the issue and posts the first grilling question as a comment |
| `issue_comment: created` | Agent reads the updated conversation, asks the next question, or updates the description with clarifications |

### Filtering

- Only processes issues where the **creator** is `rikukissa` or `naftis`
- Skips comments from `github-actions[bot]` to prevent infinite loops

## Prerequisites

1. **OpenCode Zen API key** — Add `OPENCODE_ZEN_API_KEY` to Actions secrets
2. **OpenCode GitHub App** — Install [github.com/apps/opencode-agent](https://github.com/apps/opencode-agent) on the repo (optional if using `use_github_token: true` with `issues: write` permission)

## File

| File | Description |
|---|---|
| `.github/workflows/ai-critique-issue.yml` | The workflow definition (50 lines) |

Closes #13080.