### PR TITLE
feat: add 'allOf'-operation on workqueue flag filters

### DIFF
--- a/packages/commons/src/events/EventIndex.ts
+++ b/packages/commons/src/events/EventIndex.ts
@@ -101,7 +101,8 @@ export const Range = z
 export const ContainsFlags = z
   .object({
     anyOf: z.array(Flag).optional(),
-    noneOf: z.array(Flag).optional()
+    noneOf: z.array(Flag).optional(),
+    allOf: z.array(Flag).optional()
   })
   .meta({
     id: 'ContainsFlags'

--- a/packages/events/src/service/indexing/indexing.test.ts
+++ b/packages/events/src/service/indexing/indexing.test.ts
@@ -277,6 +277,30 @@ const anyOfStatusPayload: QueryType = {
   ]
 }
 
+const allOfFlagsPayload: QueryType = {
+  type: 'and',
+  clauses: [
+    {
+      flags: {
+        allOf: ['validated', 'approval-required-for-late-registration']
+      }
+    }
+  ]
+}
+
+const combinedFlagsPayload: QueryType = {
+  type: 'and',
+  clauses: [
+    {
+      flags: {
+        anyOf: ['approval-required-for-late-registration'],
+        noneOf: ['potential-duplicate'],
+        allOf: ['validated', 'approval-required-for-late-registration']
+      }
+    }
+  ]
+}
+
 const fullAndPayload: QueryType = {
   type: 'and',
   clauses: [
@@ -435,6 +459,62 @@ describe('test buildElasticQueryFromSearchPayload', () => {
           {
             bool: {
               must: [{ terms: { status: ['REGISTERED', 'DECLARED'] } }],
+              should: undefined
+            }
+          }
+        ],
+        should: undefined
+      }
+    })
+  })
+
+  test('builds query with allOf flags', async () => {
+    const result = await buildElasticQueryFromSearchPayload(allOfFlagsPayload, [
+      tennisClubMembershipEvent
+    ])
+    expect(result).toEqual({
+      bool: {
+        must: [
+          {
+            bool: {
+              must: [
+                { term: { flags: 'validated' } },
+                { term: { flags: 'approval-required-for-late-registration' } }
+              ],
+              should: undefined
+            }
+          }
+        ],
+        should: undefined
+      }
+    })
+  })
+
+  test('builds query with anyOf, noneOf and allOf flags combined', async () => {
+    const result = await buildElasticQueryFromSearchPayload(
+      combinedFlagsPayload,
+      [tennisClubMembershipEvent]
+    )
+    expect(result).toEqual({
+      bool: {
+        must: [
+          {
+            bool: {
+              must: [
+                {
+                  terms: { flags: ['approval-required-for-late-registration'] }
+                },
+                {
+                  bool: {
+                    must_not: {
+                      terms: { flags: ['potential-duplicate'] }
+                    },
+                    should: undefined
+                  }
+                },
+                { term: { flags: 'validated' } },
+                { term: { flags: 'approval-required-for-late-registration' } }
+              ],
               should: undefined
             }
           }

--- a/packages/events/src/service/indexing/query.ts
+++ b/packages/events/src/service/indexing/query.ts
@@ -249,6 +249,9 @@ function buildClause(clause: QueryExpression, eventConfigs: EventConfig[]) {
             }
           })
         }
+        if (value.allOf) {
+          must.push(...value.allOf.map((flag) => ({ term: { flags: flag } })))
+        }
         break
       }
       default:


### PR DESCRIPTION
## Description

Adds `allOf` support to the workqueue `flags` filter (`ContainsFlags` schema in `commons`), alongside the existing `anyOf`/`noneOf`. This lets a workqueue query require a record to have **all** of a set of flags (AND semantics), which was not previously expressible.

This was needed to correctly configure the "Pending approval" workqueue to only show records that are both `validated` **and** flagged `approval-required-for-late-registration` — unblocking the config fix for #11755, where late-registration records were surfacing in the wrong workqueue.

**Changes:**
- `commons`: add `allOf: Flag[]` to `ContainsFlags`
- `events`: `buildElasticQueryFromSearchPayload` emits one Elasticsearch `term` clause per flag in `allOf`
- Tests covering `allOf` alone and combined with `anyOf`/`noneOf`

CC PR: https://github.com/opencrvs/opencrvs-countryconfig/pull/1479
Farajaland PR: https://github.com/opencrvs/opencrvs-farajaland/pull/2252
Demoland PR: https://github.com/opencrvs/opencrvs-demoland/pull/71

Closes #11921

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
