### PR TITLE
fix: Typo in Secret name

### DIFF
--- a/.github/workflows/init-release.yml
+++ b/.github/workflows/init-release.yml
@@ -254,7 +254,7 @@ jobs:
       - name: Create release branch in e2e repo
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.E2E_WORKFLOW_TOKEN }}
+          github-token: ${{ secrets.E2E_WORKFLOWS_TOKEN }}
           script: |
             const branchRef = 'refs/heads/release/${{ inputs.version }}'
             const { data: ref } = await github.rest.git.getRef({


### PR DESCRIPTION
## Description

The secret `E2E_WORKFLOWS_TOKEN` is widely used over all workflows, but in init-release workflow `E2E_WORKFLOW_TOKEN` was mistakenly set.


## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
