### PR TITLE
feat: add OPENCRVS_ENVIRONMENT for explicit environment detection in employee seeder

### DIFF
--- a/charts/opencrvs-services/values.yaml
+++ b/charts/opencrvs-services/values.yaml
@@ -235,6 +235,8 @@ resources:
 # Global environment variables applied to
 # all OpenCRVS microservices (Kubernetes PODs):
 env:
+  # OPENCRVS_ENVIRONMENT: explicit environment detection in employee seeder
+  OPENCRVS_ENVIRONMENT: production
   NODE_ENV: production
   MINIO_BUCKET: ocrvs
   # LOG_LEVEL: debug

--- a/packages/toolkit/src/environment/templates.ts
+++ b/packages/toolkit/src/environment/templates.ts
@@ -98,6 +98,7 @@ export function copyChartsValues(
 
   values['lets_encrypt'] = values['traefik_mode'] === 'lets_encrypt'
   values['static_ssl'] = values['traefik_mode'] === 'static_ssl'
+  values['opencrvs_environment'] = env;
 
   function copyRecursive(src: string, dest: string) {
     const stat = fs.statSync(src)

--- a/packages/toolkit/src/environment/templates/charts-values/opencrvs-services/values.yaml
+++ b/packages/toolkit/src/environment/templates/charts-values/opencrvs-services/values.yaml
@@ -23,6 +23,7 @@ hpa:
 env:
   APN_SERVICE_URL: "http://apm-server.opencrvs-deps-{{env}}.svc.cluster.local:8200"
   MINIO_BUCKET: ocrvs
+  OPENCRVS_ENVIRONMENT: {{opencrvs_environment}}
 
 influxdb:
   host: influxdb-0.influxdb.opencrvs-deps-{{env}}.svc.cluster.local


### PR DESCRIPTION
## Description

Avoid countryconfig container crashing by default when OPENCRVS_ENVIRONMENT variable is not defined 

Related PRs:
- https://github.com/opencrvs/opencrvs-countryconfig/pull/1359
- https://github.com/opencrvs/infrastructure/pull/342


**NOTE:** When OPENCRVS_ENVIRONMENT is not set the OpenCRVS application will start, but data seeder job will fail.


## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [x] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
