### PR TITLE
fix: use npm 11 instead of latest for toolkit publish

### DIFF
--- a/.github/workflows/publish-toolkit-to-npm.yml
+++ b/.github/workflows/publish-toolkit-to-npm.yml
@@ -39,7 +39,7 @@ jobs:
           package-manager-cache: false
 
       - name: Update npm for OIDC trusted publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: Check if version exists on npm
         id: check-version


### PR DESCRIPTION
## Description

**Problem**

The "Publish toolkit to NPM registry" workflow fails on every branch at the "Update npm for OIDC trusted publishing" step with an `EBADENGINE` error ([example run](https://github.com/opencrvs/opencrvs-core/actions/runs/28999106754/job/86055868726)).

**Root cause**

The step runs `npm install -g npm@latest`. npm recently moved the `latest` dist-tag to npm 12.0.0, which requires Node `^22.22.2 || ^24.15.0 || >=26.0.0` — but the workflow runs Node 22.15.1 from `.nvmrc`, so the global install refuses to proceed.

**Fix**

Pin the install to `npm@11`. The current 11.x release supports Node `>=22.9.0` and still provides OIDC trusted publishing (added in npm 11.5.0), which is why this step exists. Pinning the major version also prevents the workflow from breaking the next time npm moves `latest`.

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
