### PR TITLE
Use hardcoded labels for archive and correction review page

### DIFF
--- a/packages/client/src/v2-events/features/events/actions/correct/review/ReviewCorrection.tsx
+++ b/packages/client/src/v2-events/features/events/actions/correct/review/ReviewCorrection.tsx
@@ -24,7 +24,6 @@ import {
   getCurrentEventState,
   isActionEnabled,
   isActionVisible,
-  isValidIcon,
   RequestedCorrectionAction,
   ValidatorContext
 } from '@opencrvs/commons/client'
@@ -302,30 +301,15 @@ export function ReviewCorrection({
     ? isActionEnabled(rejectActionConfig, eventIndex, validatorContext)
     : true
 
-  const approveLabel = approveActionConfig?.label
-    ? intl.formatMessage(approveActionConfig.label)
-    : intl.formatMessage(buttonMessages.approve)
-  const rejectLabel = rejectActionConfig?.label
-    ? intl.formatMessage(rejectActionConfig.label)
-    : intl.formatMessage(buttonMessages.reject)
-
-  const approveIcon = isValidIcon(approveActionConfig?.icon)
-    ? approveActionConfig.icon
-    : 'Check'
-  const rejectIcon = isValidIcon(rejectActionConfig?.icon)
-    ? rejectActionConfig.icon
-    : 'X'
-
-  // Default modal titles ("Approve correction?") are kept distinct from the
-  // generic button word ("Approve") so behaviour is unchanged when no label
-  // is configured; a configured label overrides both, matching the pattern
-  // used for quick-action modals (see useQuickActionModal.tsx).
-  const approveModalTitle = approveActionConfig?.label
-    ? `${intl.formatMessage(approveActionConfig.label)}?`
-    : intl.formatMessage(reviewCorrectionMessages.approveCorrection)
-  const rejectModalTitle = rejectActionConfig?.label
-    ? `${intl.formatMessage(rejectActionConfig.label)}?`
-    : intl.formatMessage(reviewCorrectionMessages.rejectCorrection)
+  // Configured labels/icons only affect the action menu; this core-owned
+  // review page keeps hardcoded button labels/icons and modal titles, while
+  // the configs' conditionals still gate visibility/enabling.
+  const approveModalTitle = intl.formatMessage(
+    reviewCorrectionMessages.approveCorrection
+  )
+  const rejectModalTitle = intl.formatMessage(
+    reviewCorrectionMessages.rejectCorrection
+  )
 
   const openApproveModal = async () => {
     await openModal((close) => (
@@ -386,8 +370,8 @@ export function ReviewCorrection({
       type="negative"
       onClick={openRejectModal}
     >
-      <Icon name={rejectIcon} />
-      {rejectLabel}
+      <Icon name="X" />
+      {intl.formatMessage(buttonMessages.reject)}
     </Button>
   )
 
@@ -400,8 +384,8 @@ export function ReviewCorrection({
       type="positive"
       onClick={openApproveModal}
     >
-      <Icon name={approveIcon} />
-      {approveLabel}
+      <Icon name="Check" />
+      {intl.formatMessage(buttonMessages.approve)}
     </Button>
   )
 

--- a/packages/client/src/v2-events/features/events/actions/dedup/DuplicateForm.tsx
+++ b/packages/client/src/v2-events/features/events/actions/dedup/DuplicateForm.tsx
@@ -26,8 +26,7 @@ import {
   getActionConfig,
   getUUID,
   isActionEnabled,
-  isActionVisible,
-  isValidIcon
+  isActionVisible
 } from '@opencrvs/commons/client'
 import { useModal } from '@client/v2-events/hooks/useModal'
 import { useValidatorContext } from '@client/v2-events/hooks/useValidatorContext'
@@ -93,17 +92,12 @@ export const DuplicateForm = ({ eventIndex }: { eventIndex: EventIndex }) => {
         validatorContext
       )
     : true
-  const notADuplicateLabel = markAsNotDuplicateActionConfig?.label
-    ? intl.formatMessage(markAsNotDuplicateActionConfig.label)
-    : intl.formatMessage(duplicateMessages.notDuplicateButton)
-  const notADuplicateIcon = isValidIcon(markAsNotDuplicateActionConfig?.icon)
-    ? markAsNotDuplicateActionConfig.icon
-    : 'NotePencil'
 
   // `archiveOnDuplicate` is a client-side combinator that fires the core
-  // MARK_AS_DUPLICATE action (then ARCHIVE) — see custom-api/index.ts — so
-  // this button's label/icon read from the same MARK_AS_DUPLICATE config as
-  // the menu entry point that navigates here, not a separate custom action.
+  // MARK_AS_DUPLICATE action (then ARCHIVE) — see custom-api/index.ts.
+  // Configured labels/icons only affect the action menu entry that navigates
+  // here; this core-owned review page keeps hardcoded button labels/icons,
+  // while the configs' conditionals still gate visibility/enabling.
   const markAsDuplicateActionConfig = getActionConfig({
     eventConfiguration: configuration,
     actionType: ActionType.MARK_AS_DUPLICATE
@@ -114,12 +108,6 @@ export const DuplicateForm = ({ eventIndex }: { eventIndex: EventIndex }) => {
   const markAsDuplicateEnabled = markAsDuplicateActionConfig
     ? isActionEnabled(markAsDuplicateActionConfig, eventIndex, validatorContext)
     : true
-  const markAsDuplicateLabel = markAsDuplicateActionConfig?.label
-    ? intl.formatMessage(markAsDuplicateActionConfig.label)
-    : intl.formatMessage(duplicateMessages.markAsDuplicateButton)
-  const markAsDuplicateIcon = isValidIcon(markAsDuplicateActionConfig?.icon)
-    ? markAsDuplicateActionConfig.icon
-    : 'Archive'
 
   const notADuplicateButton = notADuplicateVisible && (
     <Button
@@ -148,8 +136,8 @@ export const DuplicateForm = ({ eventIndex }: { eventIndex: EventIndex }) => {
         }
       }}
     >
-      <Icon name={notADuplicateIcon} />
-      {notADuplicateLabel}
+      <Icon name="NotePencil" />
+      {intl.formatMessage(duplicateMessages.notDuplicateButton)}
     </Button>
   )
 
@@ -186,8 +174,8 @@ export const DuplicateForm = ({ eventIndex }: { eventIndex: EventIndex }) => {
         }
       }}
     >
-      <Icon name={markAsDuplicateIcon} />
-      {markAsDuplicateLabel}
+      <Icon name="Archive" />
+      {intl.formatMessage(duplicateMessages.markAsDuplicateButton)}
     </Button>
   )
   return (

--- a/packages/client/src/v2-events/features/workqueues/EventOverview/components/CoreActionConfigStories/ApproveRejectCorrection.interaction.stories.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/components/CoreActionConfigStories/ApproveRejectCorrection.interaction.stories.tsx
@@ -38,10 +38,11 @@ export default meta
 type Story = StoryObj<typeof CorrectionReview>
 
 /**
- * A country config for APPROVE_CORRECTION and REJECT_CORRECTION, overriding
- * the hardcoded default label/icon (`buttonMessages.approve`/`reject` and
- * `Check`/`X` in ReviewCorrection.tsx) to prove both buttons read from
- * ActionConfig when present.
+ * A country config for APPROVE_CORRECTION and REJECT_CORRECTION with custom
+ * labels/icons, to prove the buttons on this core-owned review page do NOT
+ * read them: they keep the hardcoded defaults (`buttonMessages.approve`/
+ * `reject` and `Check`/`X` in ReviewCorrection.tsx). The configs'
+ * conditionals still gate the buttons.
  */
 const configuration = {
   ...tennisClubMembershipEvent,
@@ -142,7 +143,7 @@ const lockedEvent = {
   ]
 }
 
-export const approveRejectCorrectionLabelsAreConfigurable: Story = {
+export const correctionReviewButtonsKeepHardcodedLabelsAndIcons: Story = {
   loaders: [
     async () => {
       window.localStorage.setItem(
@@ -178,33 +179,33 @@ export const approveRejectCorrectionLabelsAreConfigurable: Story = {
 
     await waitFor(async () => {
       await expect(
-        canvas.getByRole('button', { name: /Uphold correction/i })
+        canvas.getByRole('button', { name: /^Approve$/i })
       ).toBeInTheDocument()
     })
 
     await waitFor(async () => {
       await expect(
-        canvas.getByRole('button', { name: /Decline correction/i })
+        canvas.getByRole('button', { name: /^Reject$/i })
       ).toBeInTheDocument()
     })
 
     await expect(
-      canvas.queryByRole('button', { name: /^Approve$/i })
+      canvas.queryByRole('button', { name: /Uphold correction/i })
     ).not.toBeInTheDocument()
     await expect(
-      canvas.queryByRole('button', { name: /^Reject$/i })
+      canvas.queryByRole('button', { name: /Decline correction/i })
     ).not.toBeInTheDocument()
 
     const approveButton = canvas.getByRole('button', {
-      name: /Uphold correction/i
+      name: /^Approve$/i
     })
     const rejectButton = canvas.getByRole('button', {
-      name: /Decline correction/i
+      name: /^Reject$/i
     })
 
     // Icon identity can't be asserted from the DOM (phosphor-react renders
     // plain <svg> geometry with no name-identifying attribute) — just confirm
-    // one rendered alongside each configured label.
+    // one rendered alongside each hardcoded label.
     await expect(approveButton.querySelector('svg')).toBeInTheDocument()
     await expect(rejectButton.querySelector('svg')).toBeInTheDocument()
   }
@@ -241,10 +242,10 @@ export const approveRejectCorrectionAreHiddenWhenConditionalIsNotMet: Story = {
     const canvas = within(canvasElement)
 
     await expect(
-      canvas.queryByRole('button', { name: /Uphold correction/i })
+      canvas.queryByRole('button', { name: /^Approve$/i })
     ).not.toBeInTheDocument()
     await expect(
-      canvas.queryByRole('button', { name: /Decline correction/i })
+      canvas.queryByRole('button', { name: /^Reject$/i })
     ).not.toBeInTheDocument()
   }
 }

--- a/packages/client/src/v2-events/features/workqueues/EventOverview/components/CoreActionConfigStories/MarkAsNotDuplicate.interaction.stories.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/components/CoreActionConfigStories/MarkAsNotDuplicate.interaction.stories.tsx
@@ -45,11 +45,13 @@ const tRPCMsw = createTRPCMsw<AppRouter>({
 })
 
 /**
- * A country config for MARK_AS_NOT_DUPLICATE and MARK_AS_DUPLICATE,
- * overriding the hardcoded default label/icon
+ * A country config for MARK_AS_NOT_DUPLICATE and MARK_AS_DUPLICATE with
+ * custom labels/icons, to prove the buttons on this core-owned review page
+ * do NOT read them: they keep the hardcoded defaults
  * (`duplicateMessages.notDuplicateButton`/`markAsDuplicateButton` and
- * `NotePencil`/`Archive` in ReviewDuplicate.tsx / DuplicateForm.tsx) to prove
- * both buttons on this screen read from ActionConfig when present.
+ * `NotePencil`/`Archive` in ReviewDuplicate.tsx / DuplicateForm.tsx).
+ * Configured labels/icons only affect the action menu entry that navigates
+ * here; the configs' conditionals still gate the buttons.
  * `archiveOnDuplicate` (the mutation the "mark as duplicate" button fires)
  * is a client-side combinator over the core MARK_AS_DUPLICATE action — see
  * custom-api/index.ts — so it shares this same config, not a separate one.
@@ -223,7 +225,7 @@ const lockedEvent = {
   actions: lockedActions
 }
 
-export const markAsNotDuplicateLabelAndIconAreConfigurable: Story = {
+export const duplicateReviewButtonsKeepHardcodedLabelsAndIcons: Story = {
   parameters: {
     mockingDate: new Date(),
     reactRouter: {
@@ -262,20 +264,24 @@ export const markAsNotDuplicateLabelAndIconAreConfigurable: Story = {
     const canvas = within(canvasElement)
 
     const notADuplicateButton = await canvas.findByRole('button', {
-      name: /Confirm no duplicate/i
+      name: /Not a duplicate/i
     })
     await expect(notADuplicateButton).toBeVisible()
-    await expect(canvas.queryByText(/Not a duplicate/i)).not.toBeInTheDocument()
+    await expect(
+      canvas.queryByText(/Confirm no duplicate/i)
+    ).not.toBeInTheDocument()
     // Icon identity can't be asserted from the DOM (phosphor-react renders
     // plain <svg> geometry with no name-identifying attribute) — just confirm
-    // one rendered alongside the configured label.
+    // one rendered alongside the hardcoded label.
     await expect(notADuplicateButton.querySelector('svg')).toBeInTheDocument()
 
     const markAsDuplicateButton = await canvas.findByRole('button', {
-      name: /Compare duplicates/i
+      name: /Mark as duplicate/i
     })
     await expect(markAsDuplicateButton).toBeVisible()
-    await expect(canvas.queryByText(/^Archive$/i)).not.toBeInTheDocument()
+    await expect(
+      canvas.queryByText(/Compare duplicates/i)
+    ).not.toBeInTheDocument()
     await expect(markAsDuplicateButton.querySelector('svg')).toBeInTheDocument()
   }
 }


### PR DESCRIPTION
Testland PR: https://github.com/opencrvs/opencrvs-testland/pull/2270

## Description

  Configuring `MARK_AS_DUPLICATE`, `APPROVE_CORRECTION` or `REJECT_CORRECTION` in a country config changed the button labels on the duplicate review and correction review pages, since those pages preferred the configured action label/icon over their hardcoded defaults.

  Configured labels/icons now only affect the action menu. The review pages always render their default buttons ("Not a duplicate"/"Mark as duplicate", "Approve"/"Reject"), while the configs' conditionals still gate visibility/enabling. Interaction stories updated accordingly.

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
