### PR TITLE
feat: create and backfill location version storage (JSONB)

### DIFF
--- a/packages/events/src/router/administrative-areas/administrative-areas.set.test.ts
+++ b/packages/events/src/router/administrative-areas/administrative-areas.set.test.ts
@@ -14,7 +14,12 @@ import {
   generateUuid,
   encodeScope
 } from '@opencrvs/commons'
-import { createTestClient, setupTestCase } from '@events/tests/utils'
+import {
+  createTestClient,
+  setupTestCase,
+  UUID_REGEX
+} from '@events/tests/utils'
+import { getClient } from '@events/storage/postgres/events'
 
 const scope = encodeScope({ type: 'user.data-seeding' })
 
@@ -136,6 +141,82 @@ test('updates externalId on existing administrative area when re-seeded with a v
   const updated = areas.find((a) => a.id === areaId)
 
   expect(updated?.externalId).toBe('adminpcode123')
+})
+
+test('stores a single active initial version when creating an administrative area', async () => {
+  const { user } = await setupTestCase()
+  const dataSeedingClient = createTestClient(user, [scope])
+
+  const areaId = generateUuid()
+
+  await dataSeedingClient.administrativeAreas.set([
+    {
+      id: areaId,
+      parentId: null,
+      name: 'Versioned administrative area',
+      validUntil: null,
+      externalId: 'versioned-area-pcode'
+    }
+  ])
+
+  const { versions } = await getClient()
+    .selectFrom('administrativeAreas')
+    .select('versions')
+    .where('id', '=', areaId)
+    .executeTakeFirstOrThrow()
+
+  // toEqual matches keys exactly, so this also asserts the version element
+  // contains no parent reference (parentId).
+  expect(versions).toEqual([
+    {
+      versionId: expect.stringMatching(UUID_REGEX),
+      effectiveFrom: '0001-01-01',
+      name: 'Versioned administrative area',
+      externalId: 'versioned-area-pcode',
+      status: 'active'
+    }
+  ])
+})
+
+test('stores an additional inactive version when creating an administrative area with validUntil', async () => {
+  const { user } = await setupTestCase()
+  const dataSeedingClient = createTestClient(user, [scope])
+
+  const areaId = generateUuid()
+
+  await dataSeedingClient.administrativeAreas.set([
+    {
+      id: areaId,
+      parentId: null,
+      name: 'Deprecated administrative area',
+      validUntil: '2027-03-15T23:30:00.000Z',
+      externalId: 'deprecated-area-pcode'
+    }
+  ])
+
+  const { versions } = await getClient()
+    .selectFrom('administrativeAreas')
+    .select('versions')
+    .where('id', '=', areaId)
+    .executeTakeFirstOrThrow()
+
+  expect(versions).toEqual([
+    {
+      versionId: expect.stringMatching(UUID_REGEX),
+      effectiveFrom: '0001-01-01',
+      name: 'Deprecated administrative area',
+      externalId: 'deprecated-area-pcode',
+      status: 'active'
+    },
+    {
+      versionId: expect.stringMatching(UUID_REGEX),
+      // UTC date part of the given validUntil
+      effectiveFrom: '2027-03-15',
+      name: 'Deprecated administrative area',
+      externalId: 'deprecated-area-pcode',
+      status: 'inactive'
+    }
+  ])
 })
 
 test('seeding administrative areas is additive, not destructive', async () => {

--- a/packages/events/src/router/locations/locations.set.test.ts
+++ b/packages/events/src/router/locations/locations.set.test.ts
@@ -14,7 +14,12 @@ import {
   Location,
   encodeScope
 } from '@opencrvs/commons'
-import { createTestClient, setupTestCase } from '@events/tests/utils'
+import {
+  createTestClient,
+  setupTestCase,
+  UUID_REGEX
+} from '@events/tests/utils'
+import { getClient } from '@events/storage/postgres/events'
 
 const scope = encodeScope({ type: 'user.data-seeding' })
 
@@ -130,6 +135,133 @@ test('updates externalId on existing location when re-seeded with a value', asyn
   const updated = locations.find((l) => l.id === locationId)
 
   expect(updated?.externalId).toBe('pcode123')
+})
+
+test('stores a single active initial version when creating a location', async () => {
+  const { user } = await setupTestCase()
+  const dataSeedingClient = createTestClient(user, [scope])
+
+  const locationId = generateUuid()
+
+  await dataSeedingClient.locations.set([
+    {
+      id: locationId,
+      administrativeAreaId: null,
+      name: 'Versioned location',
+      validUntil: null,
+      locationType: 'CRVS_OFFICE',
+      externalId: 'versioned-location-pcode'
+    }
+  ])
+
+  const { versions } = await getClient()
+    .selectFrom('locations')
+    .select('versions')
+    .where('id', '=', locationId)
+    .executeTakeFirstOrThrow()
+
+  // toEqual matches keys exactly, so this also asserts the version element
+  // contains no parent reference (administrativeAreaId).
+  expect(versions).toEqual([
+    {
+      versionId: expect.stringMatching(UUID_REGEX),
+      effectiveFrom: '0001-01-01',
+      name: 'Versioned location',
+      externalId: 'versioned-location-pcode',
+      status: 'active'
+    }
+  ])
+})
+
+test('stores an additional inactive version when creating a location with validUntil', async () => {
+  const { user } = await setupTestCase()
+  const dataSeedingClient = createTestClient(user, [scope])
+
+  const locationId = generateUuid()
+
+  await dataSeedingClient.locations.set([
+    {
+      id: locationId,
+      administrativeAreaId: null,
+      name: 'Deprecated location',
+      validUntil: '2027-03-15T23:30:00.000Z',
+      locationType: 'CRVS_OFFICE',
+      externalId: 'deprecated-location-pcode'
+    }
+  ])
+
+  const { versions } = await getClient()
+    .selectFrom('locations')
+    .select('versions')
+    .where('id', '=', locationId)
+    .executeTakeFirstOrThrow()
+
+  expect(versions).toEqual([
+    {
+      versionId: expect.stringMatching(UUID_REGEX),
+      effectiveFrom: '0001-01-01',
+      name: 'Deprecated location',
+      externalId: 'deprecated-location-pcode',
+      status: 'active'
+    },
+    {
+      versionId: expect.stringMatching(UUID_REGEX),
+      // UTC date part of the given validUntil
+      effectiveFrom: '2027-03-15',
+      name: 'Deprecated location',
+      externalId: 'deprecated-location-pcode',
+      status: 'inactive'
+    }
+  ])
+})
+
+test('does not modify versions when re-seeding an existing location with a new name', async () => {
+  const { user } = await setupTestCase()
+  const dataSeedingClient = createTestClient(user, [scope])
+
+  const locationId = generateUuid()
+
+  await dataSeedingClient.locations.set([
+    {
+      id: locationId,
+      administrativeAreaId: null,
+      name: 'Original name',
+      validUntil: null,
+      locationType: 'CRVS_OFFICE',
+      externalId: 'renamed-location-pcode'
+    }
+  ])
+
+  const { versions: versionsAfterInsert } = await getClient()
+    .selectFrom('locations')
+    .select('versions')
+    .where('id', '=', locationId)
+    .executeTakeFirstOrThrow()
+
+  await dataSeedingClient.locations.set([
+    {
+      id: locationId,
+      administrativeAreaId: null,
+      name: 'Renamed location',
+      validUntil: null,
+      locationType: 'CRVS_OFFICE',
+      externalId: 'renamed-location-pcode'
+    }
+  ])
+
+  const updated = await getClient()
+    .selectFrom('locations')
+    .select(['name', 'versions'])
+    .where('id', '=', locationId)
+    .executeTakeFirstOrThrow()
+
+  // The flat column updates, but re-seeding deliberately leaves versions
+  // untouched: still the original single element with the original name.
+  expect(updated.name).toBe('Renamed location')
+  expect(updated.versions).toEqual(versionsAfterInsert)
+  expect(updated.versions).toEqual([
+    expect.objectContaining({ name: 'Original name', status: 'active' })
+  ])
 })
 
 test('seeding locations is additive, not destructive', async () => {

--- a/packages/events/src/storage/postgres/administrative-hierarchy/administrative-areas.ts
+++ b/packages/events/src/storage/postgres/administrative-hierarchy/administrative-areas.ts
@@ -14,6 +14,7 @@ import { Kysely, sql } from 'kysely'
 import { AdministrativeArea, logger, UUID } from '@opencrvs/commons'
 import { getClient } from '@events/storage/postgres/events'
 import Schema from '../events/schema/Database'
+import { buildInitialVersions } from './locations'
 
 export async function getAdministrativeAreas({
   ids,
@@ -69,7 +70,8 @@ export async function setAdministrativeAreasInTrx(
           parentId: aa.parentId,
           validUntil: aa.validUntil,
           deletedAt: null,
-          externalId: aa.externalId
+          externalId: aa.externalId,
+          versions: buildInitialVersions(aa)
         }))
       )
       .onConflict((oc) =>

--- a/packages/events/src/storage/postgres/administrative-hierarchy/locations.ts
+++ b/packages/events/src/storage/postgres/administrative-hierarchy/locations.ts
@@ -11,7 +11,7 @@
 
 import { Kysely, RawBuilder, sql } from 'kysely'
 import { chunk } from 'lodash'
-import { Location, logger, UUID } from '@opencrvs/commons'
+import { getUUID, Location, logger, UUID } from '@opencrvs/commons'
 import { getClient } from '@events/storage/postgres/events'
 import { NewLocations } from '../events/schema/app/Locations'
 import Schema from '../events/schema/Database'
@@ -28,9 +28,55 @@ export function clearAdministrativeHierarchyCache() {
   administrativeHierarchyByIdCache.clear()
 }
 
+interface InitialVersion {
+  versionId: UUID
+  effectiveFrom: string
+  name: string
+  externalId: string | null
+  status: 'active' | 'inactive'
+}
+
+/**
+ * Builds the initial `versions` jsonb value for a location or administrative
+ * area row on insert. The first version is always active from the beginning of
+ * time. If the row has `validUntil` set, an inactive version effective from
+ * that date (UTC) is appended.
+ */
+export function buildInitialVersions({
+  name,
+  externalId,
+  validUntil
+}: {
+  name: string
+  externalId?: string | null
+  validUntil?: string | null
+}): RawBuilder<InitialVersion[]> {
+  const activeVersion: InitialVersion = {
+    versionId: getUUID(),
+    effectiveFrom: '0001-01-01',
+    name,
+    externalId: externalId ?? null,
+    status: 'active'
+  }
+
+  const versions = validUntil
+    ? [
+        activeVersion,
+        {
+          ...activeVersion,
+          versionId: getUUID(),
+          effectiveFrom: new Date(validUntil).toISOString().slice(0, 10),
+          status: 'inactive' as const
+        }
+      ]
+    : [activeVersion]
+
+  return sql`cast (${JSON.stringify(versions)} as jsonb)`
+}
+
 export async function setLocationsInTrx(
   trx: Kysely<Schema>,
-  locations: NewLocations[]
+  locations: Omit<NewLocations, 'versions'>[]
 ) {
   // Insert new locations in chunks to avoid exceeding max query size
   for (const [index, batch] of chunk(
@@ -42,7 +88,13 @@ export async function setLocationsInTrx(
     )
     await trx
       .insertInto('locations')
-      .values(batch.map((loc) => ({ ...loc, deletedAt: null })))
+      .values(
+        batch.map((loc) => ({
+          ...loc,
+          deletedAt: null,
+          versions: buildInitialVersions(loc)
+        }))
+      )
       .onConflict((oc) =>
         oc.column('id').doUpdateSet({
           name: () =>
@@ -73,7 +125,9 @@ export async function setLocationsInTrx(
   }
 }
 
-export async function setLocations(locations: NewLocations[]) {
+export async function setLocations(
+  locations: Omit<NewLocations, 'versions'>[]
+) {
   const db = getClient()
 
   await setLocationsInTrx(db, locations)
@@ -212,7 +266,9 @@ export function getAdministrativeHierarchyByIdCte(
  * @returns The list of location hierarchy ids, ex: [admin_area_1_id, admin_area_2_id, locationId]
  */
 
-export async function getAdministrativeHierarchyById(id: string): Promise<UUID[]> {
+export async function getAdministrativeHierarchyById(
+  id: string
+): Promise<UUID[]> {
   const cached = administrativeHierarchyByIdCache.get(id)
   if (cached) {
     return cached

--- a/packages/events/src/storage/postgres/events/schema/app/AdministrativeAreas.ts
+++ b/packages/events/src/storage/postgres/events/schema/app/AdministrativeAreas.ts
@@ -21,6 +21,12 @@ export default interface AdministrativeAreasTable {
   validUntil: ColumnType<string | null, string | null, string | null>
 
   externalId: ColumnType<string | null, string | null, string | null>
+
+  versions: ColumnType<
+    Record<string, any>,
+    Record<string, any>,
+    Record<string, any>
+  >
 }
 
 export type AdministrativeAreas = Selectable<AdministrativeAreasTable>

--- a/packages/events/src/storage/postgres/events/schema/app/Locations.ts
+++ b/packages/events/src/storage/postgres/events/schema/app/Locations.ts
@@ -23,6 +23,12 @@ export default interface LocationsTable {
   administrativeAreaId: ColumnType<UUID | null, UUID | null, UUID | null>
 
   externalId: ColumnType<string | null, string | null, string | null>
+
+  versions: ColumnType<
+    Record<string, any>,
+    Record<string, any>,
+    Record<string, any>
+  >
 }
 
 export type Locations = Selectable<LocationsTable>

--- a/packages/events/src/tests/postgres-migrations.sql
+++ b/packages/events/src/tests/postgres-migrations.sql
@@ -68,7 +68,9 @@ CREATE TABLE app.administrative_areas (
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
     deleted_at timestamp with time zone,
     valid_until timestamp with time zone,
-    external_id text
+    external_id text,
+    versions jsonb NOT NULL,
+    CONSTRAINT administrative_areas_versions_nonempty CHECK (((jsonb_typeof(versions) = 'array'::text) AND (jsonb_array_length(versions) >= 1)))
 );
 
 
@@ -287,7 +289,9 @@ CREATE TABLE app.locations (
     location_type text,
     valid_until timestamp with time zone,
     administrative_area_id uuid,
-    external_id text
+    external_id text,
+    versions jsonb NOT NULL,
+    CONSTRAINT locations_versions_nonempty CHECK (((jsonb_typeof(versions) = 'array'::text) AND (jsonb_array_length(versions) >= 1)))
 );
 
 

--- a/packages/events/src/tests/utils.ts
+++ b/packages/events/src/tests/utils.ts
@@ -58,6 +58,9 @@ import {
   setupHierarchyWithUsers
 } from './generators'
 
+export const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
 export const TEST_SYSTEM_ID = '9f3c6b7e-2a91-4f6d-b8d2-5c0e3a4f1b72' as UUID
 export const TEST_SYSTEM_ID_2 = '4d1a8c90-7e5b-4a3f-9c2d-1f6b8e7a2c55' as UUID
 export const REINDEX_SYSTEM_ID = 'e2b7f6a1-3d94-4c8e-a5f9-6b2d0c1a9e33' as UUID

--- a/packages/migration/src/migrations/events/1784033588369_add-versions-column-to-locations-and-administrative-areas.sql
+++ b/packages/migration/src/migrations/events/1784033588369_add-versions-column-to-locations-and-administrative-areas.sql
@@ -56,6 +56,9 @@ ALTER TABLE app.administrative_areas
   ADD CONSTRAINT administrative_areas_versions_nonempty
   CHECK (jsonb_typeof(versions) = 'array' AND jsonb_array_length(versions) >= 1);
 
+ALTER TABLE app.locations ALTER COLUMN versions SET NOT NULL;
+ALTER TABLE app.administrative_areas ALTER COLUMN versions SET NOT NULL;
+
 -- Down Migration
 ALTER TABLE app.locations DROP COLUMN versions;
 ALTER TABLE app.administrative_areas DROP COLUMN versions;

--- a/packages/migration/src/migrations/events/1784033588369_add-versions-column-to-locations-and-administrative-areas.sql
+++ b/packages/migration/src/migrations/events/1784033588369_add-versions-column-to-locations-and-administrative-areas.sql
@@ -1,0 +1,61 @@
+-- Up Migration
+ALTER TABLE app.locations ADD COLUMN versions jsonb;
+ALTER TABLE app.administrative_areas ADD COLUMN versions jsonb;
+
+UPDATE app.locations
+SET versions = jsonb_build_array(
+    jsonb_build_object(
+      'versionId', gen_random_uuid(),
+      'effectiveFrom', '0001-01-01',
+      'name', name,
+      'externalId', external_id,
+      'status', 'active'
+    )
+  ) || CASE
+    WHEN valid_until IS NOT NULL THEN jsonb_build_array(
+      jsonb_build_object(
+        'versionId', gen_random_uuid(),
+        'effectiveFrom', to_char(valid_until AT TIME ZONE 'UTC', 'YYYY-MM-DD'),
+        'name', name,
+        'externalId', external_id,
+        'status', 'inactive'
+      )
+    )
+    ELSE '[]'::jsonb
+  END
+WHERE versions IS NULL;
+
+UPDATE app.administrative_areas
+SET versions = jsonb_build_array(
+    jsonb_build_object(
+      'versionId', gen_random_uuid(),
+      'effectiveFrom', '0001-01-01',
+      'name', name,
+      'externalId', external_id,
+      'status', 'active'
+    )
+  ) || CASE
+    WHEN valid_until IS NOT NULL THEN jsonb_build_array(
+      jsonb_build_object(
+        'versionId', gen_random_uuid(),
+        'effectiveFrom', to_char(valid_until AT TIME ZONE 'UTC', 'YYYY-MM-DD'),
+        'name', name,
+        'externalId', external_id,
+        'status', 'inactive'
+      )
+    )
+    ELSE '[]'::jsonb
+  END
+WHERE versions IS NULL;
+
+ALTER TABLE app.locations
+  ADD CONSTRAINT locations_versions_nonempty
+  CHECK (jsonb_typeof(versions) = 'array' AND jsonb_array_length(versions) >= 1);
+
+ALTER TABLE app.administrative_areas
+  ADD CONSTRAINT administrative_areas_versions_nonempty
+  CHECK (jsonb_typeof(versions) = 'array' AND jsonb_array_length(versions) >= 1);
+
+-- Down Migration
+ALTER TABLE app.locations DROP COLUMN versions;
+ALTER TABLE app.administrative_areas DROP COLUMN versions;


### PR DESCRIPTION
## Description

First slice of location versioning (epic #6691): adds the append-only `versions` JSONB storage from #13131.

- New migration adds `versions` to `app.locations` and `app.administrative_areas`, backfills every row, then sets `NOT NULL` with a non-empty-array `CHECK`. Since there is no `status` column, the backfill derives it from `valid_until`: a sentinel-dated `active` element, plus a second `inactive` element (at the UTC date of `valid_until`) where set — as agreed on the issue. `effectiveFrom` values are plain dates.
- The `set` upserts now build the initial version element on insert, so seeding keeps working under the `NOT NULL` constraint. The conflict path deliberately leaves `versions` untouched — update semantics belong to the write API (#13134). The `validUntil`-driven second element is transitional and goes away when the field leaves the wire model (#13133).
- Kanel types and the test schema dump are regenerated.

**Deviation from the issue's ACs:** no GIN indexes are created. Resolution reads fetch rows and walk the array in code — no query filters by array contents — so the index would have nothing to serve. Flagged on #13131; a one-line forward migration can add it later if a containment query ever appears.

Integration tests cover the insert paths on both tables: single-element shape, the two-element `validUntil` case, no parent reference inside elements, and re-seeding leaving `versions` unchanged.

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
