### PR TITLE
[OCRVS-13124] Cherry pick "suppress mobile PIN re-lock during file and signature uploads"

### DIFF
--- a/.github/workflows/deploy-to-feature-environment.yml
+++ b/.github/workflows/deploy-to-feature-environment.yml
@@ -231,20 +231,20 @@ jobs:
           HEAD_COMMIT_HASH=$(echo "$PR_DATA" | jq -r '.headRefOid' | cut -c1-7)
           echo "HEAD_COMMIT_HASH=${HEAD_COMMIT_HASH}" >> $GITHUB_ENV
 
-      - name: Check if branch exists in opencrvs-farajaland repo
+      - name: Check if branch exists in opencrvs-testland repo
         run: |
-          FARAJALAND_REPO=https://github.com/opencrvs/opencrvs-farajaland
+          FARAJALAND_REPO=https://github.com/opencrvs/opencrvs-testland
           BASE_BRANCH="${{ github.base_ref || 'develop' }}"
 
           if git ls-remote $FARAJALAND_REPO refs/heads/${{ env.BRANCH_NAME }} | grep -q "${{ env.BRANCH_NAME }}"; then
             COMMIT_HASH=$(git ls-remote $FARAJALAND_REPO refs/heads/${{ env.BRANCH_NAME }} | cut -c1-7)
-            echo "Branch ${{ env.BRANCH_NAME }} exists in opencrvs-farajaland repo: $COMMIT_HASH"
+            echo "Branch ${{ env.BRANCH_NAME }} exists in opencrvs-testland repo: $COMMIT_HASH"
           elif git ls-remote $FARAJALAND_REPO refs/heads/$BASE_BRANCH | grep -q "$BASE_BRANCH"; then
             COMMIT_HASH=$(git ls-remote $FARAJALAND_REPO refs/heads/$BASE_BRANCH | cut -c1-7)
-            echo "Branch ${{ env.BRANCH_NAME }} doesn't exist in opencrvs-farajaland repo. Will use commit hash: '$COMMIT_HASH' from base branch: '$BASE_BRANCH'"
+            echo "Branch ${{ env.BRANCH_NAME }} doesn't exist in opencrvs-testland repo. Will use commit hash: '$COMMIT_HASH' from base branch: '$BASE_BRANCH'"
           else
             COMMIT_HASH=$(git ls-remote $FARAJALAND_REPO refs/heads/develop | cut -c1-7)
-            echo "Branch ${{ env.BRANCH_NAME }} doesn't exist in opencrvs-farajaland repo. Will use commit hash: '$COMMIT_HASH' from 'develop' branch"
+            echo "Branch ${{ env.BRANCH_NAME }} doesn't exist in opencrvs-testland repo. Will use commit hash: '$COMMIT_HASH' from 'develop' branch"
           fi
           echo "FARAJALAND_COMMIT_HASH=${COMMIT_HASH}" >> $GITHUB_ENV
       - name: Parse the stack name

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.9.16 Release Candidate
 
+### Bug fixes
+
+- On mobile, uploading a file or signature no longer triggers the PIN re-lock screen. Opening the native file picker or camera briefly backgrounds the app, which was previously indistinguishable from the user actually leaving the app. [#13124](https://github.com/opencrvs/opencrvs-core/issues/13124)
+
 ## 1.9.15 Release Candidate
 
 ### Improvements

--- a/packages/client/src/components/ProtectedPage.tsx
+++ b/packages/client/src/components/ProtectedPage.tsx
@@ -33,10 +33,15 @@ import { LoadingBar } from '@opencrvs/components/src/LoadingBar/LoadingBar'
 import { RouteComponentProps, withRouter } from './WithRouterProps'
 import { getAuthenticated } from '@client/profile/profileSelectors'
 import { IStoreState } from '@client/store'
+import { shouldBypassLock } from '@client/utils/lockBypass'
 export const SCREEN_LOCK = 'screenLock'
 
 type OwnProps = PropsWithChildren<{
-  unprotectedRouteElements: string[]
+  // Kept for the legacy (V1) declaration flow, which tolerates the app
+  // backgrounding at any point on these routes, not just right after an
+  // upload click. shouldBypassLock() covers the narrower, click-triggered
+  // case (e.g. v2-events routes, which don't match these route names).
+  unprotectedRouteElements?: string[]
 }>
 
 type DispatchProps = {
@@ -120,9 +125,11 @@ class ProtectedPageComponent extends React.Component<Props, IProtectPageState> {
       (route) => this.props.router.location.pathname.includes(route)
     )
 
+    const lockShouldBeBypassed = onUnprotectedPage || shouldBypassLock()
+
     const newState = { ...this.state }
 
-    if (!alreadyLocked && !onUnprotectedPage) {
+    if (!alreadyLocked && !lockShouldBeBypassed) {
       newState.secured = false
       if (await this.getPIN()) {
         newState.pinExists = true

--- a/packages/client/src/components/form/DocumentUploadField/DocumentUploaderWithOption.tsx
+++ b/packages/client/src/components/form/DocumentUploadField/DocumentUploaderWithOption.tsx
@@ -23,6 +23,7 @@ import { formMessages } from '@client/i18n/messages'
 import { messages } from '@client/i18n/messages/views/imageUpload'
 import imageCompression from 'browser-image-compression'
 import { bytesToMB } from '@client/utils/imageUtils'
+import { setLockBypass } from '@client/utils/lockBypass'
 
 const DEFAULT_MAX_SIZE_MB = 5
 
@@ -296,7 +297,13 @@ export const DocumentUploaderWithOption = (props: IFullProps) => {
         <FullWidthImageUploader
           id="upload_document"
           name={props.name}
-          onClick={(e) => !isValid() && e.preventDefault()}
+          onClick={(e) => {
+            if (!isValid()) {
+              e.preventDefault()
+              return
+            }
+            setLockBypass()
+          }}
           onChange={handleFileChange}
           disabled={filesBeingProcessed.length > 0}
         >
@@ -317,7 +324,13 @@ export const DocumentUploaderWithOption = (props: IFullProps) => {
           <DocumentUploadButton
             id="upload_document"
             name={props.name}
-            onClick={(e) => !isValid() && e.preventDefault()}
+            onClick={(e) => {
+              if (!isValid()) {
+                e.preventDefault()
+                return
+              }
+              setLockBypass()
+            }}
             onChange={handleFileChange}
             disabled={filesBeingProcessed.length > 0}
           >

--- a/packages/client/src/components/form/DocumentUploadField/SimpleDocumentUploader.tsx
+++ b/packages/client/src/components/form/DocumentUploadField/SimpleDocumentUploader.tsx
@@ -22,6 +22,7 @@ import styled from 'styled-components'
 import { DocumentListPreview } from './DocumentListPreview'
 import { buttonMessages, formMessages as messages } from '@client/i18n/messages'
 import { getBase64String } from '@client/utils/imageUtils'
+import { setLockBypass } from '@client/utils/lockBypass'
 
 const DocumentUploader = styled(ImageUploader)`
   color: ${({ theme }) => theme.colors.primary};
@@ -170,6 +171,7 @@ const SimpleDocumentUploaderComponent = ({
           id="upload_document"
           name={name}
           onChange={handleFileChange}
+          onClick={setLockBypass}
         >
           {intl.formatMessage(messages.uploadFile)}
         </DocumentUploader>

--- a/packages/client/src/components/form/SignatureField/SignatureUploader.tsx
+++ b/packages/client/src/components/form/SignatureField/SignatureUploader.tsx
@@ -23,6 +23,7 @@ import {
   validationMessages
 } from '@client/i18n/messages'
 import { getBase64String } from '@client/utils/imageUtils'
+import { setLockBypass } from '@client/utils/lockBypass'
 import { Stack } from '@opencrvs/components/lib/Stack'
 import { Button } from '@opencrvs/components/lib/Button'
 import { Icon } from '@opencrvs/components/lib/Icon'
@@ -108,6 +109,7 @@ export function SignatureUploader({
             </Button>
             <ImageUploader
               {...props}
+              onClick={setLockBypass}
               onChange={async (file) => {
                 const fileSizeMB = file.size / (1024 * 1024) // convert bytes to megabytes
                 if (fileSizeMB > maxSizeMb) {

--- a/packages/client/src/utils/lockBypass.ts
+++ b/packages/client/src/utils/lockBypass.ts
@@ -1,0 +1,89 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+
+/**
+ * @module lockBypass
+ *
+ * Lets the app skip the mobile PIN lock when an intentional user action
+ * sends the tab to the background.
+ *
+ * On mobile, many user actions briefly background the tab — opening a file
+ * picker, launching the camera, redirecting to an external app, and so on.
+ * Without this, the PIN screen would appear every time the user comes back.
+ *
+ * Flow:
+ *   1. Caller arms the bypass via {@link setLockBypass} just before the action.
+ *   2. `ProtectedPage` checks via {@link shouldBypassLock} on visibility
+ *      change to decide whether to lock.
+ *   3. The bypass is cleared when the window regains focus — i.e. when the
+ *      user actually returns from the external action.
+ */
+
+/**
+ * How long the bypass stays valid (3 minutes).
+ *
+ * Long enough for slow user actions like camera permission prompts. Short
+ * enough that a forgotten flag can't disable the PIN lock on a later real
+ * background event.
+ */
+const LOCK_BYPASS_TTL_MS = 180_000
+
+/**
+ * The expiry timestamp of the pending bypass. `0` means no bypass pending.
+ * Comparing against `Date.now()` enforces the TTL with no need for a timer.
+ */
+let bypassValidUntil = 0
+
+/**
+ * Clear the bypass as soon as the user returns to the tab.
+ *
+ * The `focus` event on `window` fires when the tab regains focus — i.e.
+ * the user closed the file picker / camera / external app and is back.
+ * Tying the clear to this event (rather than to the lock check) keeps the
+ * read in {@link shouldBypassLock} side-effect-free, and ensures the
+ * bypass survives until the user actually returns.
+ */
+if (typeof window !== 'undefined') {
+  window.addEventListener('focus', () => {
+    bypassValidUntil = 0
+  })
+}
+
+/**
+ * Tells `ProtectedPage` to skip the PIN lock on the next visibility change.
+ *
+ * Call this right before any user action that temporarily backgrounds the
+ * tab — opening a native picker, launching the camera, redirecting to an
+ * external app, etc. The flag is cleared the moment the window regains
+ * focus, and auto-expires after 3 minutes as a safety net.
+ *
+ * @example
+ * <button onClick={setLockBypass}>Open camera</button>
+ */
+export function setLockBypass(): void {
+  bypassValidUntil = Date.now() + LOCK_BYPASS_TTL_MS
+}
+
+/**
+ * Pure query: returns `true` if a bypass is currently pending, `false`
+ * otherwise.
+ *
+ * Has no side effect — multiple calls return the same value until either
+ * the window regains focus (cleared by the focus listener) or the TTL
+ * elapses.
+ *
+ * Called by `ProtectedPage` on visibility change to decide whether to lock.
+ *
+ * @returns `true` to skip the lock, `false` to lock as usual.
+ */
+export function shouldBypassLock(): boolean {
+  return bypassValidUntil > Date.now()
+}

--- a/packages/client/src/v2-events/components/forms/inputs/FileInput/DocumentUploaderWithOption.tsx
+++ b/packages/client/src/v2-events/components/forms/inputs/FileInput/DocumentUploaderWithOption.tsx
@@ -27,6 +27,7 @@ import { buttonMessages, formMessages as messages } from '@client/i18n/messages'
 import { useIntlWithFormData } from '@client/v2-events/messages/utils'
 import { useImageEditorModal } from '@client/v2-events/components/ImageEditorModal'
 import { useImageProcessing } from '@client/utils/imageUtils'
+import { setLockBypass } from '@client/utils/lockBypass'
 import { DocumentUploader } from './SimpleDocumentUploader'
 import { DocumentListPreview } from './DocumentListPreview'
 import { DocumentPreview } from './DocumentPreview'
@@ -263,6 +264,7 @@ function DocumentUploaderWithOption({
           id={name}
           name={name}
           onChange={handleFileChange}
+          onClick={setLockBypass}
         >
           {intl.formatMessage(messages.uploadFile)}
         </DocumentUploader>

--- a/packages/client/src/v2-events/components/forms/inputs/FileInput/SimpleDocumentUploader.tsx
+++ b/packages/client/src/v2-events/components/forms/inputs/FileInput/SimpleDocumentUploader.tsx
@@ -15,6 +15,7 @@ import { MimeType, FieldValue, FileFieldValue } from '@opencrvs/commons/client'
 import { ErrorText } from '@opencrvs/components/lib/ErrorText'
 import { ImageUploader } from '@opencrvs/components/lib/ImageUploader'
 import { formMessages as messages } from '@client/i18n/messages'
+import { setLockBypass } from '@client/utils/lockBypass'
 import { DocumentPreview } from './DocumentPreview'
 import { SingleDocumentPreview } from './SingleDocumentPreview'
 import { useOnFileChange } from './useOnFileChange'
@@ -133,6 +134,7 @@ export function SimpleDocumentUploader({
         id={name}
         name={name}
         onChange={handleFileChange}
+        onClick={setLockBypass}
       >
         {intl.formatMessage(messages.uploadFile)}
       </DocumentUploader>

--- a/packages/client/src/v2-events/components/forms/inputs/SignatureField/SignatureField.interaction.stories.tsx
+++ b/packages/client/src/v2-events/components/forms/inputs/SignatureField/SignatureField.interaction.stories.tsx
@@ -28,6 +28,7 @@ import {
 import { FormFieldGenerator } from '@client/v2-events/components/forms/FormFieldGenerator'
 import { AppRouter, TRPCProvider } from '@client/v2-events/trpc'
 import { TestImage } from '@client/v2-events/features/events/fixtures'
+import { shouldBypassLock } from '@client/utils/lockBypass'
 import { getTestValidatorContext } from '../../../../../../.storybook/decorators'
 import { SignatureField } from './SignatureField'
 
@@ -214,6 +215,160 @@ export const SignatureFileUpload: StoryObj<typeof StyledFormFieldGenerator> = {
       // alt text of the image
       await canvas.findByAltText('Signature')
     })
+  }
+}
+
+/**
+ * Regression test for the mobile PIN-lock-during-upload fix.
+ *
+ * Every uploader that opens a native picker — `SignatureField`,
+ * `SimpleDocumentUploader` (FILE), and `DocumentUploaderWithOption`
+ * (FILE_WITH_OPTIONS) — must arm the bypass flag (via `setLockBypass`)
+ * before the picker is invoked. Otherwise `ProtectedPage` triggers the
+ * PIN re-lock as soon as the picker sends the page to background,
+ * interrupting the upload mid-flow.
+ *
+ * Renders all three uploaders on the same form and checks each Upload
+ * button in turn. Asserts via `shouldBypassLock()` — the same call
+ * `ProtectedPage` would make on a visibility transition.
+ */
+export const UploadButtonsArmLockBypass: StoryObj<
+  typeof StyledFormFieldGenerator
+> = {
+  name: 'Upload buttons arm PIN-lock bypass (Signature / File / FileWithOptions)',
+  parameters: {
+    layout: 'centered',
+    reactRouter: {
+      router: {
+        path: '/event/:eventId',
+        element: (
+          <StyledFormFieldGenerator
+            fields={[
+              {
+                id: 'storybook.signature',
+                type: FieldType.SIGNATURE,
+                configuration: {
+                  maxFileSize: 1 * 1024 * 1024,
+                  acceptedFileTypes: [MimeType.enum['image/png']]
+                },
+                signaturePromptLabel: generateTranslationConfig('Signature'),
+                label: generateTranslationConfig('Upload signature')
+              },
+              {
+                id: 'storybook.file',
+                type: FieldType.FILE,
+                configuration: {
+                  maxFileSize: 1 * 1024 * 1024,
+                  acceptedFileTypes: [MimeType.enum['image/png']]
+                },
+                label: generateTranslationConfig('Upload document')
+              },
+              {
+                id: 'storybook.fileWithOption',
+                type: FieldType.FILE_WITH_OPTIONS,
+                configuration: {
+                  maxFileSize: 1 * 1024 * 1024,
+                  acceptedFileTypes: [MimeType.enum['image/png']]
+                },
+                label: generateTranslationConfig('Upload supporting document'),
+                options: [
+                  {
+                    value: 'forest',
+                    label: generateTranslationConfig('Forest')
+                  },
+                  {
+                    value: 'beach',
+                    label: generateTranslationConfig('Beach')
+                  }
+                ]
+              }
+            ]}
+            id="my-form"
+            validatorContext={getTestValidatorContext()}
+          />
+        )
+      },
+      initialPath: '/event/123-abcd-213'
+    },
+    chromatic: { disableSnapshot: true }
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+
+    /**
+     * Both `formMessages.uploadFile` and `buttonMessages.upload` resolve to
+     * the string "Upload", so all three uploader buttons share that name.
+     * `findAllByRole` returns them in DOM order, which matches the order of
+     * the `fields` array above: [signature, file, fileWithOption].
+     */
+    const getUploadButtons = async () =>
+      canvas.findAllByRole('button', { name: 'Upload' })
+
+    /**
+     * Dispatching a `focus` event on `window` simulates the user returning
+     * from the native picker / camera / external app — the same signal the
+     * lockBypass module listens for to clear the pending bypass.
+     */
+    const simulateReturnFromPicker = () =>
+      window.dispatchEvent(new Event('focus'))
+
+    await step('Bypass flag is not armed before user interacts', async () => {
+      // Drain any pending bypass a previous story may have left behind.
+      simulateReturnFromPicker()
+      await expect(shouldBypassLock()).toBe(false)
+    })
+
+    await step(
+      'SignatureField upload arms the bypass, focus return clears it',
+      async () => {
+        const [signatureUpload] = await getUploadButtons()
+        await userEvent.click(signatureUpload)
+
+        // Upload click armed the bypass — repeated reads stay true because
+        // shouldBypassLock is a pure query.
+        await expect(shouldBypassLock()).toBe(true)
+        await expect(shouldBypassLock()).toBe(true)
+
+        // User returns from the picker → focus listener clears the flag,
+        // so a later real background event still triggers the PIN re-lock.
+        simulateReturnFromPicker()
+        await expect(shouldBypassLock()).toBe(false)
+      }
+    )
+
+    await step(
+      'FILE field upload arms the bypass, focus return clears it',
+      async () => {
+        const [, fileUpload] = await getUploadButtons()
+        await userEvent.click(fileUpload)
+
+        await expect(shouldBypassLock()).toBe(true)
+
+        simulateReturnFromPicker()
+        await expect(shouldBypassLock()).toBe(false)
+      }
+    )
+
+    await step(
+      'FILE_WITH_OPTIONS upload arms the bypass, focus return clears it',
+      async () => {
+        // The Upload button is disabled until a document type is picked.
+        // Open the react-select dropdown and choose an option to enable it.
+        const selectControl = canvasElement.querySelector(
+          '.react-select__control'
+        ) as HTMLElement
+        await userEvent.click(selectControl)
+        await userEvent.click(await canvas.findByText('Forest'))
+
+        const [, , fileWithOptionUpload] = await getUploadButtons()
+        await userEvent.click(fileWithOptionUpload)
+
+        await expect(shouldBypassLock()).toBe(true)
+
+        simulateReturnFromPicker()
+        await expect(shouldBypassLock()).toBe(false)
+      }
+    )
   }
 }
 

--- a/packages/client/src/v2-events/components/forms/inputs/SignatureField/SignatureField.tsx
+++ b/packages/client/src/v2-events/components/forms/inputs/SignatureField/SignatureField.tsx
@@ -26,6 +26,7 @@ import {
   getFullDocumentPath,
   getUnsignedFileUrl
 } from '@client/v2-events/cache'
+import { setLockBypass } from '@client/utils/lockBypass'
 import { useOnFileChange } from '../FileInput/useOnFileChange'
 import { SignatureCanvasModal } from './components/SignatureCanvasModal'
 
@@ -142,7 +143,11 @@ function SignatureFieldInput({
               <Icon name="Pen" />
               {intl.formatMessage(messages.signatureOpenSignatureInput)}
             </Button>
-            <ImageUploader disabled={disabled} onChange={handleFileChange}>
+            <ImageUploader
+              disabled={disabled}
+              onChange={handleFileChange}
+              onClick={setLockBypass}
+            >
               {intl.formatMessage(buttonMessages.upload)}
             </ImageUploader>
           </Stack>


### PR DESCRIPTION
## Why

Reported in [#13124](https://github.com/opencrvs/opencrvs-core/issues/13124), *"Users cant use mobile phones to upload pictures"*:

> Somalia reporting ... "We are doing mass registration at door to door, so since we registration agents is using there mobile we have this mobile upload/PIN issue has already been fixed in OpenCRVS Core 2.0. Since Somalia must remain on version 1.9.15 for a while, could we please backport the fix to the release/1.9.15 branch? I think the relevant commits are 7566f7a779 and d55797d835, we just need to apply only the required fix and confirm that normal mobile PIN locking still works."

The root cause is tracked in [#12646](https://github.com/opencrvs/opencrvs-core/issues/12646): on mobile, opening the native file/camera picker briefly backgrounds the tab. `ProtectedPage` treated that exactly like a genuine backgrounding event and force-relocked the app, kicking the user to the PIN / Forgotten-PIN screen mid-upload — interrupting signature and document uploads during birth/death declarations.

This PR backports the fix already on `develop` (commits `7566f7a779` / `d55797d835`, merged via #12703) onto this release line.

## What changes

- Adds `packages/client/src/utils/lockBypass.ts`: `setLockBypass()` arms a short-lived bypass flag when called right before an upload button opens the native picker; `shouldBypassLock()` is a pure query `ProtectedPage` checks on visibility change. The flag clears the moment the window regains `focus` (user returned from the picker), with a 3-minute TTL as a safety net.
- Wires `onClick={setLockBypass}` into the v2-events upload entry points: `SimpleDocumentUploader.tsx`, `DocumentUploaderWithOption.tsx`, `SignatureField.tsx`.
- **Differs from the develop commits:** this release branch still carries the legacy V1 declaration flow (`FEATURES.V2_EVENTS === false`), which `develop` has since removed entirely. That flow has its own separate uploader components that never received any bypass wiring upstream, and it still depends on the old route-based `unprotectedRouteElements` allowlist in `ProtectedPage`/`App.tsx`. Rather than deleting that allowlist (which is what the develop commits did, safely, only because the legacy flow no longer exists there), `ProtectedPage.handleVisibilityChange` now checks `onUnprotectedPage || shouldBypassLock()` — keeping the old mechanism for the legacy flow while adding the new, click-precise one for v2-events (whose routes never matched the old route-name substrings, which is exactly why the bug happened there in the first place). `App.tsx` is otherwise unchanged.
- Also wires `setLockBypass` into the 3 legacy V1 uploaders as defense-in-depth: `components/form/DocumentUploadField/SimpleDocumentUploader.tsx`, `components/form/DocumentUploadField/DocumentUploaderWithOption.tsx`, `components/form/SignatureField/SignatureUploader.tsx`.
- Adds a Storybook interaction test, `UploadButtonsArmLockBypass`, to `SignatureField.interaction.stories.tsx`, covering all three v2-events uploaders (Signature / File / FileWithOptions).

## How to test

**Automated:**
- `yarn test-storybook` (or serve `storybook-static` and run `npx test-storybook`) filtered to `SignatureField.interaction` and `File.interaction` — confirm `UploadButtonsArmLockBypass` and all pre-existing stories pass.
- `yarn vitest run src/views/RegisterForm/DeclarationForm.test.tsx src/views/Unlock/Unlock.test.tsx src/views/Unlock/ForgotPIN.test.tsx` — confirm all pass (this is the regression guard for the legacy V1 flow; it caught a real break during development when the old route-based allowlist was removed outright instead of combined with the new check).

**Manual:**
- On a mobile device (or a mobile viewport with touch emulation), start a birth/death declaration, tap the signature or document Upload button, and confirm the native file picker opens without being kicked to the PIN or Forgotten-PIN screen.
- Confirm normal PIN locking still works: background the app for longer than 3 minutes, or background it without ever tapping Upload, and confirm the PIN screen still appears as expected.