### PR TITLE
Fix: Custom conditionals are not evaluated in the Edit and Declare actions

### DIFF
--- a/packages/client/src/v2-events/features/events/actions/declare/DeclareActionMenu.tsx
+++ b/packages/client/src/v2-events/features/events/actions/declare/DeclareActionMenu.tsx
@@ -71,7 +71,7 @@ function useDeclarationActions(event: EventDocument) {
   } = useEventFormNavigation()
   const { eventConfiguration } = useEventConfiguration(eventType)
   const formConfig = getDeclaration(eventConfiguration)
-  const validatorContext = useValidatorContext()
+  const validatorContext = useValidatorContext(event)
   const declaration = useEventFormData((state) => state.getFormValues())
   const { getAnnotation } = useActionAnnotation()
   const annotation = getAnnotation()

--- a/packages/client/src/v2-events/features/events/actions/edit/EditActionMenu.tsx
+++ b/packages/client/src/v2-events/features/events/actions/edit/EditActionMenu.tsx
@@ -198,7 +198,7 @@ function useEditActions(event: EventDocument) {
   const events = useEvents()
   const formConfig = getDeclaration(eventConfiguration)
   const declaration = useEventFormData((state) => state.getFormValues())
-  const validatorContext = useValidatorContext()
+  const validatorContext = useValidatorContext(event)
   const reviewConfig = getActionReview(eventConfiguration, ActionType.DECLARE)
 
   const formFields = formConfig.pages.flatMap((page) => page.fields)


### PR DESCRIPTION
## Description

All other actions pass the event to the `useValidatorContext` hook with the exception of Edit and Declare.

This result in custom conditionals like `export const declaredRecord = defineConditional({` not being evaluated and always being false, so the values never come through.

Passed event parameter to the validator context and issue is resolved.

Fixes: https://github.com/opencrvs/opencrvs-core/issues/13167

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
