### PR TITLE
Fix user list pagination

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,16 @@
   "engines": {
     "node": "22.x.x"
   },
-  "workspaces": [
-    "packages/*",
-    "packages/toolkit/create-countryconfig"
-  ],
+  "workspaces": {
+    "packages": [
+      "packages/*",
+      "packages/toolkit/create-countryconfig"
+    ],
+    "nohoist": [
+      "**/@vitest/coverage-v8",
+      "**/@vitest/coverage-v8/**"
+    ]
+  },
   "scripts": {
     "postinstall": "patch-package && node development-environment/link-ts6-api.js",
     "start": "lerna run build --scope @opencrvs/commons && lerna run build --scope @opencrvs/components && lerna run --stream --parallel $OTHER_LERNA_FLAGS start",

--- a/packages/client/src/v2-events/features/team/Team.interaction.stories.tsx
+++ b/packages/client/src/v2-events/features/team/Team.interaction.stories.tsx
@@ -504,7 +504,7 @@ export const Pagination: Story = {
       await canvas.findByText('Agent Number 01', { selector: '#profile-link' })
       await canvas.findByText('Agent Number 10', { selector: '#profile-link' })
       // The 11th user belongs to page 2 and must not be rendered yet.
-      expect(
+      await expect(
         canvas.queryByText('Agent Number 11', { selector: '#profile-link' })
       ).toBeNull()
     })
@@ -522,11 +522,11 @@ export const Pagination: Story = {
       await canvas.findByText('Agent Number 11', { selector: '#profile-link' })
       await canvas.findByText('Agent Number 15', { selector: '#profile-link' })
       // Page 1 users are no longer rendered.
-      expect(
+      await expect(
         canvas.queryByText('Agent Number 01', { selector: '#profile-link' })
       ).toBeNull()
       // Sanity check: exactly the 5 remaining users are shown on page 2.
-      expect(
+      await expect(
         canvas.getAllByText(/^Agent Number \d\d$/, {
           selector: '#profile-link'
         })

--- a/packages/client/src/v2-events/features/team/Team.interaction.stories.tsx
+++ b/packages/client/src/v2-events/features/team/Team.interaction.stories.tsx
@@ -9,10 +9,10 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 import type { Meta, StoryObj } from '@storybook/react'
-import { userEvent, within } from '@storybook/test'
+import { expect, userEvent, within } from '@storybook/test'
 import { createTRPCMsw, httpLink } from '@vafanassieff/msw-trpc'
 import superjson from 'superjson'
-import { TestUserRole } from '@opencrvs/commons/client'
+import { TestUserRole, User, UUID } from '@opencrvs/commons/client'
 import { AppRouter } from '@client/v2-events/trpc'
 import { routesConfig } from '@client/v2-events/routes'
 import * as V1_LEGACY_ROUTES from '@client/navigation/routes'
@@ -27,6 +27,22 @@ const tRPCMsw = createTRPCMsw<AppRouter>({
 const generator = testDataGenerator()
 const felix = generator.user.registrationAgent().v2
 const kennedy = generator.user.localRegistrar().v2
+
+// UserList shows USERS_PER_PAGE (10) users per page. Build 15 users in a single
+// office so the list spans two pages and the pagination controls appear.
+const USERS_PER_PAGE = 10
+const manyUsers: User[] = Array.from({ length: 15 }, (_, index) => {
+  const n = index + 1
+  return {
+    ...felix,
+    id: `11111111-1111-4111-8111-${String(n).padStart(12, '0')}` as UUID,
+    name: {
+      firstname: 'Agent',
+      surname: `Number ${String(n).padStart(2, '0')}`
+    },
+    primaryOfficeId: felix.primaryOfficeId
+  }
+})
 
 const mockRoles = [
   { id: TestUserRole.enum.REGISTRATION_AGENT, scopes: [] },
@@ -45,9 +61,7 @@ function findMenuTriggerForUser(
   const profileLinks = Array.from(
     container.querySelectorAll<HTMLButtonElement>('#profile-link')
   )
-  const nameCell = profileLinks.find(
-    (el) => el.textContent.trim() === userName
-  )
+  const nameCell = profileLinks.find((el) => el.textContent.trim() === userName)
   if (!nameCell) {
     throw new Error(`User row not found for: ${userName}`)
   }
@@ -461,6 +475,62 @@ export const ToggleUserActivation: Story = {
       )
 
       await canvas.findAllByText('Active')
+    })
+  }
+}
+
+export const Pagination: Story = {
+  parameters: {
+    msw: {
+      handlers: {
+        user: [
+          tRPCMsw.user.search.query(() => manyUsers),
+          // The logged-in user is fetched via user.get for permission checks, so
+          // this handler must stay even though the list itself uses user.search.
+          tRPCMsw.user.get.query(
+            (id) =>
+              manyUsers.find((u) => u.id === id) ??
+              generator.user.nationalSystemAdmin().v2
+          ),
+          tRPCMsw.user.roles.list.query(() => mockRoles)
+        ]
+      }
+    }
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+
+    await step('Page 1 shows the first 10 users', async () => {
+      await canvas.findByText('Agent Number 01', { selector: '#profile-link' })
+      await canvas.findByText('Agent Number 10', { selector: '#profile-link' })
+      // The 11th user belongs to page 2 and must not be rendered yet.
+      expect(
+        canvas.queryByText('Agent Number 11', { selector: '#profile-link' })
+      ).toBeNull()
+    })
+
+    await step('Navigate to page 2', async () => {
+      // The pagination bar is duplicated for desktop/mobile layouts, so click
+      // the first matching page-2 button.
+      const [pageTwoButton] = await canvas.findAllByRole('button', {
+        name: '2'
+      })
+      await userEvent.click(pageTwoButton)
+    })
+
+    await step('Page 2 shows the remaining users', async () => {
+      await canvas.findByText('Agent Number 11', { selector: '#profile-link' })
+      await canvas.findByText('Agent Number 15', { selector: '#profile-link' })
+      // Page 1 users are no longer rendered.
+      expect(
+        canvas.queryByText('Agent Number 01', { selector: '#profile-link' })
+      ).toBeNull()
+      // Sanity check: exactly the 5 remaining users are shown on page 2.
+      expect(
+        canvas.getAllByText(/^Agent Number \d\d$/, {
+          selector: '#profile-link'
+        })
+      ).toHaveLength(15 - USERS_PER_PAGE)
     })
   }
 }

--- a/packages/client/src/views/SysAdmin/Team/user/UserList.tsx
+++ b/packages/client/src/views/SysAdmin/Team/user/UserList.tsx
@@ -61,7 +61,7 @@ import { useOnlineStatus } from '../../../../utils'
 import { useAdministrativeAreas } from '../../../../v2-events/hooks/useAdministrativeAreas'
 import { UserActivationModal } from './UserActivationModal'
 
-const DEFAULT_FIELD_AGENT_LIST_SIZE = 10
+const USERS_PER_PAGE = 10
 const DEFAULT_PAGE_NUMBER = 1
 
 const UserTable = styled(BodyContent)`
@@ -282,13 +282,7 @@ function UserListComponent({ userDetails }: UserListProps) {
     isLoading,
     error
   } = searchUsers.useQuery(
-    {
-      primaryOfficeId: locationId,
-      count: DEFAULT_FIELD_AGENT_LIST_SIZE,
-      skip: (currentPageNumber - 1) * DEFAULT_FIELD_AGENT_LIST_SIZE,
-      sortBy: 'firstname',
-      sortOrder: 'asc'
-    },
+    { primaryOfficeId: locationId, sortBy: 'firstname', sortOrder: 'asc' },
     { enabled: !!locationId }
   )
 
@@ -619,7 +613,15 @@ function UserListComponent({ userDetails }: UserListProps) {
       userDetails: UserDetails | null
     }) {
       const totalData = users.length
-      const userContent = generateUserContents(users, locationId, userDetails)
+      const paginatedUsers = users.slice(
+        (currentPageNumber - 1) * USERS_PER_PAGE,
+        currentPageNumber * USERS_PER_PAGE
+      )
+      const userContent = generateUserContents(
+        paginatedUsers,
+        locationId,
+        userDetails
+      )
 
       return (
         <UserTable id="user_list">
@@ -639,10 +641,10 @@ function UserListComponent({ userDetails }: UserListProps) {
               valueHeader={intl.formatMessage(constantsMessages.labelRole)}
             />
           )}
-          {totalData > DEFAULT_FIELD_AGENT_LIST_SIZE && (
+          {totalData > USERS_PER_PAGE && (
             <Pagination
               currentPage={currentPageNumber}
-              totalPages={Math.ceil(totalData / DEFAULT_FIELD_AGENT_LIST_SIZE)}
+              totalPages={Math.ceil(totalData / USERS_PER_PAGE)}
               onPageChange={(currentPage: number) =>
                 setCurrentPageNumber(currentPage)
               }

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -58,7 +58,7 @@
     "@types/jsonwebtoken": "^9.0.10",
     "@typescript-eslint/eslint-plugin": "8.63.0",
     "@typescript-eslint/parser": "8.63.0",
-    "@vitest/coverage-v8": "2.1.5",
+    "@vitest/coverage-v8": "2.1.9",
     "cross-env": "^7.0.0",
     "eslint": "^9.23.0",
     "eslint-config-prettier": "^10.1.1",

--- a/packages/events/src/router/user/index.ts
+++ b/packages/events/src/router/user/index.ts
@@ -93,8 +93,20 @@ const UserSearch = z.object({
   email: z.string().optional(),
   status: z.string().optional(),
   primaryOfficeId: z.string().optional(),
-  count: z.number().min(0),
-  skip: z.number().min(0),
+  count: z
+    .number()
+    .min(0)
+    .optional()
+    .describe(
+      'Optional count of users to return. When omitted, the endpoint returns every matching user (no limit).'
+    ),
+  skip: z
+    .number()
+    .min(0)
+    .default(0)
+    .describe(
+      'Optional skip of users to return. When omitted, the endpoint returns the first page of users.'
+    ),
   sortBy: z
     .enum([
       'createdAt',
@@ -241,7 +253,10 @@ export function searchUsersRoute(
           primaryOfficeId: primaryOfficeId,
           administrativeAreaId: ctx.user.administrativeAreaId
         })
-        return allUsers.slice(input.skip, input.skip + input.count)
+        return allUsers.slice(
+          input.skip,
+          input.count === undefined ? undefined : input.skip + input.count
+        )
       }
 
       if (accessLevel === JurisdictionFilter.enum.location) {

--- a/packages/events/src/router/user/user.search.test.ts
+++ b/packages/events/src/router/user/user.search.test.ts
@@ -158,6 +158,51 @@ test('respects count and skip for pagination', async () => {
   expect(page[0].id).toBe(all[1].id)
 })
 
+test('returns all matching users (no limit) when count is omitted', async () => {
+  const { user, seed, generator } = await setupTestCase()
+  const client = createTestClient(user, withSearchAll)
+
+  const office = user.primaryOfficeId
+
+  // Seed more users
+  for (let i = 0; i < 12; i++) {
+    await seed.user(generator.user.create({ primaryOfficeId: office }))
+  }
+
+  const limited = await client.user.search({
+    ...defaultSearch,
+    primaryOfficeId: office
+  })
+
+  const unlimited = await client.user.search({
+    sortOrder: 'asc',
+    primaryOfficeId: office
+  })
+
+  // `defaultSearch` caps at count: 10, the omitted-count search returns everyone.
+  expect(limited).toHaveLength(10)
+  expect(unlimited.length).toBeGreaterThan(limited.length)
+})
+
+test('skip defaults to 0 when omitted', async () => {
+  const { user, seed, generator } = await setupTestCase()
+  const client = createTestClient(user, withSearchAll)
+
+  await seed.user(
+    generator.user.create({ primaryOfficeId: user.primaryOfficeId })
+  )
+
+  const withExplicitSkip = await client.user.search({
+    ...defaultSearch,
+    skip: 0
+  })
+  const withoutSkip = await client.user.search({ count: 10, sortOrder: 'asc' })
+
+  expect(withoutSkip.map((u) => u.id)).toEqual(
+    withExplicitSkip.map((u) => u.id)
+  )
+})
+
 test('sortOrder asc and desc by createdAt are reversed', async () => {
   const { user, seed, generator } = await setupTestCase()
   const client = createTestClient(user, withSearchAll)

--- a/packages/events/src/service/users/api.ts
+++ b/packages/events/src/service/users/api.ts
@@ -77,8 +77,8 @@ export type SearchUsersPayload = {
   primaryOfficeId?: UUID
   administrativeAreaId?: UUID
   locationId?: UUID
-  count: number
-  skip: number
+  count?: number
+  skip?: number
   sortBy: UserSortBy
   sortOrder: 'asc' | 'desc'
 }

--- a/packages/events/src/storage/postgres/events/users.ts
+++ b/packages/events/src/storage/postgres/events/users.ts
@@ -299,11 +299,17 @@ function buildSearchUsersBaseQuery(
 }
 
 export async function searchUsersWithInput(input: SearchUsersPayload) {
-  return buildSearchUsersBaseQuery(input)
-    .orderBy(sortColumn[input.sortBy], input.sortOrder)
-    .limit(input.count)
-    .offset(input.skip)
-    .execute()
+  let query = buildSearchUsersBaseQuery(input).orderBy(
+    sortColumn[input.sortBy],
+    input.sortOrder
+  )
+  if (input.count !== undefined) {
+    query = query.limit(input.count)
+  }
+  if (input.skip) {
+    query = query.offset(input.skip)
+  }
+  return query.execute()
 }
 
 export async function searchAllUsersWithInput(

--- a/yarn.lock
+++ b/yarn.lock
@@ -9226,10 +9226,10 @@
     c8 "^7.12.0"
     vitest "0.25.8"
 
-"@vitest/coverage-v8@2.1.5":
-  version "2.1.5"
-  resolved "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.1.5.tgz"
-  integrity sha512-/RoopB7XGW7UEkUndRXF87A9CwkoZAJW01pj8/3pgmDVsjMH2IKy6H1A38po9tmUlwhSyYs0az82rbKd9Yaynw==
+"@vitest/coverage-v8@2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@vitest/coverage-v8/-/coverage-v8-2.1.9.tgz#060bebfe3705c1023bdc220e17fdea4bd9e2b24d"
+  integrity sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==
   dependencies:
     "@ampproject/remapping" "^2.3.0"
     "@bcoe/v8-coverage" "^0.2.3"


### PR DESCRIPTION
## Description

* Make the count/skip optional on `user.search` trpc endpoint
* Frontend user list now fetches all users and does pagination on frontend
* Additionally, fix the `yarn test` command on `packages/events` by using proper version of `@vitest/coverage-v8`

I considered removing the count/skip logic on the backend endpoint altogether, but it _could_ be used by some existing system integrations, which I dont want to break.

Before:
https://github.com/user-attachments/assets/24f14af8-cfc7-42b9-9749-ee9f51724cb0

After:
https://github.com/user-attachments/assets/777a2318-4f73-4723-907b-c0214eab99da

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
