### PR TITLE
ci(toolkit): stop publishing rc builds on every commit

### DIFF
--- a/.github/workflows/publish-toolkit-to-npm.yml
+++ b/.github/workflows/publish-toolkit-to-npm.yml
@@ -6,6 +6,7 @@
 # & Healthcare Disclaimer located at http://opencrvs.org/license.
 #
 # Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+#
 name: Publish toolkit to NPM registry
 on:
   workflow_dispatch:
@@ -14,9 +15,6 @@ on:
         description: Branch to publish from
         default: develop
         required: true
-  push:
-    branches:
-      - '**'
   release:
     types: [published]
 

--- a/.github/workflows/publish-toolkit-to-npm.yml
+++ b/.github/workflows/publish-toolkit-to-npm.yml
@@ -15,8 +15,9 @@ on:
         description: Branch to publish from
         default: develop
         required: true
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*' # Matches v1.2.3, v1.2.3-beta, v1.2.3-rc.1
 
 permissions:
   id-token: write


### PR DESCRIPTION
Toolkit publish will be triggered whenever a new semantic versioned tag is pushed. We still retain the option to manually trigger it.
