### PR TITLE
Fix jurisdiction security issue `user.sendResetPasswordInvite` API

### DIFF
--- a/packages/events/src/router/user/index.ts
+++ b/packages/events/src/router/user/index.ts
@@ -32,7 +32,6 @@ import {
   UserOrSystemSummaryWithStatus
 } from '@opencrvs/commons'
 import {
-  allowedWithAnyOfScopes,
   canAccessUserWithScopes,
   canCreateUserWithScopes,
   canSearchUsers,
@@ -713,8 +712,8 @@ export const userRouter = router({
       })
     }),
   sendResetPasswordInvite: userAndSystemProcedure
-    .use(allowedWithAnyOfScopes(['user.edit']))
     .input(UUID)
+    .use(canAccessUserWithScopes(['user.edit']))
     .mutation(async ({ input, ctx }) => {
       const userId = UUID.parse(input)
       const auditLogIdentifiers = getAuditLogIdentifiers(ctx.token)

--- a/packages/events/src/router/user/user.sendResetPasswordInvite.test.ts
+++ b/packages/events/src/router/user/user.sendResetPasswordInvite.test.ts
@@ -20,6 +20,10 @@ import { createTestClient, setupTestCase } from '@events/tests/utils'
 import { getUserCredentialsByUserId } from '@events/storage/postgres/events/users'
 
 const USER_EDIT_SCOPE = encodeScope({ type: 'user.edit' })
+const USER_EDIT_LOCATION_SCOPE = encodeScope({
+  type: 'user.edit',
+  options: { accessLevel: 'location' }
+})
 
 test('sendResetPasswordInvite throws NOT_FOUND when user does not exist', async () => {
   const { user } = await setupTestCase()
@@ -112,4 +116,32 @@ test('sendResetPasswordInvite requires user.edit scope', async () => {
   await expect(
     limitedClient.user.sendResetPasswordInvite(targetUser.id)
   ).rejects.toMatchObject(new TRPCError({ code: 'FORBIDDEN' }))
+})
+
+test('sendResetPasswordInvite is jurisdiction-enforced: cannot reset a user outside the caller jurisdiction', async () => {
+  const { user, users } = await setupTestCase()
+  const outOfJurisdictionTarget = users[1]
+
+  const client = createTestClient(user, [USER_EDIT_LOCATION_SCOPE])
+
+  await expect(
+    client.user.sendResetPasswordInvite(outOfJurisdictionTarget.id)
+  ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+})
+
+test('sendResetPasswordInvite allows a location-scoped admin to reset a user in their jurisdiction', async () => {
+  const { user, locations, seed, generator } = await setupTestCase()
+
+  const sameOfficeTarget = await seed.user(
+    generator.user.create({
+      primaryOfficeId: locations[0].id,
+      administrativeAreaId: locations[0].administrativeAreaId
+    })
+  )
+
+  const client = createTestClient(user, [USER_EDIT_LOCATION_SCOPE])
+
+  await expect(
+    client.user.sendResetPasswordInvite(sameOfficeTarget.id)
+  ).resolves.not.toThrow()
 })


### PR DESCRIPTION
## Description

This issue was reported via email:

> 2) sendResetPasswordInvite — cross-jurisdiction lockout (CWE-863, CVSS 5.4 Medium)
Guarded by allowedWithAnyOfScopes(['user.edit']) (scope presence only) while siblings resendInvite/sendUsernameReminder use canAccessUserWithScopes(['user.edit']) (jurisdiction-enforced). A district-scoped user.edit admin can overwrite the password hash of any out-of-jurisdiction user (incl. a national admin) → cross-jurisdiction lockout. (updatePasswordHashAndSalt overwrites unconditionally.)

Fix:
* Use `canAccessUserWithScopes()` middleware instead of `allowedWithAnyOfScopes()`
* Add unit tests

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
