### PR TITLE
Bust cache if user office or role changes

### DIFF
--- a/packages/client/src/v2-events/routes/config.tsx
+++ b/packages/client/src/v2-events/routes/config.tsx
@@ -192,7 +192,10 @@ export const routesConfig = {
     return (
       <NavigationHistoryProvider>
         <TRPCErrorBoundary>
-          <TRPCProvider storeIdentifier={currentUser.id}>
+          <TRPCProvider
+            storeIdentifier={currentUser.id}
+            accessKey={`${currentUser.primaryOfficeId ?? ''}:${currentUser.role}`}
+          >
             <Outlet />
             <Debug />
             <Toaster />

--- a/packages/client/src/v2-events/routes/config.tsx
+++ b/packages/client/src/v2-events/routes/config.tsx
@@ -194,7 +194,7 @@ export const routesConfig = {
         <TRPCErrorBoundary>
           <TRPCProvider
             storeIdentifier={currentUser.id}
-            userCacheKey={`${currentUser.primaryOfficeId ?? ''}:${currentUser.role}`}
+            userCacheKey={`${currentUser.primaryOfficeId}:${currentUser.role}`}
           >
             <Outlet />
             <Debug />

--- a/packages/client/src/v2-events/routes/config.tsx
+++ b/packages/client/src/v2-events/routes/config.tsx
@@ -194,7 +194,7 @@ export const routesConfig = {
         <TRPCErrorBoundary>
           <TRPCProvider
             storeIdentifier={currentUser.id}
-            accessKey={`${currentUser.primaryOfficeId ?? ''}:${currentUser.role}`}
+            userCacheKey={`${currentUser.primaryOfficeId ?? ''}:${currentUser.role}`}
           >
             <Outlet />
             <Debug />

--- a/packages/client/src/v2-events/trpc.tsx
+++ b/packages/client/src/v2-events/trpc.tsx
@@ -187,18 +187,25 @@ export const trpcOptionsProxy = createTRPCOptionsProxy({
 
 export function TRPCProvider({
   children,
+  waitForClientRestored = true,
+  storeIdentifier = `DEFAULT_IDENTIFIER_FOR_TESTS_ONLY__THIS_SHOULD_NEVER_SHOW_OUTSIDE_STORYBOOK_${getUUID()}`,
+  accessKey
+}: {
+  children: React.ReactNode
+  /**
+   * In cases where multiple Storybooks are running against the same origin, when run in parallel, they may interfere with each other
+   * When tests are fast. Generate UUID to isolate storage for each Storybook instance. App uses userId for this purpose.
+   */
+  storeIdentifier?: string
   /*
    * Should never be "false" outside test environments where we might want to get access
    * to the query client before the client is restored from the persisted storage.
    */
-  waitForClientRestored = true,
-  // In cases where multiple Storybooks are running against the same origin, when run in parallel, they may interfere with each other
-  // When tests are fast. Generate UUID to isolate storage for each Storybook instance. App uses userId for this purpose.
-  storeIdentifier = `DEFAULT_IDENTIFIER_FOR_TESTS_ONLY__THIS_SHOULD_NEVER_SHOW_OUTSIDE_STORYBOOK_${getUUID()}`
-}: {
-  children: React.ReactNode
-  storeIdentifier?: string
   waitForClientRestored?: boolean
+  /**
+   * A signature of the user's current access (e.g. office + role). We want to bust the cache when the user's access rights change.
+   */
+  accessKey?: string
 }) {
   const [queriesRestored, setQueriesRestored] = React.useState(false)
 
@@ -207,7 +214,7 @@ export function TRPCProvider({
       client={queryClient}
       persistOptions={{
         persister: createIDBPersister(storeIdentifier),
-        buster: `persisted-indexed-db-v${CACHE_VERSION}`,
+        buster: `persisted-indexed-db-v${CACHE_VERSION}-${accessKey}`,
         maxAge: Infinity,
         dehydrateOptions: {
           shouldDehydrateQuery: (query) => {

--- a/packages/client/src/v2-events/trpc.tsx
+++ b/packages/client/src/v2-events/trpc.tsx
@@ -189,7 +189,7 @@ export function TRPCProvider({
   children,
   waitForClientRestored = true,
   storeIdentifier = `DEFAULT_IDENTIFIER_FOR_TESTS_ONLY__THIS_SHOULD_NEVER_SHOW_OUTSIDE_STORYBOOK_${getUUID()}`,
-  accessKey
+  userCacheKey
 }: {
   children: React.ReactNode
   /**
@@ -205,7 +205,7 @@ export function TRPCProvider({
   /**
    * A signature of the user's current access (e.g. office + role). We want to bust the cache when the user's access rights change.
    */
-  accessKey?: string
+  userCacheKey?: string
 }) {
   const [queriesRestored, setQueriesRestored] = React.useState(false)
 
@@ -214,7 +214,7 @@ export function TRPCProvider({
       client={queryClient}
       persistOptions={{
         persister: createIDBPersister(storeIdentifier),
-        buster: `persisted-indexed-db-v${CACHE_VERSION}-${accessKey}`,
+        buster: `persisted-indexed-db-v${CACHE_VERSION}-${userCacheKey}`,
         maxAge: Infinity,
         dehydrateOptions: {
           shouldDehydrateQuery: (query) => {

--- a/packages/testland/e2e/testcases/team/user-office-change.spec.ts
+++ b/packages/testland/e2e/testcases/team/user-office-change.spec.ts
@@ -220,41 +220,28 @@ test('Scope changes after office change - user loses access when the office chan
   await test.step('User can no longer find the record or drafts after the office change', async () => {
     await logout(page)
 
-    // Log the moved user back in on a fresh browser context. The client
-    // persists the drafts cache to IndexedDB (keyed by user id) and does not
-    // clear it on logout, so reusing the same context would rehydrate the
-    // drafts created before the move even though the server cleared them. A
-    // fresh context reflects the server state — what the user sees on a clean
-    // session.
-    const freshContext = await browser.newContext()
-    const freshPage = await freshContext.newPage()
-
     const { refreshToken } = await getAuthTokens(username, NEW_USER_PASSWORD)
     expect(refreshToken).toBeDefined()
 
-    await freshPage.goto(`${CLIENT_URL}?refreshToken=${refreshToken}`)
-    await freshPage.waitForSelector('#pin-input, #appSpinner', {
+    await page.goto(`${CLIENT_URL}?refreshToken=${refreshToken}`)
+    await page.waitForSelector('#pin-input, #appSpinner', {
       state: 'visible'
     })
-    await createPIN(freshPage)
-    await freshPage.goto(CLIENT_URL)
 
-    await searchFromSearchBar(freshPage, trackingId, false)
+    await searchFromSearchBar(page, trackingId, false)
     await expect(
-      freshPage.getByRole('button', { name: trackingId, exact: true })
+      page.getByRole('button', { name: trackingId, exact: true })
     ).not.toBeVisible()
 
-    await freshPage.goto(CLIENT_URL)
-    const draftCountAfterChange = await countDraftRows(freshPage, 0)
+    await page.goto(CLIENT_URL)
+    const draftCountAfterChange = await countDraftRows(page, 0)
     expect(draftCountAfterChange).toBe(0)
     expect(draftCountBeforeChange).toBeGreaterThan(0)
 
-    await freshPage.goto(`${CLIENT_URL}/events/${eventId}`)
+    await page.goto(`${CLIENT_URL}/events/${eventId}`)
     await expect(
-      freshPage.getByText(`No event or draft found with id: ${eventId}`)
+      page.getByText(`No event or draft found with id: ${eventId}`)
     ).toBeVisible()
-
-    await freshContext.close()
   })
 })
 
@@ -405,45 +392,35 @@ test('Scope changes after office and role changes', async ({ browser }) => {
   await test.step('User can no longer find the record or drafts after the office and role change', async () => {
     await logout(page)
 
-    // Fresh context so the moved user's session doesn't rehydrate the drafts
-    // cache persisted (in IndexedDB, keyed by user id) before the move — see
-    // the note in the first test case.
-    const freshContext = await browser.newContext()
-    const freshPage = await freshContext.newPage()
-
     const { refreshToken } = await getAuthTokens(username, NEW_USER_PASSWORD)
     expect(refreshToken).toBeDefined()
 
-    await freshPage.goto(`${CLIENT_URL}?refreshToken=${refreshToken}`)
-    await freshPage.waitForSelector('#pin-input, #appSpinner', {
+    await page.goto(`${CLIENT_URL}?refreshToken=${refreshToken}`)
+    await page.waitForSelector('#pin-input, #appSpinner', {
       state: 'visible'
     })
-    await createPIN(freshPage)
-    await freshPage.goto(CLIENT_URL)
 
-    await searchFromSearchBar(freshPage, trackingId, false)
+    await searchFromSearchBar(page, trackingId, false)
     await expect(
-      freshPage.getByRole('button', { name: trackingId, exact: true })
+      page.getByRole('button', { name: trackingId, exact: true })
     ).not.toBeVisible()
 
-    await freshPage.goto(CLIENT_URL)
+    await page.goto(CLIENT_URL)
 
     await expectVersionCard(
-      freshPage,
+      page,
       fullName,
       'Hospital Official',
       'Isamba District Office'
     )
 
-    const draftCountAfterChange = await countDraftRows(freshPage, 0)
+    const draftCountAfterChange = await countDraftRows(page, 0)
     expect(draftCountAfterChange).toBe(0)
     expect(draftCountBeforeChange).toBeGreaterThan(0)
 
-    await freshPage.goto(`${CLIENT_URL}/events/${eventId}`)
+    await page.goto(`${CLIENT_URL}/events/${eventId}`)
     await expect(
-      freshPage.getByText(`No event or draft found with id: ${eventId}`)
+      page.getByText(`No event or draft found with id: ${eventId}`)
     ).toBeVisible()
-
-    await freshContext.close()
   })
 })


### PR DESCRIPTION
## Description

Resolves comment https://github.com/opencrvs/opencrvs-core/issues/13174#issuecomment-5032415741

This resolves issues where user could have seen obsolote drafts after office change

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
