### PR TITLE
Refactor colours to primitives + semantic tokens (#12628)

### DIFF
--- a/packages/components/src/Accordion/Accordion.tsx
+++ b/packages/components/src/Accordion/Accordion.tsx
@@ -12,10 +12,12 @@ import React, { useState } from 'react'
 import styled from 'styled-components'
 import { Link, Stack, Text } from '../'
 import { Icon } from '../Icon'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 const Container = styled.div`
   box-sizing: border-box;
-  border-bottom: 1px solid ${({ theme }) => theme.colors.grey200};
+  border-bottom: 1px solid ${lightColors['border/default']};
   padding: 0;
   width: 100%;
 `
@@ -26,11 +28,11 @@ const AccordionHeader = styled.div`
   flex-direction: row;
 
   &:hover {
-    background: ${({ theme }) => theme.colors.grey100};
+    background: ${lightColors['action/secondary']};
     cursor: pointer;
   }
   &:active {
-    background: ${({ theme }) => theme.colors.grey200};
+    background: ${lightColors['action/secondaryHover']};
     cursor: pointer;
   }
 `

--- a/packages/components/src/Accordion/Accordion.tsx
+++ b/packages/components/src/Accordion/Accordion.tsx
@@ -12,7 +12,6 @@ import React, { useState } from 'react'
 import styled from 'styled-components'
 import { Link, Stack, Text } from '../'
 import { Icon } from '../Icon'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 const Container = styled.div`

--- a/packages/components/src/Alert/Alert.tsx
+++ b/packages/components/src/Alert/Alert.tsx
@@ -14,20 +14,21 @@ import { Check, Help, Cross, NotificationError, Notification } from '../icons'
 import { Spinner } from '../Spinner'
 import { Button } from '../Button'
 import { Text } from '../Text'
-import { colors } from '../colors'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 export type AlertType = 'success' | 'warning' | 'loading' | 'info' | 'error'
 
 const Container = styled.div<{
   $type?: AlertType
 }>`
-  --color: ${({ $type, theme }) => `
-    ${$type === 'success' ? theme.colors.positive : ''}
-    ${$type === 'loading' ? theme.colors.primary : ''}
-    ${$type === 'info' ? theme.colors.teal : ''}
-    ${$type === 'error' ? theme.colors.negative : ''}
-    ${$type === 'warning' ? theme.colors.orange : ''}
-    ${$type === undefined ? theme.colors.positive : ''}
+  --color: ${({ $type }) => `
+    ${$type === 'success' ? lightColors['feedback/positive'] : ''}
+    ${$type === 'loading' ? lightColors['feedback/info'] : ''}
+    ${$type === 'info' ? lightColors['feedback/info'] : ''}
+    ${$type === 'error' ? lightColors['feedback/negative'] : ''}
+    ${$type === 'warning' ? lightColors['feedback/warning'] : ''}
+    ${$type === undefined ? lightColors['feedback/positive'] : ''}
   `};
 
   display: flex;
@@ -37,7 +38,7 @@ const Container = styled.div<{
   background: linear-gradient(
     to right,
     var(--color) 48px,
-    ${({ theme }) => theme.colors.white} 48px
+    ${lightColors['surface/default']} 48px
   );
 `
 
@@ -47,7 +48,7 @@ const IconContainer = styled.div`
   align-items: center;
   height: 48px;
   width: 48px;
-  color: ${({ theme }) => theme.colors.white};
+  color: ${lightColors['text/onAction']};
 `
 
 const Close = styled(Button)`
@@ -108,7 +109,7 @@ export const Alert = ({
           {type === 'loading' && (
             <Spinner
               id="in-progress-floating-notification"
-              baseColor={colors.white}
+              baseColor={lightColors['text/onAction']}
               size={20}
             />
           )}

--- a/packages/components/src/Alert/Alert.tsx
+++ b/packages/components/src/Alert/Alert.tsx
@@ -14,7 +14,6 @@ import { Check, Help, Cross, NotificationError, Notification } from '../icons'
 import { Spinner } from '../Spinner'
 import { Button } from '../Button'
 import { Text } from '../Text'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 export type AlertType = 'success' | 'warning' | 'loading' | 'info' | 'error'

--- a/packages/components/src/AppBar/AppBar.tsx
+++ b/packages/components/src/AppBar/AppBar.tsx
@@ -14,12 +14,14 @@ import { grid } from '../grid'
 import { Stack } from '../Stack'
 import { Text } from '../Text'
 import { useWindowSize } from '../hooks'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 const AppBarWrapper = styled.div`
   display: flex;
   flex-direction: column;
   width: 100%;
-  background: ${({ theme }) => theme.colors.white};
+  background: ${lightColors['surface/default']};
 `
 
 const AppBarRowOne = styled.div`
@@ -28,7 +30,7 @@ const AppBarRowOne = styled.div`
   align-items: center;
   height: 56px;
   padding: 0 16px;
-  border-bottom: 1px solid ${({ theme }) => theme.colors.grey300};
+  border-bottom: 1px solid ${lightColors['border/strong']};
 `
 
 const AppBarRowTwo = styled.div`
@@ -36,7 +38,7 @@ const AppBarRowTwo = styled.div`
   display: flex;
   align-items: center;
   height: 56px;
-  border-bottom: 1px solid ${({ theme }) => theme.colors.grey300};
+  border-bottom: 1px solid ${lightColors['border/strong']};
 `
 
 const Left = styled.div`

--- a/packages/components/src/AppBar/AppBar.tsx
+++ b/packages/components/src/AppBar/AppBar.tsx
@@ -14,7 +14,6 @@ import { grid } from '../grid'
 import { Stack } from '../Stack'
 import { Text } from '../Text'
 import { useWindowSize } from '../hooks'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 const AppBarWrapper = styled.div`

--- a/packages/components/src/Banner/Banner.tsx
+++ b/packages/components/src/Banner/Banner.tsx
@@ -12,7 +12,6 @@ import React from 'react'
 import { Box } from '../Box'
 import { IStackProps, Stack } from '../Stack'
 import styled from 'styled-components'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 export type BannerVariant = 'active' | 'inactive' | 'pending' | 'default'

--- a/packages/components/src/Banner/Banner.tsx
+++ b/packages/components/src/Banner/Banner.tsx
@@ -12,23 +12,25 @@ import React from 'react'
 import { Box } from '../Box'
 import { IStackProps, Stack } from '../Stack'
 import styled from 'styled-components'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 export type BannerVariant = 'active' | 'inactive' | 'pending' | 'default'
 
 const Wrapper = styled(Box)<{ variant: BannerVariant }>`
   padding: 0;
   overflow: hidden;
-  --banner-background-color: ${({ variant, theme }) => `
-    ${variant === 'active' ? theme.colors.greenLighter : ''}
-    ${variant === 'inactive' ? theme.colors.redLighter : ''}
-    ${variant === 'pending' ? theme.colors.orangeLighter : ''}
-    ${variant === 'default' ? theme.colors.primaryLighter : ''}
+  --banner-background-color: ${({ variant }) => `
+    ${variant === 'active' ? lightColors['feedback/positiveSubtle'] : ''}
+    ${variant === 'inactive' ? lightColors['feedback/negativeSubtle'] : ''}
+    ${variant === 'pending' ? lightColors['feedback/warningSubtle'] : ''}
+    ${variant === 'default' ? lightColors['feedback/infoSubtle'] : ''}
   `};
-  --banner-border-color: ${({ variant, theme }) => `
-    ${variant === 'active' ? theme.colors.green : ''}
-    ${variant === 'inactive' ? theme.colors.red : ''}
-    ${variant === 'pending' ? theme.colors.orange : ''}
-    ${variant === 'default' ? theme.colors.primary : ''}
+  --banner-border-color: ${({ variant }) => `
+    ${variant === 'active' ? lightColors['feedback/positive'] : ''}
+    ${variant === 'inactive' ? lightColors['feedback/negative'] : ''}
+    ${variant === 'pending' ? lightColors['feedback/warning'] : ''}
+    ${variant === 'default' ? lightColors['feedback/info'] : ''}
   `};
   border: 1px solid var(--banner-border-color);
 `

--- a/packages/components/src/Bar/Bar.tsx
+++ b/packages/components/src/Bar/Bar.tsx
@@ -12,6 +12,8 @@ import * as React from 'react'
 import styled, { withTheme } from 'styled-components'
 import { IDataPoint } from '../chart-datapoint-types'
 import { ITheme } from '../theme'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 export interface IBarChartProps {
   data: IDataPoint[]
@@ -26,7 +28,7 @@ const Estimate = styled.div`
   height: 60px;
   width: 100%;
   box-sizing: border-box;
-  border: 2px dashed ${({ theme }) => theme.colors.primary};
+  border: 2px dashed ${lightColors['action/primary']};
   padding: 6px;
 `
 
@@ -60,7 +62,7 @@ const calculateSum = (points: IDataPoint[]) =>
   points.reduce((sum, item) => sum + item.value, 0)
 
 export const Bar = withTheme((props: IBarChartProps & { theme: ITheme }) => {
-  const { data, theme } = props
+  const { data } = props
   const fromSmallest = [...data].sort((a, b) => a.value - b.value)
 
   const estimatePoint = fromSmallest.find(({ estimate }) => Boolean(estimate))
@@ -74,7 +76,7 @@ export const Bar = withTheme((props: IBarChartProps & { theme: ITheme }) => {
   const totalValue =
     allTotalPoints.length > 0 ? sumOfTotalPoints : otherPointsValue
 
-  const colours = [theme.colors.primary]
+  const colours = [lightColors['action/primary']]
 
   if (estimatePoint) {
     return (

--- a/packages/components/src/Bar/Bar.tsx
+++ b/packages/components/src/Bar/Bar.tsx
@@ -12,7 +12,6 @@ import * as React from 'react'
 import styled, { withTheme } from 'styled-components'
 import { IDataPoint } from '../chart-datapoint-types'
 import { ITheme } from '../theme'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 export interface IBarChartProps {

--- a/packages/components/src/Box/Box.tsx
+++ b/packages/components/src/Box/Box.tsx
@@ -10,6 +10,8 @@
  */
 import * as React from 'react'
 import styled from 'styled-components'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 export interface IBox extends React.HTMLAttributes<HTMLDivElement> {}
 
@@ -17,8 +19,8 @@ const Wrapper = styled.div<IBox>`
   position: relative;
   border-radius: 4px;
   padding: 24px;
-  border: 1px solid ${({ theme }) => theme.colors.grey300};
-  background: ${({ theme }) => theme.colors.white};
+  border: 1px solid ${lightColors['border/strong']};
+  background: ${lightColors['surface/default']};
   @media (max-width: ${({ theme }) => theme.grid.breakpoints.md}px) {
     border: 0;
     padding: 16px;

--- a/packages/components/src/Box/Box.tsx
+++ b/packages/components/src/Box/Box.tsx
@@ -10,7 +10,6 @@
  */
 import * as React from 'react'
 import styled from 'styled-components'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 export interface IBox extends React.HTMLAttributes<HTMLDivElement> {}

--- a/packages/components/src/Breadcrumb/Breadcrumb.tsx
+++ b/packages/components/src/Breadcrumb/Breadcrumb.tsx
@@ -13,7 +13,6 @@ import { Link } from '../Link'
 import { Stack } from '../Stack'
 import { Text } from '../Text'
 import styled from 'styled-components'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 export interface IBreadCrumbData {

--- a/packages/components/src/Breadcrumb/Breadcrumb.tsx
+++ b/packages/components/src/Breadcrumb/Breadcrumb.tsx
@@ -13,6 +13,8 @@ import { Link } from '../Link'
 import { Stack } from '../Stack'
 import { Text } from '../Text'
 import styled from 'styled-components'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 export interface IBreadCrumbData {
   paramId: string | null | undefined
@@ -24,7 +26,7 @@ const BreadcrumbLink = styled(Link)`
     display: inline-block;
     content: '/';
     padding-left: 4px;
-    color: ${({ theme }) => theme.colors.copy};
+    color: ${lightColors['text/primary']};
   }
 `
 

--- a/packages/components/src/Button/Button.styles.ts
+++ b/packages/components/src/Button/Button.styles.ts
@@ -12,7 +12,6 @@
 import { css } from 'styled-components'
 // Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
-import { primitives } from '../primitives'
 
 export const base = ({ fullWidth }: { fullWidth?: boolean }) => css`
   ${({ theme }) => theme.fonts.bold16};
@@ -88,7 +87,7 @@ export const secondary = css`
   }
 
   &:focus-visible {
-    border: 1.5px solid ${primitives.grey[900]};
+    border: 1.5px solid ${lightColors['border/emphasis']};
     background: ${lightColors['feedback/focus']};
     color: ${lightColors['text/primary']};
   }
@@ -111,9 +110,9 @@ export const secondaryNegative = css`
   }
 
   &:focus-visible {
-    border: 1.5px solid ${primitives.red[900]};
+    border: 1.5px solid ${lightColors['action/negativePressed']};
     background: ${lightColors['feedback/focus']};
-    color: ${primitives.red[900]};
+    color: ${lightColors['action/negativePressed']};
   }
 `
 
@@ -161,7 +160,7 @@ export const negative = css`
     background: ${lightColors['action/negativePressed']};
   }
   &:active {
-    background-color: ${primitives.red[900]};
+    background-color: ${lightColors['action/negativePressed']};
   }
 `
 

--- a/packages/components/src/Button/Button.styles.ts
+++ b/packages/components/src/Button/Button.styles.ts
@@ -10,7 +10,6 @@
  */
 
 import { css } from 'styled-components'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 export const base = ({ fullWidth }: { fullWidth?: boolean }) => css`

--- a/packages/components/src/Button/Button.styles.ts
+++ b/packages/components/src/Button/Button.styles.ts
@@ -10,6 +10,9 @@
  */
 
 import { css } from 'styled-components'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
+import { primitives } from '../primitives'
 
 export const base = ({ fullWidth }: { fullWidth?: boolean }) => css`
   ${({ theme }) => theme.fonts.bold16};
@@ -41,137 +44,137 @@ export const base = ({ fullWidth }: { fullWidth?: boolean }) => css`
   }
 
   &:focus-visible {
-    background: ${({ theme }) => theme.colors.yellow};
-    color: ${({ theme }) => theme.colors.grey600};
+    background: ${lightColors['feedback/focus']};
+    color: ${lightColors['text/primary']};
   }
 `
 
 export const primary = ({ loading }: { loading?: boolean }) => css`
-  color: ${({ theme }) => theme.colors.white};
-  background: ${({ theme }) => theme.colors.primary};
+  color: ${lightColors['text/onAction']};
+  background: ${lightColors['action/primary']};
 
   svg {
-    color: ${({ theme }) => theme.colors.white};
+    color: ${lightColors['text/onAction']};
   }
 
   &:hover {
-    background: ${({ theme }) => theme.colors.primaryDark};
+    background: ${lightColors['action/primaryHover']};
   }
   &:active {
-    background-color: ${({ theme }) => theme.colors.primaryDarker};
+    background-color: ${lightColors['action/primaryPressed']};
   }
 
   ${loading &&
   css`
-    background: ${({ theme }) => theme.colors.primaryDark};
+    background: ${lightColors['action/primaryHover']};
   `}
 `
 
 export const secondary = css`
-  border: 1.5px solid ${({ theme }) => theme.colors.primary};
-  color: ${({ theme }) => theme.colors.copy};
-  background: ${({ theme }) => theme.colors.white};
+  border: 1.5px solid ${lightColors['action/primary']};
+  color: ${lightColors['text/primary']};
+  background: ${lightColors['surface/default']};
 
   svg {
-    color: ${({ theme }) => theme.colors.primary};
+    color: ${lightColors['action/primary']};
   }
 
   &:hover {
-    border: 1.5px solid ${({ theme }) => theme.colors.primaryDark};
-    background: ${({ theme }) => theme.colors.grey100};
+    border: 1.5px solid ${lightColors['action/primaryHover']};
+    background: ${lightColors['action/secondary']};
   }
   &:active {
-    background: ${({ theme }) => theme.colors.grey200};
+    background: ${lightColors['action/secondaryHover']};
   }
 
   &:focus-visible {
-    border: 1.5px solid ${({ theme }) => theme.colors.grey600};
-    background: ${({ theme }) => theme.colors.yellow};
-    color: ${({ theme }) => theme.colors.grey600};
+    border: 1.5px solid ${primitives.grey[900]};
+    background: ${lightColors['feedback/focus']};
+    color: ${lightColors['text/primary']};
   }
 `
 export const secondaryNegative = css`
-  border: 1.5px solid ${({ theme }) => theme.colors.negative};
-  color: ${({ theme }) => theme.colors.copy};
+  border: 1.5px solid ${lightColors['action/negative']};
+  color: ${lightColors['text/primary']};
 
   svg {
-    color: ${({ theme }) => theme.colors.negative};
+    color: ${lightColors['action/negative']};
   }
 
   &:hover {
-    background: ${({ theme }) => theme.colors.grey100};
-    border: 1.5px solid ${({ theme }) => theme.colors.negativeDark};
+    background: ${lightColors['action/secondary']};
+    border: 1.5px solid ${lightColors['action/negativePressed']};
   }
 
   &:active {
-    background: ${({ theme }) => theme.colors.grey200};
+    background: ${lightColors['action/secondaryHover']};
   }
 
   &:focus-visible {
-    border: 1.5px solid ${({ theme }) => theme.colors.negativeDarker};
-    background: ${({ theme }) => theme.colors.yellow};
-    color: ${({ theme }) => theme.colors.negativeDarker};
+    border: 1.5px solid ${primitives.red[900]};
+    background: ${lightColors['feedback/focus']};
+    color: ${primitives.red[900]};
   }
 `
 
 export const tertiary = css`
-  color: ${({ theme }) => theme.colors.copy};
+  color: ${lightColors['text/primary']};
 
   svg {
-    color: ${({ theme }) => theme.colors.primary};
+    color: ${lightColors['action/primary']};
   }
 
   &:hover {
-    background: ${({ theme }) => theme.colors.grey100};
+    background: ${lightColors['action/secondary']};
   }
 
   &:active {
-    background: ${({ theme }) => theme.colors.grey200};
+    background: ${lightColors['action/secondaryHover']};
   }
 `
 
 export const positive = css`
-  background: ${({ theme }) => theme.colors.positive};
-  color: ${({ theme }) => theme.colors.white};
+  background: ${lightColors['action/positive']};
+  color: ${lightColors['text/onAction']};
 
   svg {
-    color: ${({ theme }) => theme.colors.white};
+    color: ${lightColors['text/onAction']};
   }
 
   &:hover {
-    background: ${({ theme }) => theme.colors.positiveDark};
+    background: ${lightColors['action/positiveHover']};
   }
   &:active {
-    background-color: ${({ theme }) => theme.colors.positiveDarker};
+    background-color: ${lightColors['action/positivePressed']};
   }
 `
 
 export const negative = css`
-  background: ${({ theme }) => theme.colors.negative};
-  color: ${({ theme }) => theme.colors.white};
+  background: ${lightColors['action/negative']};
+  color: ${lightColors['text/onAction']};
 
   svg {
-    color: ${({ theme }) => theme.colors.white};
+    color: ${lightColors['text/onAction']};
   }
 
   &:hover {
-    background: ${({ theme }) => theme.colors.negativeDark};
+    background: ${lightColors['action/negativePressed']};
   }
   &:active {
-    background-color: ${({ theme }) => theme.colors.negativeDarker};
+    background-color: ${primitives.red[900]};
   }
 `
 
 export const icon = css`
-  color: ${({ theme }) => theme.colors.primary};
+  color: ${lightColors['action/primary']};
   border-radius: 100%;
   aspect-ratio: 1 / 1;
 
   &:hover {
-    background: ${({ theme }) => theme.colors.grey100};
+    background: ${lightColors['action/secondary']};
   }
   &:active {
-    background: ${({ theme }) => theme.colors.grey200};
+    background: ${lightColors['action/secondaryHover']};
   }
   svg {
     margin-left: -8px;
@@ -180,16 +183,16 @@ export const icon = css`
 `
 
 export const iconPrimary = css`
-  color: ${({ theme }) => theme.colors.white};
-  background: ${({ theme }) => theme.colors.primary};
+  color: ${lightColors['text/onAction']};
+  background: ${lightColors['action/primary']};
   border-radius: 100%;
   aspect-ratio: 1 / 1;
 
   &:hover {
-    background: ${({ theme }) => theme.colors.primaryDark};
+    background: ${lightColors['action/primaryHover']};
   }
   &:active {
-    background: ${({ theme }) => theme.colors.primaryDarker};
+    background: ${lightColors['action/primaryPressed']};
   }
   svg {
     margin-left: -8px;

--- a/packages/components/src/Checkbox/Checkbox.tsx
+++ b/packages/components/src/Checkbox/Checkbox.tsx
@@ -40,7 +40,7 @@ const Check = styled.span<{ size?: string; disabled?: boolean }>`
   display: inline-block;
   border-radius: 4px;
   background: ${({ disabled }) =>
-    disabled ? lightColors['action/disabled'] : lightColors['border/emphasis']};
+    disabled ? lightColors['action/disabled'] : lightColors['surface/inverse']};
   ${({ size }) =>
     size === 'large'
       ? `height: 40px;

--- a/packages/components/src/Checkbox/Checkbox.tsx
+++ b/packages/components/src/Checkbox/Checkbox.tsx
@@ -11,7 +11,6 @@
 import * as React from 'react'
 import styled from 'styled-components'
 import { Tick, TickLarge } from '../icons'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 const Label = styled.label<{ disabled?: boolean }>`

--- a/packages/components/src/Checkbox/Checkbox.tsx
+++ b/packages/components/src/Checkbox/Checkbox.tsx
@@ -11,6 +11,9 @@
 import * as React from 'react'
 import styled from 'styled-components'
 import { Tick, TickLarge } from '../icons'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
+import { primitives } from '../primitives'
 
 const Label = styled.label<{ disabled?: boolean }>`
   display: flex;
@@ -22,23 +25,23 @@ const Label = styled.label<{ disabled?: boolean }>`
   padding: 8px 8px;
   align-items: center;
   isolation: isolate;
-  color: ${({ theme, disabled }) =>
-    disabled ? theme.colors.disabled : theme.colors.copy};
+  color: ${({ disabled }) =>
+    disabled ? lightColors['text/disabled'] : lightColors['text/primary']};
   ${({ theme }) => theme.fonts.h4};
   cursor: pointer;
   &:hover {
-    background: ${({ theme }) => theme.colors.grey100};
+    background: ${lightColors['action/secondary']};
   }
   &:active {
-    background: ${({ theme }) => theme.colors.grey200};
+    background: ${lightColors['action/secondaryHover']};
   }
 `
 
 const Check = styled.span<{ size?: string; disabled?: boolean }>`
   display: inline-block;
   border-radius: 4px;
-  background: ${({ theme, disabled }) =>
-    disabled ? theme.colors.grey200 : theme.colors.grey600};
+  background: ${({ disabled }) =>
+    disabled ? lightColors['action/disabled'] : primitives.grey[900]};
   ${({ size }) =>
     size === 'large'
       ? `height: 40px;
@@ -51,12 +54,12 @@ const Check = styled.span<{ size?: string; disabled?: boolean }>`
   transition: border 0.25s linear;
   -webkit-transition: border 0.25s linear;
   position: relative;
-  color: ${({ theme, disabled }) =>
-    disabled ? theme.colors.disabled : theme.colors.grey600};
+  color: ${({ disabled }) =>
+    disabled ? lightColors['text/disabled'] : lightColors['text/primary']};
   &::after {
     position: absolute;
     content: '';
-    background: ${({ theme }) => theme.colors.white};
+    background: ${lightColors['surface/default']};
     ${({ size }) =>
       size === 'large'
         ? `height: 36px;
@@ -98,8 +101,8 @@ const Input = styled.input`
 
   &:active ~ ${Check} {
     &::after {
-      border: 2px solid ${({ theme }) => theme.colors.grey600};
-      box-shadow: ${({ theme }) => theme.colors.yellow} 0 0 0 3px;
+      border: 2px solid ${primitives.grey[900]};
+      box-shadow: ${lightColors['feedback/focus']} 0 0 0 3px;
       width: ${({ size }) => `max(18px, ${(size ?? 0) - 6}px)`};
       height: ${({ size }) => `max(18px, ${(size ?? 0) - 6}px)`};
     }
@@ -108,8 +111,8 @@ const Input = styled.input`
   &:focus ~ ${Check} {
     &::after {
       box-sizing: content-box;
-      border: 2px solid ${({ theme }) => theme.colors.grey600};
-      box-shadow: ${({ theme }) => theme.colors.yellow} 0 0 0 3px;
+      border: 2px solid ${primitives.grey[900]};
+      box-shadow: ${lightColors['feedback/focus']} 0 0 0 3px;
       width: ${({ size }) => `max(18px, ${(size ?? 0) - 6}px)`};
       height: ${({ size }) => `max(18px, ${(size ?? 0) - 6}px)`};
     }

--- a/packages/components/src/Checkbox/Checkbox.tsx
+++ b/packages/components/src/Checkbox/Checkbox.tsx
@@ -13,7 +13,6 @@ import styled from 'styled-components'
 import { Tick, TickLarge } from '../icons'
 // Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
-import { primitives } from '../primitives'
 
 const Label = styled.label<{ disabled?: boolean }>`
   display: flex;
@@ -41,7 +40,7 @@ const Check = styled.span<{ size?: string; disabled?: boolean }>`
   display: inline-block;
   border-radius: 4px;
   background: ${({ disabled }) =>
-    disabled ? lightColors['action/disabled'] : primitives.grey[900]};
+    disabled ? lightColors['action/disabled'] : lightColors['border/emphasis']};
   ${({ size }) =>
     size === 'large'
       ? `height: 40px;
@@ -101,7 +100,7 @@ const Input = styled.input`
 
   &:active ~ ${Check} {
     &::after {
-      border: 2px solid ${primitives.grey[900]};
+      border: 2px solid ${lightColors['border/emphasis']};
       box-shadow: ${lightColors['feedback/focus']} 0 0 0 3px;
       width: ${({ size }) => `max(18px, ${(size ?? 0) - 6}px)`};
       height: ${({ size }) => `max(18px, ${(size ?? 0) - 6}px)`};
@@ -111,7 +110,7 @@ const Input = styled.input`
   &:focus ~ ${Check} {
     &::after {
       box-sizing: content-box;
-      border: 2px solid ${primitives.grey[900]};
+      border: 2px solid ${lightColors['border/emphasis']};
       box-shadow: ${lightColors['feedback/focus']} 0 0 0 3px;
       width: ${({ size }) => `max(18px, ${(size ?? 0) - 6}px)`};
       height: ${({ size }) => `max(18px, ${(size ?? 0) - 6}px)`};

--- a/packages/components/src/ComparisonListView/ComparisonListView.tsx
+++ b/packages/components/src/ComparisonListView/ComparisonListView.tsx
@@ -14,7 +14,6 @@ import styled from 'styled-components'
 import { Row } from './RowView'
 import { Stack } from '../Stack'
 import { Text } from '../Text'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 const Grid = styled.div<{ headingCount: number }>`

--- a/packages/components/src/ComparisonListView/ComparisonListView.tsx
+++ b/packages/components/src/ComparisonListView/ComparisonListView.tsx
@@ -14,6 +14,8 @@ import styled from 'styled-components'
 import { Row } from './RowView'
 import { Stack } from '../Stack'
 import { Text } from '../Text'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 const Grid = styled.div<{ headingCount: number }>`
   display: grid;
@@ -21,14 +23,14 @@ const Grid = styled.div<{ headingCount: number }>`
     `repeat(${headingCount}, 1fr)`};
   grid-auto-rows: minmax(50px, auto);
   border-bottom: 1px solid;
-  border-color: ${({ theme }) => theme.colors.grey200};
+  border-color: ${lightColors['border/default']};
   > div {
-    border-bottom: 1px solid ${({ theme }) => theme.colors.grey200};
+    border-bottom: 1px solid ${lightColors['border/default']};
   }
   @media (max-width: ${({ theme }) => theme.grid.breakpoints.md}px) {
     grid-template-columns: auto;
     > div:not(:nth-last-child(-n + 1)) {
-      border-bottom: 1px solid ${({ theme }) => theme.colors.grey200};
+      border-bottom: 1px solid ${lightColors['border/default']};
     }
   }
 `

--- a/packages/components/src/Content/Container.tsx
+++ b/packages/components/src/Content/Container.tsx
@@ -9,6 +9,8 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 import styled from 'styled-components'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 export const BodyContent = styled.div`
   max-width: 1140px;
@@ -21,16 +23,16 @@ export const BodyContent = styled.div`
 `
 
 export const Container = styled.div<{ isCertificatesConfigPage?: boolean }>`
-  background-color: ${({ isCertificatesConfigPage, theme }) =>
+  background-color: ${({ isCertificatesConfigPage }) =>
     isCertificatesConfigPage === true
-      ? theme.colors.background
-      : theme.colors.white};
+      ? lightColors['surface/page']
+      : lightColors['surface/default']};
   position: absolute;
   min-height: 100vh;
   width: 100%;
 `
 export const FullBodyContent = styled.div`
-  background-color: ${({ theme }) => theme.colors.background};
+  background-color: ${lightColors['surface/page']};
   flex: 1;
   width: 100%;
   height: 100%;

--- a/packages/components/src/Content/Container.tsx
+++ b/packages/components/src/Content/Container.tsx
@@ -9,7 +9,6 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 import styled from 'styled-components'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 export const BodyContent = styled.div`

--- a/packages/components/src/Content/Content.tsx
+++ b/packages/components/src/Content/Content.tsx
@@ -12,7 +12,6 @@ import * as React from 'react'
 import { ReactElement } from 'react'
 import styled from 'styled-components'
 import { colors } from '../colors'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 const Container = styled.div<{ size: ContentSize }>`

--- a/packages/components/src/Content/Content.tsx
+++ b/packages/components/src/Content/Content.tsx
@@ -12,6 +12,8 @@ import * as React from 'react'
 import { ReactElement } from 'react'
 import styled from 'styled-components'
 import { colors } from '../colors'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 const Container = styled.div<{ size: ContentSize }>`
   position: relative;
@@ -29,8 +31,8 @@ const Container = styled.div<{ size: ContentSize }>`
         return '568px'
     }
   }};
-  border: 1px solid ${({ theme }) => theme.colors.grey300};
-  background: ${({ theme }) => theme.colors.white};
+  border: 1px solid ${lightColors['border/strong']};
+  background: ${lightColors['surface/default']};
   @media (max-width: ${({ theme }) => theme.grid.breakpoints.md}px) {
     margin: 0;
     height: 100%;
@@ -45,7 +47,7 @@ const Header = styled.div`
   justify-content: center;
   flex-direction: column;
   padding: 0 24px;
-  border-bottom: 1px solid ${({ theme }) => theme.colors.grey300};
+  border-bottom: 1px solid ${lightColors['border/strong']};
   @media (max-width: ${({ theme }) => theme.grid.breakpoints.lg}px) {
     border: 0;
     padding: 0;
@@ -61,11 +63,11 @@ const TopActionBar = styled.div`
 `
 export const SubHeader = styled.div`
   padding-bottom: 24px;
-  color: ${({ theme }) => theme.colors.supportingCopy};
+  color: ${lightColors['text/secondary']};
   ${({ theme }) => theme.fonts.reg16};
 `
 export const Body = styled.div`
-  color: ${({ theme }) => theme.colors.copy};
+  color: ${lightColors['text/primary']};
   ${({ theme }) => theme.fonts.reg16};
 `
 const Footer = styled.div`
@@ -81,7 +83,7 @@ const HeaderBottom = styled.div`
   width: 100%;
   @media (max-width: ${({ theme }) => theme.grid.breakpoints.lg}px) {
     padding: 24px;
-    border-bottom: 1px solid ${({ theme }) => theme.colors.grey300};
+    border-bottom: 1px solid ${lightColors['border/strong']};
   }
   @media (max-width: ${({ theme }) => theme.grid.breakpoints.md}px) {
     padding: 0 16px 16px;
@@ -145,12 +147,12 @@ const TitleContainer = styled.div<{ titleColor?: keyof typeof colors }>`
 
 const Title = styled.div`
   ${({ theme }) => theme.fonts.h1}
-  color: ${({ theme }) => theme.colors.copy};
+  color: ${lightColors['text/primary']};
 `
 
 const Icon = styled.div`
   height: 24px;
-  background-color: ${({ theme }) => theme.colors.white};
+  background-color: ${lightColors['surface/default']};
   @media (max-width: ${({ theme }) => theme.grid.breakpoints.lg}px) {
     display: none;
   }

--- a/packages/components/src/Dialog/Dialog.tsx
+++ b/packages/components/src/Dialog/Dialog.tsx
@@ -13,7 +13,6 @@ import styled from 'styled-components'
 import { Text } from '../Text'
 import { Button } from '../Button'
 import { Icon } from '../Icon'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 export interface IDialogProps {

--- a/packages/components/src/Dialog/Dialog.tsx
+++ b/packages/components/src/Dialog/Dialog.tsx
@@ -13,6 +13,8 @@ import styled from 'styled-components'
 import { Text } from '../Text'
 import { Button } from '../Button'
 import { Icon } from '../Icon'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 export interface IDialogProps {
   id?: string
@@ -35,7 +37,7 @@ const DialogWrapper = styled.div`
   left: 0;
   bottom: 0;
   right: 0;
-  background-color: ${({ theme }) => theme.colors.opacity54};
+  background-color: ${lightColors['overlay/scrim']};
   display: flex;
   justify-content: center;
   align-items: center;
@@ -65,7 +67,7 @@ const DialogContainer = styled.div<{
              border-radius: 0;
              }
       `}
-  background-color: ${({ theme }) => theme.colors.white};
+  background-color: ${lightColors['surface/raised']};
   border-radius: 4px;
   box-shadow: ${({ theme }) => theme.shadows.heavy};
   display: flex;
@@ -75,7 +77,7 @@ const DialogContainer = styled.div<{
 const DialogHeader = styled.div`
   display: flex;
   padding: 12px 32px;
-  border-bottom: 1px solid ${({ theme }) => theme.colors.grey200};
+  border-bottom: 1px solid ${lightColors['border/default']};
   justify-content: space-between;
   min-height: 40px;
 `
@@ -87,7 +89,7 @@ const DialogTitle = styled.div`
 
 const DialogContent = styled.div`
   ${({ theme }) => theme.fonts.reg16};
-  color: ${({ theme }) => theme.colors.supportingCopy};
+  color: ${lightColors['text/secondary']};
   padding: 24px 32px;
   flex-grow: 1;
   overflow-y: auto;
@@ -103,7 +105,7 @@ const DialogFooter = styled.div`
   display: flex;
   gap: 8px;
   justify-content: flex-end;
-  border-top: 1px solid ${({ theme }) => theme.colors.grey200};
+  border-top: 1px solid ${lightColors['border/default']};
 `
 
 export function Dialog({

--- a/packages/components/src/Divider/Divider.tsx
+++ b/packages/components/src/Divider/Divider.tsx
@@ -9,7 +9,6 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 import styled from 'styled-components'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 export interface DividerProps {

--- a/packages/components/src/Divider/Divider.tsx
+++ b/packages/components/src/Divider/Divider.tsx
@@ -9,6 +9,8 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 import styled from 'styled-components'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 export interface DividerProps {
   width?: string
@@ -18,7 +20,7 @@ export interface DividerProps {
 }
 
 export const Divider = styled.div<DividerProps>`
-  ${({ children, border, color, theme, width }) =>
+  ${({ children, border, color, width }) =>
     children
       ? `
   display: flex;
@@ -29,7 +31,7 @@ export const Divider = styled.div<DividerProps>`
     flex: 1;
     content: '';
     padding: 0 1px 1px;
-    background-color: ${color || theme.colors.grey200};
+    background-color: ${color || lightColors['border/default']};
     margin: 16px;
   }
 
@@ -44,12 +46,12 @@ export const Divider = styled.div<DividerProps>`
       : `
   margin-bottom: 20px;
   padding: 8px 0px;
-  border-bottom: ${border || '1px'} solid ${color || theme.colors.grey200};
+  border-bottom: ${border || '1px'} solid ${color || lightColors['border/default']};
   width: ${width || '100%'};`}
 `
 
 export const DividerVertical = styled.div`
-  background: ${({ theme }) => theme.colors.grey200};
+  background: ${lightColors['border/default']};
   width: 1px;
   height: 100%;
   min-height: 24px;

--- a/packages/components/src/DocumentViewer/DocumentViewer.tsx
+++ b/packages/components/src/DocumentViewer/DocumentViewer.tsx
@@ -13,11 +13,13 @@ import styled from 'styled-components'
 import { Select, ISelectOption as SelectComponentOptions } from '../Select'
 import PanViewer from './components/PanViewer'
 import PanControls from './components/PanControls'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 const ViewerWrapper = styled.div`
   position: relative;
-  background-color: ${({ theme }) => theme.colors.white};
-  border: 1px solid ${({ theme }) => theme.colors.grey300};
+  background-color: ${lightColors['surface/default']};
+  border: 1px solid ${lightColors['border/strong']};
   border-radius: 4px;
   box-sizing: border-box;
   height: calc(100vh - 104px);
@@ -40,8 +42,8 @@ const ViewerHeader = styled.div`
   padding: 0 16px;
   z-index: 99;
   justify-content: space-between;
-  background-color: ${({ theme }) => theme.colors.white};
-  border-bottom: 1px solid ${({ theme }) => theme.colors.grey300};
+  background-color: ${lightColors['surface/default']};
+  border-bottom: 1px solid ${lightColors['border/strong']};
 `
 
 const ViewerImage = styled.div`

--- a/packages/components/src/DocumentViewer/DocumentViewer.tsx
+++ b/packages/components/src/DocumentViewer/DocumentViewer.tsx
@@ -13,7 +13,6 @@ import styled from 'styled-components'
 import { Select, ISelectOption as SelectComponentOptions } from '../Select'
 import PanViewer from './components/PanViewer'
 import PanControls from './components/PanControls'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 const ViewerWrapper = styled.div`

--- a/packages/components/src/Dropdown/Dropdown.tsx
+++ b/packages/components/src/Dropdown/Dropdown.tsx
@@ -13,7 +13,6 @@ import React, { ReactNode, useEffect } from 'react'
 import { disabled } from '../Button/Button.styles'
 import styled from 'styled-components'
 import { DropdownProvider, useDropdown } from './DropdownContext'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 const StyledWrapper = styled.nav`

--- a/packages/components/src/Dropdown/Dropdown.tsx
+++ b/packages/components/src/Dropdown/Dropdown.tsx
@@ -13,6 +13,8 @@ import React, { ReactNode, useEffect } from 'react'
 import { disabled } from '../Button/Button.styles'
 import styled from 'styled-components'
 import { DropdownProvider, useDropdown } from './DropdownContext'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 const StyledWrapper = styled.nav`
   position: relative;
@@ -46,8 +48,8 @@ const StyledContent = styled.ul.withConfig({
   // Forward popover prop directly
 })<StyledContentProp>`
   border-radius: 4px;
-  border: 1px solid ${({ theme }) => theme.colors.grey300};
-  background-color: ${({ theme }) => theme.colors.white};
+  border: 1px solid ${lightColors['border/strong']};
+  background-color: ${lightColors['surface/raised']};
   ${({ theme }) => theme.shadows.light};
   text-align: left;
   min-width: 256px;
@@ -72,13 +74,13 @@ const Label = styled.li`
 
 const Separator = styled.div<{ weight: number }>`
   border-bottom: ${({ weight }) => `${weight}px solid `}
-    ${({ theme }) => theme.colors.grey300};
+    ${lightColors['border/strong']};
   margin: 4px 0;
 `
 
 const MenuItem = styled.li<{ disabled?: boolean }>`
   ${({ theme }) => theme.fonts.bold14};
-  color: ${({ theme }) => theme.colors.grey600};
+  color: ${lightColors['text/primary']};
   display: flex;
   align-items: center;
   gap: 12px;
@@ -87,15 +89,15 @@ const MenuItem = styled.li<{ disabled?: boolean }>`
   border-radius: 2px;
   padding: 8px 12px;
   &:hover {
-    background: ${({ theme }) => theme.colors.grey100};
-    color: ${({ theme }) => theme.colors.grey600};
+    background: ${lightColors['action/secondary']};
+    color: ${lightColors['text/primary']};
   }
   &:active {
-    background: ${({ theme }) => theme.colors.grey200};
-    color: ${({ theme }) => theme.colors.grey600};
+    background: ${lightColors['action/secondaryHover']};
+    color: ${lightColors['text/primary']};
   }
   &:focus-visible {
-    background-color: ${({ theme }) => theme.colors.yellow};
+    background-color: ${lightColors['feedback/focus']};
   }
   ${(props) => props.disabled && disabled}
 `

--- a/packages/components/src/ErrorMessage/ErrorMessage.tsx
+++ b/packages/components/src/ErrorMessage/ErrorMessage.tsx
@@ -9,7 +9,6 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 import styled from 'styled-components'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 /** @deprecated in favor of `<Toast>` / `<Alert>` */

--- a/packages/components/src/ErrorMessage/ErrorMessage.tsx
+++ b/packages/components/src/ErrorMessage/ErrorMessage.tsx
@@ -9,11 +9,13 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 import styled from 'styled-components'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 /** @deprecated in favor of `<Toast>` / `<Alert>` */
 export const ErrorMessage = styled.p`
-  color: ${({ theme }) => theme.colors.white};
-  background: ${({ theme }) => theme.colors.negative};
+  color: ${lightColors['text/onAction']};
+  background: ${lightColors['action/negative']};
   padding: 8px 24px;
   text-align: center;
 `

--- a/packages/components/src/EventTopBar/EventTopBar.tsx
+++ b/packages/components/src/EventTopBar/EventTopBar.tsx
@@ -15,12 +15,14 @@ import { DeclarationIcon, Cross } from '../icons'
 import { ToggleMenu } from '../ToggleMenu'
 import { Button } from '../Button'
 import { Icon } from '../Icon'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 const TopBar = styled.div`
   padding: 0 ${({ theme }) => theme.grid.margin}px;
   height: 56px;
-  background: ${({ theme }) => theme.colors.white};
-  border-bottom: 1px solid ${({ theme }) => theme.colors.grey300};
+  background: ${lightColors['surface/default']};
+  border-bottom: 1px solid ${lightColors['border/strong']};
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -32,7 +34,7 @@ const TopBar = styled.div`
 const TopBarTitle = styled.h4`
   ${({ theme }) => theme.fonts.h4};
   padding-left: 16px;
-  color: ${({ theme }) => theme.colors.copy};
+  color: ${lightColors['text/primary']};
 `
 
 const ActionContainer = styled.span`

--- a/packages/components/src/EventTopBar/EventTopBar.tsx
+++ b/packages/components/src/EventTopBar/EventTopBar.tsx
@@ -15,7 +15,6 @@ import { DeclarationIcon, Cross } from '../icons'
 import { ToggleMenu } from '../ToggleMenu'
 import { Button } from '../Button'
 import { Icon } from '../Icon'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 const TopBar = styled.div`

--- a/packages/components/src/ExpandingMenu/ExpandingMenu.tsx
+++ b/packages/components/src/ExpandingMenu/ExpandingMenu.tsx
@@ -10,7 +10,6 @@
  */
 import React from 'react'
 import styled from 'styled-components'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 const NavigationMainWrapper = styled.div`

--- a/packages/components/src/ExpandingMenu/ExpandingMenu.tsx
+++ b/packages/components/src/ExpandingMenu/ExpandingMenu.tsx
@@ -12,7 +12,6 @@ import React from 'react'
 import styled from 'styled-components'
 // Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
-import { primitives } from '../primitives'
 
 const NavigationMainWrapper = styled.div`
   width: 100%;
@@ -34,7 +33,7 @@ const Backdrop = styled.div`
       opacity: 0.8;
     }
   }
-  background: ${primitives.grey[900]};
+  background: ${lightColors['overlay/scrim']};
   opacity: 0.8;
   position: absolute;
   top: 0;
@@ -55,7 +54,7 @@ const NavigationContainer = styled.div`
   }
   display: flex;
   flex-direction: column;
-  background: ${lightColors['surface/sunken']};
+  background: ${lightColors['surface/inset']};
   width: 320px;
   height: 100vh;
   animation: 300ms ease-out 0s 1 slideInFromLeft;

--- a/packages/components/src/ExpandingMenu/ExpandingMenu.tsx
+++ b/packages/components/src/ExpandingMenu/ExpandingMenu.tsx
@@ -10,11 +10,14 @@
  */
 import React from 'react'
 import styled from 'styled-components'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
+import { primitives } from '../primitives'
 
 const NavigationMainWrapper = styled.div`
   width: 100%;
   ${({ theme }) => theme.fonts.reg16};
-  color: ${({ theme }) => theme.colors.copy};
+  color: ${lightColors['text/primary']};
   height: 100vh;
   z-index: 99999;
   position: fixed;
@@ -31,7 +34,7 @@ const Backdrop = styled.div`
       opacity: 0.8;
     }
   }
-  background: ${({ theme }) => theme.colors.grey600};
+  background: ${primitives.grey[900]};
   opacity: 0.8;
   position: absolute;
   top: 0;
@@ -52,7 +55,7 @@ const NavigationContainer = styled.div`
   }
   display: flex;
   flex-direction: column;
-  background: ${({ theme }) => theme.colors.grey100};
+  background: ${lightColors['surface/sunken']};
   width: 320px;
   height: 100vh;
   animation: 300ms ease-out 0s 1 slideInFromLeft;

--- a/packages/components/src/FormTabs/components/Tabs.tsx
+++ b/packages/components/src/FormTabs/components/Tabs.tsx
@@ -11,6 +11,8 @@
 import styled from 'styled-components'
 import { Button, IButtonProps } from '../../buttons'
 import { ITabColor } from '../FormTabs'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../../semantics'
 
 export const Tabs = styled.div`
   display: flex;
@@ -26,14 +28,14 @@ export interface IProps extends IButtonProps {
 }
 
 export const Tab = styled(Button)<IProps>`
-  --color: ${({ theme, activeColor }) =>
-    activeColor ? activeColor : theme.colors.primary};
+  --color: ${({ activeColor }) =>
+    activeColor ? activeColor : lightColors['action/primary']};
   border-radius: 0;
   margin-top: 8px;
   margin-right: 16px;
   padding: 0;
-  color: ${({ disabled, theme }) =>
-    disabled ? theme.colors.grey300 : 'var(--color)'};
+  color: ${({ disabled }) =>
+    disabled ? lightColors['text/disabled'] : 'var(--color)'};
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
   border-bottom: ${({ active }) =>
     active ? `2px solid var(--color)` : '2px solid transparent'};
@@ -41,7 +43,7 @@ export const Tab = styled(Button)<IProps>`
     padding: 0px;
   }
   &:hover:enabled {
-    border-bottom: 2px solid ${({ theme }) => theme.colors.grey300};
+    border-bottom: 2px solid ${lightColors['border/strong']};
   }
 
   &:disabled {

--- a/packages/components/src/FormTabs/components/Tabs.tsx
+++ b/packages/components/src/FormTabs/components/Tabs.tsx
@@ -11,7 +11,6 @@
 import styled from 'styled-components'
 import { Button, IButtonProps } from '../../buttons'
 import { ITabColor } from '../FormTabs'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../../semantics'
 
 export const Tabs = styled.div`

--- a/packages/components/src/Frame/Frame.tsx
+++ b/packages/components/src/Frame/Frame.tsx
@@ -16,6 +16,8 @@ import {
   SkipToContent,
   MAIN_CONTENT_ANCHOR_ID
 } from './components/SkipToContent'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 export interface FrameProps {
   /** Accepts a header component that will be rendered at the top-most portion of an application frame */
@@ -52,7 +54,7 @@ const FrameMainContent = styled.main`
   grid-area: content;
   height: 100%;
   overflow-y: auto;
-  background: ${({ theme }) => theme.colors.background};
+  background: ${lightColors['surface/page']};
 `
 
 export function Frame({

--- a/packages/components/src/Frame/Frame.tsx
+++ b/packages/components/src/Frame/Frame.tsx
@@ -16,7 +16,6 @@ import {
   SkipToContent,
   MAIN_CONTENT_ANCHOR_ID
 } from './components/SkipToContent'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 export interface FrameProps {

--- a/packages/components/src/Frame/components/Section.tsx
+++ b/packages/components/src/Frame/components/Section.tsx
@@ -9,7 +9,6 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 import styled from 'styled-components'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../../semantics'
 
 export const Section = styled.div`

--- a/packages/components/src/Frame/components/Section.tsx
+++ b/packages/components/src/Frame/components/Section.tsx
@@ -9,6 +9,8 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 import styled from 'styled-components'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../../semantics'
 
 export const Section = styled.div`
   display: grid;
@@ -26,7 +28,7 @@ export const SectionFormBackAction = styled.div`
 
   @media (max-width: ${({ theme }) => theme.grid.breakpoints.md}px) {
     gap: 0;
-    background: ${({ theme }) => theme.colors.white};
+    background: ${lightColors['surface/default']};
     align-items: centre;
     justify-items: start;
   }

--- a/packages/components/src/Frame/components/SkipToContent.tsx
+++ b/packages/components/src/Frame/components/SkipToContent.tsx
@@ -11,6 +11,8 @@
 import React from 'react'
 import styled from 'styled-components'
 import { Link } from '../../Link'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../../semantics'
 
 export const SkipToContentContainer = styled(Link)`
   left: 0;
@@ -21,8 +23,8 @@ export const SkipToContentContainer = styled(Link)`
   padding: 16px;
   filter: drop-shadow(0px 2px 4px rgba(34, 34, 34, 0.24));
   margin: 8px;
-  background: ${({ theme }) => theme.colors.yellow};
-  color: ${({ theme }) => theme.colors.copy};
+  background: ${lightColors['feedback/focus']};
+  color: ${lightColors['text/primary']};
 
   &:not(:focus-visible) {
     transition: transform 400ms;

--- a/packages/components/src/Frame/components/SkipToContent.tsx
+++ b/packages/components/src/Frame/components/SkipToContent.tsx
@@ -11,7 +11,6 @@
 import React from 'react'
 import styled from 'styled-components'
 import { Link } from '../../Link'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../../semantics'
 
 export const SkipToContentContainer = styled(Link)`

--- a/packages/components/src/IdReader/components.tsx
+++ b/packages/components/src/IdReader/components.tsx
@@ -11,9 +11,11 @@
 import styled from 'styled-components'
 import { Box } from '../Box'
 import { Stack } from '../Stack'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 export const MainContainer = styled(Box)`
-  background: ${({ theme }) => theme.colors.background};
+  background: ${lightColors['surface/page']};
   border: none;
   flex: 1;
 `

--- a/packages/components/src/IdReader/components.tsx
+++ b/packages/components/src/IdReader/components.tsx
@@ -11,7 +11,6 @@
 import styled from 'styled-components'
 import { Box } from '../Box'
 import { Stack } from '../Stack'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 export const MainContainer = styled(Box)`

--- a/packages/components/src/IdReader/readers/QrReader/InfoBox.tsx
+++ b/packages/components/src/IdReader/readers/QrReader/InfoBox.tsx
@@ -14,7 +14,6 @@ import styled from 'styled-components'
 import { Stack } from '../../../Stack'
 import { Text } from '../../../Text'
 import { Icon, IconProps } from '../../../Icon'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../../../semantics'
 
 interface InfoBoxProps {

--- a/packages/components/src/IdReader/readers/QrReader/InfoBox.tsx
+++ b/packages/components/src/IdReader/readers/QrReader/InfoBox.tsx
@@ -14,6 +14,8 @@ import styled from 'styled-components'
 import { Stack } from '../../../Stack'
 import { Text } from '../../../Text'
 import { Icon, IconProps } from '../../../Icon'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../../../semantics'
 
 interface InfoBoxProps {
   iconName: IconProps['name']
@@ -21,14 +23,14 @@ interface InfoBoxProps {
 }
 
 const Container = styled(Box)`
-  background-color: ${({ theme }) => theme.colors.background};
+  background-color: ${lightColors['surface/page']};
   border: 0;
   flex: 1;
 `
 const IconContainer = styled.div`
   height: 44px;
   width: 44px;
-  background-color: ${({ theme }) => theme.colors.white};
+  background-color: ${lightColors['surface/default']};
   border-radius: 50%;
   display: flex;
   justify-content: center;

--- a/packages/components/src/IdReader/readers/QrReader/QrReader.tsx
+++ b/packages/components/src/IdReader/readers/QrReader/QrReader.tsx
@@ -21,9 +21,11 @@ import { Text } from '../../../Text'
 import { ErrorHandler, ScannableQrReader } from '../../types'
 import { useWindowSize } from '../../../hooks'
 import { getTheme } from '../../../theme'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../../../semantics'
 
 const ScannerBox = styled(Box)`
-  background: ${({ theme }) => theme.colors.background};
+  background: ${lightColors['surface/page']};
   width: 100%;
   padding: 12px;
   border: 0;

--- a/packages/components/src/IdReader/readers/QrReader/QrReader.tsx
+++ b/packages/components/src/IdReader/readers/QrReader/QrReader.tsx
@@ -21,7 +21,6 @@ import { Text } from '../../../Text'
 import { ErrorHandler, ScannableQrReader } from '../../types'
 import { useWindowSize } from '../../../hooks'
 import { getTheme } from '../../../theme'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../../../semantics'
 
 const ScannerBox = styled(Box)`

--- a/packages/components/src/InputField/InputDescriptor.tsx
+++ b/packages/components/src/InputField/InputDescriptor.tsx
@@ -10,7 +10,6 @@
  */
 import React, { ReactNode } from 'react'
 import styled from 'styled-components'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 export const InputDescriptor = styled.p`

--- a/packages/components/src/InputField/InputDescriptor.tsx
+++ b/packages/components/src/InputField/InputDescriptor.tsx
@@ -10,10 +10,12 @@
  */
 import React, { ReactNode } from 'react'
 import styled from 'styled-components'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 export const InputDescriptor = styled.p`
   ${({ theme }) => theme.fonts.reg16};
-  color: ${({ theme }) => theme.colors.supportingCopy};
+  color: ${lightColors['text/secondary']};
   width: 100%;
   margin: 0;
   padding-bottom: 8px;

--- a/packages/components/src/InputField/InputError.tsx
+++ b/packages/components/src/InputField/InputError.tsx
@@ -10,6 +10,8 @@
  */
 import * as React from 'react'
 import styled from 'styled-components'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 export interface IInputError {
   id: string
@@ -22,5 +24,5 @@ export const InputError = styled.div<IInputError>`
   padding-top: 4px;
   display: inline-block;
   ${({ theme }) => theme.fonts.bold14}
-  color: ${({ theme }) => theme.colors.negative};
+  color: ${lightColors['feedback/negative']};
 `

--- a/packages/components/src/InputField/InputError.tsx
+++ b/packages/components/src/InputField/InputError.tsx
@@ -10,7 +10,6 @@
  */
 import * as React from 'react'
 import styled from 'styled-components'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 export interface IInputError {

--- a/packages/components/src/InputField/InputField.tsx
+++ b/packages/components/src/InputField/InputField.tsx
@@ -13,24 +13,26 @@ import styled from 'styled-components'
 import { InputError } from './InputError'
 import { InputLabel } from './InputLabel'
 import { InputDescriptor } from './InputDescriptor'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 const InputHeader = styled.div``
 const ComponentWrapper = styled.span``
 const InputDescription = styled.p`
   ${({ theme }) => theme.fonts.reg16};
-  color: ${({ theme }) => theme.colors.copy};
+  color: ${lightColors['text/primary']};
 `
 
 const DefaultInputWrapper = styled.div``
 const HighlightedInputWrapper = styled.div`
-  border: 1px solid ${({ theme }) => theme.colors.primary};
+  border: 1px solid ${lightColors['action/primary']};
   border-radius: 4px;
   padding-bottom: 16px;
   overflow: hidden;
 
   label {
-    background-color: ${({ theme }) => theme.colors.primaryLighter};
-    border-bottom: ${({ theme }) => `1px solid ${theme.colors.primary}`};
+    background-color: ${lightColors['feedback/infoSubtle']};
+    border-bottom: 1px solid ${lightColors['action/primary']};
     padding: 12px 16px;
   }
 

--- a/packages/components/src/InputField/InputField.tsx
+++ b/packages/components/src/InputField/InputField.tsx
@@ -13,7 +13,6 @@ import styled from 'styled-components'
 import { InputError } from './InputError'
 import { InputLabel } from './InputLabel'
 import { InputDescriptor } from './InputDescriptor'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 const InputHeader = styled.div``

--- a/packages/components/src/InputField/InputLabel.tsx
+++ b/packages/components/src/InputField/InputLabel.tsx
@@ -11,6 +11,8 @@
 import * as React from 'react'
 import styled from 'styled-components'
 import ReactTooltip from 'react-tooltip'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 export type IInputLabel = {
   inputDescriptor?: string
@@ -23,8 +25,8 @@ export type IInputLabel = {
 
 const StyledInputLabel = styled.label<IInputLabel>`
   ${({ theme }) => theme.fonts.h4};
-  color: ${({ disabled, theme }) =>
-    disabled ? theme.colors.disabled : theme.colors.copy};
+  color: ${({ disabled }) =>
+    disabled ? lightColors['text/disabled'] : lightColors['text/primary']};
   width: 100%;
   margin-bottom: 5px;
   display: inline-block;
@@ -34,8 +36,8 @@ const Required = styled.span<
   { disabled?: boolean } & React.LabelHTMLAttributes<HTMLLabelElement>
 >`
   ${({ theme }) => theme.fonts.h4};
-  color: ${({ disabled, theme }) =>
-    disabled ? theme.colors.disabled : theme.colors.negative};
+  color: ${({ disabled }) =>
+    disabled ? lightColors['text/disabled'] : lightColors['feedback/negative']};
   flex-grow: 0;
 `
 

--- a/packages/components/src/InputField/InputLabel.tsx
+++ b/packages/components/src/InputField/InputLabel.tsx
@@ -11,7 +11,6 @@
 import * as React from 'react'
 import styled from 'styled-components'
 import ReactTooltip from 'react-tooltip'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 export type IInputLabel = {

--- a/packages/components/src/LineChart/LineChart.tsx
+++ b/packages/components/src/LineChart/LineChart.tsx
@@ -15,7 +15,6 @@ import styled, { withTheme } from 'styled-components'
 import { CategoricalChartFunc } from 'recharts/types/chart/generateCategoricalChart'
 // Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
-import { primitives } from '../primitives'
 
 const {
   CartesianGrid,
@@ -190,21 +189,21 @@ class LineChartComponent extends React.Component<IProps> {
 
             <Line
               dataKey={dataKeys[0]}
-              stroke={primitives.grey[200]}
+              stroke={lightColors['border/subtle']}
               dot={false}
               activeDot={false}
               strokeWidth={3}
             />
             <Line
               dataKey={dataKeys[1]}
-              stroke={primitives.blue[200]}
+              stroke={lightColors['feedback/info']}
               dot={false}
               activeDot={false}
               strokeWidth={3}
             />
             <Line
               dataKey={dataKeys[2]}
-              stroke={primitives.blue[300]}
+              stroke={lightColors['feedback/positive']}
               dot={false}
               activeDot={(dotProps: unknown) => (
                 <CustomizedDot {...(dotProps as ICustomisedDot)} theme={theme} />

--- a/packages/components/src/LineChart/LineChart.tsx
+++ b/packages/components/src/LineChart/LineChart.tsx
@@ -13,7 +13,6 @@ import * as Recharts from 'recharts'
 import { ITheme } from '../theme'
 import styled, { withTheme } from 'styled-components'
 import { CategoricalChartFunc } from 'recharts/types/chart/generateCategoricalChart'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 const {

--- a/packages/components/src/LineChart/LineChart.tsx
+++ b/packages/components/src/LineChart/LineChart.tsx
@@ -13,6 +13,9 @@ import * as Recharts from 'recharts'
 import { ITheme } from '../theme'
 import styled, { withTheme } from 'styled-components'
 import { CategoricalChartFunc } from 'recharts/types/chart/generateCategoricalChart'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
+import { primitives } from '../primitives'
 
 const {
   CartesianGrid,
@@ -85,8 +88,8 @@ function CustomizedDot(props: ICustomisedDot) {
         cx={8}
         cy={8}
         r={5}
-        fill={theme.colors.white}
-        stroke={theme.colors.yellow}
+        fill={lightColors['surface/default']}
+        stroke={lightColors['feedback/focus']}
         strokeWidth={3}
       />
     </svg>
@@ -115,7 +118,7 @@ function CustomizedAxisTick(props: IThemedAxisTickProps) {
         x={0}
         y={0}
         dy={24}
-        fill={theme.colors.copy}
+        fill={lightColors['text/primary']}
         fontFamily={theme.fontFamily}
         fontSize={12}
         fontWeight="normal"
@@ -187,21 +190,21 @@ class LineChartComponent extends React.Component<IProps> {
 
             <Line
               dataKey={dataKeys[0]}
-              stroke={theme.colors.grey200}
+              stroke={primitives.grey[200]}
               dot={false}
               activeDot={false}
               strokeWidth={3}
             />
             <Line
               dataKey={dataKeys[1]}
-              stroke={theme.colors.tealLight}
+              stroke={primitives.blue[200]}
               dot={false}
               activeDot={false}
               strokeWidth={3}
             />
             <Line
               dataKey={dataKeys[2]}
-              stroke={theme.colors.teal}
+              stroke={primitives.blue[300]}
               dot={false}
               activeDot={(dotProps: unknown) => (
                 <CustomizedDot {...(dotProps as ICustomisedDot)} theme={theme} />
@@ -210,7 +213,7 @@ class LineChartComponent extends React.Component<IProps> {
             />
 
             <Tooltip
-              cursor={{ stroke: theme.colors.yellow }}
+              cursor={{ stroke: lightColors['feedback/focus'] }}
               content={(tooltipProps) =>
                 tooltipContent(tooltipProps as unknown as IDataPoint)
               }

--- a/packages/components/src/Link/Link.tsx
+++ b/packages/components/src/Link/Link.tsx
@@ -11,7 +11,6 @@
 import React from 'react'
 import { fonts, IFont } from '../fonts'
 import { colors, IColor } from '../colors'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 import styled, { css } from 'styled-components'
 

--- a/packages/components/src/Link/Link.tsx
+++ b/packages/components/src/Link/Link.tsx
@@ -11,6 +11,8 @@
 import React from 'react'
 import { fonts, IFont } from '../fonts'
 import { colors, IColor } from '../colors'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 import styled, { css } from 'styled-components'
 
 export interface LinkProps
@@ -67,11 +69,11 @@ const StyledLink = styled.button<{
   }
 
   &:focus-visible {
-    background: ${({ theme }) => theme.colors.yellow};
-    box-shadow: 0 -2px ${({ theme }) => theme.colors.yellow},
-      0px 2px ${({ theme }) => theme.colors.yellow},
-      0 4px ${({ theme }) => theme.colors.copy};
-    color: ${({ theme }) => theme.colors.grey600};
+    background: ${lightColors['feedback/focus']};
+    box-shadow: 0 -2px ${lightColors['feedback/focus']},
+      0px 2px ${lightColors['feedback/focus']},
+      0 4px ${lightColors['text/primary']};
+    color: ${lightColors['text/primary']};
     outline: none;
     text-decoration: none;
   }

--- a/packages/components/src/ListConfig/ListConfig.tsx
+++ b/packages/components/src/ListConfig/ListConfig.tsx
@@ -11,7 +11,6 @@
 import React from 'react'
 import styled from 'styled-components'
 import { Text } from '../Text'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 export interface IListConfigRowProps {

--- a/packages/components/src/ListConfig/ListConfig.tsx
+++ b/packages/components/src/ListConfig/ListConfig.tsx
@@ -11,6 +11,8 @@
 import React from 'react'
 import styled from 'styled-components'
 import { Text } from '../Text'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 export interface IListConfigRowProps {
   id?: string
@@ -29,8 +31,8 @@ export const ConfigHeader = styled.table`
   border-collapse: collapse;
   width: 100%;
   th {
-    border-bottom: 1px solid ${({ theme }) => theme.colors.grey200};
-    color: ${({ theme }) => theme.colors.grey400};
+    border-bottom: 1px solid ${lightColors['border/default']};
+    color: ${lightColors['text/disabled']};
     ${({ theme }) => theme.fonts.bold12};
     padding: 12px 8px;
     text-align: left;
@@ -60,7 +62,7 @@ export const ConfigRow = styled.table`
   width: 100%;
 
   td {
-    border-bottom: 1px solid ${({ theme }) => theme.colors.grey200};
+    border-bottom: 1px solid ${lightColors['border/default']};
     padding: 20px 8px;
     vertical-align: center;
   }

--- a/packages/components/src/ListReview/components/Header.tsx
+++ b/packages/components/src/ListReview/components/Header.tsx
@@ -10,12 +10,14 @@
  */
 import React from 'react'
 import styled from 'styled-components'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../../semantics'
 
 export const HeaderContainer = styled.tr<{
   fontVariant: HeaderFontVariant
 }>`
   th {
-    border-bottom: 2px solid ${({ theme }) => theme.colors.grey200};
+    border-bottom: 2px solid ${lightColors['border/default']};
     padding: 20px 0;
     text-align: left;
     ${({ theme, fontVariant }) => theme.fonts[fontVariant ?? 'reg16']};

--- a/packages/components/src/ListReview/components/Header.tsx
+++ b/packages/components/src/ListReview/components/Header.tsx
@@ -10,7 +10,6 @@
  */
 import React from 'react'
 import styled from 'styled-components'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../../semantics'
 
 export const HeaderContainer = styled.tr<{

--- a/packages/components/src/ListReview/components/Row.tsx
+++ b/packages/components/src/ListReview/components/Row.tsx
@@ -10,9 +10,11 @@
  */
 import React from 'react'
 import styled from 'styled-components'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../../semantics'
 
 export const RowContainer = styled.tr`
-  border-bottom: 1px solid ${({ theme }) => theme.colors.grey100};
+  border-bottom: 1px solid ${lightColors['border/subtle']};
 
   td {
     padding: 14px 0;

--- a/packages/components/src/ListReview/components/Row.tsx
+++ b/packages/components/src/ListReview/components/Row.tsx
@@ -10,7 +10,6 @@
  */
 import React from 'react'
 import styled from 'styled-components'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../../semantics'
 
 export const RowContainer = styled.tr`

--- a/packages/components/src/ListUser/ListUser.tsx
+++ b/packages/components/src/ListUser/ListUser.tsx
@@ -10,6 +10,8 @@
  */
 import React from 'react'
 import styled from 'styled-components'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 export interface IListUserProps {
   labelHeader?: React.ReactNode
@@ -27,8 +29,8 @@ export const UserHeader = styled.table`
   border-collapse: collapse;
   width: 100%;
   th {
-    border-bottom: 1px solid ${({ theme }) => theme.colors.grey200};
-    color: ${({ theme }) => theme.colors.grey400};
+    border-bottom: 1px solid ${lightColors['border/default']};
+    color: ${lightColors['text/disabled']};
     ${({ theme }) => theme.fonts.bold12};
     text-align: left;
     padding: 8px 0;
@@ -57,7 +59,7 @@ export const UserRow = styled.table`
   width: 100%;
 
   td {
-    border-bottom: 1px solid ${({ theme }) => theme.colors.grey200};
+    border-bottom: 1px solid ${lightColors['border/default']};
     padding: 8px 0;
   }
   td:first-child {

--- a/packages/components/src/ListUser/ListUser.tsx
+++ b/packages/components/src/ListUser/ListUser.tsx
@@ -10,7 +10,6 @@
  */
 import React from 'react'
 import styled from 'styled-components'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 export interface IListUserProps {

--- a/packages/components/src/ListViewSimplified/ListViewSimplified.tsx
+++ b/packages/components/src/ListViewSimplified/ListViewSimplified.tsx
@@ -10,7 +10,6 @@
  */
 import React from 'react'
 import styled from 'styled-components'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 export type IRowListViewSize = 'small' | 'medium'

--- a/packages/components/src/ListViewSimplified/ListViewSimplified.tsx
+++ b/packages/components/src/ListViewSimplified/ListViewSimplified.tsx
@@ -10,6 +10,8 @@
  */
 import React from 'react'
 import styled from 'styled-components'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 export type IRowListViewSize = 'small' | 'medium'
 
@@ -24,14 +26,14 @@ const Grid = styled.div<{
   ${({ rowHeight }) =>
     rowHeight === 'small' && 'grid-auto-rows: minmax(48px, auto);'}
   ${({ bottomBorder }) => bottomBorder && 'border-bottom: 1px solid'};
-  border-color: ${({ theme }) => theme.colors.grey200};
+  border-color: ${lightColors['border/default']};
   > div:not(:nth-last-child(-n + 4)) {
-    border-bottom: 1px solid ${({ theme }) => theme.colors.grey200};
+    border-bottom: 1px solid ${lightColors['border/default']};
   }
   @media (max-width: ${({ theme }) => theme.grid.breakpoints.md}px) {
     grid-template-columns: auto;
     > div:not(:nth-last-child(-n + 1)) {
-      border-bottom: 1px solid ${({ theme }) => theme.colors.grey200};
+      border-bottom: 1px solid ${lightColors['border/default']};
     }
   }
 `
@@ -51,7 +53,7 @@ const ValueContainer = styled.div<{ compactLabel?: boolean }>`
   ${({ compactLabel }) => (!compactLabel ? 'flex: 0 1 50%;' : '')}
   ${({ compactLabel }) => (compactLabel ? 'margin:0 auto;' : '')}
   align-items: center;
-  color: ${({ theme }) => theme.colors.grey600};
+  color: ${lightColors['text/primary']};
   @media (max-width: ${({ theme }) => theme.grid.breakpoints.md}px) {
     display: none;
   }

--- a/packages/components/src/LoadingBar/LoadingBar.tsx
+++ b/packages/components/src/LoadingBar/LoadingBar.tsx
@@ -12,9 +12,11 @@ import { Text } from '../Text'
 import { Stack } from '../Stack'
 import React from 'react'
 import styled, { keyframes } from 'styled-components'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 const ProgressBackground = styled.div`
-  background: ${({ theme }) => theme.colors.grey100};
+  background: ${lightColors['surface/sunken']};
   height: 100vh;
   width: 100%;
   display: flex;
@@ -30,7 +32,7 @@ const ProgressBar = styled.div`
   margin-top: 27px;
   border-radius: 100px;
   opacity: 0px;
-  background: ${({ theme }) => theme.colors.grey300};
+  background: ${lightColors['action/secondaryPressed']};
 `
 
 const ProgressAnimation = keyframes`
@@ -47,7 +49,7 @@ const Progress = styled.div`
   gap: 0px;
   border-radius: 100px;
   opacity: 0px;
-  background: ${({ theme }) => theme.colors.primary};
+  background: ${lightColors['action/primary']};
   animation: ${ProgressAnimation} 300s ease;
 `
 export const LoadingBar = () => (

--- a/packages/components/src/LoadingBar/LoadingBar.tsx
+++ b/packages/components/src/LoadingBar/LoadingBar.tsx
@@ -12,7 +12,6 @@ import { Text } from '../Text'
 import { Stack } from '../Stack'
 import React from 'react'
 import styled, { keyframes } from 'styled-components'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 const ProgressBackground = styled.div`

--- a/packages/components/src/LoadingBar/LoadingBar.tsx
+++ b/packages/components/src/LoadingBar/LoadingBar.tsx
@@ -16,7 +16,7 @@ import styled, { keyframes } from 'styled-components'
 import { lightColors } from '../semantics'
 
 const ProgressBackground = styled.div`
-  background: ${lightColors['surface/sunken']};
+  background: ${lightColors['surface/inset']};
   height: 100vh;
   width: 100%;
   display: flex;

--- a/packages/components/src/LoadingGrey/LoadingGrey.tsx
+++ b/packages/components/src/LoadingGrey/LoadingGrey.tsx
@@ -9,11 +9,13 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 import styled from 'styled-components'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 export const LoadingGrey = styled.span<{
   width?: number
 }>`
-  background: ${({ theme }) => theme.colors.background};
+  background: ${lightColors['surface/page']};
   display: inline-block;
   height: 24px;
   width: ${({ width }) => (width ? `${width}%` : '100%')};

--- a/packages/components/src/LoadingGrey/LoadingGrey.tsx
+++ b/packages/components/src/LoadingGrey/LoadingGrey.tsx
@@ -9,7 +9,6 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 import styled from 'styled-components'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 export const LoadingGrey = styled.span<{

--- a/packages/components/src/LocationSearch/LocationSearch.tsx
+++ b/packages/components/src/LocationSearch/LocationSearch.tsx
@@ -10,6 +10,9 @@
  */
 import * as React from 'react'
 import styled from 'styled-components'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
+import { primitives } from '../primitives'
 import { Icon } from '../Icon'
 import { Button } from '../Button'
 import { InputError } from '../InputField/InputError'
@@ -43,27 +46,27 @@ const SearchTextInput = styled.input<{ error?: boolean; touched?: boolean }>`
   ${({ theme }) => theme.fonts.reg19};
   padding-left: 40px;
 
-  color: ${({ theme }) => theme.colors.copy};
-  background: ${({ theme }) => theme.colors.white};
+  color: ${lightColors['text/primary']};
+  background: ${lightColors['surface/default']};
   border: 1.5px solid
-    ${({ theme, error, touched }) =>
-      error && touched ? theme.colors.negative : theme.colors.copy};
+    ${({ error, touched }) =>
+      error && touched ? lightColors['feedback/negative'] : primitives.grey[900]};
 
   &:focus {
-    outline: 0.5px solid ${({ theme }) => theme.colors.grey600};
-    border: 1.5px solid ${({ theme }) => theme.colors.grey600};
-    box-shadow: 0 0 0px 4px ${({ theme }) => theme.colors.yellow};
+    outline: 0.5px solid ${primitives.grey[900]};
+    border: 1.5px solid ${primitives.grey[900]};
+    box-shadow: 0 0 0px 4px ${lightColors['feedback/focus']};
   }
 
   &:disabled {
-    color: ${({ theme }) => theme.colors.disabled};
-    border: 1.5px solid ${({ theme }) => theme.colors.disabled};
+    color: ${lightColors['text/disabled']};
+    border: 1.5px solid ${lightColors['text/disabled']};
     box-shadow: none;
   }
 `
 
 const DropDownWrapper = styled.ul`
-  background: ${({ theme }) => theme.colors.white};
+  background: ${lightColors['surface/raised']};
   box-shadow: 0px 2px 8px rgba(53, 67, 93, 0.54);
   border-radius: 4px;
   position: absolute;
@@ -80,18 +83,18 @@ const DropDownItem = styled.li`
   height: 40px;
   border-radius: 4px;
   margin-bottom: 2px;
-  background-color: ${({ theme }) => theme.colors.white};
+  background-color: ${lightColors['surface/raised']};
   padding: 8px 16px;
   white-space: nowrap;
   cursor: pointer;
   ${({ theme }) => theme.fonts.reg18};
-  color: ${({ theme }) => theme.colors.copy};
+  color: ${lightColors['text/primary']};
 
   &:hover {
-    background: ${({ theme }) => theme.colors.grey100};
+    background: ${lightColors['action/secondary']};
   }
   &:active {
-    background: ${({ theme }) => theme.colors.grey200};
+    background: ${lightColors['action/secondaryHover']};
   }
 `
 export interface ISearchLocation {

--- a/packages/components/src/LocationSearch/LocationSearch.tsx
+++ b/packages/components/src/LocationSearch/LocationSearch.tsx
@@ -10,7 +10,6 @@
  */
 import * as React from 'react'
 import styled from 'styled-components'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 import { Icon } from '../Icon'
 import { Button } from '../Button'

--- a/packages/components/src/LocationSearch/LocationSearch.tsx
+++ b/packages/components/src/LocationSearch/LocationSearch.tsx
@@ -12,7 +12,6 @@ import * as React from 'react'
 import styled from 'styled-components'
 // Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
-import { primitives } from '../primitives'
 import { Icon } from '../Icon'
 import { Button } from '../Button'
 import { InputError } from '../InputField/InputError'
@@ -50,11 +49,11 @@ const SearchTextInput = styled.input<{ error?: boolean; touched?: boolean }>`
   background: ${lightColors['surface/default']};
   border: 1.5px solid
     ${({ error, touched }) =>
-      error && touched ? lightColors['feedback/negative'] : primitives.grey[900]};
+      error && touched ? lightColors['feedback/negative'] : lightColors['border/emphasis']};
 
   &:focus {
-    outline: 0.5px solid ${primitives.grey[900]};
-    border: 1.5px solid ${primitives.grey[900]};
+    outline: 0.5px solid ${lightColors['border/emphasis']};
+    border: 1.5px solid ${lightColors['border/emphasis']};
     box-shadow: 0 0 0px 4px ${lightColors['feedback/focus']};
   }
 

--- a/packages/components/src/Modal/Modal.tsx
+++ b/packages/components/src/Modal/Modal.tsx
@@ -10,6 +10,8 @@
  */
 import React from 'react'
 import styled from 'styled-components'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 import { Cross } from '../icons'
 
 interface IProps {
@@ -37,16 +39,16 @@ const Backdrop = styled.div`
 const ModalContent = styled.div`
   width: 70%;
   border-radius: 2px;
-  background-color: ${({ theme }) => theme.colors.white};
+  background-color: ${lightColors['surface/raised']};
   padding: 50px;
-  color: ${({ theme }) => theme.colors.copy};
+  color: ${lightColors['text/primary']};
   text-align: center;
   ${({ theme }) => theme.fonts.reg18};
   position: relative;
 `
 
 const Heading = styled.h3`
-  color: ${({ theme }) => theme.colors.copy};
+  color: ${lightColors['text/primary']};
   text-align: center;
   margin-bottom: 24px;
   ${({ theme }) => theme.fonts.h4};

--- a/packages/components/src/Modal/Modal.tsx
+++ b/packages/components/src/Modal/Modal.tsx
@@ -10,7 +10,6 @@
  */
 import React from 'react'
 import styled from 'styled-components'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 import { Cross } from '../icons'
 

--- a/packages/components/src/PINKeypad/PINKeypad.tsx
+++ b/packages/components/src/PINKeypad/PINKeypad.tsx
@@ -10,7 +10,6 @@
  */
 import React, { useState, useRef, useEffect } from 'react'
 import styled from 'styled-components'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 interface IProps {

--- a/packages/components/src/PINKeypad/PINKeypad.tsx
+++ b/packages/components/src/PINKeypad/PINKeypad.tsx
@@ -10,6 +10,8 @@
  */
 import React, { useState, useRef, useEffect } from 'react'
 import styled from 'styled-components'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 interface IProps {
   id?: string
@@ -32,7 +34,7 @@ const StyledInput = styled.input`
 const DotFilled = styled.span`
   height: 18px;
   width: 18px;
-  background-color: ${({ theme }) => theme.colors.primary};
+  background-color: ${lightColors['action/primary']};
   border-radius: 50%;
   display: inline-block;
   margin: 0 8px;
@@ -41,7 +43,7 @@ const DotFilled = styled.span`
 const DotUnfilled = styled.span`
   height: 18px;
   width: 18px;
-  border: 2px solid ${({ theme }) => theme.colors.primary};
+  border: 2px solid ${lightColors['action/primary']};
   border-radius: 50%;
   display: inline-block;
   margin: 0 8px;

--- a/packages/components/src/PageWrapper/PageWrapper.tsx
+++ b/packages/components/src/PageWrapper/PageWrapper.tsx
@@ -10,7 +10,6 @@
  */
 import * as React from 'react'
 import styled from 'styled-components'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 const Page = styled.div`

--- a/packages/components/src/PageWrapper/PageWrapper.tsx
+++ b/packages/components/src/PageWrapper/PageWrapper.tsx
@@ -10,12 +10,14 @@
  */
 import * as React from 'react'
 import styled from 'styled-components'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 const Page = styled.div`
   display: flex;
   min-width: ${({ theme }) => theme.grid.minWidth}px;
   flex-direction: column;
-  background-color: ${({ theme }) => theme.colors.background};
+  background-color: ${lightColors['surface/page']};
   min-height: 100vh;
   ${({ theme }) => theme.fonts.reg16};
 `
@@ -29,7 +31,7 @@ const Content = styled.section`
   flex: 1;
   width: 100%;
   height: 100%;
-  color: ${({ theme }) => theme.colors.copy};
+  color: ${lightColors['text/primary']};
   ${({ theme }) => theme.fonts.reg16};
 `
 

--- a/packages/components/src/Pagination/Pagination.tsx
+++ b/packages/components/src/Pagination/Pagination.tsx
@@ -12,6 +12,8 @@ import * as React from 'react'
 import styled from 'styled-components'
 import { Button } from '../Button'
 import { Icon } from '../Icon'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 export type IPaginationVariant = 'small' | 'large' // small for desktop and large for mobile
 
@@ -71,8 +73,10 @@ const DotsButton = styled(Button)`
 const StyledPageNumber = styled.span<{ isCurrentPage: boolean; size?: string }>`
   ${({ theme, size }) =>
     size && size === 'large' ? theme.fonts.h4 : theme.fonts.bold12};
-  color: ${({ theme, isCurrentPage }) =>
-    isCurrentPage ? theme.colors.grey600 : theme.colors.grey400};
+  color: ${({ isCurrentPage }) =>
+    isCurrentPage
+      ? lightColors['text/primary']
+      : lightColors['text/disabled']};
 `
 export const Pagination = ({
   totalPages,

--- a/packages/components/src/Pagination/Pagination.tsx
+++ b/packages/components/src/Pagination/Pagination.tsx
@@ -12,7 +12,6 @@ import * as React from 'react'
 import styled from 'styled-components'
 import { Button } from '../Button'
 import { Icon } from '../Icon'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 export type IPaginationVariant = 'small' | 'large' // small for desktop and large for mobile

--- a/packages/components/src/Pill/Pill.tsx
+++ b/packages/components/src/Pill/Pill.tsx
@@ -11,6 +11,9 @@
 import React from 'react'
 import styled from 'styled-components'
 import { IFont } from '../fonts'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
+import { primitives } from '../primitives'
 
 type IPillType = 'active' | 'inactive' | 'pending' | 'default'
 
@@ -40,25 +43,25 @@ const StyledPill = styled.span<{
   type: IPillType
   pillTheme: IPillTheme
 }>`
-  --lighterShade: ${({ type, theme }) => `
-    ${type === 'active' ? theme.colors.greenLight : ''}
-    ${type === 'inactive' ? theme.colors.redLight : ''}
-    ${type === 'pending' ? theme.colors.orangeLight : ''}
-    ${type === 'default' ? theme.colors.primaryLight : ''}
+  --lighterShade: ${({ type }) => `
+    ${type === 'active' ? lightColors['feedback/positiveSubtle'] : ''}
+    ${type === 'inactive' ? lightColors['feedback/negativeSubtle'] : ''}
+    ${type === 'pending' ? lightColors['feedback/warningSubtle'] : ''}
+    ${type === 'default' ? lightColors['feedback/infoSubtle'] : ''}
   `};
 
-  --mediumShade: ${({ type, theme }) => `
-  ${type === 'active' ? theme.colors.green : ''}
-  ${type === 'inactive' ? theme.colors.red : ''}
-  ${type === 'pending' ? theme.colors.orange : ''}
-  ${type === 'default' ? theme.colors.primary : ''}
+  --mediumShade: ${({ type }) => `
+  ${type === 'active' ? lightColors['feedback/positive'] : ''}
+  ${type === 'inactive' ? lightColors['feedback/negative'] : ''}
+  ${type === 'pending' ? lightColors['feedback/warning'] : ''}
+  ${type === 'default' ? lightColors['feedback/info'] : ''}
 `};
 
-  --darkerShade: ${({ type, theme }) => `
-  ${type === 'active' ? theme.colors.greenDark : ''}
-  ${type === 'inactive' ? theme.colors.redDark : ''}
-  ${type === 'pending' ? theme.colors.orangeDark : ''}
-  ${type === 'default' ? theme.colors.primaryDark : ''}
+  --darkerShade: ${({ type }) => `
+  ${type === 'active' ? primitives.green[800] : ''}
+  ${type === 'inactive' ? primitives.red[800] : ''}
+  ${type === 'pending' ? primitives.orange[800] : ''}
+  ${type === 'default' ? primitives.blue[800] : ''}
 `};
 
   ${({ pillTheme }) =>

--- a/packages/components/src/Pill/Pill.tsx
+++ b/packages/components/src/Pill/Pill.tsx
@@ -11,7 +11,6 @@
 import React from 'react'
 import styled from 'styled-components'
 import { IFont } from '../fonts'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 type IPillType = 'active' | 'inactive' | 'pending' | 'default'

--- a/packages/components/src/Pill/Pill.tsx
+++ b/packages/components/src/Pill/Pill.tsx
@@ -13,7 +13,6 @@ import styled from 'styled-components'
 import { IFont } from '../fonts'
 // Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
-import { primitives } from '../primitives'
 
 type IPillType = 'active' | 'inactive' | 'pending' | 'default'
 
@@ -58,10 +57,10 @@ const StyledPill = styled.span<{
 `};
 
   --darkerShade: ${({ type }) => `
-  ${type === 'active' ? primitives.green[800] : ''}
-  ${type === 'inactive' ? primitives.red[800] : ''}
-  ${type === 'pending' ? primitives.orange[800] : ''}
-  ${type === 'default' ? primitives.blue[800] : ''}
+  ${type === 'active' ? lightColors['feedback/positive'] : ''}
+  ${type === 'inactive' ? lightColors['feedback/negative'] : ''}
+  ${type === 'pending' ? lightColors['feedback/warning'] : ''}
+  ${type === 'default' ? lightColors['feedback/info'] : ''}
 `};
 
   ${({ pillTheme }) =>

--- a/packages/components/src/ProgressBar/ProgressBar.tsx
+++ b/packages/components/src/ProgressBar/ProgressBar.tsx
@@ -11,7 +11,6 @@
 import * as React from 'react'
 import styled from 'styled-components'
 import { Line } from 'rc-progress'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 const HeaderWrapper = styled.div`

--- a/packages/components/src/ProgressBar/ProgressBar.tsx
+++ b/packages/components/src/ProgressBar/ProgressBar.tsx
@@ -11,6 +11,8 @@
 import * as React from 'react'
 import styled from 'styled-components'
 import { Line } from 'rc-progress'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 const HeaderWrapper = styled.div`
   display: flex;
@@ -21,8 +23,8 @@ const HeaderWrapper = styled.div`
 const TitleLink = styled.div<{ disabled?: boolean }>`
   ${({ disabled }) => (disabled ? '' : 'cursor: pointer;')};
   ${({ theme }) => theme.fonts.reg16};
-  color: ${({ theme, disabled }) =>
-    disabled ? theme.colors.copy : theme.colors.primary};
+  color: ${({ disabled }) =>
+    disabled ? lightColors['text/primary'] : lightColors['text/link']};
   ${({ disabled }) => (disabled ? '' : 'text-decoration: underline')};
 `
 const ValueHolder = styled.div`
@@ -32,12 +34,12 @@ const Value = styled.span`
   ${({ theme }) => theme.fonts.bold16};
 `
 const Percentage = styled.span`
-  color: ${({ theme }) => theme.colors.grey400};
+  color: ${lightColors['text/disabled']};
 `
 const LoaderBox = styled.span<{
   width?: number
 }>`
-  background: ${({ theme }) => theme.colors.background};
+  background: ${lightColors['surface/page']};
   display: inline-block;
   height: 24px;
   width: ${({ width }) => (width ? `${width}%` : '100%')};

--- a/packages/components/src/Radio/Radio.tsx
+++ b/packages/components/src/Radio/Radio.tsx
@@ -10,6 +10,8 @@
  */
 import * as React from 'react'
 import styled from 'styled-components'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 const Wrapper = styled.li`
   padding-top: 5px;
@@ -21,14 +23,14 @@ const Label = styled.label`
   position: relative;
   left: 6px;
   top: -2px;
-  color: ${({ theme }) => theme.colors.copy};
+  color: ${lightColors['text/primary']};
   ${({ theme }) => theme.fonts.reg16};
   cursor: pointer;
 `
 
 const Check = styled.span`
   display: inline-block;
-  background: ${({ theme }) => theme.colors.primary};
+  background: ${lightColors['action/primary']};
   border-radius: 50%;
   height: 22px;
   width: 22px;
@@ -40,7 +42,7 @@ const Check = styled.span`
     display: block;
     position: relative;
     content: '';
-    background: ${({ theme }) => theme.colors.white};
+    background: ${lightColors['surface/default']};
     border-radius: 50%;
     height: 14px;
     width: 14px;
@@ -54,7 +56,7 @@ const Check = styled.span`
     display: block;
     position: relative;
     content: '';
-    background: ${({ theme }) => theme.colors.white};
+    background: ${lightColors['surface/default']};
     border-radius: 50%;
     height: 18px;
     width: 18px;
@@ -75,7 +77,7 @@ const Input = styled.input`
   /* stylelint-disable */
   &:checked ~ ${Check}::after {
     /* stylelint-enable */
-    background: ${({ theme }) => theme.colors.primary};
+    background: ${lightColors['action/primary']};
   }
 `
 

--- a/packages/components/src/Radio/Radio.tsx
+++ b/packages/components/src/Radio/Radio.tsx
@@ -10,7 +10,6 @@
  */
 import * as React from 'react'
 import styled from 'styled-components'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 const Wrapper = styled.li`

--- a/packages/components/src/Radio/RadioButton.tsx
+++ b/packages/components/src/Radio/RadioButton.tsx
@@ -11,7 +11,6 @@
 import * as React from 'react'
 import styled from 'styled-components'
 import { Icon } from '../Icon'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 const Label = styled.label<{ disabled?: boolean }>`

--- a/packages/components/src/Radio/RadioButton.tsx
+++ b/packages/components/src/Radio/RadioButton.tsx
@@ -13,7 +13,6 @@ import styled from 'styled-components'
 import { Icon } from '../Icon'
 // Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
-import { primitives } from '../primitives'
 
 const Label = styled.label<{ disabled?: boolean }>`
   display: flex;
@@ -99,7 +98,7 @@ const Input = styled.input`
 
   &:active ~ ${Radio} {
     &::after {
-      border: 1.5px solid ${primitives.grey[900]};
+      border: 1.5px solid ${lightColors['border/emphasis']};
       box-shadow: ${lightColors['feedback/focus']} 0 0 0 3px;
       width: ${({ size }) => `max(21px, ${(size ?? 0) - 6}px)`};
       height: ${({ size }) => `max(21px, ${(size ?? 0) - 6}px)`};
@@ -116,7 +115,7 @@ const Input = styled.input`
   &:focus ~ ${Radio} {
     &::after {
       box-sizing: content-box;
-      border: 1.5px solid ${primitives.grey[900]};
+      border: 1.5px solid ${lightColors['border/emphasis']};
       box-shadow: ${lightColors['feedback/focus']} 0 0 0 3px;
       width: ${({ size }) => `max(21px, ${(size ?? 0) - 6}px)`};
       height: ${({ size }) => `max(21px, ${(size ?? 0) - 6}px)`};

--- a/packages/components/src/Radio/RadioButton.tsx
+++ b/packages/components/src/Radio/RadioButton.tsx
@@ -11,6 +11,9 @@
 import * as React from 'react'
 import styled from 'styled-components'
 import { Icon } from '../Icon'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
+import { primitives } from '../primitives'
 
 const Label = styled.label<{ disabled?: boolean }>`
   display: flex;
@@ -21,15 +24,15 @@ const Label = styled.label<{ disabled?: boolean }>`
   padding: 8px 8px;
   align-items: center;
   isolation: isolate;
-  color: ${({ theme, disabled }) =>
-    disabled ? theme.colors.disabled : theme.colors.copy};
+  color: ${({ disabled }) =>
+    disabled ? lightColors['text/disabled'] : lightColors['text/primary']};
   ${({ theme }) => theme.fonts.h4};
   cursor: pointer;
   &:hover {
-    background: ${({ theme }) => theme.colors.grey100};
+    background: ${lightColors['action/secondary']};
   }
   &:active {
-    background: ${({ theme }) => theme.colors.grey200};
+    background: ${lightColors['action/secondaryHover']};
   }
 `
 
@@ -39,10 +42,10 @@ const Radio = styled.span<{
 }>`
   display: inline-block;
   border-radius: 100%;
-  background: ${({ theme, disabled }) =>
-    disabled ? theme.colors.disabled : theme.colors.copy};
-  color: ${({ theme, disabled }) =>
-    disabled ? theme.colors.disabled : theme.colors.copy};
+  background: ${({ disabled }) =>
+    disabled ? lightColors['action/disabled'] : lightColors['text/primary']};
+  color: ${({ disabled }) =>
+    disabled ? lightColors['text/disabled'] : lightColors['text/primary']};
   ${({ size }) =>
     size === 'large'
       ? `height: 40px;
@@ -55,7 +58,7 @@ const Radio = styled.span<{
   &::after {
     position: absolute;
     content: '';
-    background: ${({ theme }) => theme.colors.white};
+    background: ${lightColors['surface/default']};
     ${({ size }) =>
       size === 'large'
         ? `height: 37px;
@@ -96,8 +99,8 @@ const Input = styled.input`
 
   &:active ~ ${Radio} {
     &::after {
-      border: 1.5px solid ${({ theme }) => theme.colors.grey600};
-      box-shadow: ${({ theme }) => theme.colors.yellow} 0 0 0 3px;
+      border: 1.5px solid ${primitives.grey[900]};
+      box-shadow: ${lightColors['feedback/focus']} 0 0 0 3px;
       width: ${({ size }) => `max(21px, ${(size ?? 0) - 6}px)`};
       height: ${({ size }) => `max(21px, ${(size ?? 0) - 6}px)`};
     }
@@ -113,8 +116,8 @@ const Input = styled.input`
   &:focus ~ ${Radio} {
     &::after {
       box-sizing: content-box;
-      border: 1.5px solid ${({ theme }) => theme.colors.grey600};
-      box-shadow: ${({ theme }) => theme.colors.yellow} 0 0 0 3px;
+      border: 1.5px solid ${primitives.grey[900]};
+      box-shadow: ${lightColors['feedback/focus']} 0 0 0 3px;
       width: ${({ size }) => `max(21px, ${(size ?? 0) - 6}px)`};
       height: ${({ size }) => `max(21px, ${(size ?? 0) - 6}px)`};
     }

--- a/packages/components/src/Radio/RadioGroup.tsx
+++ b/packages/components/src/Radio/RadioGroup.tsx
@@ -13,6 +13,8 @@ import { RadioButton } from './RadioButton'
 import { NoticeWrapper } from '../DateField'
 import { InputLabel } from '../InputField/InputLabel'
 import styled from 'styled-components'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 const Wrapper = styled.div`
   width: 100%;
@@ -49,7 +51,7 @@ const LargeList = styled.ul<{ flexDirection?: string }>`
 const NestedChildren = styled.div`
   margin: 15px 0px 0px 18px;
   padding-left: 33px;
-  border-left: 4px solid ${({ theme }) => theme.colors.copy};
+  border-left: 4px solid ${lightColors['text/primary']};
   padding-top: 0px !important;
 `
 

--- a/packages/components/src/Radio/RadioGroup.tsx
+++ b/packages/components/src/Radio/RadioGroup.tsx
@@ -13,7 +13,6 @@ import { RadioButton } from './RadioButton'
 import { NoticeWrapper } from '../DateField'
 import { InputLabel } from '../InputField/InputLabel'
 import styled from 'styled-components'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 const Wrapper = styled.div`

--- a/packages/components/src/SearchTool/SearchTool.tsx
+++ b/packages/components/src/SearchTool/SearchTool.tsx
@@ -13,7 +13,6 @@ import { ClearText } from '../icons'
 import { Button } from '../Button'
 import { Icon } from '../Icon'
 import styled from 'styled-components'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 type SearchCriterias =

--- a/packages/components/src/SearchTool/SearchTool.tsx
+++ b/packages/components/src/SearchTool/SearchTool.tsx
@@ -13,6 +13,9 @@ import { ClearText } from '../icons'
 import { Button } from '../Button'
 import { Icon } from '../Icon'
 import styled from 'styled-components'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
+import { primitives } from '../primitives'
 
 type SearchCriterias =
   | 'TRACKING_ID'
@@ -23,28 +26,28 @@ type SearchCriterias =
   | 'EMAIL'
 
 const SearchBox = styled.div`
-  background: ${({ theme }) => theme.colors.grey100};
+  background: ${lightColors['surface/sunken']};
   box-sizing: border-box;
   width: 664px;
   height: 40px;
   border-radius: 40px;
 
   &:hover {
-    outline: 1px solid ${({ theme }) => theme.colors.grey400};
-    background: ${({ theme }) => theme.colors.grey100};
+    outline: 1px solid ${lightColors['border/strong']};
+    background: ${lightColors['surface/sunken']};
   }
 
   &:focus-within {
-    outline: 2px solid ${({ theme }) => theme.colors.grey600};
-    background: ${({ theme }) => theme.colors.white};
+    outline: 2px solid ${primitives.grey[900]};
+    background: ${lightColors['surface/default']};
   }
 
   &:active {
-    outline: 2px solid ${({ theme }) => theme.colors.grey600};
+    outline: 2px solid ${primitives.grey[900]};
   }
 
   &:focus-within input {
-    background: ${({ theme }) => theme.colors.white};
+    background: ${lightColors['surface/default']};
   }
 
   @media (max-width: ${({ theme }) => theme.grid.breakpoints.xl}px) {
@@ -62,7 +65,7 @@ const Wrapper = styled.form`
   border-radius: 2px;
   display: flex;
   ${({ theme }) => theme.fonts.bold14};
-  color: ${({ theme }) => theme.colors.primary};
+  color: ${lightColors['text/link']};
   padding: 0px 8px 0px 4px;
   position: relative;
 `
@@ -74,7 +77,7 @@ const SearchInput = styled.input`
   flex-grow: 1;
   &:focus {
     outline: none;
-    background-color: ${({ theme }) => theme.colors.white};
+    background-color: ${lightColors['surface/default']};
   }
 
   @media (max-width: ${({ theme }) => theme.grid.breakpoints.md}px) {
@@ -86,14 +89,14 @@ export const LabelButton = styled(Button)`
   width: auto;
   height: auto;
   border-radius: 2px;
-  color: ${({ theme }) => theme.colors.primary};
+  color: ${lightColors['text/link']};
   ${({ theme }) => theme.fonts.bold14};
 `
 
 const DropDownWrapper = styled.ul`
-  background: ${({ theme }) => theme.colors.white};
+  background: ${lightColors['surface/raised']};
   border-radius: 4px;
-  border: 1px solid ${({ theme }) => theme.colors.grey300};
+  border: 1px solid ${lightColors['border/strong']};
   ${({ theme }) => theme.shadows.light};
   position: absolute;
   padding: 6px 0;
@@ -108,7 +111,7 @@ const DropDownWrapper = styled.ul`
 
 const DropDownItem = styled.li`
   ${({ theme }) => theme.fonts.bold14};
-  color: ${({ theme }) => theme.colors.grey500};
+  color: ${lightColors['text/tertiary']};
   display: flex;
   align-items: center;
   gap: 8px;
@@ -117,16 +120,16 @@ const DropDownItem = styled.li`
   border-radius: 4px;
   padding: 8px 12px;
   &:hover {
-    color: ${({ theme }) => theme.colors.grey600};
-    background: ${({ theme }) => theme.colors.grey100};
+    color: ${lightColors['text/primary']};
+    background: ${lightColors['action/secondary']};
   }
   &:active {
-    color: ${({ theme }) => theme.colors.grey600};
-    background: ${({ theme }) => theme.colors.grey200};
+    color: ${lightColors['text/primary']};
+    background: ${lightColors['action/secondaryHover']};
   }
 
   &:focus-visible {
-    background-color: ${({ theme }) => theme.colors.yellow};
+    background-color: ${lightColors['feedback/focus']};
   }
 `
 
@@ -136,7 +139,7 @@ const AdvancedSearchWrapper = styled.div`
   flex-flow: column nowrap;
   align-items: stretch;
   margin-top: 6px;
-  border-top: 1px solid ${({ theme }) => theme.colors.grey300};
+  border-top: 1px solid ${lightColors['border/strong']};
   padding: 6px;
   padding-bottom: 0;
 `

--- a/packages/components/src/SearchTool/SearchTool.tsx
+++ b/packages/components/src/SearchTool/SearchTool.tsx
@@ -15,7 +15,6 @@ import { Icon } from '../Icon'
 import styled from 'styled-components'
 // Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
-import { primitives } from '../primitives'
 
 type SearchCriterias =
   | 'TRACKING_ID'
@@ -26,7 +25,7 @@ type SearchCriterias =
   | 'EMAIL'
 
 const SearchBox = styled.div`
-  background: ${lightColors['surface/sunken']};
+  background: ${lightColors['surface/inset']};
   box-sizing: border-box;
   width: 664px;
   height: 40px;
@@ -34,16 +33,16 @@ const SearchBox = styled.div`
 
   &:hover {
     outline: 1px solid ${lightColors['border/strong']};
-    background: ${lightColors['surface/sunken']};
+    background: ${lightColors['surface/inset']};
   }
 
   &:focus-within {
-    outline: 2px solid ${primitives.grey[900]};
+    outline: 2px solid ${lightColors['border/emphasis']};
     background: ${lightColors['surface/default']};
   }
 
   &:active {
-    outline: 2px solid ${primitives.grey[900]};
+    outline: 2px solid ${lightColors['border/emphasis']};
   }
 
   &:focus-within input {

--- a/packages/components/src/Select/Select.tsx
+++ b/packages/components/src/Select/Select.tsx
@@ -15,7 +15,6 @@ import { Props } from 'react-select/lib/Select'
 import { Icon } from '../Icon'
 // Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
-import { primitives } from '../primitives'
 
 import { IndicatorProps } from 'react-select/lib/components/indicators'
 
@@ -80,8 +79,8 @@ const StyledSelect = styled(ReactSelect)<IStyledSelectProps>`
               : lightColors['text/primary']};
     }
     &:focus {
-      outline: 0.5px solid ${primitives.grey[900]};
-      border: 1.5px solid ${primitives.grey[900]};
+      outline: 0.5px solid ${lightColors['border/emphasis']};
+      border: 1.5px solid ${lightColors['border/emphasis']};
       color: ${lightColors['text/primary']};
     }
   }
@@ -95,8 +94,8 @@ const StyledSelect = styled(ReactSelect)<IStyledSelectProps>`
   }
 
   .react-select__control--is-focused {
-    outline: 0.5px solid ${primitives.grey[900]};
-    border: 1.5px solid ${primitives.grey[900]};
+    outline: 0.5px solid ${lightColors['border/emphasis']};
+    border: 1.5px solid ${lightColors['border/emphasis']};
     box-shadow: 0 0 0 4px ${lightColors['feedback/focus']};
   }
 
@@ -124,7 +123,7 @@ const StyledSelect = styled(ReactSelect)<IStyledSelectProps>`
     background-color: ${lightColors['surface/hover']};
     color: ${lightColors['text/primary']};
     &:active {
-      background: ${lightColors['surface/sunken']};
+      background: ${lightColors['surface/inset']};
       color: ${lightColors['text/primary']};
     }
   }

--- a/packages/components/src/Select/Select.tsx
+++ b/packages/components/src/Select/Select.tsx
@@ -13,6 +13,9 @@ import { default as ReactSelect, components } from 'react-select'
 import styled from 'styled-components'
 import { Props } from 'react-select/lib/Select'
 import { Icon } from '../Icon'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
+import { primitives } from '../primitives'
 
 import { IndicatorProps } from 'react-select/lib/components/indicators'
 
@@ -43,48 +46,48 @@ const DropdownIndicator = (props: IndicatorProps<ISelectOption>) => {
 const StyledSelect = styled(ReactSelect)<IStyledSelectProps>`
   width: 100%;
   ${({ theme }) => theme.fonts.reg19};
-  background: ${({ theme }) => theme.colors.white};
-  color: ${({ theme }) => theme.colors.grey600};
+  background: ${lightColors['surface/default']};
+  color: ${lightColors['text/primary']};
   border-radius: 4px;
   &:hover {
-    box-shadow: 0 0 0 4px ${({ theme }) => theme.colors.grey200};
+    box-shadow: 0 0 0 4px ${lightColors['border/default']};
   }
 
   .react-select__control {
     height: 48px;
     cursor: pointer;
     border: 1.5px solid
-      ${({ error, touched, disabled, theme }) =>
+      ${({ error, touched, disabled }) =>
         error && touched
-          ? theme.colors.negative
+          ? lightColors['feedback/negative']
           : disabled
-            ? theme.colors.grey300
-            : theme.colors.copy};
+            ? lightColors['border/strong']
+            : lightColors['text/primary']};
     &:hover {
       border: 1.5px solid
-        ${({ error, touched, disabled, theme }) =>
+        ${({ error, touched, disabled }) =>
           error && touched
-            ? theme.colors.negative
+            ? lightColors['feedback/negative']
             : disabled
-              ? theme.colors.grey300
-              : theme.colors.copy};
+              ? lightColors['border/strong']
+              : lightColors['text/primary']};
       outline: 0.5px solid
-        ${({ error, touched, disabled, theme }) =>
+        ${({ error, touched, disabled }) =>
           error && touched
-            ? theme.colors.negative
+            ? lightColors['feedback/negative']
             : disabled
-              ? theme.colors.grey300
-              : theme.colors.copy};
+              ? lightColors['border/strong']
+              : lightColors['text/primary']};
     }
     &:focus {
-      outline: 0.5px solid ${({ theme }) => theme.colors.grey600};
-      border: 1.5px solid ${({ theme }) => theme.colors.grey600};
-      color: ${({ theme }) => theme.colors.grey600};
+      outline: 0.5px solid ${primitives.grey[900]};
+      border: 1.5px solid ${primitives.grey[900]};
+      color: ${lightColors['text/primary']};
     }
   }
 
   .react-select__placeholder {
-    color: ${({ theme }) => theme.colors.grey400};
+    color: ${lightColors['text/disabled']};
   }
 
   .react-select__indicator-separator {
@@ -92,17 +95,17 @@ const StyledSelect = styled(ReactSelect)<IStyledSelectProps>`
   }
 
   .react-select__control--is-focused {
-    outline: 0.5px solid ${({ theme }) => theme.colors.grey600};
-    border: 1.5px solid ${({ theme }) => theme.colors.grey600};
-    box-shadow: 0 0 0 4px ${({ theme }) => theme.colors.yellow};
+    outline: 0.5px solid ${primitives.grey[900]};
+    border: 1.5px solid ${primitives.grey[900]};
+    box-shadow: 0 0 0 4px ${lightColors['feedback/focus']};
   }
 
   .react-select__control--is-active {
-    box-shadow: 0 0 0 4px ${({ theme }) => theme.colors.yellow};
+    box-shadow: 0 0 0 4px ${lightColors['feedback/focus']};
   }
 
   .react-select__control--is-disabled {
-    background-color: ${({ theme }) => theme.colors.white};
+    background-color: ${lightColors['surface/default']};
   }
 
   .react-select__value-container {
@@ -114,28 +117,28 @@ const StyledSelect = styled(ReactSelect)<IStyledSelectProps>`
     border-radius: 4px;
     padding: 10px 16px;
     ${({ theme }) => theme.fonts.reg18};
-    background-color: ${({ theme }) => theme.colors.white};
+    background-color: ${lightColors['surface/default']};
   }
 
   .react-select__option--is-focused {
-    background-color: ${({ theme }) => theme.colors.grey50};
-    color: ${({ theme }) => theme.colors.copy};
+    background-color: ${lightColors['surface/hover']};
+    color: ${lightColors['text/primary']};
     &:active {
-      background: ${({ theme }) => theme.colors.grey100};
-      color: ${({ theme }) => theme.colors.copy};
+      background: ${lightColors['surface/sunken']};
+      color: ${lightColors['text/primary']};
     }
   }
   .react-select__option--is-selected {
-    background-color: ${({ theme }) => theme.colors.grey200};
-    color: ${({ theme }) => theme.colors.copy};
+    background-color: ${lightColors['action/secondaryHover']};
+    color: ${lightColors['text/primary']};
     &:active {
-      background: ${({ theme }) => theme.colors.grey200};
-      color: ${({ theme }) => theme.colors.copy};
+      background: ${lightColors['action/secondaryHover']};
+      color: ${lightColors['text/primary']};
     }
   }
 
   .react-select__single-value--is-disabled {
-    color: ${({ theme }) => theme.colors.grey500};
+    color: ${lightColors['text/tertiary']};
   }
 
   .react-select__menu {

--- a/packages/components/src/Select/Select.tsx
+++ b/packages/components/src/Select/Select.tsx
@@ -13,7 +13,6 @@ import { default as ReactSelect, components } from 'react-select'
 import styled from 'styled-components'
 import { Props } from 'react-select/lib/Select'
 import { Icon } from '../Icon'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 import { IndicatorProps } from 'react-select/lib/components/indicators'

--- a/packages/components/src/Select/Select2.tsx
+++ b/packages/components/src/Select/Select2.tsx
@@ -51,7 +51,7 @@ const StyledSelect = styled(ReactSelect)<{
     border: 2px solid ${lightColors['action/primary']};
     &:hover {
       border: 2px solid ${lightColors['action/primary']};
-      background-color: ${lightColors['surface/sunken']};
+      background-color: ${lightColors['surface/inset']};
     }
   }
 
@@ -74,7 +74,7 @@ const StyledSelect = styled(ReactSelect)<{
   }
 
   .react-select__option--is-focused {
-    background-color: ${lightColors['surface/sunken']};
+    background-color: ${lightColors['surface/inset']};
     color: ${lightColors['text/primary']};
     &:active {
       background: ${lightColors['action/secondaryHover']};

--- a/packages/components/src/Select/Select2.tsx
+++ b/packages/components/src/Select/Select2.tsx
@@ -13,6 +13,8 @@ import ReactSelect, { components } from 'react-select'
 import styled from 'styled-components'
 import { IndicatorProps } from 'react-select/lib/components/indicators'
 import { ArrowDownBlue } from '../icons'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 export interface ISelect2Option {
   value: string
@@ -40,21 +42,21 @@ const StyledSelect = styled(ReactSelect)<{
   .react-select__control {
     ${({ defaultWidth }) =>
       defaultWidth ? `min-width: ${defaultWidth}px` : 'min-width: 240px'};
-    background-color: ${({ theme }) => theme.colors.white};
+    background-color: ${lightColors['surface/default']};
     justify-content: center;
     min-height: 32px;
     max-height: 32px;
     ${({ theme }) => theme.fonts.bold14};
     text-transform: none;
-    border: 2px solid ${({ theme }) => theme.colors.primary};
+    border: 2px solid ${lightColors['action/primary']};
     &:hover {
-      border: 2px solid ${({ theme }) => theme.colors.primary};
-      background-color: ${({ theme }) => theme.colors.grey100};
+      border: 2px solid ${lightColors['action/primary']};
+      background-color: ${lightColors['surface/sunken']};
     }
   }
 
   .react-select__control--is-focused {
-    box-shadow: 0 0 0px 3px ${({ theme }) => theme.colors.yellow};
+    box-shadow: 0 0 0px 3px ${lightColors['feedback/focus']};
   }
 
   .react-select__indicator-separator {
@@ -68,29 +70,29 @@ const StyledSelect = styled(ReactSelect)<{
   }
 
   .react-select__option {
-    background-color: ${({ theme }) => theme.colors.white};
+    background-color: ${lightColors['surface/default']};
   }
 
   .react-select__option--is-focused {
-    background-color: ${({ theme }) => theme.colors.grey100};
-    color: ${({ theme }) => theme.colors.copy};
+    background-color: ${lightColors['surface/sunken']};
+    color: ${lightColors['text/primary']};
     &:active {
-      background: ${({ theme }) => theme.colors.grey200};
-      color: ${({ theme }) => theme.colors.copy};
+      background: ${lightColors['action/secondaryHover']};
+      color: ${lightColors['text/primary']};
     }
   }
 
   .react-select__option--is-selected {
-    background-color: ${({ theme }) => theme.colors.primary};
-    color: ${({ theme }) => theme.colors.white};
+    background-color: ${lightColors['action/primary']};
+    color: ${lightColors['text/onAction']};
     &:active {
-      background: ${({ theme }) => theme.colors.primaryDark};
-      color: ${({ theme }) => theme.colors.white};
+      background: ${lightColors['action/primaryHover']};
+      color: ${lightColors['text/onAction']};
     }
   }
 
   .react-select__single-value {
-    color: ${({ theme }) => theme.colors.primary};
+    color: ${lightColors['text/link']};
   }
 `
 

--- a/packages/components/src/Select/Select2.tsx
+++ b/packages/components/src/Select/Select2.tsx
@@ -13,7 +13,6 @@ import ReactSelect, { components } from 'react-select'
 import styled from 'styled-components'
 import { IndicatorProps } from 'react-select/lib/components/indicators'
 import { ArrowDownBlue } from '../icons'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 export interface ISelect2Option {

--- a/packages/components/src/SideNavigation/ConnectionStatus.tsx
+++ b/packages/components/src/SideNavigation/ConnectionStatus.tsx
@@ -10,6 +10,8 @@
  */
 import React from 'react'
 import styled from 'styled-components'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 interface ConnectionStatusProps {
   isOnline?: boolean
@@ -20,14 +22,16 @@ const Dot = styled.span<{ isOnline: boolean }>`
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  background-color: ${({ isOnline, theme }) =>
-    isOnline ? theme.colors.green : theme.colors.red};
+  background-color: ${({ isOnline }) =>
+    isOnline
+      ? lightColors['feedback/positive']
+      : lightColors['feedback/negative']};
   margin-right: 4px;
 `
 
 const Label = styled.span`
   ${({ theme }) => theme.fonts.reg12};
-  color: ${({ theme }) => theme.colors.grey500};
+  color: ${lightColors['text/tertiary']};
 `
 
 const Container = styled.div`

--- a/packages/components/src/SideNavigation/ConnectionStatus.tsx
+++ b/packages/components/src/SideNavigation/ConnectionStatus.tsx
@@ -10,7 +10,6 @@
  */
 import React from 'react'
 import styled from 'styled-components'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 interface ConnectionStatusProps {

--- a/packages/components/src/SideNavigation/LeftNavigation.tsx
+++ b/packages/components/src/SideNavigation/LeftNavigation.tsx
@@ -12,7 +12,6 @@
 import * as React from 'react'
 import styled from 'styled-components'
 import { ConnectionStatus } from './ConnectionStatus'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 export interface ILeftNavigationProps {

--- a/packages/components/src/SideNavigation/LeftNavigation.tsx
+++ b/packages/components/src/SideNavigation/LeftNavigation.tsx
@@ -12,6 +12,8 @@
 import * as React from 'react'
 import styled from 'styled-components'
 import { ConnectionStatus } from './ConnectionStatus'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 export interface ILeftNavigationProps {
   applicationName: string
@@ -37,18 +39,18 @@ const LeftNavigationContainer = styled.div<{
     navigationWidth ? navigationWidth : 282}px;
   height: 100vh;
   overflow-y: auto;
-  background-color: ${({ theme }) => theme.colors.white};
-  border-right: 1px solid ${({ theme }) => theme.colors.grey300};
+  background-color: ${lightColors['surface/default']};
+  border-right: 1px solid ${lightColors['border/strong']};
   @media (max-width: ${({ theme }) => theme.grid.breakpoints.lg}px) {
     ${({ navigationWidth }) => !navigationWidth && `display: none;`}
   }
 `
 const UserInfo = styled.div`
-  background: ${({ theme }) => theme.colors.white};
+  background: ${lightColors['surface/default']};
   padding: 32px 24px;
   text-align: justify;
   border: 0px;
-  border-bottom: 1px solid ${({ theme }) => theme.colors.grey300};
+  border-bottom: 1px solid ${lightColors['border/strong']};
   @media (min-width: ${({ theme }) => theme.grid.breakpoints.lg}px) {
     display: none;
   }
@@ -65,8 +67,8 @@ const Role = styled.p`
 const ApplicationNameContainer = styled.div`
   padding: 16px 20px;
   height: 56px;
-  background-color: ${({ theme }) => theme.colors.white};
-  border-bottom: 1px solid ${({ theme }) => theme.colors.grey300};
+  background-color: ${lightColors['surface/default']};
+  border-bottom: 1px solid ${lightColors['border/strong']};
   box-sizing: border-box;
   @media (max-width: ${({ theme }) => theme.grid.breakpoints.lg}px) {
     display: none;
@@ -80,10 +82,10 @@ const ApplicationName = styled.div`
 `
 
 const VersionCard = styled.div`
-  color: ${({ theme }) => theme.colors.grey400};
+  color: ${lightColors['text/disabled']};
   height: auto;
   padding: 16px;
-  background-color: ${({ theme }) => theme.colors.grey50};
+  background-color: ${lightColors['surface/page']};
   margin: 16px;
   border-radius: 8px;
   display: flex;
@@ -107,12 +109,12 @@ const MenuItem = styled.div`
 
 const VersionCardName = styled.span`
   ${({ theme }) => theme.fonts.bold12};
-  color: ${({ theme }) => theme.colors.grey600};
+  color: ${lightColors['text/primary']};
   display: block;
 `
 const UserDescription = styled.span`
   ${({ theme }) => theme.fonts.reg12};
-  color: ${({ theme }) => theme.colors.grey500};
+  color: ${lightColors['text/tertiary']};
 `
 
 export const LeftNavigation = (props: ILeftNavigationProps) => {

--- a/packages/components/src/SideNavigation/NavigationGroup.tsx
+++ b/packages/components/src/SideNavigation/NavigationGroup.tsx
@@ -11,7 +11,6 @@
 
 import * as React from 'react'
 import styled from 'styled-components'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 export interface INavigationGroup

--- a/packages/components/src/SideNavigation/NavigationGroup.tsx
+++ b/packages/components/src/SideNavigation/NavigationGroup.tsx
@@ -11,13 +11,15 @@
 
 import * as React from 'react'
 import styled from 'styled-components'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 export interface INavigationGroup
   extends React.HTMLAttributes<HTMLDivElement> {}
 
 const NavigationGroupContainer = styled.div`
   padding: 6px;
-  box-shadow: 0px 8px 2px -8px ${({ theme }) => theme.colors.grey300};
+  box-shadow: 0px 8px 2px -8px ${lightColors['border/strong']};
 `
 
 interface IProps {

--- a/packages/components/src/SideNavigation/NavigationItem.tsx
+++ b/packages/components/src/SideNavigation/NavigationItem.tsx
@@ -11,7 +11,6 @@
 
 import * as React from 'react'
 import styled from 'styled-components'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 export interface INavigationItemProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement> {

--- a/packages/components/src/SideNavigation/NavigationItem.tsx
+++ b/packages/components/src/SideNavigation/NavigationItem.tsx
@@ -11,6 +11,8 @@
 
 import * as React from 'react'
 import styled from 'styled-components'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 export interface INavigationItemProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   icon?: () => React.ReactNode
@@ -30,27 +32,29 @@ const ItemContainer = styled.button<{ isSelected?: boolean }>`
   outline: none;
   border-radius: 4px;
   padding: 0 8px;
-  background-color: ${({ theme, isSelected }) =>
-    isSelected ? theme.colors.grey100 : theme.colors.white};
+  background-color: ${({ isSelected }) =>
+    isSelected
+      ? lightColors['surface/sunken']
+      : lightColors['surface/default']};
   ${({ theme }) => theme.fonts.bold14};
-  color: ${({ theme, isSelected }) =>
-    isSelected ? theme.colors.copy : theme.colors.grey500};
+  color: ${({ isSelected }) =>
+    isSelected ? lightColors['text/primary'] : lightColors['text/tertiary']};
 
   &:hover {
-    background: ${({ theme }) => theme.colors.grey50};
-    color: ${({ theme }) => theme.colors.grey600};
+    background: ${lightColors['surface/hover']};
+    color: ${lightColors['text/primary']};
   }
 
   &:active {
-    background-color: ${({ theme }) => theme.colors.grey100};
-    color: ${({ theme }) => theme.colors.grey600};
+    background-color: ${lightColors['surface/sunken']};
+    color: ${lightColors['text/primary']};
   }
   &:focus-visible {
     ${({ theme }) => theme.fonts.bold14};
-    background-color: ${({ theme }) => theme.colors.yellow};
-    color: ${({ theme }) => theme.colors.grey600};
+    background-color: ${lightColors['feedback/focus']};
+    color: ${lightColors['text/primary']};
     svg {
-      color: ${({ theme }) => theme.colors.grey600};
+      color: ${lightColors['text/primary']};
     }
   }
 `

--- a/packages/components/src/SideNavigation/NavigationItem.tsx
+++ b/packages/components/src/SideNavigation/NavigationItem.tsx
@@ -34,7 +34,7 @@ const ItemContainer = styled.button<{ isSelected?: boolean }>`
   padding: 0 8px;
   background-color: ${({ isSelected }) =>
     isSelected
-      ? lightColors['surface/sunken']
+      ? lightColors['surface/inset']
       : lightColors['surface/default']};
   ${({ theme }) => theme.fonts.bold14};
   color: ${({ isSelected }) =>
@@ -46,7 +46,7 @@ const ItemContainer = styled.button<{ isSelected?: boolean }>`
   }
 
   &:active {
-    background-color: ${lightColors['surface/sunken']};
+    background-color: ${lightColors['surface/inset']};
     color: ${lightColors['text/primary']};
   }
   &:focus-visible {

--- a/packages/components/src/SideNavigation/NavigationSubItem.tsx
+++ b/packages/components/src/SideNavigation/NavigationSubItem.tsx
@@ -11,6 +11,8 @@
 
 import * as React from 'react'
 import styled from 'styled-components'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 export interface INavigationSubItemProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement> {
@@ -20,30 +22,30 @@ export interface INavigationSubItemProps
 
 export const SubItemContainer = styled.button<{ isSelected?: boolean }>`
   border: 0;
-  background-color: ${({ theme }) => theme.colors.white};
+  background-color: ${lightColors['surface/default']};
   outline: none;
   border-radius: 4px;
   cursor: pointer;
   width: 100%;
   min-height: 32px;
-  color: ${({ isSelected, theme }) =>
-    isSelected ? theme.colors.grey600 : theme.colors.grey500};
+  color: ${({ isSelected }) =>
+    isSelected ? lightColors['text/primary'] : lightColors['text/tertiary']};
   ${({ isSelected, theme }) =>
     isSelected ? theme.fonts.bold14 : theme.fonts.reg14};
   &:hover {
-    color: ${({ theme }) => theme.colors.grey600};
+    color: ${lightColors['text/primary']};
     ${({ theme }) => theme.fonts.bold14};
   }
 
   &:active {
-    color: ${({ theme }) => theme.colors.grey600};
+    color: ${lightColors['text/primary']};
     ${({ theme }) => theme.fonts.bold14};
   }
 
   &:focus-visible {
     ${({ theme }) => theme.fonts.bold14};
-    background-color: ${({ theme }) => theme.colors.yellow};
-    color: ${({ theme }) => theme.colors.grey600};
+    background-color: ${lightColors['feedback/focus']};
+    color: ${lightColors['text/primary']};
   }
 `
 

--- a/packages/components/src/SideNavigation/NavigationSubItem.tsx
+++ b/packages/components/src/SideNavigation/NavigationSubItem.tsx
@@ -11,7 +11,6 @@
 
 import * as React from 'react'
 import styled from 'styled-components'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 export interface INavigationSubItemProps

--- a/packages/components/src/Spinner/Spinner.tsx
+++ b/packages/components/src/Spinner/Spinner.tsx
@@ -10,6 +10,8 @@
  */
 import * as React from 'react'
 import styled from 'styled-components'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 export interface ISpinner extends React.HTMLAttributes<HTMLDivElement> {
   id: string
@@ -29,7 +31,7 @@ const StyledSpinner = styled.div<ISpinner>`
 
     & circle {
       stroke: ${({ baseColor }) =>
-        baseColor ? baseColor : ({ theme }) => theme.colors.primary};
+        baseColor ? baseColor : lightColors['action/primary']};
       stroke-linecap: round;
       animation: dash 1.5s ease-in-out infinite;
     }

--- a/packages/components/src/Spinner/Spinner.tsx
+++ b/packages/components/src/Spinner/Spinner.tsx
@@ -10,7 +10,6 @@
  */
 import * as React from 'react'
 import styled from 'styled-components'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 export interface ISpinner extends React.HTMLAttributes<HTMLDivElement> {

--- a/packages/components/src/SubSectionDivider/SubSectionDivider.tsx
+++ b/packages/components/src/SubSectionDivider/SubSectionDivider.tsx
@@ -10,7 +10,6 @@
  */
 import * as React from 'react'
 import styled from 'styled-components'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 const SubSectionWrapper = styled.div`

--- a/packages/components/src/SubSectionDivider/SubSectionDivider.tsx
+++ b/packages/components/src/SubSectionDivider/SubSectionDivider.tsx
@@ -10,23 +10,25 @@
  */
 import * as React from 'react'
 import styled from 'styled-components'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 const SubSectionWrapper = styled.div`
-  border-top: solid 1px ${({ theme }) => theme.colors.grey200};
+  border-top: solid 1px ${lightColors['border/default']};
   padding: 24px 0;
   flex-direction: row;
 `
 
 const Title = styled.div`
   ${({ theme }) => theme.fonts.h3};
-  color: ${({ theme }) => theme.colors.copy};
+  color: ${lightColors['text/primary']};
 `
 const Optional = styled.span<
   { disabled?: boolean } & React.LabelHTMLAttributes<HTMLLabelElement>
 >`
   ${({ theme }) => theme.fonts.reg18};
-  color: ${({ disabled, theme }) =>
-    disabled ? theme.colors.disabled : theme.colors.placeholderCopy};
+  color: ${({ disabled }) =>
+    disabled ? lightColors['text/disabled'] : lightColors['text/tertiary']};
   flex-grow: 0;
 `
 

--- a/packages/components/src/Summary/components/Row.tsx
+++ b/packages/components/src/Summary/components/Row.tsx
@@ -12,7 +12,8 @@
 import React from 'react'
 import styled from 'styled-components'
 import { Text } from '../../Text'
-import { colors } from '../../colors'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../../semantics'
 
 const RowContainer = styled.tr``
 
@@ -37,7 +38,7 @@ const LockedBox = styled.div`
   height: 24px;
   border-radius: 4px;
   cursor: not-allowed;
-  background-color: ${colors.grey200};
+  background-color: ${lightColors['action/disabled']};
 
   @media (max-width: ${({ theme }) => theme.grid.breakpoints.md}px) {
     width: 100%;

--- a/packages/components/src/Summary/components/Row.tsx
+++ b/packages/components/src/Summary/components/Row.tsx
@@ -12,7 +12,6 @@
 import React from 'react'
 import styled from 'styled-components'
 import { Text } from '../../Text'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../../semantics'
 
 const RowContainer = styled.tr``

--- a/packages/components/src/Table/Table.tsx
+++ b/packages/components/src/Table/Table.tsx
@@ -37,7 +37,7 @@ const TableHeader = styled.div<{
 }>`
   ${({ fixedWidth, totalWidth }) =>
     fixedWidth ? `width: ${fixedWidth}px;` : `width: ${totalWidth || 100}%;`}
-  background: ${lightColors['surface/sunken']};
+  background: ${lightColors['surface/inset']};
   padding: 10px 0px;
   display: flex;
   align-items: top;
@@ -113,7 +113,7 @@ const TableFooter = styled(RowWrapper)<{
     fixedWidth ? `width: ${fixedWidth}px;` : `width: ${totalWidth || 100}%;`}
   display: flex;
   align-items: top;
-  background: ${lightColors['surface/sunken']};
+  background: ${lightColors['surface/inset']};
   border-top: 2px solid ${lightColors['border/strong']};
   border-bottom: none;
   & span {

--- a/packages/components/src/Table/Table.tsx
+++ b/packages/components/src/Table/Table.tsx
@@ -17,6 +17,8 @@ import {
   ColumnContentAlignment
 } from '../Workqueue'
 import { Pagination } from '../Pagination'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 const Wrapper = styled.div<{
   fixedWidth: number | undefined
@@ -27,7 +29,7 @@ const Wrapper = styled.div<{
   @media (max-width: ${({ fixedWidth }) => fixedWidth}px) {
     width: 100%;
   }
-  background: ${({ theme }) => theme.colors.white};
+  background: ${lightColors['surface/default']};
 `
 const TableHeader = styled.div<{
   totalWidth?: number
@@ -35,11 +37,11 @@ const TableHeader = styled.div<{
 }>`
   ${({ fixedWidth, totalWidth }) =>
     fixedWidth ? `width: ${fixedWidth}px;` : `width: ${totalWidth || 100}%;`}
-  background: ${({ theme }) => theme.colors.grey100};
+  background: ${lightColors['surface/sunken']};
   padding: 10px 0px;
   display: flex;
   align-items: top;
-  border-bottom: 1px solid ${({ theme }) => theme.colors.grey300};
+  border-bottom: 1px solid ${lightColors['border/strong']};
   border-radius: 2px 2px 0 0;
 
   & span:first-child {
@@ -53,14 +55,14 @@ const TableHeader = styled.div<{
 
 const TableHeaderText = styled.div`
   ${({ theme }) => theme.fonts.bold14};
-  color: ${({ theme }) => theme.colors.grey600};
+  color: ${lightColors['text/primary']};
 `
 
 const TableBody = styled.div<{
   footerColumns: boolean
   columns: IColumn[]
 }>`
-  color: ${({ theme }) => theme.colors.copy};
+  color: ${lightColors['text/primary']};
   ${({ theme, columns }) =>
     columns.length > 3 && columns.length <= 5
       ? theme.fonts.reg14
@@ -90,7 +92,7 @@ const RowWrapper = styled.div<{
   min-height: 48px;
   padding-top: 10px;
   padding-bottom: 10px;
-  border-bottom: 1px solid ${({ theme }) => theme.colors.grey200};
+  border-bottom: 1px solid ${lightColors['border/default']};
 
   &:last-child {
     ${({ hideTableBottomBorder }) =>
@@ -111,11 +113,11 @@ const TableFooter = styled(RowWrapper)<{
     fixedWidth ? `width: ${fixedWidth}px;` : `width: ${totalWidth || 100}%;`}
   display: flex;
   align-items: top;
-  background: ${({ theme }) => theme.colors.grey100};
-  border-top: 2px solid ${({ theme }) => theme.colors.grey300};
+  background: ${lightColors['surface/sunken']};
+  border-top: 2px solid ${lightColors['border/strong']};
   border-bottom: none;
   & span {
-    color: ${({ theme }) => theme.colors.copy};
+    color: ${lightColors['text/primary']};
     ${({ theme }) => theme.fonts.bold14};
   }
   & span:first-child {
@@ -137,7 +139,7 @@ const ContentWrapper = styled.span<{
   flex-shrink: 0;
   text-align: ${({ alignment }) => (alignment ? alignment.toString() : 'left')};
   cursor: ${({ sortable }) => (sortable ? 'pointer' : 'default')};
-  color: ${({ theme }) => theme.colors.grey400};
+  color: ${lightColors['text/disabled']};
   padding: 0 4px;
 `
 const ValueWrapper = styled.span<{
@@ -163,18 +165,18 @@ const ValueWrapper = styled.span<{
   ${({ color }) => color && `color: ${color};`}
 `
 const Error = styled.span`
-  color: ${({ theme }) => theme.colors.negative};
+  color: ${lightColors['feedback/negative']};
 `
 const ErrorText = styled.div<{ isFullPage?: boolean }>`
   ${({ theme }) => theme.fonts.h3};
   text-align: left;
   margin-left: ${({ isFullPage }) => (isFullPage ? `40px` : `10px`)};
-  color: ${({ theme }) => theme.colors.copy};
+  color: ${lightColors['text/primary']};
 `
 export const LoadingTableGrey = styled.span<{
   width?: number
 }>`
-  background: ${({ theme }) => theme.colors.background};
+  background: ${lightColors['surface/page']};
   display: inline-block;
   height: 24px;
   width: ${({ width }) => (width ? `${width}%` : '100%')};
@@ -189,12 +191,12 @@ const TableScrollerHorizontal = styled.div<{
     border-radius: 8px;
     width: 8px;
     height: 8px;
-    background: ${({ theme }) => theme.colors.grey200};
+    background: ${lightColors['border/default']};
   }
 
   &::-webkit-scrollbar-thumb {
     border-radius: 8px;
-    background: ${({ theme }) => theme.colors.grey400};
+    background: ${lightColors['border/strong']};
   }
 `
 const TableScroller = styled.div<{

--- a/packages/components/src/Table/Table.tsx
+++ b/packages/components/src/Table/Table.tsx
@@ -17,7 +17,6 @@ import {
   ColumnContentAlignment
 } from '../Workqueue'
 import { Pagination } from '../Pagination'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 const Wrapper = styled.div<{

--- a/packages/components/src/TextArea/TextArea.tsx
+++ b/packages/components/src/TextArea/TextArea.tsx
@@ -12,7 +12,6 @@ import * as React from 'react'
 import styled from 'styled-components'
 // Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
-import { primitives } from '../primitives'
 
 interface ITextAreaProps
   extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
@@ -26,7 +25,7 @@ const StyledTextArea = styled.textarea<ITextAreaProps>`
   padding: 8px 16px;
   min-height: 104px;
   border-radius: 4px;
-  border: 1.5px solid ${primitives.grey[900]};
+  border: 1.5px solid ${lightColors['border/emphasis']};
   background-color: ${lightColors['surface/default']};
   color: ${({ disabled }) =>
     disabled ? lightColors['text/disabled'] : lightColors['text/primary']};
@@ -35,8 +34,8 @@ const StyledTextArea = styled.textarea<ITextAreaProps>`
     box-shadow: 0 0 0px 4px ${lightColors['border/default']};
   }
   &:focus {
-    outline: 0.5px solid ${primitives.grey[900]};
-    border: 1.5px solid $ ${primitives.grey[900]};
+    outline: 0.5px solid ${lightColors['border/emphasis']};
+    border: 1.5px solid $ ${lightColors['border/emphasis']};
     box-shadow: 0 0 0px 4px ${lightColors['feedback/focus']};
   }
 

--- a/packages/components/src/TextArea/TextArea.tsx
+++ b/packages/components/src/TextArea/TextArea.tsx
@@ -10,7 +10,6 @@
  */
 import * as React from 'react'
 import styled from 'styled-components'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 interface ITextAreaProps

--- a/packages/components/src/TextArea/TextArea.tsx
+++ b/packages/components/src/TextArea/TextArea.tsx
@@ -10,6 +10,9 @@
  */
 import * as React from 'react'
 import styled from 'styled-components'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
+import { primitives } from '../primitives'
 
 interface ITextAreaProps
   extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
@@ -23,28 +26,28 @@ const StyledTextArea = styled.textarea<ITextAreaProps>`
   padding: 8px 16px;
   min-height: 104px;
   border-radius: 4px;
-  border: 1.5px solid ${({ theme }) => theme.colors.grey600};
-  background-color: ${({ theme }) => theme.colors.white};
-  color: ${({ theme, disabled }) =>
-    disabled ? theme.colors.disabled : theme.colors.copy};
+  border: 1.5px solid ${primitives.grey[900]};
+  background-color: ${lightColors['surface/default']};
+  color: ${({ disabled }) =>
+    disabled ? lightColors['text/disabled'] : lightColors['text/primary']};
 
   &:hover {
-    box-shadow: 0 0 0px 4px ${({ theme }) => theme.colors.grey200};
+    box-shadow: 0 0 0px 4px ${lightColors['border/default']};
   }
   &:focus {
-    outline: 0.5px solid ${({ theme }) => theme.colors.grey600};
-    border: 1.5px solid $ ${({ theme }) => theme.colors.grey600};
-    box-shadow: 0 0 0px 4px ${({ theme }) => theme.colors.yellow};
+    outline: 0.5px solid ${primitives.grey[900]};
+    border: 1.5px solid $ ${primitives.grey[900]};
+    box-shadow: 0 0 0px 4px ${lightColors['feedback/focus']};
   }
 
   &::-webkit-input-placeholder {
-    color: ${({ theme }) => theme.colors.placeholderCopy};
+    color: ${lightColors['text/tertiary']};
   }
   &::-moz-placeholder {
-    color: ${({ theme }) => theme.colors.placeholderCopy};
+    color: ${lightColors['text/tertiary']};
   }
   &:-ms-input-placeholder {
-    color: ${({ theme }) => theme.colors.placeholderCopy};
+    color: ${lightColors['text/tertiary']};
   }
 `
 

--- a/packages/components/src/TextInput/TextInput.tsx
+++ b/packages/components/src/TextInput/TextInput.tsx
@@ -12,7 +12,6 @@ import * as React from 'react'
 import styled from 'styled-components'
 // Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
-import { primitives } from '../primitives'
 
 export interface ICustomProps {
   error?: boolean
@@ -59,8 +58,8 @@ const StyledInputContainer = styled.div<{
       box-shadow: 0 0 0 4px ${lightColors['border/default']};
     }
     &:focus-within {
-      outline: 0.5px solid ${primitives.grey[900]};
-      border: 1.5px solid ${primitives.grey[900]};
+      outline: 0.5px solid ${lightColors['border/emphasis']};
+      border: 1.5px solid ${lightColors['border/emphasis']};
       box-shadow: 0 0 0px 4px ${lightColors['feedback/focus']};
     }
   `}

--- a/packages/components/src/TextInput/TextInput.tsx
+++ b/packages/components/src/TextInput/TextInput.tsx
@@ -10,7 +10,6 @@
  */
 import * as React from 'react'
 import styled from 'styled-components'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 export interface ICustomProps {

--- a/packages/components/src/TextInput/TextInput.tsx
+++ b/packages/components/src/TextInput/TextInput.tsx
@@ -10,6 +10,9 @@
  */
 import * as React from 'react'
 import styled from 'styled-components'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
+import { primitives } from '../primitives'
 
 export interface ICustomProps {
   error?: boolean
@@ -44,34 +47,34 @@ const StyledInputContainer = styled.div<{
   box-sizing: border-box;
   overflow: hidden;
 
-  ${({ error, touched, disabled, theme }) => `
+  ${({ error, touched, disabled }) => `
     border: 1.5px solid ${
       error && touched
-        ? theme.colors.negative
+        ? lightColors['feedback/negative']
         : disabled
-        ? theme.colors.grey300
-        : theme.colors.copy
+        ? lightColors['border/strong']
+        : lightColors['text/primary']
     };
     &:hover {
-      box-shadow: 0 0 0 4px ${theme.colors.grey200};
+      box-shadow: 0 0 0 4px ${lightColors['border/default']};
     }
     &:focus-within {
-      outline: 0.5px solid ${theme.colors.grey600};
-      border: 1.5px solid ${theme.colors.grey600};
-      box-shadow: 0 0 0px 4px ${theme.colors.yellow};
+      outline: 0.5px solid ${primitives.grey[900]};
+      border: 1.5px solid ${primitives.grey[900]};
+      box-shadow: 0 0 0px 4px ${lightColors['feedback/focus']};
     }
   `}
 `
 
 const StyledPrefix = styled.span`
   ${({ theme }) => theme.fonts.reg19};
-  color: ${({ theme }) => theme.colors.grey400};
+  color: ${lightColors['text/disabled']};
   user-select: none;
 `
 
 const StyledPostfix = styled.span`
   ${({ theme }) => theme.fonts.reg19};
-  color: ${({ theme }) => theme.colors.grey400};
+  color: ${lightColors['text/disabled']};
   user-select: none;
 `
 
@@ -83,20 +86,20 @@ const StyledInput = styled.input<ICustomProps>`
   outline: none;
   border: none;
   ${({ theme }) => theme.fonts.reg19};
-  color: ${({ theme, disabled }) =>
-    disabled ? theme.colors.grey500 : theme.colors.copy};
-  background: ${({ theme }) => theme.colors.white};
+  color: ${({ disabled }) =>
+    disabled ? lightColors['text/tertiary'] : lightColors['text/primary']};
+  background: ${lightColors['surface/default']};
 
   &::-webkit-input-placeholder {
-    color: ${({ theme }) => theme.colors.placeholderCopy};
+    color: ${lightColors['text/tertiary']};
   }
 
   &::-moz-placeholder {
-    color: ${({ theme }) => theme.colors.placeholderCopy};
+    color: ${lightColors['text/tertiary']};
   }
 
   &:-ms-input-placeholder {
-    color: ${({ theme }) => theme.colors.placeholderCopy};
+    color: ${lightColors['text/tertiary']};
   }
 
   &::-webkit-outer-spin-button,

--- a/packages/components/src/Toast/Toast.tsx
+++ b/packages/components/src/Toast/Toast.tsx
@@ -16,7 +16,6 @@ import { Text } from '../Text'
 import { Link } from '../Link'
 // Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
-import { primitives } from '../primitives'
 import { useToastVisibility } from './useToastVisibility'
 import { Icon } from '../Icon'
 
@@ -45,7 +44,7 @@ const Container = styled.div<{
         : ''
     }
     ${$type === 'error' ? lightColors['action/negativePressed'] : ''}
-    ${$type === 'warning' ? primitives.orange[800] : ''}
+    ${$type === 'warning' ? lightColors['feedback/warning'] : ''}
     ${$type === undefined ? lightColors['action/positiveHover'] : ''}
   `};
   background: var(--color);

--- a/packages/components/src/Toast/Toast.tsx
+++ b/packages/components/src/Toast/Toast.tsx
@@ -14,7 +14,6 @@ import { Spinner } from '../Spinner'
 import { Button } from '../Button'
 import { Text } from '../Text'
 import { Link } from '../Link'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 import { useToastVisibility } from './useToastVisibility'
 import { Icon } from '../Icon'

--- a/packages/components/src/Toast/Toast.tsx
+++ b/packages/components/src/Toast/Toast.tsx
@@ -14,7 +14,9 @@ import { Spinner } from '../Spinner'
 import { Button } from '../Button'
 import { Text } from '../Text'
 import { Link } from '../Link'
-import { colors } from '../colors'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
+import { primitives } from '../primitives'
 import { useToastVisibility } from './useToastVisibility'
 import { Icon } from '../Icon'
 
@@ -35,12 +37,16 @@ const shallowToast = keyframes`
 const Container = styled.div<{
   $type?: ToastType
 }>`
-  --color: ${({ $type, theme }) => `
-    ${$type === 'success' ? theme.colors.positiveDark : ''}
-    ${$type === 'loading' || $type === 'info' ? theme.colors.primaryDark : ''}
-    ${$type === 'error' ? theme.colors.negativeDark : ''}
-    ${$type === 'warning' ? theme.colors.orangeDark : ''}
-    ${$type === undefined ? theme.colors.positiveDark : ''}
+  --color: ${({ $type }) => `
+    ${$type === 'success' ? lightColors['action/positiveHover'] : ''}
+    ${
+      $type === 'loading' || $type === 'info'
+        ? lightColors['action/primaryHover']
+        : ''
+    }
+    ${$type === 'error' ? lightColors['action/negativePressed'] : ''}
+    ${$type === 'warning' ? primitives.orange[800] : ''}
+    ${$type === undefined ? lightColors['action/positiveHover'] : ''}
   `};
   background: var(--color);
   border-radius: 8px;
@@ -78,7 +84,7 @@ const ActionLink = styled(Link)`
 `
 
 const Close = styled(Button)`
-  color: ${({ theme }) => theme.colors.white};
+  color: ${lightColors['text/onAction']};
   margin-top: 4px;
   margin-right: 4px;
   &:hover {
@@ -125,7 +131,7 @@ export function Toast({
         <SpinnerContainer>
           <Spinner
             id="in-progress-floating-notification"
-            baseColor={colors.white}
+            baseColor={lightColors['text/onAction']}
             size={20}
           />
         </SpinnerContainer>

--- a/packages/components/src/Toggle/Toggle.tsx
+++ b/packages/components/src/Toggle/Toggle.tsx
@@ -10,6 +10,8 @@
  */
 import styled from 'styled-components'
 import * as React from 'react'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 const CheckBoxWrapper = styled.div`
   position: relative;
@@ -17,7 +19,7 @@ const CheckBoxWrapper = styled.div`
   height: 24px;
   border-radius: 100px;
   :focus-within {
-    box-shadow: 0px 0px 0px 2px ${({ theme }) => theme.colors.yellow};
+    box-shadow: 0px 0px 0px 2px ${lightColors['feedback/focus']};
   }
 `
 const CheckBoxLabel = styled.label<{ checked: boolean }>`
@@ -27,11 +29,13 @@ const CheckBoxLabel = styled.label<{ checked: boolean }>`
   width: 46px;
   height: 24px;
   border-radius: 100px;
-  background: ${({ checked, theme }) =>
-    checked ? theme.colors.positive : theme.colors.grey300};
+  background: ${({ checked }) =>
+    checked
+      ? lightColors['action/positive']
+      : lightColors['action/secondaryPressed']};
   :hover {
-    background: ${({ checked, theme }) =>
-      checked ? theme.colors.positiveDark : theme.colors.grey400};
+    background: ${({ checked }) =>
+      checked ? lightColors['action/positiveHover'] : lightColors['text/disabled']};
   }
   cursor: pointer;
   &::after {
@@ -47,7 +51,7 @@ const CheckBoxLabel = styled.label<{ checked: boolean }>`
     margin-bottom: 3px;
     margin-left: ${({ checked }) => (checked ? '24px' : '4px')};
     margin-right: ${({ checked }) => (checked ? '4px' : '24px')};
-    background: ${({ theme }) => theme.colors.white};
+    background: ${lightColors['text/onAction']};
     transition: margin-left 0.2s;
   }
 `

--- a/packages/components/src/Toggle/Toggle.tsx
+++ b/packages/components/src/Toggle/Toggle.tsx
@@ -10,7 +10,6 @@
  */
 import styled from 'styled-components'
 import * as React from 'react'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 const CheckBoxWrapper = styled.div`

--- a/packages/components/src/Tooltip/Tooltip.tsx
+++ b/packages/components/src/Tooltip/Tooltip.tsx
@@ -12,7 +12,6 @@ import React from 'react'
 import styled from 'styled-components'
 // Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
-import { primitives } from '../primitives'
 
 const TooltipWrapper = styled.div`
   position: relative;
@@ -21,7 +20,7 @@ const TooltipWrapper = styled.div`
 
 const TooltipContent = styled.div<{ position: TooltipProps['position'] }>`
   visibility: hidden;
-  background-color: ${primitives.grey[900]};
+  background-color: ${lightColors['border/emphasis']};
   ${({ theme }) => theme.fonts.bold12};
   color: ${lightColors['text/onAction']};
   text-align: center;

--- a/packages/components/src/Tooltip/Tooltip.tsx
+++ b/packages/components/src/Tooltip/Tooltip.tsx
@@ -10,7 +10,6 @@
  */
 import React from 'react'
 import styled from 'styled-components'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 const TooltipWrapper = styled.div`

--- a/packages/components/src/Tooltip/Tooltip.tsx
+++ b/packages/components/src/Tooltip/Tooltip.tsx
@@ -10,6 +10,9 @@
  */
 import React from 'react'
 import styled from 'styled-components'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
+import { primitives } from '../primitives'
 
 const TooltipWrapper = styled.div`
   position: relative;
@@ -18,9 +21,9 @@ const TooltipWrapper = styled.div`
 
 const TooltipContent = styled.div<{ position: TooltipProps['position'] }>`
   visibility: hidden;
-  background-color: ${({ theme }) => theme.colors.grey600};
+  background-color: ${primitives.grey[900]};
   ${({ theme }) => theme.fonts.bold12};
-  color: ${({ theme }) => theme.colors.white};
+  color: ${lightColors['text/onAction']};
   text-align: center;
   border-radius: 8px;
   padding: 6px 12px;

--- a/packages/components/src/Tooltip/Tooltip.tsx
+++ b/packages/components/src/Tooltip/Tooltip.tsx
@@ -20,7 +20,7 @@ const TooltipWrapper = styled.div`
 
 const TooltipContent = styled.div<{ position: TooltipProps['position'] }>`
   visibility: hidden;
-  background-color: ${lightColors['border/emphasis']};
+  background-color: ${lightColors['surface/inverse']};
   ${({ theme }) => theme.fonts.bold12};
   color: ${lightColors['text/onAction']};
   text-align: center;

--- a/packages/components/src/VerticalBar/VerticalBar.tsx
+++ b/packages/components/src/VerticalBar/VerticalBar.tsx
@@ -23,7 +23,6 @@ import {
 import { ITheme } from '../theme'
 import { IDataPoint } from '../chart-datapoint-types'
 import { CustomizedXAxisTick } from './components/AxisTick'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 const Container = styled.div`

--- a/packages/components/src/VerticalBar/VerticalBar.tsx
+++ b/packages/components/src/VerticalBar/VerticalBar.tsx
@@ -23,6 +23,8 @@ import {
 import { ITheme } from '../theme'
 import { IDataPoint } from '../chart-datapoint-types'
 import { CustomizedXAxisTick } from './components/AxisTick'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 const Container = styled.div`
   margin-top: 30px;
@@ -44,7 +46,10 @@ const sumUpAllValues = (data: IDataPoint[]) =>
 export const VerticalBar = withTheme(
   (props: IVerticalBarProps & { theme: ITheme }) => {
     const { data, theme, xAxisLabel, yAxisLabel } = props
-    const colours = [theme.colors.primary, theme.colors.grey400]
+    const colours = [
+      lightColors['action/primary'],
+      lightColors['text/disabled']
+    ]
 
     return (
       <Container>
@@ -91,7 +96,7 @@ export const VerticalBar = withTheme(
               dataKey="label"
             >
               <Label
-                fill={theme.colors.primary}
+                fill={lightColors['feedback/info']}
                 fontFamily={theme.fontFamily}
                 offset={20}
                 value={xAxisLabel}
@@ -100,7 +105,7 @@ export const VerticalBar = withTheme(
             </XAxis>
             <YAxis width={30} tickLine={false} axisLine={false} tick={false}>
               <Label
-                fill={theme.colors.primary}
+                fill={lightColors['feedback/info']}
                 fontFamily={theme.fontFamily}
                 transform="rotate(-90)"
                 dy={-40}
@@ -113,7 +118,7 @@ export const VerticalBar = withTheme(
               vertical={false}
               horizontal={false}
               fillOpacity="0.05"
-              fill={theme.colors.primary}
+              fill={lightColors['feedback/info']}
             />
 
             <Bar dataKey="value">

--- a/packages/components/src/VerticalBar/components/AxisTick.tsx
+++ b/packages/components/src/VerticalBar/components/AxisTick.tsx
@@ -12,6 +12,8 @@ import * as React from 'react'
 import { withTheme } from 'styled-components'
 import { ITheme } from '../../theme'
 import { IDataPoint } from '../../chart-datapoint-types'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../../semantics'
 
 export interface ICustomizedAxisTick {
   x: number
@@ -33,7 +35,7 @@ export const CustomizedXAxisTick = withTheme(
           dy={16}
           fontFamily={theme.fontFamily}
           textAnchor="middle"
-          fill={theme.colors.primary}
+          fill={lightColors['feedback/info']}
         >
           {payload && payload.label}
         </text>
@@ -43,7 +45,7 @@ export const CustomizedXAxisTick = withTheme(
           dy={16}
           fontFamily={theme.fontFamily}
           textAnchor="middle"
-          fill={theme.colors.primary}
+          fill={lightColors['feedback/info']}
         >
           {payload && `${Math.round((payload.value / totalValue) * 100)}%`}
         </text>
@@ -54,7 +56,7 @@ export const CustomizedXAxisTick = withTheme(
           fontFamily={theme.fontFamily}
           fontSize={12}
           textAnchor="middle"
-          fill={theme.colors.copy}
+          fill={lightColors['text/primary']}
         >
           {payload && payload.value}
         </text>
@@ -73,7 +75,7 @@ export const CustomizedYAxisTick = withTheme(
           fontFamily={theme.fontFamily}
           textAnchor="end"
           height={22}
-          fill={theme.colors.primary}
+          fill={lightColors['feedback/info']}
         >
           {payload && payload.value}
         </text>

--- a/packages/components/src/VerticalBar/components/AxisTick.tsx
+++ b/packages/components/src/VerticalBar/components/AxisTick.tsx
@@ -12,7 +12,6 @@ import * as React from 'react'
 import { withTheme } from 'styled-components'
 import { ITheme } from '../../theme'
 import { IDataPoint } from '../../chart-datapoint-types'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../../semantics'
 
 export interface ICustomizedAxisTick {

--- a/packages/components/src/ViewData/DataRow.tsx
+++ b/packages/components/src/ViewData/DataRow.tsx
@@ -11,12 +11,14 @@
 import * as React from 'react'
 import styled from 'styled-components'
 import { Link } from '../Link'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 const Container = styled.div`
   display: flex;
   flex-direction: row;
   flex-wrap: nowrap;
-  border-bottom: 1px solid ${({ theme }) => theme.colors.grey200};
+  border-bottom: 1px solid ${lightColors['border/default']};
   padding: 16px 0px;
   @media (max-width: ${({ theme }) => theme.grid.breakpoints.md}px) {
     flex-direction: column;
@@ -58,7 +60,7 @@ const Value = styled.div`
 
 const PlaceHolder = styled.div`
   ${({ theme }) => theme.fonts.reg16};
-  color: ${({ theme }) => theme.colors.supportingCopy};
+  color: ${lightColors['text/secondary']};
   flex: 1;
 `
 const Action = styled.div`

--- a/packages/components/src/ViewData/DataRow.tsx
+++ b/packages/components/src/ViewData/DataRow.tsx
@@ -11,7 +11,6 @@
 import * as React from 'react'
 import styled from 'styled-components'
 import { Link } from '../Link'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 const Container = styled.div`

--- a/packages/components/src/ViewData/ListRow.tsx
+++ b/packages/components/src/ViewData/ListRow.tsx
@@ -12,12 +12,14 @@ import * as React from 'react'
 import styled from 'styled-components'
 import { Link } from '../Link'
 import { Button } from '../Button'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 const Container = styled.div`
   display: flex;
   flex-direction: row;
   flex-wrap: nowrap;
-  border-bottom: 1px solid ${({ theme }) => theme.colors.grey200};
+  border-bottom: 1px solid ${lightColors['border/default']};
   padding: 16px 0px;
   width: 100%;
   &:last-child {
@@ -86,7 +88,7 @@ const HideOnDesktop = styled.div`
 
 const PlaceHolder = styled.div`
   ${({ theme }) => theme.fonts.reg16};
-  color: ${({ theme }) => theme.colors.supportingCopy};
+  color: ${lightColors['text/secondary']};
   flex: 1;
 `
 const Action = styled.div`

--- a/packages/components/src/ViewData/ListRow.tsx
+++ b/packages/components/src/ViewData/ListRow.tsx
@@ -12,7 +12,6 @@ import * as React from 'react'
 import styled from 'styled-components'
 import { Link } from '../Link'
 import { Button } from '../Button'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 const Container = styled.div`

--- a/packages/components/src/Workqueue/Workqueue.tsx
+++ b/packages/components/src/Workqueue/Workqueue.tsx
@@ -19,7 +19,6 @@ import { SortIcon } from '../icons/SortIcon'
 import { IAction } from '../common-types'
 import { ListItemAction } from './components/ListItemAction'
 import { useWindowSize } from '../hooks'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 const Wrapper = styled.div`

--- a/packages/components/src/Workqueue/Workqueue.tsx
+++ b/packages/components/src/Workqueue/Workqueue.tsx
@@ -19,26 +19,28 @@ import { SortIcon } from '../icons/SortIcon'
 import { IAction } from '../common-types'
 import { ListItemAction } from './components/ListItemAction'
 import { useWindowSize } from '../hooks'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 const Wrapper = styled.div`
   width: 100%;
 `
 const TableHeader = styled.div`
-  color: ${({ theme }) => theme.colors.grey600};
-  background-color: ${({ theme }) => theme.colors.grey100};
+  color: ${lightColors['text/primary']};
+  background-color: ${lightColors['surface/sunken']};
   ${({ theme }) => theme.fonts.bold14};
   height: 36px;
   display: flex;
   align-items: center;
   padding: 0 16px;
-  border-bottom: 1px solid ${({ theme }) => theme.colors.grey300};
+  border-bottom: 1px solid ${lightColors['border/strong']};
   @media (max-width: ${({ theme }) => theme.grid.breakpoints.lg}px) {
     display: none;
   }
 `
 
 export const NoResultText = styled.div`
-  color: ${({ theme }) => theme.colors.grey600};
+  color: ${lightColors['text/primary']};
   ${({ theme }) => theme.fonts.bold16}
   text-align: left;
   @media (max-width: ${({ theme }) => theme.grid.breakpoints.lg}px) {

--- a/packages/components/src/Workqueue/Workqueue.tsx
+++ b/packages/components/src/Workqueue/Workqueue.tsx
@@ -27,7 +27,7 @@ const Wrapper = styled.div`
 `
 const TableHeader = styled.div`
   color: ${lightColors['text/primary']};
-  background-color: ${lightColors['surface/sunken']};
+  background-color: ${lightColors['surface/inset']};
   ${({ theme }) => theme.fonts.bold14};
   height: 36px;
   display: flex;

--- a/packages/components/src/Workqueue/components/ListItemAction.tsx
+++ b/packages/components/src/Workqueue/components/ListItemAction.tsx
@@ -15,8 +15,10 @@ import { ArrowExpansionButton } from '../../buttons/ArrowExpansionButton'
 import { Button } from '../../Button'
 import { ColumnContentAlignment, IAction } from '../../common-types'
 import { IActionComponent } from '..'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../../semantics'
 const Container = styled.div`
-  background: ${({ theme }) => theme.colors.white};
+  background: ${lightColors['surface/default']};
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/packages/components/src/Workqueue/components/ListItemAction.tsx
+++ b/packages/components/src/Workqueue/components/ListItemAction.tsx
@@ -15,7 +15,6 @@ import { ArrowExpansionButton } from '../../buttons/ArrowExpansionButton'
 import { Button } from '../../Button'
 import { ColumnContentAlignment, IAction } from '../../common-types'
 import { IActionComponent } from '..'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../../semantics'
 const Container = styled.div`
   background: ${lightColors['surface/default']};

--- a/packages/components/src/Workqueue/components/WorkqueueRowDesktop.tsx
+++ b/packages/components/src/Workqueue/components/WorkqueueRowDesktop.tsx
@@ -11,7 +11,6 @@
 import * as React from 'react'
 import styled from 'styled-components'
 import { IActionObject, ColumnContentAlignment, IAction, IColumn } from '..'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../../semantics'
 
 export interface IWorkqueueRow {

--- a/packages/components/src/Workqueue/components/WorkqueueRowDesktop.tsx
+++ b/packages/components/src/Workqueue/components/WorkqueueRowDesktop.tsx
@@ -11,6 +11,8 @@
 import * as React from 'react'
 import styled from 'styled-components'
 import { IActionObject, ColumnContentAlignment, IAction, IColumn } from '..'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../../semantics'
 
 export interface IWorkqueueRow {
   displayItems: Array<Record<string, unknown>>
@@ -31,11 +33,11 @@ export interface IWorkqueueRow {
 }
 
 const StyledBox = styled.div<{ hideLastBorder?: boolean }>`
-  color: ${({ theme }) => theme.colors.copy};
+  color: ${lightColors['text/primary']};
   ${({ theme }) => theme.fonts.reg16};
   display: flex;
   align-items: center;
-  border-bottom: 1px solid ${({ theme }) => theme.colors.grey200};
+  border-bottom: 1px solid ${lightColors['border/default']};
   &:last-child {
     ${({ hideLastBorder }) => hideLastBorder && ` border-bottom: 0;`}
   }
@@ -71,7 +73,7 @@ export const ContentWrapper = styled.div<{
 `
 
 export const Error = styled.span`
-  color: ${({ theme }) => theme.colors.negative};
+  color: ${lightColors['feedback/negative']};
 `
 
 export const IconWrapper = styled(ContentWrapper)`

--- a/packages/components/src/Workqueue/components/WorkqueueRowMobile.tsx
+++ b/packages/components/src/Workqueue/components/WorkqueueRowMobile.tsx
@@ -17,18 +17,20 @@ import {
   ContentWrapper
 } from './WorkqueueRowDesktop'
 import { IActionObject, IAction } from '../types'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../../semantics'
 
 const StyledBox = styled.div`
-  color: ${({ theme }) => theme.colors.copy};
+  color: ${lightColors['text/primary']};
   ${({ theme }) => theme.fonts.reg16};
   display: flex;
   align-items: center;
-  border: 1px solid ${({ theme }) => theme.colors.grey300};
+  border: 1px solid ${lightColors['border/strong']};
   box-sizing: border-box;
   border-radius: 4px;
   height: 80px;
   max-width: 520px;
-  background-color: ${({ theme }) => theme.colors.white};
+  background-color: ${lightColors['surface/default']};
   margin: auto;
   margin-bottom: 8px;
 `

--- a/packages/components/src/Workqueue/components/WorkqueueRowMobile.tsx
+++ b/packages/components/src/Workqueue/components/WorkqueueRowMobile.tsx
@@ -17,7 +17,6 @@ import {
   ContentWrapper
 } from './WorkqueueRowDesktop'
 import { IActionObject, IAction } from '../types'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../../semantics'
 
 const StyledBox = styled.div`

--- a/packages/components/src/buttons/Button.tsx
+++ b/packages/components/src/buttons/Button.tsx
@@ -11,7 +11,6 @@
 import * as React from 'react'
 import { IButtonSize, dimensionsMap } from '.'
 import styled from 'styled-components'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 export enum ICON_ALIGNMENT {

--- a/packages/components/src/buttons/Button.tsx
+++ b/packages/components/src/buttons/Button.tsx
@@ -11,6 +11,8 @@
 import * as React from 'react'
 import { IButtonSize, dimensionsMap } from '.'
 import styled from 'styled-components'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 export enum ICON_ALIGNMENT {
   LEFT,
@@ -33,7 +35,7 @@ const ButtonBase = styled.button.withConfig({
   background: transparent;
   &:disabled {
     path {
-      stroke: ${({ theme }) => theme.colors.disabled};
+      stroke: ${lightColors['text/disabled']};
     }
   }
   -webkit-tap-highlight-color: transparent;

--- a/packages/components/src/buttons/CircleButton.tsx
+++ b/packages/components/src/buttons/CircleButton.tsx
@@ -10,6 +10,8 @@
  */
 import styled from 'styled-components'
 import React from 'react'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 type IButtonSize = 'small' | 'medium' | 'large'
 
@@ -20,7 +22,7 @@ const dimensionMap = {
 }
 
 const Button = styled.button<ICircleButtonProps & { size: IButtonSize }>`
-  color: ${({ theme }) => theme.colors.primary};
+  color: ${lightColors['action/primary']};
   transition: background 0.4s ease;
   border: none;
   background: none;
@@ -31,23 +33,23 @@ const Button = styled.button<ICircleButtonProps & { size: IButtonSize }>`
   align-items: center;
   border-radius: 100%;
   &:hover:not([disabled]) {
-    ${({ theme, dark }) =>
+    ${({ dark }) =>
       dark
-        ? theme.colors.primaryDark
-        : 'background-color: ' + theme.colors.grey200};
+        ? lightColors['action/primaryHover']
+        : 'background-color: ' + lightColors['action/secondaryHover']};
   }
   &:not([data-focus-visible-added]):not([disabled]):hover {
-    ${({ theme, dark }) =>
+    ${({ dark }) =>
       dark
-        ? theme.colors.primaryDark
-        : 'background-color: ' + theme.colors.grey200};
+        ? lightColors['action/primaryHover']
+        : 'background-color: ' + lightColors['action/secondaryHover']};
   }
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
   &:focus {
     outline: none;
-    background: ${({ theme }) => theme.colors.yellow};
-    color: ${({ theme }) => theme.colors.copy};
+    background: ${lightColors['feedback/focus']};
+    color: ${lightColors['text/primary']};
   }
   &:not([data-focus-visible-added]):not([disabled]) {
     background: none;
@@ -56,13 +58,13 @@ const Button = styled.button<ICircleButtonProps & { size: IButtonSize }>`
   }
   &:active:not([data-focus-visible-added]):not([disabled]) {
     outline: none;
-    background: ${({ theme }) => theme.colors.grey200};
-    color: ${({ theme }) => theme.colors.copy};
+    background: ${lightColors['action/secondaryHover']};
+    color: ${lightColors['text/primary']};
   }
   &:disabled {
     cursor: default;
     path {
-      stroke: ${({ theme }) => theme.colors.grey200};
+      stroke: ${lightColors['action/disabled']};
     }
   }
 `

--- a/packages/components/src/buttons/CircleButton.tsx
+++ b/packages/components/src/buttons/CircleButton.tsx
@@ -10,7 +10,6 @@
  */
 import styled from 'styled-components'
 import React from 'react'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 type IButtonSize = 'small' | 'medium' | 'large'

--- a/packages/components/src/buttons/ExpansionButton.tsx
+++ b/packages/components/src/buttons/ExpansionButton.tsx
@@ -12,6 +12,8 @@ import * as React from 'react'
 import styled from 'styled-components'
 import { Button, IButtonProps } from './Button'
 import { PlusTransparent, MinusTransparent } from '../icons'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 export const StyledButton = styled(Button)`
   border: none;
@@ -22,15 +24,15 @@ export const StyledButton = styled(Button)`
   border-radius: 100%;
   align-items: center;
   &:hover {
-    background-color: ${({ theme }) => theme.colors.grey100};
+    background-color: ${lightColors['action/secondary']};
   }
   &:not([data-focus-visible-added]):hover {
-    background-color: ${({ theme }) => theme.colors.grey100};
+    background-color: ${lightColors['action/secondary']};
   }
   &:focus {
     outline: none;
-    background: ${({ theme }) => theme.colors.yellow};
-    color: ${({ theme }) => theme.colors.copy};
+    background: ${lightColors['feedback/focus']};
+    color: ${lightColors['text/primary']};
   }
   &:not([data-focus-visible-added]) {
     background: none;
@@ -39,8 +41,8 @@ export const StyledButton = styled(Button)`
   }
   &:active:not([data-focus-visible-added]) {
     outline: none;
-    background: ${({ theme }) => theme.colors.yellow};
-    color: ${({ theme }) => theme.colors.copy};
+    background: ${lightColors['feedback/focus']};
+    color: ${lightColors['text/primary']};
   }
 `
 export interface IExpansionButtonProps extends IButtonProps {

--- a/packages/components/src/buttons/ExpansionButton.tsx
+++ b/packages/components/src/buttons/ExpansionButton.tsx
@@ -12,7 +12,6 @@ import * as React from 'react'
 import styled from 'styled-components'
 import { Button, IButtonProps } from './Button'
 import { PlusTransparent, MinusTransparent } from '../icons'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 export const StyledButton = styled(Button)`

--- a/packages/components/src/buttons/FloatingActionButton.tsx
+++ b/packages/components/src/buttons/FloatingActionButton.tsx
@@ -11,11 +11,13 @@
 import * as React from 'react'
 
 import styled from 'styled-components'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 const ButtonStyled = styled.button`
   height: 56px;
   width: 56px;
   border-radius: 100%;
-  background: ${({ theme }) => theme.colors.primary};
+  background: ${lightColors['action/primary']};
   ${({ theme }) => theme.shadows.light};
   justify-content: center;
   outline: none;
@@ -23,20 +25,20 @@ const ButtonStyled = styled.button`
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
   &:hover:enabled {
-    ${({ theme }) => theme.colors.primaryDark};
-    color: ${({ theme }) => theme.colors.white};
+    ${lightColors['action/primaryHover']};
+    color: ${lightColors['text/onAction']};
   }
 
   &:active:enabled {
-    background: ${({ theme }) => theme.colors.primary};
-    border: 3px solid ${({ theme }) => theme.colors.yellow};
+    background: ${lightColors['action/primary']};
+    border: 3px solid ${lightColors['feedback/focus']};
     outline: none;
   }
 
   &:disabled {
-    background-color: ${({ theme }) => theme.colors.disabled};
+    background-color: ${lightColors['action/disabled']};
     cursor: not-allowed;
-    color: ${({ theme }) => theme.colors.disabled};
+    color: ${lightColors['text/disabled']};
   }
 `
 interface IButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {

--- a/packages/components/src/buttons/FloatingActionButton.tsx
+++ b/packages/components/src/buttons/FloatingActionButton.tsx
@@ -11,7 +11,6 @@
 import * as React from 'react'
 
 import styled from 'styled-components'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 const ButtonStyled = styled.button`
   height: 56px;

--- a/packages/components/src/buttons/LinkButton.tsx
+++ b/packages/components/src/buttons/LinkButton.tsx
@@ -10,7 +10,6 @@
  */
 import styled from 'styled-components'
 import { Button } from './Button'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 /** @deprecated Use Link instead */

--- a/packages/components/src/buttons/LinkButton.tsx
+++ b/packages/components/src/buttons/LinkButton.tsx
@@ -10,6 +10,8 @@
  */
 import styled from 'styled-components'
 import { Button } from './Button'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 /** @deprecated Use Link instead */
 export const LinkButton = styled(Button)<{
@@ -17,34 +19,34 @@ export const LinkButton = styled(Button)<{
 }>`
   ${({ theme, isBoldLink }) =>
     isBoldLink ? theme.fonts.bold16 : theme.fonts.reg16}
-  color: ${({ theme }) => theme.colors.grey400};
+  color: ${lightColors['text/disabled']};
   padding: 0;
   margin-left: -8px;
   border-radius: 2px;
   &:focus {
-    background: ${({ theme }) => theme.colors.yellow};
-    color: ${({ theme }) => theme.colors.copy};
+    background: ${lightColors['feedback/focus']};
+    color: ${lightColors['text/primary']};
   }
   &:not([data-focus-visible-added]) {
     background: transparent;
     padding: 0;
-    color: ${({ theme }) => theme.colors.primary};
+    color: ${lightColors['text/link']};
   }
 
   &:active {
-    color: ${({ theme }) => theme.colors.primaryDark};
+    color: ${lightColors['action/primaryHover']};
     text-decoration-line: underline;
     text-underline-offset: 4px;
   }
 
   &:hover {
-    color: ${({ theme }) => theme.colors.primaryDark};
+    color: ${lightColors['action/primaryHover']};
     text-decoration-line: underline;
     text-underline-offset: 4px;
   }
 
   &:disabled {
-    color: ${({ theme }) => theme.colors.grey300};
+    color: ${lightColors['text/disabled']};
     background-color: transparent;
   }
 `

--- a/packages/components/src/colors.ts
+++ b/packages/components/src/colors.ts
@@ -84,7 +84,7 @@ export const colors = {
   // Secondary Red
   /** @deprecated use `lightColors['action/negative']` or `feedback/negative` */
   red: primitives.red[500],
-  /** @deprecated use `lightColors['action/negativePressed']` / `primitives.red[800]` */
+  /** @deprecated use `lightColors['action/negativeHover']` / `primitives.red[800]` */
   redDark: primitives.red[800],
   /** @deprecated use `primitives.red[900]` */
   redDarker: primitives.red[900],
@@ -94,7 +94,7 @@ export const colors = {
   redLighter: primitives.red[50],
 
   // Secondary Yellow
-  /** @deprecated no palette equivalent — legacy brand yellow (v4 `yellow` ramp is a different hue; `feedback/focus` = `yellow[300]` #FDE047) */
+  /** @deprecated no palette equivalent — legacy brand yellow (v4 `yellow` ramp is a different hue; `feedback/focus` = `yellow[500]` #EAB308) */
   yellow: '#FBD91E',
   /** @deprecated no palette equivalent — legacy brand yellow */
   yellowDark: '#E2B605',
@@ -122,7 +122,7 @@ export const colors = {
   white: primitives.white,
   /** @deprecated use `primitives.grey[50]`, `surface/page` or `surface/hover` */
   grey50: primitives.grey[50],
-  /** @deprecated use `primitives.grey[100]`, `surface/sunken`, `border/subtle` or `action/secondary` */
+  /** @deprecated use `primitives.grey[100]`, `surface/inset`, `border/subtle` or `action/secondary` */
   grey100: primitives.grey[100],
   /** @deprecated use `primitives.grey[200]`, `border/default` or `action/disabled` */
   grey200: primitives.grey[200],
@@ -158,7 +158,7 @@ export const colors = {
   neutralLighter: primitives.orange[50],
   /** @deprecated use `lightColors['action/negative']` or `feedback/negative` */
   negative: primitives.red[500],
-  /** @deprecated use `lightColors['action/negativePressed']` / `primitives.red[800]` */
+  /** @deprecated use `lightColors['action/negativeHover']` / `primitives.red[800]` */
   negativeDark: primitives.red[800],
   /** @deprecated use `primitives.red[900]` */
   negativeDarker: primitives.red[900],

--- a/packages/components/src/colors.ts
+++ b/packages/components/src/colors.ts
@@ -9,90 +9,177 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 
+import { primitives } from './primitives'
+
+/**
+ * @deprecated The flat `colors` palette is a backwards-compatibility shim kept
+ * only so existing consumers keep working while packages migrate onto the
+ * two-tier token system (`primitives` + `lightColors`/`darkColors` from
+ * `./semantics`).
+ *
+ * Do not add to it, and do not reference it in new code. Each key carries an
+ * `@deprecated` pointer to its semantic replacement, and each value is
+ * re-expressed via `primitives` where the palette still contains it — mapped by
+ * VALUE, not by name (note e.g. old `grey600` / `copy` = #222222 =
+ * `primitives.grey[900]`, NOT `grey[600]`).
+ *
+ * Values here are the ORIGINAL flat-palette values, preserved exactly so that
+ * consumers still on the flat keys (client, login) do not shift. Because the v4
+ * Figma palette renumbered and revalued several ramps, a number of legacy
+ * values (`primaryLighter`, the brand `yellow*`, `teal*`, `orange`, `redLight`,
+ * `negativeLighter`, `opacity24/54`) no longer exist in `primitives` and are
+ * kept as raw hex here rather than forced onto a mismatching token.
+ */
 export const colors = {
   // Primary Blue
-  primary: '#1447B9',
-  primaryDark: '#0D3691',
-  primaryDarker: '#0E225D',
-  primaryLight: '#C7DDFF',
+  /** @deprecated use `lightColors['action/primary']`, `text/link` or `feedback/info` */
+  primary: primitives.blue[500],
+  /** @deprecated use `lightColors['action/primaryHover']` */
+  primaryDark: primitives.blue[800],
+  /** @deprecated use `lightColors['action/primaryPressed']` */
+  primaryDarker: primitives.blue[900],
+  /** @deprecated use `primitives.blue[100]` (also `feedback/infoSubtle`) */
+  primaryLight: primitives.blue[100],
+  /** @deprecated no palette equivalent — off-palette light blue (nearest: `primitives.blue[100]` #C7DDFF) */
   primaryLighter: '#E7F0FC',
+  /** @deprecated no semantic equivalent — off-palette accent blue */
   primaryBlue: '#1470FF',
 
   // Secondary Purple
-  purple: '#785AE6',
-  purpleDark: '#45288A',
-  purpleDarker: '#373050',
-  purpleLight: '#D8D3F8',
-  purpleLighter: '#F0ECF9',
+  /** @deprecated use `primitives.purple[500]` */
+  purple: primitives.purple[500],
+  /** @deprecated use `primitives.purple[800]` */
+  purpleDark: primitives.purple[800],
+  /** @deprecated use `primitives.purple[900]` */
+  purpleDarker: primitives.purple[900],
+  /** @deprecated use `primitives.purple[100]` */
+  purpleLight: primitives.purple[100],
+  /** @deprecated use `primitives.purple[50]` */
+  purpleLighter: primitives.purple[50],
 
   // Secondary Orange
+  /** @deprecated no palette equivalent — off-palette orange (see `feedback/warning` = `orange[500]` for the warning accent) */
   orange: '#E99B63',
-  orangeDark: '#B65618',
-  orangeDarker: '#753919',
-  orangeLight: '#F9DFAF',
-  orangeLighter: '#FEF9EE',
+  /** @deprecated use `primitives.orange[800]` */
+  orangeDark: primitives.orange[800],
+  /** @deprecated use `primitives.orange[900]` */
+  orangeDarker: primitives.orange[900],
+  /** @deprecated use `primitives.orange[100]` */
+  orangeLight: primitives.orange[100],
+  /** @deprecated use `primitives.orange[50]` */
+  orangeLighter: primitives.orange[50],
 
   // Secondary Green
-  green: '#39AB7F',
-  greenDark: '#1D7E5E',
-  greenDarker: '#15503F',
-  greenLight: '#B3E7CE',
-  greenLighter: '#EFFAF5',
+  /** @deprecated use `lightColors['action/positive']` or `feedback/positive` */
+  green: primitives.green[500],
+  /** @deprecated use `lightColors['action/positiveHover']` */
+  greenDark: primitives.green[800],
+  /** @deprecated use `lightColors['action/positivePressed']` */
+  greenDarker: primitives.green[900],
+  /** @deprecated use `primitives.green[100]` (also `feedback/positiveSubtle`) */
+  greenLight: primitives.green[100],
+  /** @deprecated use `primitives.green[50]` */
+  greenLighter: primitives.green[50],
 
   // Secondary Red
-  red: '#D53F3F',
-  redDark: '#B02525',
-  redDarker: '#792323',
+  /** @deprecated use `lightColors['action/negative']` or `feedback/negative` */
+  red: primitives.red[500],
+  /** @deprecated use `lightColors['action/negativePressed']` / `primitives.red[800]` */
+  redDark: primitives.red[800],
+  /** @deprecated use `primitives.red[900]` */
+  redDarker: primitives.red[900],
+  /** @deprecated no palette equivalent — off-palette light red */
   redLight: '#FCE4E4',
-  redLighter: '#FDF3F3',
+  /** @deprecated use `lightColors['feedback/negativeSubtle']` / `primitives.red[50]` */
+  redLighter: primitives.red[50],
 
   // Secondary Yellow
+  /** @deprecated no palette equivalent — legacy brand yellow (v4 `yellow` ramp is a different hue; `feedback/focus` = `yellow[300]` #FDE047) */
   yellow: '#FBD91E',
+  /** @deprecated no palette equivalent — legacy brand yellow */
   yellowDark: '#E2B605',
+  /** @deprecated no palette equivalent — legacy brand yellow */
   yellowDarker: '#85530E',
+  /** @deprecated no palette equivalent — legacy brand yellow */
   yellowLight: '#FEFCC3',
+  /** @deprecated no palette equivalent — legacy brand yellow */
   yellowLighter: '#FEFDE8',
 
   // Secondary Teal
+  /** @deprecated no palette equivalent — off-palette teal (see `primitives.ocean` for the v4 ocean ramp) */
   teal: '#4A8AD7',
+  /** @deprecated no palette equivalent — off-palette teal */
   tealDark: '#2B70C3',
-  tealDarker: '#0A3944',
+  /** @deprecated use `primitives.ocean[900]` */
+  tealDarker: primitives.ocean[900],
+  /** @deprecated no palette equivalent — off-palette teal */
   tealLight: '#9EC0E9',
+  /** @deprecated no palette equivalent — off-palette teal */
   tealLighter: '#DCE8F7',
 
   // Grey
-  white: '#FFFFFF',
-  grey50: '#F8F8F8',
-  grey100: '#F2F2F2',
-  grey200: '#E1E1E1',
-  grey300: '#CECECE',
-  grey400: '#B5B5B5',
-  grey500: '#6B6B6B',
-  grey600: '#222222',
+  /** @deprecated use `lightColors['surface/default']` or `text/onAction` */
+  white: primitives.white,
+  /** @deprecated use `primitives.grey[50]`, `surface/page` or `surface/hover` */
+  grey50: primitives.grey[50],
+  /** @deprecated use `primitives.grey[100]`, `surface/sunken`, `border/subtle` or `action/secondary` */
+  grey100: primitives.grey[100],
+  /** @deprecated use `primitives.grey[200]`, `border/default` or `action/disabled` */
+  grey200: primitives.grey[200],
+  /** @deprecated use `primitives.grey[300]`, `border/strong` or `action/secondaryPressed` */
+  grey300: primitives.grey[300],
+  /** @deprecated use `primitives.grey[400]` or `text/disabled` */
+  grey400: primitives.grey[400],
+  /** @deprecated use `primitives.grey[500]` or `text/tertiary` */
+  grey500: primitives.grey[500],
+  /** @deprecated #222222 is now `primitives.grey[900]` (NOT grey[600]) — use `text/primary` */
+  grey600: primitives.grey[900],
 
   // Utility
-  positive: '#39AB7F',
-  positiveDark: '#1D7E5E',
-  positiveDarker: '#15503F',
-  positiveLight: '#B3E7CE',
-  positiveLighter: '#EFFAF5',
-  neutral: '#EA8A25',
-  neutralDark: '#B65618',
-  neutralDarker: '#753919',
-  neutralLight: '#F9DFAF',
-  neutralLighter: '#FEF9EE',
-  negative: '#D53F3F',
-  negativeDark: '#B02525',
-  negativeDarker: '#792323',
-  negativeLight: '#E79393',
+  /** @deprecated use `lightColors['action/positive']` */
+  positive: primitives.green[500],
+  /** @deprecated use `lightColors['action/positiveHover']` */
+  positiveDark: primitives.green[800],
+  /** @deprecated use `lightColors['action/positivePressed']` */
+  positiveDarker: primitives.green[900],
+  /** @deprecated use `primitives.green[100]` */
+  positiveLight: primitives.green[100],
+  /** @deprecated use `primitives.green[50]` (also `feedback/positiveSubtle`) */
+  positiveLighter: primitives.green[50],
+  /** @deprecated use `lightColors['feedback/warning']` / `primitives.orange[500]` */
+  neutral: primitives.orange[500],
+  /** @deprecated use `primitives.orange[800]` */
+  neutralDark: primitives.orange[800],
+  /** @deprecated use `primitives.orange[900]` */
+  neutralDarker: primitives.orange[900],
+  /** @deprecated use `primitives.orange[100]` */
+  neutralLight: primitives.orange[100],
+  /** @deprecated use `primitives.orange[50]` (also `feedback/warningSubtle`) */
+  neutralLighter: primitives.orange[50],
+  /** @deprecated use `lightColors['action/negative']` or `feedback/negative` */
+  negative: primitives.red[500],
+  /** @deprecated use `lightColors['action/negativePressed']` / `primitives.red[800]` */
+  negativeDark: primitives.red[800],
+  /** @deprecated use `primitives.red[900]` */
+  negativeDarker: primitives.red[900],
+  /** @deprecated use `primitives.red[100]` */
+  negativeLight: primitives.red[100],
+  /** @deprecated no palette equivalent — off-palette light red (see `feedback/negativeSubtle`) */
   negativeLighter: '#FAE6E6',
+  /** @deprecated no direct equivalent — see `lightColors['overlay/subtle']` (grey/900 @ 24%) */
   opacity24: 'rgba(41, 47, 51, 0.24)',
+  /** @deprecated no direct equivalent — see `lightColors['overlay/scrim']` (grey/900 @ 54%) */
   opacity54: 'rgba(41, 47, 51, 0.54)',
-  copy: '#222222',
-  supportingCopy: '#6B6B6B',
-  placeholderCopy: '#B5B5B5',
-  disabled: '#B5B5B5',
-  background: '#F8F8F8'
+  /** @deprecated use `lightColors['text/primary']` */
+  copy: primitives.grey[900],
+  /** @deprecated use `lightColors['text/secondary']` (note: the semantic token is `grey[600]` #525252; this legacy value is `grey[500]` #6B6B6B) */
+  supportingCopy: primitives.grey[500],
+  /** @deprecated use `lightColors['text/tertiary']` (note: the semantic token is `grey[500]` #6B6B6B; this legacy value is `grey[400]` #B5B5B5) */
+  placeholderCopy: primitives.grey[400],
+  /** @deprecated use `lightColors['text/disabled']` or `action/disabled` */
+  disabled: primitives.grey[400],
+  /** @deprecated use `lightColors['surface/page']` */
+  background: primitives.grey[50]
 }
 
 export const gradients = {

--- a/packages/components/src/icons/Cross.tsx
+++ b/packages/components/src/icons/Cross.tsx
@@ -9,7 +9,6 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 import * as React from 'react'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 export const Cross = (props: React.HTMLAttributes<SVGElement>) => {

--- a/packages/components/src/icons/Cross.tsx
+++ b/packages/components/src/icons/Cross.tsx
@@ -9,11 +9,8 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 import * as React from 'react'
-
-const colors = {
-  primary: '#2684FF',
-  danger: '#DE350B'
-}
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 export const Cross = (props: React.HTMLAttributes<SVGElement>) => {
   let fill: string
@@ -25,10 +22,10 @@ export const Cross = (props: React.HTMLAttributes<SVGElement>) => {
       fill = 'currentColor'
       break
     case 'red':
-      fill = colors.danger
+      fill = lightColors['feedback/negative']
       break
     default:
-      fill = colors.primary
+      fill = lightColors['feedback/info']
   }
   return (
     <svg width={24} height={24} fill="none" {...props}>

--- a/packages/components/src/icons/Download.tsx
+++ b/packages/components/src/icons/Download.tsx
@@ -9,7 +9,6 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 import * as React from 'react'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 export const Download = ({

--- a/packages/components/src/icons/Download.tsx
+++ b/packages/components/src/icons/Download.tsx
@@ -9,7 +9,8 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 import * as React from 'react'
-import { colors } from '../colors'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 export const Download = ({
   isFailed
@@ -27,7 +28,7 @@ export const Download = ({
       fillRule="evenodd"
       clipRule="evenodd"
       d="M12 3C7.02944 3 3 7.02944 3 12C3 16.9706 7.02944 21 12 21C16.9706 21 21 16.9706 21 12C21 7.02944 16.9706 3 12 3ZM1 12C1 5.92487 5.92487 1 12 1C18.0751 1 23 5.92487 23 12C23 18.0751 18.0751 23 12 23C5.92487 23 1 18.0751 1 12ZM12 7C12.5523 7 13 7.44771 13 8L13 13.5858L15.2929 11.2929C15.6834 10.9024 16.3166 10.9024 16.7071 11.2929C17.0976 11.6834 17.0976 12.3166 16.7071 12.7071L12.7071 16.7071C12.5196 16.8946 12.2652 17 12 17C11.7348 17 11.4804 16.8946 11.2929 16.7071L7.29289 12.7071C6.90237 12.3166 6.90237 11.6834 7.29289 11.2929C7.68342 10.9024 8.31658 10.9024 8.70711 11.2929L11 13.5858L11 8C11 7.44772 11.4477 7 12 7Z"
-      fill={isFailed ? colors.negative : colors.primary}
+      fill={isFailed ? lightColors['feedback/negative'] : lightColors['feedback/info']}
     />
   </svg>
 )

--- a/packages/components/src/icons/Uploaded.tsx
+++ b/packages/components/src/icons/Uploaded.tsx
@@ -9,7 +9,8 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 import * as React from 'react'
-import { colors } from '../colors'
+// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
+import { lightColors } from '../semantics'
 
 export const Uploaded = ({
   isFailed
@@ -26,7 +27,7 @@ export const Uploaded = ({
         fillRule="evenodd"
         clipRule="evenodd"
         d="M1 12C1 5.92487 5.92487 1 12 1C18.0751 1 23 5.92487 23 12C23 18.0751 18.0751 23 12 23C5.92487 23 1 18.0751 1 12Z"
-        fill={isFailed ? colors.negative : colors.positive}
+        fill={isFailed ? lightColors['feedback/negative'] : lightColors['feedback/positive']}
       />
       <path
         d="M12 7C12.2652 7 12.5196 7.10536 12.7071 7.29289L16.7071 11.2929C17.0976 11.6834 17.0976 12.3166 16.7071 12.7071C16.3166 13.0976 15.6834 13.0976 15.2929 12.7071L13 10.4142L13 16C13 16.5523 12.5523 17 12 17C11.4477 17 11 16.5523 11 16L11 10.4142L8.70711 12.7071C8.31658 13.0976 7.68342 13.0976 7.29289 12.7071C6.90237 12.3166 6.90237 11.6834 7.29289 11.2929L11.2929 7.29289C11.4804 7.10536 11.7348 7 12 7Z"

--- a/packages/components/src/icons/Uploaded.tsx
+++ b/packages/components/src/icons/Uploaded.tsx
@@ -9,7 +9,6 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 import * as React from 'react'
-// Direct light-theme token access; dark-mode theme switching lands in a follow-up PR (#12628).
 import { lightColors } from '../semantics'
 
 export const Uploaded = ({

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -80,6 +80,8 @@ export * from './WarningMessage'
 export * from './Workqueue'
 
 export * from './colors'
+export * from './primitives'
+export * from './semantics'
 export * from './fonts'
 export * from './grid'
 export * from './theme'

--- a/packages/components/src/primitives.ts
+++ b/packages/components/src/primitives.ts
@@ -18,9 +18,9 @@
  * never reference primitives directly — go through the semantic tokens in
  * `semantics.ts` (`lightColors` / `darkColors`) instead.
  *
- * Values mirror Figma exactly. Note the ramps run 50 / 100 / 200 / 300 / 500 /
- * 700 / 800 / 900 (grey adds 600 and 950); `red` additionally has a `600`
- * (#C23636) referenced by `action/negativeHover`.
+ * Values mirror the Figma Variables "Primitives" collection exactly. The ramps
+ * run 50 / 100 / 200 / 300 / 500 / 700 / 800 / 900 (grey additionally has 600
+ * and 950).
  */
 export const primitives = {
   black: '#000000',
@@ -101,7 +101,6 @@ export const primitives = {
     200: '#E37E7E',
     300: '#DE6969',
     500: '#D53F3F',
-    600: '#C23636',
     700: '#C33232',
     800: '#B02525',
     900: '#792323'

--- a/packages/components/src/primitives.ts
+++ b/packages/components/src/primitives.ts
@@ -1,0 +1,120 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+
+/**
+ * Primitives — the raw colour palette, organised by hue and numeric scale,
+ * transcribed from the Figma v4 Design System "Primitives" collection:
+ * https://www.figma.com/design/fi2i59UhtoxW0crnknz6wv/v4---OpenCRVS-Design-System?node-id=31-56
+ *
+ * This is the ONLY place raw hex values are allowed to live. Components must
+ * never reference primitives directly — go through the semantic tokens in
+ * `semantics.ts` (`lightColors` / `darkColors`) instead.
+ *
+ * Values mirror Figma exactly. Note the ramps run 50 / 100 / 200 / 300 / 500 /
+ * 700 / 800 / 900 (grey adds 600 and 950); `red` additionally has a `600`
+ * (#C23636) referenced by `action/negativeHover`.
+ */
+export const primitives = {
+  black: '#000000',
+  white: '#FFFFFF',
+
+  blue: {
+    50: '#F4F8FE',
+    100: '#C7DDFF',
+    200: '#99B7F0',
+    300: '#6B92E0',
+    500: '#1447B9',
+    700: '#103EA5',
+    800: '#0D3691',
+    900: '#0E225D'
+  },
+
+  grey: {
+    50: '#F8F8F8',
+    100: '#F2F2F2',
+    200: '#E1E1E1',
+    300: '#CECECE',
+    400: '#B5B5B5',
+    500: '#6B6B6B',
+    600: '#525252',
+    700: '#3F3F3F',
+    800: '#2A2A2A',
+    900: '#222222',
+    950: '#0E0E0E'
+  },
+
+  green: {
+    50: '#EFFAF5',
+    100: '#B3E7CE',
+    200: '#94D8BB',
+    300: '#76C9A7',
+    500: '#39AB7F',
+    700: '#2B956F',
+    800: '#1D7E5E',
+    900: '#15503F'
+  },
+
+  ocean: {
+    50: '#EBF7FA',
+    100: '#AEDFEA',
+    200: '#8AC7D4',
+    300: '#66AFBE',
+    500: '#1E7F93',
+    700: '#206C7E',
+    800: '#225968',
+    900: '#0A3944'
+  },
+
+  orange: {
+    50: '#FEF9EE',
+    100: '#F9DFAF',
+    200: '#F5C889',
+    300: '#F1B162',
+    500: '#EA8A25',
+    700: '#D0701F',
+    800: '#B65618',
+    900: '#753919'
+  },
+
+  purple: {
+    50: '#F0ECF9',
+    100: '#D8D3F8',
+    200: '#C0B5F4',
+    300: '#A896EF',
+    500: '#785AE6',
+    700: '#5F41B8',
+    800: '#45288A',
+    900: '#373050'
+  },
+
+  red: {
+    50: '#FDF3F3',
+    100: '#E79393',
+    200: '#E37E7E',
+    300: '#DE6969',
+    500: '#D53F3F',
+    600: '#C23636',
+    700: '#C33232',
+    800: '#B02525',
+    900: '#792323'
+  },
+
+  yellow: {
+    50: '#FEFCE8',
+    100: '#FEF9C3',
+    200: '#FEF08A',
+    300: '#FDE047',
+    500: '#EAB308',
+    700: '#A16207',
+    800: '#854D0E',
+    900: '#713F12'
+  }
+} as const

--- a/packages/components/src/semantics.ts
+++ b/packages/components/src/semantics.ts
@@ -1,0 +1,179 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+
+import { primitives as p } from './primitives'
+
+/**
+ * Semantic tokens — intent-based colour names that reference primitives,
+ * transcribed from the Figma v4 Design System "Semantic" collection:
+ * https://www.figma.com/design/fi2i59UhtoxW0crnknz6wv/v4---OpenCRVS-Design-System?node-id=53-308
+ *
+ * Every token is defined once for light (`lightColors`) and once for dark
+ * (`darkColors`); both satisfy `SemanticColors` so the two themes cannot drift
+ * out of sync. Components should reference these tokens rather than primitives
+ * or raw hex.
+ *
+ * The `→ primitive` in each trailing comment records the Figma light/dark
+ * mapping so drift between code and design is easy to spot.
+ */
+
+/** Turn a primitive hex into an rgba() string — used only for `overlay/*`,
+ *  which Figma defines as a grey/black primitive applied at a fixed alpha. */
+const alpha = (hex: string, a: number) => {
+  const value = parseInt(hex.slice(1), 16)
+  const r = (value >> 16) & 255
+  const g = (value >> 8) & 255
+  const b = value & 255
+  return `rgba(${r}, ${g}, ${b}, ${a})`
+}
+
+export type SemanticColors = {
+  'action/primary': string
+  'action/primaryHover': string
+  'action/primaryPressed': string
+  'action/secondary': string
+  'action/secondaryHover': string
+  'action/secondaryPressed': string
+  'action/positive': string
+  'action/positiveHover': string
+  'action/positivePressed': string
+  'action/negative': string
+  'action/negativeHover': string
+  'action/negativePressed': string
+  'action/disabled': string
+
+  'border/default': string
+  'border/subtle': string
+  'border/strong': string
+
+  'feedback/focus': string
+  'feedback/info': string
+  'feedback/infoSubtle': string
+  'feedback/negative': string
+  'feedback/negativeSubtle': string
+  'feedback/positive': string
+  'feedback/positiveSubtle': string
+  'feedback/warning': string
+  'feedback/warningSubtle': string
+
+  'overlay/scrim': string
+  'overlay/subtle': string
+
+  'surface/default': string
+  'surface/hover': string
+  'surface/page': string
+  'surface/raised': string
+  'surface/selected': string
+  'surface/sunken': string
+
+  'text/primary': string
+  'text/secondary': string
+  'text/tertiary': string
+  'text/disabled': string
+  'text/link': string
+  'text/onAction': string
+}
+
+export const lightColors: SemanticColors = {
+  'action/primary': p.blue[500], //          Primary CTA fill (buttons, toggles on)
+  'action/primaryHover': p.blue[800], //     Primary button hover
+  'action/primaryPressed': p.blue[900], //   Primary button pressed / active
+  'action/secondary': p.grey[100], //        Secondary button fill (neutral)
+  'action/secondaryHover': p.grey[200], //   Secondary button hover
+  'action/secondaryPressed': p.grey[300], // Secondary button pressed
+  'action/positive': p.green[500], //        Confirm / approve action fill
+  'action/positiveHover': p.green[700], //   Positive button hover
+  'action/positivePressed': p.green[900], // Positive button pressed
+  'action/negative': p.red[500], //          Destructive action fill (delete, reject)
+  'action/negativeHover': p.red[600], //     Negative button hover
+  'action/negativePressed': p.red[800], //   Negative button pressed
+  'action/disabled': p.grey[200], //         Disabled button / control fill
+
+  'border/default': p.grey[200], // Default control border (inputs, cards)
+  'border/subtle': p.grey[100], //  Faintest border (table rows, list separators)
+  'border/strong': p.grey[300], //  Stronger-than-default border
+
+  'feedback/focus': p.yellow[300], //         Keyboard focus indicator
+  'feedback/info': p.blue[500], //            Informational accent (Figma labels this blue/600; it resolves to blue/500)
+  'feedback/infoSubtle': p.blue[100], //      Info banner / toast background
+  'feedback/negative': p.red[500], //         Error accent (icon, banner border)
+  'feedback/negativeSubtle': p.red[50], //    Error background
+  'feedback/positive': p.green[500], //       Success accent
+  'feedback/positiveSubtle': p.green[100], // Success background
+  'feedback/warning': p.orange[500], //       Warning accent
+  'feedback/warningSubtle': p.orange[100], // Warning background
+
+  'overlay/scrim': alpha(p.grey[900], 0.54), //  Modal / drawer backdrop
+  'overlay/subtle': alpha(p.grey[900], 0.24), // Lighter dim (popovers, hover scrims)
+
+  'surface/default': p.white, //     Default card / component background
+  'surface/hover': p.grey[50], //    Hover state for rows, list items
+  'surface/page': p.grey[50], //     Page / app background
+  'surface/raised': p.white, //      Raised surface (cards, modals)
+  'surface/selected': p.blue[50], // Selected row / nav item background
+  'surface/sunken': p.grey[100], //  Inset surface (textarea, code block)
+
+  'text/primary': p.grey[900], //   Body text, headings
+  'text/secondary': p.grey[600], // Less prominent text (subtitles)
+  'text/tertiary': p.grey[500], //  Captions, helper text, placeholders
+  'text/disabled': p.grey[400], //  Disabled text
+  'text/link': p.blue[500], //      Hyperlink text
+  'text/onAction': p.white //       Text on coloured action fills (white on primary)
+}
+
+export const darkColors: SemanticColors = {
+  'action/primary': p.blue[500],
+  'action/primaryHover': p.blue[200],
+  'action/primaryPressed': p.blue[100],
+  'action/secondary': p.grey[800],
+  'action/secondaryHover': p.grey[700],
+  'action/secondaryPressed': p.grey[600],
+  'action/positive': p.green[500],
+  'action/positiveHover': p.green[200],
+  'action/positivePressed': p.green[100],
+  'action/negative': p.red[500],
+  'action/negativeHover': p.red[200],
+  'action/negativePressed': p.red[50],
+  'action/disabled': p.grey[700],
+
+  'border/default': p.grey[700],
+  'border/subtle': p.grey[800],
+  'border/strong': p.grey[600],
+
+  'feedback/focus': p.yellow[300],
+  'feedback/info': p.blue[500],
+  'feedback/infoSubtle': p.blue[900],
+  'feedback/negative': p.red[500],
+  'feedback/negativeSubtle': p.red[900],
+  'feedback/positive': p.green[500],
+  'feedback/positiveSubtle': p.green[900],
+  'feedback/warning': p.orange[500],
+  'feedback/warningSubtle': p.orange[900],
+
+  'overlay/scrim': alpha(p.black, 0.64),
+  'overlay/subtle': alpha(p.black, 0.32),
+
+  'surface/default': p.grey[900],
+  'surface/hover': p.grey[800],
+  'surface/page': p.grey[950],
+  'surface/raised': p.grey[800],
+  'surface/selected': p.blue[900],
+  'surface/sunken': p.black,
+
+  'text/primary': p.grey[100],
+  'text/secondary': p.grey[400],
+  'text/tertiary': p.grey[500],
+  'text/disabled': p.grey[600],
+  'text/link': p.blue[200],
+  'text/onAction': p.white
+}
+
+export type SemanticColor = keyof SemanticColors

--- a/packages/components/src/semantics.ts
+++ b/packages/components/src/semantics.ts
@@ -12,17 +12,17 @@
 import { primitives as p } from './primitives'
 
 /**
- * Semantic tokens — intent-based colour names that reference primitives,
- * transcribed from the Figma v4 Design System "Semantic" collection:
- * https://www.figma.com/design/fi2i59UhtoxW0crnknz6wv/v4---OpenCRVS-Design-System?node-id=53-308
+ * Semantic tokens — intent-based colour names that reference primitives.
+ *
+ * Transcribed from the Figma v4 Design System **Variables** panel ("Semantic"
+ * collection, Light + Dark modes) — the authoritative source, not the
+ * documentation swatch frame (which can lag the variables).
+ * https://www.figma.com/design/fi2i59UhtoxW0crnknz6wv/v4---OpenCRVS-Design-System
  *
  * Every token is defined once for light (`lightColors`) and once for dark
- * (`darkColors`); both satisfy `SemanticColors` so the two themes cannot drift
- * out of sync. Components should reference these tokens rather than primitives
- * or raw hex.
- *
- * The `→ primitive` in each trailing comment records the Figma light/dark
- * mapping so drift between code and design is easy to spot.
+ * (`darkColors`); both satisfy `SemanticColors` so the two themes cannot drift.
+ * Components reference these tokens exclusively — never primitives or raw hex.
+ * The trailing comment on each light token records its Figma primitive alias.
  */
 
 /** Turn a primitive hex into an rgba() string — used only for `overlay/*`,
@@ -53,6 +53,9 @@ export type SemanticColors = {
   'border/default': string
   'border/subtle': string
   'border/strong': string
+  'border/focus': string
+  'border/emphasis': string
+  'border/action': string
 
   'feedback/focus': string
   'feedback/info': string
@@ -72,7 +75,7 @@ export type SemanticColors = {
   'surface/page': string
   'surface/raised': string
   'surface/selected': string
-  'surface/sunken': string
+  'surface/inset': string
 
   'text/primary': string
   'text/secondary': string
@@ -83,72 +86,78 @@ export type SemanticColors = {
 }
 
 export const lightColors: SemanticColors = {
-  'action/primary': p.blue[500], //          Primary CTA fill (buttons, toggles on)
-  'action/primaryHover': p.blue[800], //     Primary button hover
-  'action/primaryPressed': p.blue[900], //   Primary button pressed / active
-  'action/secondary': p.grey[100], //        Secondary button fill (neutral)
-  'action/secondaryHover': p.grey[200], //   Secondary button hover
-  'action/secondaryPressed': p.grey[300], // Secondary button pressed
-  'action/positive': p.green[500], //        Confirm / approve action fill
-  'action/positiveHover': p.green[700], //   Positive button hover
-  'action/positivePressed': p.green[900], // Positive button pressed
-  'action/negative': p.red[500], //          Destructive action fill (delete, reject)
-  'action/negativeHover': p.red[600], //     Negative button hover
-  'action/negativePressed': p.red[800], //   Negative button pressed
-  'action/disabled': p.grey[200], //         Disabled button / control fill
+  'action/primary': p.blue[500], //          blue/500  — Primary CTA fill
+  'action/primaryHover': p.blue[800], //     blue/800  — Primary button hover
+  'action/primaryPressed': p.blue[900], //   blue/900  — Primary button pressed
+  'action/secondary': p.grey[100], //        grey/100  — Secondary button fill
+  'action/secondaryHover': p.grey[200], //   grey/200  — Secondary button hover
+  'action/secondaryPressed': p.grey[300], // grey/300  — Secondary button pressed
+  'action/positive': p.green[500], //        green/500 — Confirm / approve fill
+  'action/positiveHover': p.green[800], //   green/800 — Positive button hover
+  'action/positivePressed': p.green[900], // green/900 — Positive button pressed
+  'action/negative': p.red[500], //          red/500   — Destructive action fill
+  'action/negativeHover': p.red[800], //     red/800   — Negative button hover
+  'action/negativePressed': p.red[900], //   red/900   — Negative button pressed
+  'action/disabled': p.grey[200], //         grey/200  — Disabled control fill
 
-  'border/default': p.grey[200], // Default control border (inputs, cards)
-  'border/subtle': p.grey[100], //  Faintest border (table rows, list separators)
-  'border/strong': p.grey[300], //  Stronger-than-default border
+  'border/default': p.grey[300], //  grey/300  — Default control border
+  'border/subtle': p.grey[200], //   grey/200  — Faintest border / separator
+  'border/strong': p.grey[400], //   grey/400  — Stronger-than-default border
+  'border/focus': p.yellow[500], //  yellow/500 (feedback/focus) — Focus ring border
+  'border/emphasis': p.grey[900], // grey/900  — High-contrast divider / outline
+  'border/action': p.blue[500], //   blue/500  — Border on interactive elements
 
-  'feedback/focus': p.yellow[300], //         Keyboard focus indicator
-  'feedback/info': p.blue[500], //            Informational accent (Figma labels this blue/600; it resolves to blue/500)
-  'feedback/infoSubtle': p.blue[100], //      Info banner / toast background
-  'feedback/negative': p.red[500], //         Error accent (icon, banner border)
-  'feedback/negativeSubtle': p.red[50], //    Error background
-  'feedback/positive': p.green[500], //       Success accent
-  'feedback/positiveSubtle': p.green[100], // Success background
-  'feedback/warning': p.orange[500], //       Warning accent
-  'feedback/warningSubtle': p.orange[100], // Warning background
+  'feedback/focus': p.yellow[500], //         yellow/500 — Keyboard focus indicator
+  'feedback/info': p.blue[500], //            blue/500   — Informational accent
+  'feedback/infoSubtle': p.blue[50], //       blue/50    — Info background
+  'feedback/negative': p.red[500], //         red/500    — Error accent
+  'feedback/negativeSubtle': p.red[50], //    red/50     — Error background
+  'feedback/positive': p.green[500], //       green/500  — Success accent
+  'feedback/positiveSubtle': p.green[50], //  green/50   — Success background
+  'feedback/warning': p.orange[500], //       orange/500 — Warning accent
+  'feedback/warningSubtle': p.orange[50], //  orange/50  — Warning background
 
-  'overlay/scrim': alpha(p.grey[900], 0.54), //  Modal / drawer backdrop
-  'overlay/subtle': alpha(p.grey[900], 0.24), // Lighter dim (popovers, hover scrims)
+  'overlay/scrim': alpha(p.grey[900], 0.54), //  grey/900 @ 54% — Modal / drawer backdrop
+  'overlay/subtle': alpha(p.grey[900], 0.24), // grey/900 @ 24% — Lighter dim
 
-  'surface/default': p.white, //     Default card / component background
-  'surface/hover': p.grey[50], //    Hover state for rows, list items
-  'surface/page': p.grey[50], //     Page / app background
-  'surface/raised': p.white, //      Raised surface (cards, modals)
-  'surface/selected': p.blue[50], // Selected row / nav item background
-  'surface/sunken': p.grey[100], //  Inset surface (textarea, code block)
+  'surface/default': p.white, //     white    — Default component background
+  'surface/hover': p.grey[50], //    grey/50  — Hover state for rows / list items
+  'surface/page': p.grey[50], //     grey/50  — Page / app background
+  'surface/raised': p.white, //      white    — Raised surface (cards, modals)
+  'surface/selected': p.blue[50], // blue/50  — Selected row / nav item background
+  'surface/inset': p.grey[100], //   grey/100 — Inset surface (textarea, code block)
 
-  'text/primary': p.grey[900], //   Body text, headings
-  'text/secondary': p.grey[600], // Less prominent text (subtitles)
-  'text/tertiary': p.grey[500], //  Captions, helper text, placeholders
-  'text/disabled': p.grey[400], //  Disabled text
-  'text/link': p.blue[500], //      Hyperlink text
-  'text/onAction': p.white //       Text on coloured action fills (white on primary)
+  'text/primary': p.grey[900], //   grey/900 — Body text, headings
+  'text/secondary': p.grey[600], // grey/600 — Less prominent text (subtitles)
+  'text/tertiary': p.grey[500], //  grey/500 — Captions, helper text, placeholders
+  'text/disabled': p.grey[400], //  grey/400 — Disabled text
+  'text/link': p.blue[500], //      blue/500 — Hyperlink text
+  'text/onAction': p.white //       white    — Text on coloured action fills
 }
 
 export const darkColors: SemanticColors = {
   'action/primary': p.blue[500],
-  'action/primaryHover': p.blue[200],
-  'action/primaryPressed': p.blue[100],
+  'action/primaryHover': p.blue[100],
+  'action/primaryPressed': p.blue[50],
   'action/secondary': p.grey[800],
   'action/secondaryHover': p.grey[700],
   'action/secondaryPressed': p.grey[600],
   'action/positive': p.green[500],
-  'action/positiveHover': p.green[200],
-  'action/positivePressed': p.green[100],
+  'action/positiveHover': p.green[100],
+  'action/positivePressed': p.green[50],
   'action/negative': p.red[500],
-  'action/negativeHover': p.red[200],
+  'action/negativeHover': p.red[100],
   'action/negativePressed': p.red[50],
   'action/disabled': p.grey[700],
 
   'border/default': p.grey[700],
   'border/subtle': p.grey[800],
   'border/strong': p.grey[600],
+  'border/focus': p.yellow[500],
+  'border/emphasis': p.grey[100],
+  'border/action': p.blue[100],
 
-  'feedback/focus': p.yellow[300],
+  'feedback/focus': p.yellow[500],
   'feedback/info': p.blue[500],
   'feedback/infoSubtle': p.blue[900],
   'feedback/negative': p.red[500],
@@ -166,13 +175,13 @@ export const darkColors: SemanticColors = {
   'surface/page': p.grey[950],
   'surface/raised': p.grey[800],
   'surface/selected': p.blue[900],
-  'surface/sunken': p.black,
+  'surface/inset': p.black,
 
   'text/primary': p.grey[100],
   'text/secondary': p.grey[400],
   'text/tertiary': p.grey[500],
   'text/disabled': p.grey[600],
-  'text/link': p.blue[200],
+  'text/link': p.blue[100],
   'text/onAction': p.white
 }
 

--- a/packages/components/src/semantics.ts
+++ b/packages/components/src/semantics.ts
@@ -76,6 +76,7 @@ export type SemanticColors = {
   'surface/raised': string
   'surface/selected': string
   'surface/inset': string
+  'surface/inverse': string
 
   'text/primary': string
   'text/secondary': string
@@ -126,6 +127,7 @@ export const lightColors: SemanticColors = {
   'surface/raised': p.white, //      white    — Raised surface (cards, modals)
   'surface/selected': p.blue[50], // blue/50  — Selected row / nav item background
   'surface/inset': p.grey[100], //   grey/100 — Inset surface (textarea, code block)
+  'surface/inverse': p.grey[900], // grey/900 — Inverse surface (tooltips, dark chips)
 
   'text/primary': p.grey[900], //   grey/900 — Body text, headings
   'text/secondary': p.grey[600], // grey/600 — Less prominent text (subtitles)
@@ -176,6 +178,7 @@ export const darkColors: SemanticColors = {
   'surface/raised': p.grey[800],
   'surface/selected': p.blue[900],
   'surface/inset': p.black,
+  'surface/inverse': p.grey[100],
 
   'text/primary': p.grey[100],
   'text/secondary': p.grey[400],


### PR DESCRIPTION
Closes part of #12628 — **PR 1 of 4.**

Introduces a two-tier colour token system mirroring the [v4 OpenCRVS Design System in Figma](https://www.figma.com/design/fi2i59UhtoxW0crnknz6wv/v4---OpenCRVS-Design-System) and migrates `packages/components` onto it as the reference implementation.

## What's here

- **`primitives.ts`** — the raw palette, the only place hex values live.
- **`semantics.ts`** — the full **43-token** Semantic collection (`action/*`, `border/*`, `feedback/*`, `overlay/*`, `surface/*`, `text/*`), defined for **light** (`lightColors`) and **dark** (`darkColors`), both satisfying one type so they can't drift. Dark is *defined* here, not yet applied.
- **`colors.ts`** — the old flat palette is now a **deprecated backwards-compat shim**: every key preserved and re-expressed via `primitives` (by *value*), each with an `@deprecated` pointer. `gradients`, `shadows`, `IColor` unchanged.
- **Migration** of `packages/components`'s own components (~80 files) to semantic tokens. Direct `lightColors[...]` import for now; theme-based (dark-mode) switching is deferred to PR 4. **Components reference semantic tokens exclusively — no primitives.**

## Source of truth: the Figma **Variables panel**

Tokens were transcribed directly from the Figma **Variables** collections (read via the Plugin API)

## Light-mode visual changes (intentional)

This deliberately adopts the new design-system values, so it is **not** pixel-identical. Consumers still on the flat keys (client/login) are unaffected (shim preserves old values exactly), but migrated components shift where Figma revalued (focus rings → yellow/500, borders shift one step, subtle feedback backgrounds → `/50`, secondary/placeholder text darken, Pill/Banner status tints revalued).

## Out of scope / retained shim

Components exposing a public `color?: IColor` prop (`Text`, `Link`, `Icon`, the `icons/*`, `Content`) dynamically index the flat palette and **intentionally keep the compat shim** — converting that prop API happens in the client/login PRs.

## Verification

- `packages/components` typechecks; `login` and `client` typecheck against the unchanged compat surface ✅
- Shim proven to preserve all 66 legacy values exactly ✅
- Zero `primitives.*` and zero `theme.colors.` references remain in component files ✅
- Diff fully contained to `packages/components/src` ✅

## Follow-ups

- **PR 2** — migrate `packages/client` (47 files) off the deprecated flat keys.
- **PR 3** — migrate `packages/login` (3 files), then delete the compat shim + old `IColor`.
- **PR 4** — wire theme selection (provider/context + toggle) so `darkColors` can be applied; dark-mode QA/rollout (incl. `text/onInverse` pairing for `surface/inverse`).
