### PR TITLE
fix(deps): add missing cross-env and concurrently devDependencies

### DIFF
--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -63,6 +63,7 @@
     "@typescript-eslint/eslint-plugin": "8.63.0",
     "@typescript-eslint/parser": "8.63.0",
     "@vitest/coverage-v8": "2.1.9",
+    "concurrently": "^8.0.0",
     "cross-env": "^7.0.0",
     "eslint": "^9.23.0",
     "eslint-config-prettier": "^10.1.1",

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -77,6 +77,7 @@
     "@typescript-eslint/parser": "8.63.0",
     "concurrently": "^8.0.0",
     "copyfiles": "^2.1.1",
+    "cross-env": "^7.0.0",
     "eslint": "^9.23.0",
     "eslint-config-prettier": "^10.1.1",
     "eslint-plugin-import": "^2.31.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1340,6 +1340,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: 2.1.9
         version: 2.1.9(vitest@2.1.9(@types/node@20.19.43)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.43)(typescript@7.0.2))(terser@5.31.0))
+      concurrently:
+        specifier: ^8.0.0
+        version: 8.2.2
       cross-env:
         specifier: ^7.0.0
         version: 7.0.3
@@ -1581,6 +1584,9 @@ importers:
       copyfiles:
         specifier: ^2.1.1
         version: 2.4.1
+      cross-env:
+        specifier: ^7.0.0
+        version: 7.0.3
       eslint:
         specifier: ^9.23.0
         version: 9.23.0
@@ -29088,7 +29094,7 @@ snapshots:
   extract-pg-schema@5.8.1(@electric-sql/pglite@0.4.4):
     dependencies:
       knex: 3.1.0(pg@8.17.2)
-      knex-pglite: 0.12.1(@electric-sql/pglite@0.4.4)(knex@3.1.0(pg@8.22.0))
+      knex-pglite: 0.12.1(@electric-sql/pglite@0.4.4)(knex@3.1.0(pg@8.17.2))
       pg: 8.17.2
       pg-query-emscripten: 5.1.0
       ramda: 0.31.3
@@ -32101,7 +32107,7 @@ snapshots:
 
   klona@2.0.6: {}
 
-  knex-pglite@0.12.1(@electric-sql/pglite@0.4.4)(knex@3.1.0(pg@8.22.0)):
+  knex-pglite@0.12.1(@electric-sql/pglite@0.4.4)(knex@3.1.0(pg@8.17.2)):
     dependencies:
       '@electric-sql/pglite': 0.4.4
       knex: 3.1.0(pg@8.17.2)


### PR DESCRIPTION
**Problem** — On a clean pnpm install, `gateway`'s `start` fails with `cross-env: not found`, so the dev stack can't boot it.

**Root cause** — gateway uses `cross-env` in its `start` script but doesn't declare it. Under pnpm's isolated `node_modules`, a package only gets a binary on its PATH if it declares the dependency (or if a tool sits in the root `node_modules/.bin`, which is on every package's script PATH). Yarn's flat hoisting used to put `cross-env` in the root `.bin`, so it resolved by accident until the pnpm migration removed that hoisting. Nothing else provides `cross-env`, so gateway breaks.

**Why events doesn't hit this** — events' `start` leads with `concurrently`, which it also doesn't declare — but the root `package.json` declares `concurrently`, so it's in the root `.bin` and every package resolves it. events works regardless. Its inner `cross-env` is fine too, because events already declares `cross-env`.

**Why CI stayed green** — `pnpm install` still succeeds (sibling packages declare these tools, so they exist in the store — only the per-package `.bin` link is missing), and CI runs `build`/`test`/`lint`, never the dev `start` scripts where the tools are used.

**Fix** — Declare `cross-env` in gateway (the real failure), and add `concurrently` to events as well. events doesn't currently fail — it leans on the root-level `concurrently` — so its addition is explicit hygiene: the package declares what it uses rather than relying on the root. `cross-env` is declared per-package here rather than added to the root (the way `concurrently` is), keeping each package explicit about its own tooling.
