### PR TITLE
fix: use "Select" placeholder instead of react-select default "Select..."

### DIFF
--- a/packages/client/src/v2-events/components/forms/inputs/SearchableSelect.tsx
+++ b/packages/client/src/v2-events/components/forms/inputs/SearchableSelect.tsx
@@ -20,7 +20,9 @@ import {
 import AsyncSelect, { AsyncProps } from 'react-select/async'
 import { List, RowComponentProps } from 'react-window'
 import styled from 'styled-components'
+import { useIntl } from 'react-intl'
 import { Icon } from '@opencrvs/components/src/Icon'
+import { formMessages } from '@client/i18n/messages'
 import { Option } from '../../../utils'
 
 const ITEM_HEIGHT = 40
@@ -260,8 +262,10 @@ export function SearchableSelect<T = string>({
   error,
   touched,
   disabled,
+  placeholder,
   ['data-testid']: dataTestId
 }: SearchableSelectProps<T>) {
+  const intl = useIntl()
   // React-select provides their own filteringOptions method, but it doesn't work with large option sets and virtualization.
   const loadOptions = async (searchTerm: string) => {
     const term = searchTerm.toLowerCase()
@@ -287,6 +291,7 @@ export function SearchableSelect<T = string>({
       inputId={id}
       isDisabled={disabled}
       loadOptions={loadOptions}
+      placeholder={placeholder ?? intl.formatMessage(formMessages.select)}
       touched={touched}
       value={value}
       onBlur={onBlur}

--- a/packages/client/src/v2-events/components/forms/inputs/Select.tsx
+++ b/packages/client/src/v2-events/components/forms/inputs/Select.tsx
@@ -18,7 +18,9 @@ import {
 import styled from 'styled-components'
 import { Props } from 'react-select/lib/Select'
 import { isEqual } from 'lodash'
+import { useIntl } from 'react-intl'
 import { Icon } from '@opencrvs/components'
+import { formMessages } from '@client/i18n/messages'
 import { Option } from '@client/v2-events/utils'
 
 /* Based on components/Select.tsx */
@@ -172,6 +174,7 @@ export function Select<T>({
   value,
   ...props
 }: SelectProps<T>) {
+  const intl = useIntl()
   const valueFromOptions = getSelectedOption(value, options)
 
   return (
@@ -183,6 +186,7 @@ export function Select<T>({
       isDisabled={disabled}
       isSearchable={options.length > length}
       options={options}
+      placeholder={intl.formatMessage(formMessages.select)}
       value={valueFromOptions}
       onChange={onChange}
       {...props}

--- a/packages/client/src/v2-events/components/forms/inputs/Select.tsx
+++ b/packages/client/src/v2-events/components/forms/inputs/Select.tsx
@@ -186,10 +186,10 @@ export function Select<T>({
       isDisabled={disabled}
       isSearchable={options.length > length}
       options={options}
-      placeholder={intl.formatMessage(formMessages.select)}
       value={valueFromOptions}
       onChange={onChange}
       {...props}
+      placeholder={props.placeholder ?? intl.formatMessage(formMessages.select)}
     />
   )
 }

--- a/packages/client/src/v2-events/features/events/registered-fields/Select.stories.tsx
+++ b/packages/client/src/v2-events/features/events/registered-fields/Select.stories.tsx
@@ -125,6 +125,80 @@ export const WithHiddenOption: Story = {
   }
 }
 
+async function getPlaceholderElement(canvasElement: HTMLElement) {
+  return waitFor(() => {
+    const el = canvasElement.querySelector('.react-select__placeholder')
+    if (!el) {
+      throw new Error('Placeholder not found')
+    }
+    return el
+  })
+}
+
+export const WithDefaultPlaceholder: Story = {
+  name: 'With default placeholder',
+  parameters: {
+    layout: 'centered'
+  },
+  play: async ({ canvasElement }) => {
+    // An empty select with no configured placeholder shows "Select",
+    // not react-select's built-in "Select..." default.
+    const placeholder = await getPlaceholderElement(canvasElement)
+    await expect(placeholder).toHaveTextContent(/^Select$/)
+  },
+  render: function Component(args) {
+    return (
+      <StyledFormFieldGenerator
+        {...args}
+        fields={[
+          {
+            id: 'storybook.select',
+            type: FieldType.SELECT,
+            label: generateTranslationConfig('Favourite fruit'),
+            options: [
+              { value: 'apple', label: generateTranslationConfig('Apple') },
+              { value: 'banana', label: generateTranslationConfig('Banana') }
+            ]
+          }
+        ]}
+        id="my-form"
+      />
+    )
+  }
+}
+
+export const WithConfiguredPlaceholder: Story = {
+  name: 'With configured placeholder',
+  parameters: {
+    layout: 'centered'
+  },
+  play: async ({ canvasElement }) => {
+    // A configured placeholder overrides the "Select" default.
+    const placeholder = await getPlaceholderElement(canvasElement)
+    await expect(placeholder).toHaveTextContent(/^Choose a fruit$/)
+  },
+  render: function Component(args) {
+    return (
+      <StyledFormFieldGenerator
+        {...args}
+        fields={[
+          {
+            id: 'storybook.select',
+            type: FieldType.SELECT,
+            label: generateTranslationConfig('Favourite fruit'),
+            placeholder: generateTranslationConfig('Choose a fruit'),
+            options: [
+              { value: 'apple', label: generateTranslationConfig('Apple') },
+              { value: 'banana', label: generateTranslationConfig('Banana') }
+            ]
+          }
+        ]}
+        id="my-form"
+      />
+    )
+  }
+}
+
 export const WithDisabledOption: Story = {
   name: 'With disabled option',
   parameters: {

--- a/packages/client/src/v2-events/features/events/registered-fields/Select.tsx
+++ b/packages/client/src/v2-events/features/events/registered-fields/Select.tsx
@@ -11,6 +11,7 @@
 import React from 'react'
 import { SelectField, SelectOption } from '@opencrvs/commons/client'
 import { Select as SelectComponent } from '@opencrvs/components'
+import { formMessages } from '@client/i18n/messages'
 import { useIntlWithFormData } from '@client/v2-events/messages/utils'
 import { StringifierContext } from './RegisteredField'
 
@@ -52,6 +53,7 @@ function SelectInput({
 
   return (
     <SelectComponent
+      placeholder={intl.formatMessage(formMessages.select)}
       {...props}
       data-testid={props['data-testid'] || `select__${props.id}`}
       noOptionsMessage={formattedNoOptionsMessage}

--- a/packages/client/src/v2-events/features/events/registered-fields/Select.tsx
+++ b/packages/client/src/v2-events/features/events/registered-fields/Select.tsx
@@ -53,11 +53,11 @@ function SelectInput({
 
   return (
     <SelectComponent
-      placeholder={intl.formatMessage(formMessages.select)}
       {...props}
       data-testid={props['data-testid'] || `select__${props.id}`}
       noOptionsMessage={formattedNoOptionsMessage}
       options={formattedOptions}
+      placeholder={props.placeholder ?? intl.formatMessage(formMessages.select)}
       value={inputValue}
     />
   )

--- a/packages/testland/e2e/helpers.ts
+++ b/packages/testland/e2e/helpers.ts
@@ -267,7 +267,7 @@ export const uploadImageToSection = async ({
   buttonLocator: Locator
   sectionTitle: string
 }) => {
-  await sectionLocator.getByText('Select...').click()
+  await sectionLocator.getByText('Select', { exact: true }).click()
   await sectionLocator.getByText(sectionTitle, { exact: true }).click()
 
   await uploadImage(page, buttonLocator)

--- a/packages/testland/e2e/testcases/birth/1-birth-event-declaration.spec.ts
+++ b/packages/testland/e2e/testcases/birth/1-birth-event-declaration.spec.ts
@@ -378,7 +378,7 @@ test.describe.serial('1. Birth event declaration', () => {
       test('1.8.2 Validate Supporting Document block', async () => {
         await page
           .locator('#documents____proofOfMother-form-input div')
-          .filter({ hasText: /^Select\.\.\.$/ })
+          .filter({ hasText: /^Select$/ })
           .nth(2)
           .click()
         await page.getByText('Birth Certificate', { exact: true }).click()

--- a/packages/testland/e2e/testcases/birth/3-validate-the-mother-and-father-details-page.spec.ts
+++ b/packages/testland/e2e/testcases/birth/3-validate-the-mother-and-father-details-page.spec.ts
@@ -121,7 +121,7 @@ test.describe('3. Validate the mothers and fathers details pages', () => {
 
   test.describe.serial('3.2 Validate the "National ID" field', async () => {
     test.beforeEach(async ({ page }) => {
-      await page.locator('#mother____idType').getByText('Select...').click()
+      await page.locator('#mother____idType').getByText('Select', { exact: true }).click()
       await page.getByText('National ID', { exact: true }).click()
     })
 
@@ -185,7 +185,7 @@ test.describe('3. Validate the mothers and fathers details pages', () => {
       await page.getByTestId('text__mother____nid').fill('1234567890')
       await page.getByRole('button', { name: 'Continue' }).click()
 
-      await page.locator('#father____idType').getByText('Select...').click()
+      await page.locator('#father____idType').getByText('Select', { exact: true }).click()
       await page.getByText('National ID', { exact: true }).click()
       await page.getByTestId('text__father____nid').fill('1234567890')
       await page.getByRole('heading', { name: 'Birth' }).click()

--- a/packages/testland/e2e/testcases/correction-birth/birth-correction-flow.spec.ts
+++ b/packages/testland/e2e/testcases/correction-birth/birth-correction-flow.spec.ts
@@ -350,8 +350,8 @@ test.describe.serial('Birth correction flow', () => {
     test('Enter the direct correction form to ensure form is reset', async () => {
       await selectAction(page, 'Correct')
 
-      await expect(page.locator('#requester____type')).toHaveText('Select...')
-      await expect(page.locator('#reason____option')).toHaveText('Select...')
+      await expect(page.locator('#requester____type')).toHaveText('Select')
+      await expect(page.locator('#reason____option')).toHaveText('Select')
       await page.getByTestId('exit-button')
     })
   })

--- a/packages/testland/e2e/testcases/correction-birth/correct-birth-record-2.spec.ts
+++ b/packages/testland/e2e/testcases/correction-birth/correct-birth-record-2.spec.ts
@@ -140,7 +140,7 @@ test.describe.serial('Correct record - 2', () => {
     await expect(page.getByRole('button', { name: 'Cancel' })).toBeVisible()
     await page.getByRole('button', { name: 'Confirm' }).click()
 
-    await page.getByText('Select...').click()
+    await page.getByText('Select', { exact: true }).click()
     await page.getByText('Affidavit', { exact: true }).click()
     await uploadImage(
       page,

--- a/packages/testland/e2e/testcases/correction-birth/correct-birth-record-3.spec.ts
+++ b/packages/testland/e2e/testcases/correction-birth/correct-birth-record-3.spec.ts
@@ -252,7 +252,7 @@ test.describe.serial(' Correct record - 3', () => {
     await expect(page.getByRole('button', { name: 'Cancel' })).toBeVisible()
     await page.getByRole('button', { name: 'Confirm' }).click()
 
-    await page.getByText('Select...').click()
+    await page.getByText('Select', { exact: true }).click()
     await page.getByText('Affidavit', { exact: true }).click()
     await uploadImage(
       page,

--- a/packages/testland/e2e/testcases/custom-actions-and-flags/issue-certified-copy.spec.ts
+++ b/packages/testland/e2e/testcases/custom-actions-and-flags/issue-certified-copy.spec.ts
@@ -134,7 +134,7 @@ test.describe.serial('Issue Certified Copy', () => {
     })
 
     test('Click continue after selecting collector type and template type', async () => {
-      await page.getByText('Select...').click()
+      await page.getByText('Select', { exact: true }).click()
       const selectOptionsLabels = ['Mother', 'Father', 'Someone else']
 
       for (const label of selectOptionsLabels) {


### PR DESCRIPTION
## Description

Empty select fields in the v2 events forms displayed `Select...` — react-select's built-in default placeholder — instead of `Select`.

The intended, localised copy already exists (`form.field.select.placeholder` → `Select` / `Sélectionnez`); it just wasn't being passed to react-select. This PR passes it from the three v2 select wrappers so empty selects read `Select`:

- `registered-fields/Select.tsx` — standard select fields (ID type, correction reason, requester type, …)
- `components/forms/inputs/Select.tsx` — country / role / number-with-unit / date-range selects
- `components/forms/inputs/SearchableSelect.tsx` — administrative-area / location selects

A caller-supplied `placeholder` still takes precedence; the localised `Select` is only a default.

E2E specs that asserted or targeted `Select...` were updated to `Select` (`{ exact: true }` to preserve the previous unique match).

## Verification

- `yarn lint:ts` (client + testland changed files) — pass
- `tsc --noEmit` (client) — pass

Note: the testland e2e suite requires a running stack and was not executed locally; the spec edits are copy-only and should be validated in CI.