### PR TITLE
Fix print flow config issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ The core `NOTIFY`, `DECLARE`, `REGISTER`, `ARCHIVE` and `REJECT` actions now acc
 ### Bug fixes
 
 - Keep a number field's postfix/unit label (e.g. `Kilograms (kg)` on Weight at birth) on a single line instead of wrapping onto a second row [#13216](https://github.com/opencrvs/opencrvs-core/issues/13216)
+- Bust the locally cached data when a user's office or role changes, so stale drafts and records from the previous office no longer appear after the change
 
 ## 2.0.0
 

--- a/packages/testland/e2e/testcases/custom-actions-and-flags/issue-certified-copy.spec.ts
+++ b/packages/testland/e2e/testcases/custom-actions-and-flags/issue-certified-copy.spec.ts
@@ -89,16 +89,14 @@ test.describe.serial('Issue Certified Copy', () => {
       }
 
       await page.getByText(selectOptionsLabels[2], { exact: true }).click()
-
       await expect(page.getByText('Certify record')).toBeVisible()
-
-      await page.getByRole('button', { name: 'Continue' }).click()
-      await page.getByRole('button', { name: 'Verified' }).click()
       await page.getByRole('button', { name: 'Continue' }).click()
     })
+
     test('Print', async () => {
       await printAndExpectPopup(page)
     })
+
     test('Ensure "Certified copy printed in advance of issuance" flag appears on record', async () => {
       await searchFromSearchBar(page, childName)
       const Flags = page.getByTestId('flags').filter({ hasText: 'Flags' })
@@ -120,6 +118,7 @@ test.describe.serial('Issue Certified Copy', () => {
         Flags.getByText('Certified copy printed in advance of issuance')
       ).toBeVisible()
     })
+
     test('Navigate to print', async () => {
       await selectAction(page, 'Issue certified copy')
     })
@@ -137,10 +136,12 @@ test.describe.serial('Issue Certified Copy', () => {
     test('Click continue after selecting collector type and template type', async () => {
       await page.getByText('Select...').click()
       const selectOptionsLabels = ['Mother', 'Father', 'Someone else']
+
       for (const label of selectOptionsLabels) {
         await page.getByText(label, { exact: true }).scrollIntoViewIfNeeded()
         await expect(page.getByText(label, { exact: true })).toBeVisible()
       }
+
       await page
         .getByText(selectOptionsLabels[0], { exact: true })
         .scrollIntoViewIfNeeded()
@@ -149,6 +150,7 @@ test.describe.serial('Issue Certified Copy', () => {
       await expect(page.getByRole('button', { name: 'Confirm' })).toBeEnabled()
       await page.getByRole('button', { name: 'Confirm' }).click()
     })
+
     test('Search The record and check the No Flag', async () => {
       await searchFromSearchBar(page, childName)
       const Flags = page.getByTestId('flags').filter({ hasText: 'Flags' })

--- a/packages/testland/src/events/birth/forms/printForm/collector-other.ts
+++ b/packages/testland/src/events/birth/forms/printForm/collector-other.ts
@@ -317,7 +317,12 @@ export const printCertificateCollectorOther: FieldConfig[] = [
     },
     configuration: {
       maxFileSize: 5 * 1024 * 1024, // 5 MB
-      acceptedFileTypes: ['image/png', 'image/jpg', 'image/jpeg'],
+      acceptedFileTypes: [
+        'image/png',
+        'image/jpg',
+        'image/jpeg',
+        'application/pdf'
+      ],
       fileName: {
         defaultMessage: 'Signed Affidavit',
         description: 'This is the label for the file name',

--- a/packages/testland/src/events/birth/forms/printForm/index.ts
+++ b/packages/testland/src/events/birth/forms/printForm/index.ts
@@ -54,8 +54,9 @@ export const BIRTH_CERTIFICATE_COLLECTOR_FORM = defineActionForm({
         defaultMessage: 'Verify their identity',
         description: 'This is the title of the section'
       },
-      conditional: not(
-        field('collector.requesterId').isEqualTo('SOMEONE_ELSE')
+      conditional: and(
+        not(field('collector.requesterId').isEqualTo('SOMEONE_ELSE')),
+        not(field('collector.requesterId').isEqualTo('PRINT_IN_ADVANCE'))
       ),
       fields: printCertificateCollectorIdentityVerify,
       actions: {
@@ -100,6 +101,9 @@ export const BIRTH_CERTIFICATE_COLLECTOR_FORM = defineActionForm({
         defaultMessage: 'Collect Payment',
         description: 'This is the title of the section'
       },
+      conditional: not(
+        field('collector.requesterId').isEqualTo('PRINT_IN_ADVANCE')
+      ),
       fields: [
         {
           id: 'collector.collect.payment.data.afterLateRegistrationTarget',

--- a/packages/testland/src/events/death/forms/printForm/collector-other.ts
+++ b/packages/testland/src/events/death/forms/printForm/collector-other.ts
@@ -327,7 +327,12 @@ export const printCertificateCollectorOther: FieldConfig[] = [
     },
     configuration: {
       maxFileSize: 5 * 1024 * 1024, // 5 MB
-      acceptedFileTypes: ['image/png', 'image/jpg', 'image/jpeg'],
+      acceptedFileTypes: [
+        'image/png',
+        'image/jpg',
+        'image/jpeg',
+        'application/pdf'
+      ],
       fileName: {
         defaultMessage: 'Signed Affidavit',
         description: 'This is the label for the file name',

--- a/packages/testland/src/events/death/forms/printForm/index.ts
+++ b/packages/testland/src/events/death/forms/printForm/index.ts
@@ -104,6 +104,9 @@ export const DEATH_CERTIFICATE_COLLECTOR_FORM = defineActionForm({
         defaultMessage: 'Collect Payment',
         description: 'This is the title of the section'
       },
+      conditional: not(
+        field('collector.requesterId').isEqualTo('PRINT_IN_ADVANCE')
+      ),
       fields: [
         {
           id: 'collector.collect.payment.data.afterRegistrationTarget',

--- a/packages/testland/src/translations/client.csv
+++ b/packages/testland/src/translations/client.csv
@@ -117,6 +117,7 @@ certificate.parent.details.label.nationality,Parent Nationality,Nationality,Nati
 certificate.parent.details.label.number,Parent number,Number,Numéro
 certificates.birth.certificate,Birth Certificate,Birth Certificate,Acte de naissance
 certificates.birth.certificate.copy,Birth Certificate Certified Copy,Birth Certificate Certified Copy,Copie certifiée conforme de l'acte de naissance
+certificates.birth.printedCertificateCount,Number of printed copies,"{copiesPrintedForTemplate, select, 0{} other{Copy #{copiesPrintedForTemplate}}}","{copiesPrintedForTemplate, select, 0{} other{Copie #{copiesPrintedForTemplate}}}"
 certificates.birth.registration.receipt,Birth Registration Receipt,Birth Registration Receipt,Reçu d'enregistrement de naissance
 certificates.death.certificate,Death Certificate,Death Certificate,Certificat de décès
 certificates.death.certificate.copy,Death Certificate Certified Copy,Death Certificate Certified Copy,Copie certifiée conforme du certificat de décès


### PR DESCRIPTION
## Description

Resolves:
- https://github.com/opencrvs/opencrvs-core/issues/13225
- https://github.com/opencrvs/opencrvs-core/issues/13221
- https://github.com/opencrvs/opencrvs-core/issues/13218

Changes:
* Allow PDFs on 'Signed affidavit' field
* Hide verification and fee page if printing in advance
* Add missing translation for copy count
* Also add a mention to CHANGELOG.md for my previously merged PR: https://github.com/opencrvs/opencrvs-core/pull/13208

Fixed pdf upload:
<img width="580" height="286" alt="Screenshot 2026-07-22 at 12 27 35" src="https://github.com/user-attachments/assets/c354f4fd-a6ef-48e7-8f9b-19bc4aec610f" />

Fixed copy count:
<img width="697" height="685" alt="Screenshot 2026-07-22 at 12 32 02" src="https://github.com/user-attachments/assets/3de1c6da-d54e-4206-84b1-ff93066473cf" />


## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
