### PR TITLE
fix: Enable arm64 image build on tag push

### DIFF
--- a/.github/workflows/build-images-from-branch.yml
+++ b/.github/workflows/build-images-from-branch.yml
@@ -61,7 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: ${{ (inputs.build_arm == true && fromJSON('["ubuntu-24.04", "ubuntu-24.04-arm"]')) || fromJSON('["ubuntu-24.04"]') }}
+        runner: ${{ ((inputs.build_arm == true || startsWith(github.ref, 'refs/tags/')) && fromJSON('["ubuntu-24.04", "ubuntu-24.04-arm"]')) || fromJSON('["ubuntu-24.04"]') }}
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v6
@@ -142,7 +142,7 @@ jobs:
           password: ${{ secrets.GHCR_PUBLISH_TOKEN }}
       - name: Create and push multi-arch manifest
         env:
-          BUILD_ARM: ${{ inputs.build_arm == true }}
+          BUILD_ARM: ${{ inputs.build_arm == true || startsWith(github.ref, 'refs/tags/') }}
         run: |
           REPO="ghcr.io/opencrvs/ocrvs-base"
           for TAG in ${{ needs.base.outputs.branch }} ${{ needs.base.outputs.version }}; do
@@ -161,7 +161,7 @@ jobs:
       fail-fast: false
       matrix:
         runner: ${{
-          (inputs.build_arm == true && fromJSON('["ubuntu-24.04", "ubuntu-24.04-arm"]')) ||
+          ((inputs.build_arm == true || startsWith(github.ref, 'refs/tags/')) && fromJSON('["ubuntu-24.04", "ubuntu-24.04-arm"]')) ||
           fromJSON('["ubuntu-24.04"]')
           }}
         service: ${{ fromJSON(needs.base.outputs.services) }}
@@ -230,7 +230,7 @@ jobs:
 
       - name: Create and push multi-arch manifest
         env:
-          BUILD_ARM: ${{ inputs.build_arm == true }}
+          BUILD_ARM: ${{ inputs.build_arm == true || startsWith(github.ref, 'refs/tags/') }}
         run: |
           REPO_PREFIX="ghcr.io/opencrvs/ocrvs"
 

--- a/.github/workflows/deploy-to-feature-environment.yml
+++ b/.github/workflows/deploy-to-feature-environment.yml
@@ -223,20 +223,20 @@ jobs:
           HEAD_COMMIT_HASH=$(echo "$PR_DATA" | jq -r '.headRefOid' | cut -c1-7)
           echo "HEAD_COMMIT_HASH=${HEAD_COMMIT_HASH}" >> $GITHUB_ENV
 
-      - name: Check if branch exists in opencrvs-farajaland repo
+      - name: Check if branch exists in opencrvs-testland repo
         run: |
-          FARAJALAND_REPO=https://github.com/opencrvs/opencrvs-farajaland
+          FARAJALAND_REPO=https://github.com/opencrvs/opencrvs-testland
           BASE_BRANCH="${{ github.base_ref || 'develop' }}"
 
           if git ls-remote $FARAJALAND_REPO refs/heads/${{ env.BRANCH_NAME }} | grep -q "${{ env.BRANCH_NAME }}"; then
             COMMIT_HASH=$(git ls-remote $FARAJALAND_REPO refs/heads/${{ env.BRANCH_NAME }} | cut -c1-7)
-            echo "Branch ${{ env.BRANCH_NAME }} exists in opencrvs-farajaland repo: $COMMIT_HASH"
+            echo "Branch ${{ env.BRANCH_NAME }} exists in opencrvs-testland repo: $COMMIT_HASH"
           elif git ls-remote $FARAJALAND_REPO refs/heads/$BASE_BRANCH | grep -q "$BASE_BRANCH"; then
             COMMIT_HASH=$(git ls-remote $FARAJALAND_REPO refs/heads/$BASE_BRANCH | cut -c1-7)
-            echo "Branch ${{ env.BRANCH_NAME }} doesn't exist in opencrvs-farajaland repo. Will use commit hash: '$COMMIT_HASH' from base branch: '$BASE_BRANCH'"
+            echo "Branch ${{ env.BRANCH_NAME }} doesn't exist in opencrvs-testland repo. Will use commit hash: '$COMMIT_HASH' from base branch: '$BASE_BRANCH'"
           else
             COMMIT_HASH=$(git ls-remote $FARAJALAND_REPO refs/heads/develop | cut -c1-7)
-            echo "Branch ${{ env.BRANCH_NAME }} doesn't exist in opencrvs-farajaland repo. Will use commit hash: '$COMMIT_HASH' from 'develop' branch"
+            echo "Branch ${{ env.BRANCH_NAME }} doesn't exist in opencrvs-testland repo. Will use commit hash: '$COMMIT_HASH' from 'develop' branch"
           fi
           echo "FARAJALAND_COMMIT_HASH=${COMMIT_HASH}" >> $GITHUB_ENV
       - name: Parse the stack name

--- a/.github/workflows/test-upgrade-script.yml
+++ b/.github/workflows/test-upgrade-script.yml
@@ -14,7 +14,7 @@ on:
     inputs:
       countryconfig-branch:
         description: countryconfig branch name
-        default: release-v1.9.12
+        default: release/1.9.15
         required: true
       ref:
         description: Commit SHA / branch / tag to checkout (optional)
@@ -24,7 +24,7 @@ jobs:
   test-upgrade-script:
     runs-on: ubuntu-24.04
     env:
-      COUNTRYCONFIG_BRANCH: ${{ github.event.inputs.countryconfig-branch || 'release-v1.9.11' }}
+      COUNTRYCONFIG_BRANCH: ${{ github.event.inputs.countryconfig-branch || 'release/1.9.15' }}
     steps:
       - name: Checkout opencrvs-core repository
         uses: actions/checkout@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## 2.0.1 Release Candidate
 
-## 2.0.0 Release Candidate
+### Bug fixes
+
+- Re-enable ARM-based images in the Tiltfile so local developers can run OpenCRVS on Apple silicon. [#13285](https://github.com/opencrvs/opencrvs-core/pull/13285)
+
+## 2.0.0 Release
 
 ### Upgrade guidance
 

--- a/charts/dependencies/Chart.yaml
+++ b/charts/dependencies/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opencrvs-dependencies-chart
 description: Dependencies required by OpenCRVS
 type: application
-version: v2.0.0
-appVersion: v2.0.0
+version: v2.0.1
+appVersion: v2.0.1

--- a/charts/opencrvs-application/Chart.yaml
+++ b/charts/opencrvs-application/Chart.yaml
@@ -5,5 +5,5 @@ description: |
   This chart can be used as a starting point for creating new application
   charts by providing common configurations and templates.
 type: application
-version: v2.0.0
-appVersion: 'v2.0.0'
+version: v2.0.1
+appVersion: 'v2.0.1'

--- a/charts/opencrvs-mosip/Chart.yaml
+++ b/charts/opencrvs-mosip/Chart.yaml
@@ -3,5 +3,5 @@ name: opencrvs-mosip
 description: |
   OpenCRVS API for MOSIP https://github.com/opencrvs/mosip/tree/main
 type: application
-version: v2.0.0
-appVersion: 'v2.0.0'
+version: v2.0.1
+appVersion: 'v2.0.1'

--- a/charts/opencrvs-services/Chart.yaml
+++ b/charts/opencrvs-services/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opencrvs-services
 description: OpenCRVS Services
 type: application
-version: v2.0.0
-appVersion: v2.0.0
+version: v2.0.1
+appVersion: v2.0.1

--- a/packages/toolkit/src/migrations/v2.0/checkout-upstream-files.ts
+++ b/packages/toolkit/src/migrations/v2.0/checkout-upstream-files.ts
@@ -47,7 +47,7 @@ import { execFileSync } from 'child_process'
 export const UPSTREAM_URL =
   'https://github.com/opencrvs/opencrvs-countryconfig.git'
 
-export const UPSTREAM_BRANCH = 'release-v2.0.0'
+export const UPSTREAM_BRANCH = 'release/2.0.0'
 
 // Remote name used only for the duration of this codemod. Prefixed to avoid
 // clashing with remotes the user may have (origin, upstream, etc.).

--- a/packages/toolkit/src/migrations/v2.0/merge-infrastructure-directory.ts
+++ b/packages/toolkit/src/migrations/v2.0/merge-infrastructure-directory.ts
@@ -45,7 +45,7 @@
  *     so `git merge-base HEAD upstream/develop` typically returns nothing.
  *   - With no merge-base, a 3-way merge degenerates to a 2-way diff against
  *     an empty file — every line that differs becomes a conflict.
- *   - `release-v1.9` is the latest 1.9.x release line on upstream and is a
+ *   - `release/1.9.15` is the latest 1.9.x release on upstream and is a
  *     near-perfect representation of "what `infrastructure/` looked like
  *     before v2.0", regardless of whether the fork's git history reaches it.
  *   - For files the country config never modified relative to that baseline,
@@ -70,7 +70,7 @@
  *     sides changed a binary file, the result will be invalid and a warning
  *     is printed.
  *   - Forks that are on a much older 1.9.x and never merged later 1.9 patches
- *     may see a few extra conflicts on files where 1.9.x → release-v1.9
+ *     may see a few extra conflicts on files where 1.9.x → release/1.9.15
  *     patches and v1.9 → v2.0 changes textually overlap.
  */
 
@@ -96,7 +96,7 @@ const INFRASTRUCTURE_DIR = 'infrastructure'
 // Synthetic merge-base: the tip of upstream's latest 1.9.x release line.
 // We use this branch's content as the "common ancestor" for every file,
 // since most country forks don't share git history with upstream.
-const BASE_BRANCH = 'release-v1.9'
+const BASE_BRANCH = 'release/1.9.15'
 
 /**
  * Reads `git show <ref>:<path>` as a Uint8Array (binary-safe).


### PR DESCRIPTION
## Description

Enable arm64 image build on tag push

## Testing

Workflow with ARM image builds by pushing new tag:
https://github.com/opencrvs/opencrvs-core/actions/runs/30339030045

Included fixes:
- Cherry-pick: [fix: Rename farajaland to testland](https://github.com/opencrvs/opencrvs-core/pull/13285/changes/e7569cde37f5613cc66ad68eaeddec29352e7c37)

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
