### PR TITLE
Add createdBy scope to allow filtering by the user who created the event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2.0.1 Release Candidate
 
+### Improvements
+
+- Added `createdBy` as a config paramater to filter records created by the user [#13287](https://github.com/opencrvs/opencrvs-core/issues/13287)
+
 ### Bug fixes
 
 - Re-enable ARM-based images in the Tiltfile so local developers can run OpenCRVS on Apple silicon. [#13285](https://github.com/opencrvs/opencrvs-core/pull/13285)

--- a/packages/commons/src/events/locations.test.ts
+++ b/packages/commons/src/events/locations.test.ts
@@ -34,6 +34,7 @@ describe('canAccessEventWithScope()', () => {
 
   const declaredEvent: Partial<EventIndexWithAdministrativeHierarchy> = {
     type: 'birth',
+    createdBy: createdById,
     placeOfEvent: [provinceUuid, districtUuid, officeUuid],
     legalStatuses: {
       DECLARED: {
@@ -85,6 +86,7 @@ describe('canAccessEventWithScope()', () => {
   ] satisfies RecordScopeV2['options'][]
 
   const userOptions = [
+    { createdBy: 'user' },
     { declaredBy: 'user' },
     { registeredBy: 'user' }
   ] satisfies RecordScopeV2['options'][]
@@ -212,6 +214,45 @@ describe('canAccessEventWithScope()', () => {
         ).toBe(true)
       }
     )
+
+    test('should access an event they created even when it was declared by another user (createdBy:user)', () => {
+      // The user created the record, but a different user re-declared it, so
+      // DECLARED.createdBy no longer points to them. createdBy is based on the
+      // immutable CREATE author, so it should still grant access...
+      const reDeclaredByAnotherUser: Partial<EventIndexWithAdministrativeHierarchy> =
+        {
+          ...declaredEvent,
+          createdBy: userContext.id,
+          legalStatuses: {
+            NOTIFIED: undefined,
+            DECLARED: {
+              acceptedAt: new Date().toISOString(),
+              createdAt: new Date().toISOString(),
+              createdBy: generateUuid(rng),
+              createdAtLocation: [provinceUuid, districtUuid, officeUuid]
+            },
+            REGISTERED: undefined
+          }
+        }
+
+      expect(
+        canAccessEventWithScope(
+          reDeclaredByAnotherUser,
+          { type: 'record.edit', options: { createdBy: 'user' } },
+          userContext
+        )
+      ).toBe(true)
+
+      // ...whereas a declaredBy:user scope would not, since the latest DECLARE
+      // was authored by someone else.
+      expect(
+        canAccessEventWithScope(
+          reDeclaredByAnotherUser,
+          { type: 'record.edit', options: { declaredBy: 'user' } },
+          userContext
+        )
+      ).toBe(false)
+    })
   })
 
   test('should not access event if user does not meet any of the scope options', () => {
@@ -227,6 +268,7 @@ describe('canAccessEventWithScope()', () => {
     const singleOptions = [
       { placeOfEvent: 'location' },
       { placeOfEvent: 'administrativeArea' },
+      { createdBy: 'user' },
       { declaredIn: 'location' },
       { declaredIn: 'administrativeArea' },
       { registeredIn: 'location' },

--- a/packages/commons/src/events/locations.test.ts
+++ b/packages/commons/src/events/locations.test.ts
@@ -224,7 +224,6 @@ describe('canAccessEventWithScope()', () => {
           ...declaredEvent,
           createdBy: userContext.id,
           legalStatuses: {
-            NOTIFIED: undefined,
             DECLARED: {
               acceptedAt: new Date().toISOString(),
               createdAt: new Date().toISOString(),

--- a/packages/commons/src/events/locations.ts
+++ b/packages/commons/src/events/locations.ts
@@ -164,6 +164,10 @@ export function canAccessEventWithScope(
     return false
   }
 
+  if (opts?.createdBy === UserFilter.enum.user && event.createdBy !== user.id) {
+    return false
+  }
+
   if (scopeUsesDeclaredOptions(scope)) {
     const { options } = scope
 

--- a/packages/commons/src/scopes.test.ts
+++ b/packages/commons/src/scopes.test.ts
@@ -115,6 +115,26 @@ describe('getScopeOptionValue()', () => {
 
     expect(result).toEqual(JurisdictionFilter.enum.location)
   })
+  it('should return undefined for createdBy when not set', () => {
+    const result = getScopeOptionValue(
+      { type: 'record.create', options: {} },
+      'createdBy'
+    )
+
+    expect(result).toBeUndefined()
+  })
+
+  it('should return set value for createdBy', () => {
+    const result = getScopeOptionValue(
+      {
+        type: 'record.create',
+        options: { createdBy: 'user' as const }
+      },
+      'createdBy'
+    )
+
+    expect(result).toEqual('user')
+  })
 })
 
 describe('2.0 scopes', () => {
@@ -285,6 +305,39 @@ describe('2.0 scopes', () => {
           registeredIn: 'administrativeArea',
           registeredBy: 'user'
         }
+      }
+    ])
+  })
+
+  it('Keeps the createdBy option for every record scope category', () => {
+    // createdBy is a base option (scopeOptionsPlaceEvent), so unlike declaredBy
+    // /notifiedBy it must be retained for placeEvent scope types too, not just
+    // the declared/full ones.
+    const oneScopePerCategory = [
+      ScopesWithPlaceEventOptions.options[0], // record.create
+      ScopesWithDeclaredOptions.options[0], // record.edit
+      ScopesWithFullOptions.options[0] // record.search
+    ]
+
+    const encoded = oneScopePerCategory.map((type) =>
+      encodeScope({
+        type,
+        options: { event: ['birth'], createdBy: 'user' as const }
+      })
+    )
+
+    expect(encoded.map(decodeScope)).toEqual([
+      {
+        type: 'record.create',
+        options: { event: ['birth'], createdBy: 'user' }
+      },
+      {
+        type: 'record.edit',
+        options: { event: ['birth'], createdBy: 'user' }
+      },
+      {
+        type: 'record.search',
+        options: { event: ['birth'], createdBy: 'user' }
       }
     ])
   })

--- a/packages/commons/src/scopes.ts
+++ b/packages/commons/src/scopes.ts
@@ -95,7 +95,8 @@ const userRole = z
 const scopeOptionsPlaceEvent = z
   .object({
     event: scopeByEvent,
-    placeOfEvent: JurisdictionFilter.optional()
+    placeOfEvent: JurisdictionFilter.optional(),
+    createdBy: UserFilter.optional()
   })
   .describe('Options applicable to all record scopes.')
 
@@ -157,7 +158,8 @@ export type ScopeOptionKey = z.infer<typeof ScopeOptionKey>
 const ResolvedScopeOptionsPlaceEvent = z
   .object({
     event: scopeByEvent,
-    placeOfEvent: UUID.nullish()
+    placeOfEvent: UUID.nullish(),
+    createdBy: z.string().optional()
   })
   .describe(
     'Resolved options applicable to all record scopes, with location ID instead of jurisdiction filter.'

--- a/packages/events/src/router/event/event.actions.edit.created.scopes.test.ts
+++ b/packages/events/src/router/event/event.actions.edit.created.scopes.test.ts
@@ -1,0 +1,87 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+
+import fc from 'fast-check'
+import { UserFilter, createPrng, encodeScope } from '@opencrvs/commons'
+import {
+  assertScopeResult,
+  attemptScopedAction,
+  createTestClient,
+  TEST_USER_DEFAULT_SCOPES
+} from '@events/tests/utils'
+import {
+  payloadGenerator,
+  setupHierarchyWithUsers
+} from '@events/tests/generators'
+
+test('createdBy scope filter for record.edit', async () => {
+  const rng = createPrng(56473829)
+  const generator = payloadGenerator(rng)
+
+  const { users, isUnderAdministrativeArea } = await setupHierarchyWithUsers()
+
+  // Each user creates and notifies one event, so every event has a distinct creator.
+  const eventIds: string[] = []
+  for (const user of users) {
+    const testClient = createTestClient(user, TEST_USER_DEFAULT_SCOPES)
+    const event = await testClient.event.create(generator.event.create())
+    await testClient.event.actions.notify.request(
+      generator.event.actions.notify(event.id)
+    )
+    eventIds.push(event.id)
+  }
+
+  const clientReadingAllEvents = createTestClient(users[0], [
+    encodeScope({ type: 'record.read' })
+  ])
+
+  const userOptions = fc.option(fc.constant(UserFilter.enum.user), {
+    nil: undefined
+  })
+
+  const combinations = fc.record({
+    user: fc.constantFrom(...users),
+    createdBy: userOptions
+  })
+
+  await fc.assert(
+    fc.asyncProperty(combinations, async ({ user, createdBy }) => {
+      const scope = encodeScope({
+        type: 'record.edit',
+        options: { createdBy }
+      })
+
+      // Consume one event per run so the same event is never assigned twice.
+      const randomIndex = Math.floor(Math.random() * eventIds.length)
+      const [eventId] = eventIds.splice(randomIndex, 1)
+
+      const result = await attemptScopedAction(
+        eventId,
+        user,
+        scope,
+        clientReadingAllEvents,
+        async (client) =>
+          client.event.actions.edit.request(
+            generator.event.actions.edit(eventId)
+          )
+      )
+
+      assertScopeResult(result, {
+        user,
+        event: undefined,
+        placeOfEvent: undefined,
+        isUnderAdministrativeArea,
+        createdBy
+      })
+    }),
+    { numRuns: 20 }
+  )
+}, 120000)

--- a/packages/events/src/router/event/event.get.scopes.test.ts
+++ b/packages/events/src/router/event/event.get.scopes.test.ts
@@ -16,6 +16,7 @@ import {
   JurisdictionFilter,
   TENNIS_CLUB_MEMBERSHIP,
   UserFilter,
+  createPrng,
   encodeScope,
   getDeclarationFields
 } from '@opencrvs/commons'
@@ -23,10 +24,12 @@ import { tennisClubMembershipEvent } from '@opencrvs/commons/fixtures'
 import {
   assertScopeResult,
   createTestClient,
-  setupScopeTestFixture
+  setupScopeTestFixture,
+  TEST_USER_DEFAULT_SCOPES
 } from '@events/tests/utils'
 import { createIndex } from '@events/service/indexing/indexing'
 import { getEventIndexName } from '@events/storage/elasticsearch'
+import { payloadGenerator, setupHierarchyWithUsers } from '@events/tests/generators'
 import { EventNotFoundError } from '../../service/events/events'
 
 test('Check scopes against event.get', async () => {

--- a/packages/events/src/router/event/event.get.scopes.test.ts
+++ b/packages/events/src/router/event/event.get.scopes.test.ts
@@ -118,3 +118,72 @@ test('Check scopes against event.get', async () => {
     { numRuns: 40 }
   )
 })
+
+test('Check createdBy scope against event.get', async () => {
+  const rng = createPrng(99887766)
+  const generator = payloadGenerator(rng)
+
+  const { users, isUnderAdministrativeArea } = await setupHierarchyWithUsers()
+
+  // Each user creates and notifies one event, so every event has a distinct creator.
+  const eventIds: string[] = []
+  for (const user of users) {
+    const testClient = createTestClient(user, TEST_USER_DEFAULT_SCOPES)
+    const event = await testClient.event.create(generator.event.create())
+    await testClient.event.actions.notify.request(
+      generator.event.actions.notify(event.id)
+    )
+    eventIds.push(event.id)
+  }
+
+  const clientReadingAllEvents = createTestClient(users[0], [
+    encodeScope({ type: 'record.read' })
+  ])
+
+  const userOptions = fc.option(fc.constant(UserFilter.enum.user), {
+    nil: undefined
+  })
+
+  const combinations = fc.record({
+    user: fc.constantFrom(...users),
+    createdBy: userOptions
+  })
+
+  await fc.assert(
+    fc.asyncProperty(combinations, async ({ user, createdBy }) => {
+      const scope = encodeScope({
+        type: 'record.read',
+        options: { createdBy }
+      })
+
+      const randomIndex = Math.floor(Math.random() * eventIds.length)
+      const [eventId] = eventIds.splice(randomIndex, 1)
+
+      const testClient = createTestClient(user, [scope])
+
+      let result: { success: boolean; event: EventDocument }
+      try {
+        const eventFetchedAsUser = await testClient.event.get({ eventId })
+        result = { success: true, event: eventFetchedAsUser }
+      } catch (error) {
+        if (error instanceof EventNotFoundError) {
+          const eventFetchedAsAdmin = await clientReadingAllEvents.event.get({
+            eventId
+          })
+          result = { success: false, event: eventFetchedAsAdmin }
+        } else {
+          throw error
+        }
+      }
+
+      assertScopeResult(result, {
+        user,
+        event: undefined,
+        placeOfEvent: undefined,
+        isUnderAdministrativeArea,
+        createdBy
+      })
+    }),
+    { numRuns: 20 }
+  )
+}, 120000)

--- a/packages/events/src/router/event/event.search.created.scopes.test.ts
+++ b/packages/events/src/router/event/event.search.created.scopes.test.ts
@@ -1,0 +1,82 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+
+import fc from 'fast-check'
+import {
+  TENNIS_CLUB_MEMBERSHIP,
+  UserFilter,
+  createPrng,
+  encodeScope
+} from '@opencrvs/commons'
+import { createTestClient, TEST_USER_DEFAULT_SCOPES } from '@events/tests/utils'
+import {
+  payloadGenerator,
+  setupHierarchyWithUsers
+} from '@events/tests/generators'
+
+test('createdBy scope filter for record.search', async () => {
+  const rng = createPrng(19283746)
+  const generator = payloadGenerator(rng)
+
+  const { users } = await setupHierarchyWithUsers()
+
+  // Each user creates and notifies one event, so every event has a distinct creator.
+  for (const user of users) {
+    const testClient = createTestClient(user, TEST_USER_DEFAULT_SCOPES)
+    const event = await testClient.event.create(generator.event.create())
+    await testClient.event.actions.notify.request(
+      generator.event.actions.notify(event.id)
+    )
+  }
+
+  const userOptions = fc.option(fc.constant(UserFilter.enum.user), {
+    nil: undefined
+  })
+
+  const combinations = fc.record({
+    user: fc.constantFrom(...users),
+    createdBy: userOptions
+  })
+
+  await fc.assert(
+    fc.asyncProperty(combinations, async ({ user, createdBy }) => {
+      const searchScope = encodeScope({
+        type: 'record.search',
+        options: {
+          event: [TENNIS_CLUB_MEMBERSHIP],
+          createdBy
+        }
+      })
+
+      const testClient = createTestClient(user, [searchScope])
+      const { results } = await testClient.event.search({
+        query: {
+          type: 'and',
+          clauses: [{ eventType: TENNIS_CLUB_MEMBERSHIP }]
+        }
+      })
+
+      // 1. createdBy=user: only the single event this user created is returned.
+      if (createdBy === UserFilter.enum.user) {
+        expect(results.length).toBe(1)
+        for (const r of results) {
+          expect(r.createdBy).toBe(user.id)
+        }
+      }
+
+      // 2. no createdBy filter: every event is returned, regardless of creator.
+      if (createdBy === undefined) {
+        expect(results.length).toBe(users.length)
+      }
+    }),
+    { numRuns: 100 }
+  )
+}, 120000)

--- a/packages/events/src/service/indexing/query.ts
+++ b/packages/events/src/service/indexing/query.ts
@@ -360,6 +360,11 @@ export function withJurisdictionFilters({
               term: { placeOfEvent: value }
             })
             break
+          case 'createdBy':
+            must.push({
+              term: { createdBy: value }
+            })
+            break
           case 'declaredIn':
             must.push({
               term: {

--- a/packages/events/src/service/indexing/utils.ts
+++ b/packages/events/src/service/indexing/utils.ts
@@ -474,6 +474,8 @@ export function resolveRecordActionScopeToIds(
     options: {
       event: options?.event,
       placeOfEvent: getLocationIdsFromScopeOptions(options?.placeOfEvent, user),
+      createdBy:
+        options?.createdBy === UserFilter.enum.user ? user.id : undefined,
       declaredIn: getLocationIdsFromScopeOptions(options?.declaredIn, user),
       declaredBy:
         options?.declaredBy === UserFilter.enum.user ? user.id : undefined,

--- a/packages/events/src/tests/utils.ts
+++ b/packages/events/src/tests/utils.ts
@@ -709,6 +709,7 @@ function eventMatchesScope({
   eventIndex,
   user,
   placeOfEvent,
+  createdBy,
   declaredBy,
   registeredBy,
   declaredIn,
@@ -721,6 +722,7 @@ function eventMatchesScope({
     | { id: UUID; primaryOfficeId: UUID; administrativeAreaId: UUID | null }
     | CreatedUser
   placeOfEvent?: JurisdictionFilter
+  createdBy?: UserFilter
   declaredBy?: UserFilter
   registeredBy?: UserFilter
   declaredIn?: JurisdictionFilter
@@ -731,6 +733,12 @@ function eventMatchesScope({
     adminAreaId: UUID | null
   ) => boolean
 }): boolean {
+  if (createdBy === UserFilter.enum.user) {
+    if (eventIndex.createdBy !== user.id) {
+      return false
+    }
+  }
+
   if (declaredBy === UserFilter.enum.user) {
     if (eventIndex.legalStatuses.DECLARED?.createdBy !== user.id) {
       return false
@@ -1058,6 +1066,7 @@ export function assertScopeResult(
     event,
     placeOfEvent,
     isUnderAdministrativeArea,
+    createdBy,
     declaredBy,
     declaredIn,
     registeredBy,
@@ -1070,6 +1079,7 @@ export function assertScopeResult(
       locationId: UUID,
       adminAreaId: UUID | null
     ) => boolean
+    createdBy?: UserFilter
     declaredBy?: UserFilter
     registeredBy?: UserFilter
     declaredIn?: JurisdictionFilter
@@ -1086,6 +1096,7 @@ export function assertScopeResult(
   const isAccessibleWithScope = eventMatchesScope({
     eventIndex,
     user,
+    createdBy,
     declaredBy,
     registeredBy,
     declaredIn,


### PR DESCRIPTION
## Description

Added `createdBy` as a config paramater to filter records created by the user.
Useful if a record has not been declared yet or if a record has had multiple declares.

issue: https://github.com/opencrvs/opencrvs-core/issues/13287

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [x] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
