### PR TITLE
chore: Update Traefik chart to 41.0.2 and migrate log values

### DIFF
--- a/packages/toolkit/src/environment/templates/charts-values/traefik/values.yaml
+++ b/packages/toolkit/src/environment/templates/charts-values/traefik/values.yaml
@@ -9,16 +9,15 @@
 
 # Overwriting https://github.com/traefik/traefik-helm-chart/blob/master/traefik/values.yaml
 namespaceOverride: "traefik"
-logs:
-  general:
-    # "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL", "PANIC"
-    level: "INFO"
-    # format: "common" # For local environment
-    format: "json" # For server environment
-  access:
-    # -- To enable access logs
-    enabled: true
-    format: "json"
+log:
+  # "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL", "PANIC"
+  level: "INFO"
+  # format: "common" # For local environment
+  format: "json" # For server environment
+accessLog:
+  # -- To enable access logs
+  enabled: true
+  format: "json"
 
 ingressRoute:
   dashboard:


### PR DESCRIPTION
## Description

Related issue: https://github.com/opencrvs/opencrvs-core/issues/13291

Related PR: https://github.com/opencrvs/infrastructure/pull/356

Updates the Traefik Helm chart used by dependency deployments from `39.0.0` to `41.0.2` and migrates the generated Traefik values template to the v41 logging schema.

Traefik Helm chart v41 replaces:

- `logs.general` with `log`
- `logs.access` with `accessLog`

Without this change, Helm upgrades fail schema validation with `additional properties 'logs' not allowed`.

## Changes

- Bumped `TRAEFIK_CHART_VERSION` to `41.0.2`
- Updated the Traefik environment values template to use `log` and `accessLog`
- Left generated environment files unchanged, since they are produced from the template

## Testing

- Rendered the updated Traefik values against `ghcr.io/traefik/helm/traefik:41.0.2`
- Confirmed Helm templating succeeds with the updated values schema

Code snippet after running `yarn environment:init`
<img width="773" height="341" alt="image" src="https://github.com/user-attachments/assets/c6aca205-43a8-4895-8f5f-4ffcd26138ab" />

Dependencies deployment:

Workflow: https://github.com/adskyiproger/ua-infrastructure/actions/runs/30372818017

<img width="1254" height="349" alt="image" src="https://github.com/user-attachments/assets/9b16fc42-a7d4-4343-b252-89987920941e" />



## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [x] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
