### PR TITLE
fix: Kibana is not loading due to internal/ in route path

### DIFF
--- a/charts/opencrvs-services/templates/_domain-helper.tpl
+++ b/charts/opencrvs-services/templates/_domain-helper.tpl
@@ -3,3 +3,14 @@
 {{- $http_scheme := include "http-scheme" . }}
 {{- printf "%s%s%s" $service_name ( .Values.subdomain_separator | default ".") .Values.hostname }}
 {{- end }}
+
+{{- define "render-opencrvs-host-matchers" -}}
+{{- $root := . -}}
+{{- $service_names := list "register" "login" "gateway" "events" "countryconfig" "metabase" -}}
+{{- $host_matchers := list (printf "Host(`%s`)" $root.Values.hostname) -}}
+{{- range $service_name := $service_names -}}
+{{- $host := include "render-external-subdomain" (dict "service_name" $service_name "Values" $root.Values) -}}
+{{- $host_matchers = append $host_matchers (printf "Host(`%s`)" $host) -}}
+{{- end -}}
+{{- printf "(%s)" (join " || " $host_matchers) -}}
+{{- end }}

--- a/charts/opencrvs-services/templates/internal-routes-ingressroute.yaml
+++ b/charts/opencrvs-services/templates/internal-routes-ingressroute.yaml
@@ -12,7 +12,7 @@ spec:
     - web
   {{- end }}
   routes:
-  - match: 'PathRegexp(`^/(.*/)?internal(/.*)?$`)'
+  - match: '{{ include "render-opencrvs-host-matchers" . }} && PathRegexp(`^/(.*/)?internal(/.*)?$`)'
     kind: Rule
     priority: 1000
     services:


### PR DESCRIPTION
## Description

This PR is follow up to recent fix applied at PR: https://github.com/opencrvs/opencrvs-core/pull/13266

Kibana UI are not working on e2e and non-prod environments:
<img width="1214" height="941" alt="image" src="https://github.com/user-attachments/assets/8e19b2c5-0f5f-40fd-a547-c4f708029df1" />

Rule applied by PR is too broad.

By this PR we are limiting rule to OpenCRVS services only:
- register
- login
- gateway
- events
- countryconfig
- metabase

## Testing

Internal ingressroute object exists:

<img width="569" height="131" alt="image" src="https://github.com/user-attachments/assets/67252c75-3847-4e12-ac76-984e696398ef" />

All hosts are listed under route matching rule:
<img width="1101" height="501" alt="image" src="https://github.com/user-attachments/assets/0a69495b-e9da-4a62-ac1d-7f5a146a0d50" />

Kibana is working fine:
<img width="1641" height="859" alt="image" src="https://github.com/user-attachments/assets/f8fec63c-1ae3-4328-82bc-7da03985051b" />



## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
