### PR TITLE
[OCRVS-13246] Harden the client and login Content-Security-Policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,12 @@
 
   The client still requires `unsafe-eval`: legacy v1 form conditionals, the v2-events serialised-function compiler, AJV's runtime JSON Schema compilation and Handlebars certificate templates all compile JavaScript in the browser from configuration fetched at runtime. The reasoning is documented next to the policy in `packages/client/nginx.conf`, and removing it is tracked for a future major release. Note that CSP nonces and hashes are not an alternative — they govern inline `<script>` blocks, not `eval`.
 
-  **Deployment note:** if your country configuration serves any image over plain HTTP, it will now be blocked in both apps. Serve those assets over HTTPS. [#13246](https://github.com/opencrvs/opencrvs-core/issues/13246)
+  **Deployment note:** if your country configuration serves any image over plain HTTP, it will now be blocked in both apps. Serve those assets over HTTPS.
+
+  **Two further hardening steps are deployment decisions, left to each implementation:**
+
+  - `CONTENT_SECURITY_POLICY_WILDCARD` defaults to `*.<domain>`, which trusts every subdomain — including ones the apps never call, such as Kibana, the MinIO console and webhooks. It is substituted into the policy verbatim, so you can set an explicit space-separated origin list instead; both apps work with a wildcard, an explicit list, or an empty value. The minimum sets for a default deployment are documented next to the policy in `packages/client/nginx.conf` and `packages/login/nginx.conf`.
+  - Reverse-proxy TLS cipher suites are outside OpenCRVS core. If your proxy has no explicit TLS options, Traefik and most Go-based proxies fall back to a default TLS 1.2 list that still offers CBC suites with HMAC-SHA-1. Restricting it to AEAD suites (AES-GCM, ChaCha20-Poly1305) satisfies guidance such as ANSSI-BP-035, at the cost of dropping very old clients. [#13246](https://github.com/opencrvs/opencrvs-core/issues/13246)
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 - Third-party integrations (such as MOSIP) can now authenticate with OpenCRVS using their own credentials instead of borrowing the requesting user's session. Integrations are registered automatically on startup from the country configuration, and each one signs in with its own client ID and secret. This keeps integrations working reliably even when services restart mid-request, and makes the audit trail attribute actions to the integration itself (e.g. "Registered — MOSIP") rather than to a person. The feature is opt-in: configurations with no integrations are unaffected. [#12360](https://github.com/opencrvs/opencrvs-core/issues/12360)
 
+### Improvements
+
+- Hardened the Content Security Policy served by the client and login apps, following a vulnerability scan of a national deployment. The login app no longer allows `unsafe-eval` and no longer permits scripts from the deployment's wildcard domain — it loads no third-party scripts and compiles no JavaScript at runtime. Both apps now send the `frame-ancestors`, `base-uri` and `form-action` directives, and `img-src` no longer permits plain-HTTP images. PDF previews are rendered with pdf.js code generation disabled.
+
+  The client still requires `unsafe-eval`: legacy v1 form conditionals, the v2-events serialised-function compiler, AJV's runtime JSON Schema compilation and Handlebars certificate templates all compile JavaScript in the browser from configuration fetched at runtime. The reasoning is documented next to the policy in `packages/client/nginx.conf`, and removing it is tracked for a future major release. Note that CSP nonces and hashes are not an alternative — they govern inline `<script>` blocks, not `eval`.
+
+  **Deployment note:** if your country configuration serves any image over plain HTTP, it will now be blocked in both apps. Serve those assets over HTTPS. [#13246](https://github.com/opencrvs/opencrvs-core/issues/13246)
+
 ### Bug fixes
 
 - On mobile, uploading a file or signature no longer triggers the PIN re-lock screen. Opening the native file picker or camera briefly backgrounds the app, which was previously indistinguishable from the user actually leaving the app. [#13124](https://github.com/opencrvs/opencrvs-core/issues/13124)

--- a/packages/client/nginx.conf
+++ b/packages/client/nginx.conf
@@ -58,9 +58,22 @@ add_header X-Permitted-Cross-Domain-Policies master-only;
 # style-src keeps 'unsafe-inline' for styled-components' runtime style injection and the
 # inline <style> block in index.html.
 #
-# {{CONTENT_SECURITY_POLICY_WILDCARD}} is replaced at deploy time with *.<domain>. It is
-# required in script-src so the client can load handlebars.js from the country config
-# (src/utils/referenceApi.ts).
+# {{CONTENT_SECURITY_POLICY_WILDCARD}} is replaced at deploy time by the country config.
+# It is required in script-src so the client can load handlebars.js from the country
+# config (src/utils/referenceApi.ts).
+#
+# It defaults to *.<domain>, which trusts every subdomain — including ones the app never
+# talks to, such as kibana, minio-console and webhooks. A scanner will flag that as an
+# over-broad source. The value is substituted verbatim, so a deployment can instead set an
+# explicit space-separated origin list, and this app is fine with a wildcard, an explicit
+# list, or an empty value. For a default deployment the client needs:
+#
+#   https://gateway.<domain> https://config.<domain> https://countryconfig.<domain>
+#   https://minio.<domain> https://metabase.<domain>
+#
+# metabase is needed because dashboards are embedded in an iframe and there is no
+# frame-src here, so framing falls back to default-src. Add any other origin the country
+# configuration loads in the browser, or it will be blocked.
 #
 # frame-ancestors 'self' is the CSP equivalent of the X-Frame-Options: SAMEORIGIN header
 # set above; both are sent because not every scanner recognises only one of them.

--- a/packages/client/nginx.conf
+++ b/packages/client/nginx.conf
@@ -37,14 +37,34 @@ add_header Strict-Transport-Security "max-age=31536000; includeSubDomains;";
 # that grants access to the source domain, allowing the client to continue the transaction.
 add_header X-Permitted-Cross-Domain-Policies master-only;
 
-# with Content Security Policy (CSP) enabled(and a browser that supports it(http://caniuse.com/#feat=contentsecuritypolicy),
-# you can tell the browser that it can only download content from the domains you explicitly allow
-# http://www.html5rocks.com/en/tutorials/security/content-security-policy/
-# https://www.owasp.org/index.php/Content_Security_Policy
-# I need to change our application code so we can increase security by disabling 'unsafe-inline' 'unsafe-eval'
-# directives for css and js(if you have inline css or js, you will need to keep it too).
-# more: http://www.html5rocks.com/en/tutorials/security/content-security-policy/#inline-code-considered-harmful
-add_header Content-Security-Policy "default-src 'self' {{CONTENT_SECURITY_POLICY_WILDCARD}}; connect-src 'self' {{CONTENT_SECURITY_POLICY_WILDCARD}} data:; font-src https://fonts.gstatic.com {{CONTENT_SECURITY_POLICY_WILDCARD}}; object-src 'none'; worker-src 'self' blob:; script-src 'self' 'unsafe-eval' https://sentry.io/api/embed/error-page/ {{CONTENT_SECURITY_POLICY_WILDCARD}}; style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; img-src 'self' data: http: https: blob:";
+# Content Security Policy (CSP) tells the browser which sources it may load content from.
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
+#
+# script-src keeps 'unsafe-eval' because the client compiles JavaScript at runtime in four
+# places. It cannot be dropped until all four are gone — see #13246 for the full analysis:
+#
+#   1. Legacy v1 form conditionals eval() expression strings supplied by the country
+#      configuration (src/forms/utils.ts).
+#   2. v2-events compiles serialised validators, default-value functions and sync listeners
+#      with new Function (@opencrvs/commons, conditionals/validate.ts).
+#   3. AJV compiles JSON Schema conditionals into functions with new Function. The schemas
+#      arrive from the country configuration at runtime, so they cannot be precompiled at
+#      build time the way ajv/dist/standalone would require.
+#   4. Handlebars compiles certificate templates at runtime.
+#
+# CSP nonces and hashes are not an alternative here: they gate inline <script> blocks,
+# whereas eval() and new Function are governed only by 'unsafe-eval'.
+#
+# style-src keeps 'unsafe-inline' for styled-components' runtime style injection and the
+# inline <style> block in index.html.
+#
+# {{CONTENT_SECURITY_POLICY_WILDCARD}} is replaced at deploy time with *.<domain>. It is
+# required in script-src so the client can load handlebars.js from the country config
+# (src/utils/referenceApi.ts).
+#
+# frame-ancestors 'self' is the CSP equivalent of the X-Frame-Options: SAMEORIGIN header
+# set above; both are sent because not every scanner recognises only one of them.
+add_header Content-Security-Policy "default-src 'self' {{CONTENT_SECURITY_POLICY_WILDCARD}}; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; connect-src 'self' {{CONTENT_SECURITY_POLICY_WILDCARD}} data:; font-src https://fonts.gstatic.com {{CONTENT_SECURITY_POLICY_WILDCARD}}; object-src 'none'; worker-src 'self' blob:; script-src 'self' 'unsafe-eval' https://sentry.io/api/embed/error-page/ {{CONTENT_SECURITY_POLICY_WILDCARD}}; style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; img-src 'self' data: https: blob:";
 
 server {
     listen       3000;

--- a/packages/client/src/contentSecurityPolicy.test.ts
+++ b/packages/client/src/contentSecurityPolicy.test.ts
@@ -1,0 +1,76 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+import * as fs from 'fs'
+import * as path from 'path'
+import { describe, expect, it } from 'vitest'
+
+/*
+ * The Content-Security-Policy served by nginx has historically been widened in small
+ * ad-hoc commits with no test to notice. Burkina Faso's ANSSI audit (#13246) turned the
+ * policy into a compliance commitment, so these assertions exist to make any further
+ * loosening a deliberate, reviewed act rather than a silent one.
+ *
+ * Any change here needs a matching answer to "what does the audit report say now?".
+ */
+const nginxConf = fs.readFileSync(
+  path.join(__dirname, '..', 'nginx.conf'),
+  'utf8'
+)
+
+function getDirectives(conf: string): Record<string, string[]> {
+  const header = conf.match(/add_header Content-Security-Policy "([^"]+)"/)?.[1]
+
+  if (!header) {
+    throw new Error('No Content-Security-Policy header found in nginx.conf')
+  }
+
+  return Object.fromEntries(
+    header
+      .split(';')
+      .map((directive) => directive.trim())
+      .filter(Boolean)
+      .map((directive) => {
+        const [name, ...sources] = directive.split(/\s+/)
+        return [name, sources]
+      })
+  )
+}
+
+describe('client Content-Security-Policy', () => {
+  const directives = getDirectives(nginxConf)
+
+  it('defines the directives the ANSSI audit requires', () => {
+    // frame-ancestors mirrors X-Frame-Options: SAMEORIGIN, which is also still sent
+    expect(directives['frame-ancestors']).toEqual(["'self'"])
+    expect(directives['base-uri']).toEqual(["'self'"])
+    expect(directives['form-action']).toEqual(["'self'"])
+    expect(directives['object-src']).toEqual(["'none'"])
+  })
+
+  it('does not allow plain-http images', () => {
+    // 'http:' in img-src permits mixed content on an https deployment
+    expect(directives['img-src']).not.toContain('http:')
+  })
+
+  it('does not allow inline scripts', () => {
+    expect(directives['script-src']).not.toContain("'unsafe-inline'")
+  })
+
+  /*
+   * Unlike the login app, the client cannot drop 'unsafe-eval' yet: legacy v1 form
+   * conditionals, the v2-events serialised-function compiler, AJV's runtime schema
+   * compilation and Handlebars all compile JavaScript in the browser. This asserts the
+   * exception stays a known, single exception — see the comment in nginx.conf and #13246.
+   */
+  it("still requires 'unsafe-eval', and nothing weaker would do", () => {
+    expect(directives['script-src']).toContain("'unsafe-eval'")
+  })
+})

--- a/packages/client/src/v2-events/hooks/usePreviewPdf.ts
+++ b/packages/client/src/v2-events/hooks/usePreviewPdf.ts
@@ -67,7 +67,15 @@ export function usePreviewPdf(pdfUrl: string) {
           throw new Error(`Failed to load pdfjsLib`)
         }
       }
-      const pdf = await pdfjsLib.getDocument({ data: arrayBuffer }).promise
+      /*
+       * isEvalSupported: false stops pdf.js compiling PostScript functions and font
+       * programs with new Function, which the Content-Security-Policy would otherwise
+       * have to permit. See #13246.
+       */
+      const pdf = await pdfjsLib.getDocument({
+        data: arrayBuffer,
+        isEvalSupported: false
+      }).promise
       if (cancelled) {
         return
       }

--- a/packages/login/nginx.conf
+++ b/packages/login/nginx.conf
@@ -47,6 +47,15 @@ add_header X-Permitted-Cross-Domain-Policies master-only;
 #
 # style-src keeps 'unsafe-inline' for styled-components' runtime style injection.
 #
+# {{CONTENT_SECURITY_POLICY_WILDCARD}} survives only in default-src, which is what
+# connect-src falls back to. It defaults to *.<domain> — an over-broad source a scanner
+# will flag. The value is substituted verbatim, so a deployment can set an explicit
+# space-separated origin list instead. Login needs just three:
+#
+#   https://gateway.<domain>        AUTH_API_URL, at gateway.<domain>/auth/
+#   https://config.<domain>         /publicConfig
+#   https://countryconfig.<domain>  /content/login, for country branding and copy
+#
 # frame-ancestors 'self' is the CSP equivalent of the X-Frame-Options: SAMEORIGIN header
 # set above; both are sent because not every scanner recognises only one of them.
 add_header Content-Security-Policy "default-src 'self' {{CONTENT_SECURITY_POLICY_WILDCARD}}; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; font-src https://fonts.gstatic.com; object-src 'none'; script-src 'self' https://sentry.io/api/embed/error-page/; style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; img-src 'self' data: https:";

--- a/packages/login/nginx.conf
+++ b/packages/login/nginx.conf
@@ -37,14 +37,19 @@ add_header Strict-Transport-Security "max-age=31536000; includeSubDomains;";
 # that grants access to the source domain, allowing the client to continue the transaction.
 add_header X-Permitted-Cross-Domain-Policies master-only;
 
-# with Content Security Policy (CSP) enabled(and a browser that supports it(http://caniuse.com/#feat=contentsecuritypolicy),
-# you can tell the browser that it can only download content from the domains you explicitly allow
-# http://www.html5rocks.com/en/tutorials/security/content-security-policy/
-# https://www.owasp.org/index.php/Content_Security_Policy
-# I need to change our application code so we can increase security by disabling 'unsafe-inline' 'unsafe-eval'
-# directives for css and js(if you have inline css or js, you will need to keep it too).
-# more: http://www.html5rocks.com/en/tutorials/security/content-security-policy/#inline-code-considered-harmful
-add_header Content-Security-Policy "default-src 'self' {{CONTENT_SECURITY_POLICY_WILDCARD}}; font-src https://fonts.gstatic.com; object-src 'none'; script-src 'self' 'unsafe-eval' https://sentry.io/api/embed/error-page/ {{CONTENT_SECURITY_POLICY_WILDCARD}}; style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; img-src 'self' data: http: https: ";
+# Content Security Policy (CSP) tells the browser which sources it may load content from.
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
+#
+# Unlike the client, the login app compiles no JavaScript at runtime. script-src therefore
+# needs neither 'unsafe-eval' nor the deploy-time wildcard: the only scripts login loads are
+# its own bundle and login-config.js, which is proxied same-origin through
+# /api/countryconfig/. Keep it that way. See #13246.
+#
+# style-src keeps 'unsafe-inline' for styled-components' runtime style injection.
+#
+# frame-ancestors 'self' is the CSP equivalent of the X-Frame-Options: SAMEORIGIN header
+# set above; both are sent because not every scanner recognises only one of them.
+add_header Content-Security-Policy "default-src 'self' {{CONTENT_SECURITY_POLICY_WILDCARD}}; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; font-src https://fonts.gstatic.com; object-src 'none'; script-src 'self' https://sentry.io/api/embed/error-page/; style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; img-src 'self' data: https:";
 
 server {
     listen       3020;

--- a/packages/login/src/contentSecurityPolicy.test.ts
+++ b/packages/login/src/contentSecurityPolicy.test.ts
@@ -1,0 +1,126 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+import * as fs from 'fs'
+import * as path from 'path'
+import { describe, expect, it } from 'vitest'
+
+/*
+ * login.<domain> was the host ANSSI scanned in the Burkina Faso audit (#13246), so this
+ * app's policy is the one under external commitment. The parser is duplicated from the
+ * client's equivalent test on purpose: the login app deliberately depends on neither
+ * @opencrvs/commons nor the client, which is also why it needs no 'unsafe-eval'.
+ */
+const nginxConf = fs.readFileSync(
+  path.join(__dirname, '..', 'nginx.conf'),
+  'utf8'
+)
+
+function getDirectives(conf: string): Record<string, string[]> {
+  const header = conf.match(/add_header Content-Security-Policy "([^"]+)"/)?.[1]
+
+  if (!header) {
+    throw new Error('No Content-Security-Policy header found in nginx.conf')
+  }
+
+  return Object.fromEntries(
+    header
+      .split(';')
+      .map((directive) => directive.trim())
+      .filter(Boolean)
+      .map((directive) => {
+        const [name, ...sources] = directive.split(/\s+/)
+        return [name, sources]
+      })
+  )
+}
+
+describe('login Content-Security-Policy', () => {
+  const directives = getDirectives(nginxConf)
+
+  it('defines the directives the ANSSI audit requires', () => {
+    // frame-ancestors mirrors X-Frame-Options: SAMEORIGIN, which is also still sent
+    expect(directives['frame-ancestors']).toEqual(["'self'"])
+    expect(directives['base-uri']).toEqual(["'self'"])
+    expect(directives['form-action']).toEqual(["'self'"])
+    expect(directives['object-src']).toEqual(["'none'"])
+  })
+
+  it('does not allow plain-http images', () => {
+    // 'http:' in img-src permits mixed content on an https deployment
+    expect(directives['img-src']).not.toContain('http:')
+  })
+
+  /*
+   * The login app compiles no JavaScript at runtime. If this fails, something new in the
+   * bundle calls eval() or new Function — find and remove it rather than reinstating
+   * 'unsafe-eval', because this is the policy the audit was run against.
+   */
+  it('does not allow eval or inline scripts', () => {
+    expect(directives['script-src']).not.toContain("'unsafe-eval'")
+    expect(directives['script-src']).not.toContain("'unsafe-inline'")
+  })
+
+  /*
+   * The only scripts login loads are its own bundle and login-config.js, which is proxied
+   * same-origin via /api/countryconfig/. Nothing needs the deploy-time *.<domain> wildcard,
+   * which the ANSSI report flagged as an over-broad source.
+   */
+  it('loads scripts from no wildcard origin', () => {
+    expect(directives['script-src']).not.toContain(
+      '{{CONTENT_SECURITY_POLICY_WILDCARD}}'
+    )
+  })
+})
+
+describe('login runtime without eval', () => {
+  /*
+   * google-libphonenumber bundles Google Closure's debug module loader and transpiler,
+   * which between them contain three eval() calls — vite warns about them on every build.
+   * They belong to the load-modules-from-source path, which a prebuilt dist never takes,
+   * so they should be unreachable. This asserts that, because if they ever do become
+   * reachable the login app silently needs 'unsafe-eval' back and the header above stops
+   * matching reality.
+   *
+   * The import happens before the stubs so they cover the call path, including
+   * PhoneNumberUtil's lazy metadata initialisation on first use.
+   */
+  it('formats a phone number with eval and the Function constructor disabled', async () => {
+    const { convertToMSISDN } = await import('@login/utils/dataCleanse')
+
+    const realEval = globalThis.eval
+    const RealFunction = globalThis.Function
+
+    const blockedEval = () => {
+      throw new EvalError('eval blocked by Content-Security-Policy')
+    }
+    const blockedFunction = function () {
+      throw new EvalError(
+        'Function constructor blocked by Content-Security-Policy'
+      )
+    } as unknown as FunctionConstructor
+    // keep instanceof/bind working for everything that isn't compiling a string
+    Object.defineProperty(blockedFunction, 'prototype', {
+      value: RealFunction.prototype
+    })
+
+    let result: string
+    try {
+      globalThis.eval = blockedEval as unknown as typeof globalThis.eval
+      globalThis.Function = blockedFunction
+      result = convertToMSISDN('0733333333', 'FAR')
+    } finally {
+      globalThis.eval = realEval
+      globalThis.Function = RealFunction
+    }
+
+    expect(result).toBe('+260733333333')
+  })
+})


### PR DESCRIPTION
### Why

Burkina Faso's ANSSI vulnerability scan of VENEEM left two low-severity observations open, blocking their ANO re-submission. One is the permissive CSP: `'unsafe-eval'` in `script-src`, missing `frame-ancestors`/`base-uri`/`form-action`, over-broad sources, and plain-HTTP image sources. Closes the parts of [#13246](https://github.com/opencrvs/opencrvs-core/issues/13246) that live in core.

The audited host was `login.<domain>`, so the policy under external commitment is the **login app's**, not the client's — and the login app compiles no JavaScript at runtime, so its `unsafe-eval` was copy-paste from the client config.

### What changes

- **login** — `script-src` drops `'unsafe-eval'` and the deploy-time `*.<domain>` wildcard. The only scripts it loads are its own bundle and `login-config.js`, proxied same-origin through `/api/countryconfig/`.
- **client + login** — add `frame-ancestors 'self'` (the CSP equivalent of the `X-Frame-Options: SAMEORIGIN` already sent), `base-uri 'self'` and `form-action 'self'`.
- **client + login** — `img-src` no longer permits `http:`, which allowed mixed content on an HTTPS deployment.
- **client** — `usePreviewPdf` passes `isEvalSupported: false`, so pdf.js stops compiling PostScript functions and font programs with `new Function`.
- **client** — keeps `'unsafe-eval'`, with the four reasons documented next to the policy, replacing a stale `# I need to change our application code...` TODO: legacy v1 form conditionals `eval()` country-supplied expressions, the v2-events serialised-function compiler, AJV's runtime JSON Schema compilation, and Handlebars certificate templates. All compile JS from configuration fetched at runtime, so none can be precompiled. Nonces/hashes are not an alternative — they govern inline `<script>`, not `eval`.
- **tests** — `contentSecurityPolicy.test.ts` in both packages pins the served directives (the policy had been widened in ad-hoc commits with nothing to catch it). The login test additionally runs `convertToMSISDN` with `eval` and the `Function` constructor stubbed to throw, proving the three `eval()` calls inside `google-libphonenumber`'s bundled Closure debug loader are unreachable — vite warns about them on every build, so this is asserted rather than assumed.

### How to test

- `cd packages/login && yarn test` (57 tests) and `cd packages/client && npx vitest run src/contentSecurityPolicy.test.ts`
- Validate the configs parse:
  ```sh
  sed -e 's~{{COUNTRY_CONFIG_URL_INTERNAL}}~http://127.0.0.1:3040~g' \
      -e 's~{{GATEWAY_URL_INTERNAL}}~http://127.0.0.1:7070~g' \
      -e 's~{{LOGIN_URL}}~https://login.example.org~g' \
      -e 's~{{CONTENT_SECURITY_POLICY_WILDCARD}}~*.example.org~g' \
      packages/login/nginx.conf > /tmp/conf/default.conf
  docker run --rm -v /tmp/conf:/etc/nginx/conf.d:ro \
      nginxinc/nginx-unprivileged:1.28-alpine nginx -t
  ```
- On a deployed environment, walk the **full login flow** (sign-in, 2FA, forgotten password) with devtools open and confirm zero CSP violations. This is the one gap in local verification: serving the built login bundle behind the new header confirmed the app boots, executes its bundle and loads every asset with no violations, but the config service's CORS allowlist rejects an ad-hoc test port, so the post-config steps could not be driven locally.
- Preview an uploaded **PDF** supporting document in a v2-events declaration and confirm it still renders. (pdf.js was verified to produce identical operator lists, text and fonts with code generation off, on a real 4-page PDF with embedded fonts — but there is no automated test for this hook.)
- Check `Content-Security-Policy` on both hosts after deploy: login must have no `unsafe-eval`; neither may have `http:` in `img-src`.

### Not in this PR

- **The written answer to the ticket's six questions** still needs posting on #13246 — the recommendation is "keep `unsafe-eval` on the client with documented justification, per the accepted second option", and removal is a 2.0 epic (drop v1 forms → replace the serialised-function compiler → replace runtime AJV → precompile Handlebars).
- **Tightening the client's wildcard sources** spans core's `nginx-deploy-config.sh` and countryconfig's `setup-environment.ts` (which generates `CONTENT_SECURITY_POLICY_WILDCARD` as `*.${DOMAIN}`). Landing only the core half would break deploys, so it needs a coordinated pair of PRs. The client still needs a cross-origin `script-src` entry regardless, for `${COUNTRY_CONFIG_URL}/handlebars.js`.
- **O4 (TLS CBC/SHA-1 suites)** — the ticket records this as certificate/infrastructure and not a core issue. It is neither certificate-related nor entirely outside our control: no `tls.options`/`cipherSuites` is defined anywhere in `opencrvs-countryconfig/infrastructure/`, so Traefik v2.11 falls back to Go's default TLS 1.2 list, which is exactly what serves the two flagged suites. Fixable fleet-wide with an AEAD-only cipher list in the countryconfig Traefik config; worth a separate ticket rather than leaving each country to patch it.

### Deployment note

Any country configuration serving an image over plain HTTP will now have it blocked in both apps. Those assets need to move to HTTPS.
