### PR TITLE
fix(helm): make countryconfig imagePullPolicy configurable 

### DIFF
--- a/charts/opencrvs-services/README.md
+++ b/charts/opencrvs-services/README.md
@@ -307,6 +307,11 @@ helm upgrade --install opencrvs oci://ghcr.io/opencrvs/opencrvs-services \
         <td>Defines the image pull secrets applied at Pod level for authenticating with private registries.</td>
         </tr>
         <tr>
+        <td>platform.imagePullPolicy</td>
+        <td>-</td>
+        <td>Default <code>imagePullPolicy</code> applied to all OpenCRVS service containers. Leave unset to use Kubernetes' own tag-based default (<code>IfNotPresent</code> for versioned tags, <code>Always</code> for <code>:latest</code>). Environments deploying a floating tag (e.g. <code>develop</code>) should set this to <code>Always</code>, otherwise nodes keep serving whatever image was first cached under that tag. Can be overridden at service level.</td>
+        </tr>
+        <tr>
             <th>Common Service properties</th>
             <th></th>
             <th>Properties listed below can be defined for any service</th>
@@ -335,6 +340,11 @@ helm upgrade --install opencrvs oci://ghcr.io/opencrvs/opencrvs-services \
         <td>image.repository</td>
         <td>platform.repository</td>
         <td>Overrides the default repository defined in <code>platform.repository</code>.</td>
+        </tr>
+        <tr>
+        <td>image.pullPolicy</td>
+        <td>platform.imagePullPolicy</td>
+        <td>Overrides the default <code>imagePullPolicy</code> defined in <code>platform.imagePullPolicy</code> for this service only.</td>
         </tr>
         <tr>
             <td>hpa.enabled</td>

--- a/charts/opencrvs-services/templates/_reindex-helper.tpl
+++ b/charts/opencrvs-services/templates/_reindex-helper.tpl
@@ -2,6 +2,7 @@
 - name: elasticsearch-reindex
   command: ["sh", "-c", "/data-assets/reindex.sh"]
   image: {{ include "opencrvs.image" (dict "root" . "service" .Values.utilities) }}
+  imagePullPolicy: {{ .Values.utilities.image.pullPolicy | default .Values.platform.imagePullPolicy }}
   env:
     - name: AUTH_URL
       value: "http://auth.{{ .Release.Namespace }}.svc.cluster.local:4040"
@@ -14,6 +15,7 @@
 {{- define "elasticsearch-reindex.initContainerSpec" -}}
 - name: copy-assets
   image: {{ include "opencrvs.image" (dict "root" . "service" .Values.countryconfig) }}-assets
+  imagePullPolicy: {{ .Values.countryconfig.image.pullPolicy | default .Values.platform.imagePullPolicy }}
   command:
     - sh
     - -c

--- a/charts/opencrvs-services/templates/auth-deployment.yaml
+++ b/charts/opencrvs-services/templates/auth-deployment.yaml
@@ -21,6 +21,7 @@ spec:
       {{- include "opencrvs.imagePullSecrets" (dict "root" . "service" .Values.auth) | nindent 6 }}
       containers:
         - image: {{ include "opencrvs.image" (dict "root" . "service" .Values.auth) }}
+          imagePullPolicy: {{ .Values.auth.image.pullPolicy | default .Values.platform.imagePullPolicy }}
           name: auth
           env:
           {{- include "render-otel-env-vars" (dict "Values" .Values "Release" .Release) }}

--- a/charts/opencrvs-services/templates/client-deployment.yaml
+++ b/charts/opencrvs-services/templates/client-deployment.yaml
@@ -52,6 +52,7 @@ spec:
       {{- include "opencrvs.imagePullSecrets" (dict "root" . "service" .Values.client) | nindent 6 }}
       containers:
         - image: {{ include "opencrvs.image" (dict "root" . "service" .Values.client) }}
+          imagePullPolicy: {{ .Values.client.image.pullPolicy | default .Values.platform.imagePullPolicy }}
           name: client
           env:
           {{- if and

--- a/charts/opencrvs-services/templates/countryconfig-deployment.yaml
+++ b/charts/opencrvs-services/templates/countryconfig-deployment.yaml
@@ -77,6 +77,7 @@ spec:
       containers:
         - name: countryconfig
           image: {{ include "opencrvs.image" (dict "root" . "service" .Values.countryconfig) | quote }}
+          imagePullPolicy: {{ .Values.countryconfig.image.pullPolicy | default .Values.platform.imagePullPolicy | default "IfNotPresent" }}
           env:
           {{- include "render-otel-env-vars" (dict "Values" .Values "Release" .Release) }}
             - name: CERT_PUBLIC_KEY_PATH

--- a/charts/opencrvs-services/templates/countryconfig-deployment.yaml
+++ b/charts/opencrvs-services/templates/countryconfig-deployment.yaml
@@ -77,7 +77,7 @@ spec:
       containers:
         - name: countryconfig
           image: {{ include "opencrvs.image" (dict "root" . "service" .Values.countryconfig) | quote }}
-          imagePullPolicy: {{ .Values.countryconfig.image.pullPolicy | default .Values.platform.imagePullPolicy | default "IfNotPresent" }}
+          imagePullPolicy: {{ .Values.countryconfig.image.pullPolicy | default .Values.platform.imagePullPolicy }}
           env:
           {{- include "render-otel-env-vars" (dict "Values" .Values "Release" .Release) }}
             - name: CERT_PUBLIC_KEY_PATH

--- a/charts/opencrvs-services/templates/dashboards-deployment.yaml
+++ b/charts/opencrvs-services/templates/dashboards-deployment.yaml
@@ -51,6 +51,7 @@ spec:
       initContainers:
         - name: copy-assets
           image: {{ include "opencrvs.image" (dict "root" . "service" .Values.countryconfig) }}-assets
+          imagePullPolicy: {{ .Values.countryconfig.image.pullPolicy | default .Values.platform.imagePullPolicy }}
           command:
             - sh
             - -c
@@ -63,6 +64,7 @@ spec:
       containers:
         - name: dashboards
           image: {{ include "opencrvs.image" (dict "root" . "service" .Values.dashboards) }}
+          imagePullPolicy: {{ .Values.dashboards.image.pullPolicy | default .Values.platform.imagePullPolicy }}
           command: ["/assets/run.sh"]
           env:
             - name: METABASE_DATABASE_HOST

--- a/charts/opencrvs-services/templates/data-cleanup-job.yaml
+++ b/charts/opencrvs-services/templates/data-cleanup-job.yaml
@@ -95,6 +95,7 @@ spec:
           {{- include "render-env-vars" (dict "service_name" "data_cleanup" "Values" .Values) }}
         - name: cleanup-elasticsearch
           image: {{ include "opencrvs.image" (dict "root" . "service" .Values.utilities) }}
+          imagePullPolicy: {{ .Values.utilities.image.pullPolicy | default .Values.platform.imagePullPolicy }}
           command: ["/bin/sh", "-c"]
           args:
             - |

--- a/charts/opencrvs-services/templates/data-migration-analytics-job.yaml
+++ b/charts/opencrvs-services/templates/data-migration-analytics-job.yaml
@@ -18,6 +18,7 @@ spec:
       initContainers:
         - name: copy-assets
           image: {{ include "opencrvs.image" (dict "root" . "service" .Values.countryconfig) }}-assets
+          imagePullPolicy: {{ .Values.countryconfig.image.pullPolicy | default .Values.platform.imagePullPolicy }}
           command:
             - sh
             - -c

--- a/charts/opencrvs-services/templates/data-migration-job.yaml
+++ b/charts/opencrvs-services/templates/data-migration-job.yaml
@@ -21,6 +21,7 @@ spec:
       containers:
         - name: migration
           image: {{ include "opencrvs.image" (dict "root" . "service" .Values.data_migration) }}
+          imagePullPolicy: {{ .Values.data_migration.image.pullPolicy | default .Values.platform.imagePullPolicy }}
           env:
             - name: SUPER_USER_PASSWORD
               valueFrom:

--- a/charts/opencrvs-services/templates/data-seed-job.yaml
+++ b/charts/opencrvs-services/templates/data-seed-job.yaml
@@ -20,6 +20,7 @@ spec:
       containers:
         - name: data-seed
           image: {{ include "opencrvs.image" (dict "root" . "service" .Values.data_seed) }}
+          imagePullPolicy: {{ .Values.data_seed.image.pullPolicy | default .Values.platform.imagePullPolicy }}
           env:
             - name: AUTH_HOST
               value: "http://auth.{{ .Release.Namespace }}.svc.cluster.local:4040"

--- a/charts/opencrvs-services/templates/documents-deployment.yaml
+++ b/charts/opencrvs-services/templates/documents-deployment.yaml
@@ -22,6 +22,7 @@ spec:
       {{- include "opencrvs.imagePullSecrets" (dict "root" . "service" .Values.documents) | nindent 6 }}
       containers:
         - image: {{ include "opencrvs.image" (dict "root" . "service" .Values.documents) }}
+          imagePullPolicy: {{ .Values.documents.image.pullPolicy | default .Values.platform.imagePullPolicy }}
           name: documents
           env:
           {{- include "render-otel-env-vars" (dict "Values" .Values "Release" .Release) }}

--- a/charts/opencrvs-services/templates/elasticsearch-on-deploy.yaml
+++ b/charts/opencrvs-services/templates/elasticsearch-on-deploy.yaml
@@ -19,6 +19,7 @@ spec:
         - name: elasticsearch-on-deploy
           command: ["/scripts/setup.sh"]
           image: {{ include "opencrvs.image" (dict "root" . "service" .Values.utilities) }}
+          imagePullPolicy: {{ .Values.utilities.image.pullPolicy | default .Values.platform.imagePullPolicy }}
           env:
             - name: ELASTICSEARCH_HOST
               value: {{ .Values.elasticsearch.host }}

--- a/charts/opencrvs-services/templates/events-deployment.yaml
+++ b/charts/opencrvs-services/templates/events-deployment.yaml
@@ -52,6 +52,7 @@ spec:
       containers:
         - name: events
           image: {{ include "opencrvs.image" (dict "root" . "service" .Values.events) }}
+          imagePullPolicy: {{ .Values.events.image.pullPolicy | default .Values.platform.imagePullPolicy }}
           env:
           {{- include "render-otel-env-vars" (dict "Values" .Values "Release" .Release) }}
             - name: AUTH_URL

--- a/charts/opencrvs-services/templates/gateway-deployment.yaml
+++ b/charts/opencrvs-services/templates/gateway-deployment.yaml
@@ -53,6 +53,7 @@ spec:
       containers:
         - name: gateway
           image: {{ include "opencrvs.image" (dict "root" . "service" .Values.gateway) }}
+          imagePullPolicy: {{ .Values.gateway.image.pullPolicy | default .Values.platform.imagePullPolicy }}
           env:
           {{- include "render-otel-env-vars" (dict "Values" .Values "Release" .Release) }}
             - name: CERT_PUBLIC_KEY_PATH

--- a/charts/opencrvs-services/templates/login-deployment.yaml
+++ b/charts/opencrvs-services/templates/login-deployment.yaml
@@ -49,6 +49,7 @@ spec:
       containers:
         - name: login
           image: {{ include "opencrvs.image" (dict "root" . "service" .Values.login) }}
+          imagePullPolicy: {{ .Values.login.image.pullPolicy | default .Values.platform.imagePullPolicy }}
           env:
           {{- if and
             (not (hasKey (.Values.login.env | default dict) "CONTENT_SECURITY_POLICY_WILDCARD"))

--- a/charts/opencrvs-services/values.yaml
+++ b/charts/opencrvs-services/values.yaml
@@ -237,11 +237,7 @@ platform:
   # for example: ghcr.io/opencrvs or myorg
   repository: ghcr.io/opencrvs
 
-  # Default imagePullPolicy for all OpenCRVS images. Keep as IfNotPresent for
-  # immutable version tags (e.g. v2.1.0). Environments that deploy a floating
-  # tag (e.g. "develop") should override this to "Always", otherwise nodes
-  # keep serving whatever was cached under that tag instead of picking up
-  # newer pushes.
+  # Override to "Always" for environments deploying a floating tag (e.g. "develop").
   imagePullPolicy: IfNotPresent
 
   # Secrets used to pull images from private registries, if needed.

--- a/charts/opencrvs-services/values.yaml
+++ b/charts/opencrvs-services/values.yaml
@@ -237,9 +237,6 @@ platform:
   # for example: ghcr.io/opencrvs or myorg
   repository: ghcr.io/opencrvs
 
-  # Override to "Always" for environments deploying a floating tag (e.g. "develop").
-  imagePullPolicy: IfNotPresent
-
   # Secrets used to pull images from private registries, if needed.
   # Example:
   # imagePullSecrets:

--- a/charts/opencrvs-services/values.yaml
+++ b/charts/opencrvs-services/values.yaml
@@ -63,8 +63,7 @@ minio:
   # Image used as client to run OpenCRVS configuration scripts
   image:
     repository: minio/mc
-    tag: "latest"
-
+    tag: 'latest'
 
 redis:
   host: redis-0.redis.opencrvs-deps-dev.svc.cluster.local
@@ -237,6 +236,13 @@ platform:
   # Default repository for all OpenCRVS images,
   # for example: ghcr.io/opencrvs or myorg
   repository: ghcr.io/opencrvs
+
+  # Default imagePullPolicy for all OpenCRVS images. Keep as IfNotPresent for
+  # immutable version tags (e.g. v2.1.0). Environments that deploy a floating
+  # tag (e.g. "develop") should override this to "Always", otherwise nodes
+  # keep serving whatever was cached under that tag instead of picking up
+  # newer pushes.
+  imagePullPolicy: IfNotPresent
 
   # Secrets used to pull images from private registries, if needed.
   # Example:


### PR DESCRIPTION
**Problem:** In non-prod environments (`qa`, `e2e`, `migration-staging`, `migration-production`) the `countryconfig` deployment tracks the floating `develop` image tag. Kubernetes' default `imagePullPolicy` for any non-`:latest` tag is `IfNotPresent`, so once a node has cached an image under the tag `develop`, it never rechecks the registry — new commits merged to `develop` get built and pushed, but the running pod silently keeps serving the old cached image indefinitely.

**Root cause:** no `imagePullPolicy` was set on the `countryconfig` container, so it fell back to Kubernetes' tag-based default instead of a digest-aware one.

**Fix:**
- Added a configurable `platform.imagePullPolicy` (default `IfNotPresent`, so prod-style deployments on immutable version tags like `v2.1.0` are unaffected).
- `countryconfig-deployment.yaml` now resolves `countryconfig.image.pullPolicy → platform.imagePullPolicy → "IfNotPresent"`.
- Companion infra change (opencrvs/opencrvs-testland-infrastructure#9) sets `platform.imagePullPolicy: Always` for the environments that actually deploy the floating `develop` tag.

**Tests:** verified via `helm template`, with and without the override, that `imagePullPolicy` renders correctly in both cases.
