### PR TITLE
Pass missing event parameter to validator context

### DIFF
--- a/packages/client/src/v2-events/features/events/actions/declare/DeclareActionMenu.tsx
+++ b/packages/client/src/v2-events/features/events/actions/declare/DeclareActionMenu.tsx
@@ -66,7 +66,7 @@ function useDeclarationActions(event: EventDocument) {
   } = useEventFormNavigation()
   const { eventConfiguration } = useEventConfiguration(eventType)
   const formConfig = getDeclaration(eventConfiguration)
-  const validatorContext = useValidatorContext()
+  const validatorContext = useValidatorContext(event)
   const declaration = useEventFormData((state) => state.getFormValues())
   const { getAnnotation } = useActionAnnotation()
   const annotation = getAnnotation()

--- a/packages/client/src/v2-events/features/events/actions/edit/EditActionMenu.tsx
+++ b/packages/client/src/v2-events/features/events/actions/edit/EditActionMenu.tsx
@@ -174,7 +174,7 @@ function useEditActions(event: EventDocument) {
   const events = useEvents()
   const formConfig = getDeclaration(eventConfiguration)
   const declaration = useEventFormData((state) => state.getFormValues())
-  const validatorContext = useValidatorContext()
+  const validatorContext = useValidatorContext(event)
   const reviewConfig = getActionReview(eventConfiguration, ActionType.DECLARE)
 
   const formFields = formConfig.pages.flatMap((page) => page.fields)

--- a/packages/client/src/v2-events/features/workqueues/Actions/useActionConfigurationResolver.tsx
+++ b/packages/client/src/v2-events/features/workqueues/Actions/useActionConfigurationResolver.tsx
@@ -48,7 +48,6 @@ export function useEventActionConfigurationResolver(event: EventIndex) {
   const drafts = getAllRemoteDrafts()
   const { eventConfiguration } = useEventConfiguration(event.type)
   const { onClick, modals } = useEventActionsOnClick(event)
-  const validatorContext = useValidatorContext()
   const { isActionAllowed: isActionAllowedForUser } =
     useUserAllowedActions(event)
 
@@ -57,6 +56,7 @@ export function useEventActionConfigurationResolver(event: EventIndex) {
   const { useFindEventFromCache } = events.getEvent
   const cachedEvent = useFindEventFromCache(event.id)
   const isDownloaded = Boolean(cachedEvent.data)
+  const validatorContext = useValidatorContext(cachedEvent.data)
   const isAssigning = events.actions.assignment.assign.isAssigning(event.id)
 
   const resolveAction = useCallback(
@@ -122,7 +122,6 @@ export function useEventActionConfigurationResolver(event: EventIndex) {
  */
 export function useResolveAssignmentActionConditionals(event: EventIndex) {
   const { eventConfiguration } = useEventConfiguration(event.type)
-  const validatorContext = useValidatorContext()
   const { isActionAllowed: isActionAllowedForUser } =
     useUserAllowedActions(event)
   const events = useEvents()
@@ -130,6 +129,7 @@ export function useResolveAssignmentActionConditionals(event: EventIndex) {
   const { useFindEventFromCache } = events.getEvent
   const cachedEvent = useFindEventFromCache(event.id)
   const isDownloaded = Boolean(cachedEvent.data)
+  const validatorContext = useValidatorContext(cachedEvent.data)
   const isAssigning = events.actions.assignment.assign.isAssigning(event.id)
 
   const resolveConditionals = useCallback(

--- a/packages/client/src/v2-events/features/workqueues/Actions/useCustomActionConfigs.ts
+++ b/packages/client/src/v2-events/features/workqueues/Actions/useCustomActionConfigs.ts
@@ -37,7 +37,10 @@ export function useCustomActionConfigs(event: EventIndex): {
   customActionConfigs: ActionMenuItem[]
 } {
   const scopes = useSelector(getScope)
-  const validatorContext = useValidatorContext()
+  const { useFindEventFromCache } = useEvents().getEvent
+  const cachedEvent = useFindEventFromCache(event.id)
+  const isDownloaded = Boolean(cachedEvent.data)
+  const validatorContext = useValidatorContext(cachedEvent.data)
   const { canAccessEventWithScopes } = useCanAccessEventWithScopes(event.id, [
     'record.custom-action'
   ])
@@ -52,8 +55,6 @@ export function useCustomActionConfigs(event: EventIndex): {
     event.id,
     eventConfiguration
   )
-  const { useFindEventFromCache } = useEvents().getEvent
-  const isDownloaded = Boolean(useFindEventFromCache(event.id).data)
   const assignmentStatus = getAssignmentStatus(event, userId)
 
   const isDownloadedAndAssignedToUser =


### PR DESCRIPTION
## Description

This is an addendum to this PR, already merged to master
https://github.com/opencrvs/opencrvs-core/pull/13168

ValidatorContext takes an event property which is available, but not passed.
So conditionals which reference the event will always evaluate to true.

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
