### PR TITLE
fix: throw error when single versions exist

### DIFF
--- a/packages/events/src/router/administrative-areas/administrative-areas.withdrawVersion.test.ts
+++ b/packages/events/src/router/administrative-areas/administrative-areas.withdrawVersion.test.ts
@@ -95,7 +95,7 @@ test('withdraws a pending future version and writes an audit entry', async () =>
   })
 })
 
-test('rejects withdrawing a version whose effectiveFrom has already passed', async () => {
+test('rejects withdrawing an already-effective version that is also the only version — the only-version check wins', async () => {
   const { user } = await setupTestCase()
   const client = createTestClient(user, [scope])
 
@@ -107,11 +107,13 @@ test('rejects withdrawing a version whose effectiveFrom has already passed', asy
   await expect(
     client.administrativeAreas.withdrawVersion({
       id: created.id,
+      // The initial (creation) element is already in effect — 2024-01-01 —
+      // but it is also the only version, and that check takes precedence.
       versionId: created.versions[0].versionId
     })
   ).rejects.toMatchObject({
     code: 'CONFLICT',
-    message: expect.stringContaining('already in effect')
+    message: expect.stringContaining('only one version')
   })
 })
 

--- a/packages/events/src/router/administrative-areas/administrative-areas.withdrawVersion.test.ts
+++ b/packages/events/src/router/administrative-areas/administrative-areas.withdrawVersion.test.ts
@@ -16,13 +16,13 @@ const scope = encodeScope({ type: 'location.edit' })
 
 async function createArea(
   client: ReturnType<typeof createTestClient>,
-  overrides: { name?: string; externalId?: string } = {}
+  overrides: { name?: string; externalId?: string; effectiveFrom?: string } = {}
 ) {
   return client.administrativeAreas.create({
     name: overrides.name ?? 'Original District',
     externalId: overrides.externalId ?? 'area-withdraw-test-pcode',
     parentId: null,
-    effectiveFrom: '2024-01-01',
+    effectiveFrom: overrides.effectiveFrom ?? '2024-01-01',
     status: 'active'
   })
 }
@@ -113,6 +113,41 @@ test('rejects withdrawing a version whose effectiveFrom has already passed', asy
     code: 'CONFLICT',
     message: expect.stringContaining('already in effect')
   })
+})
+
+test('rejects withdrawing the only version an administrative area has', async () => {
+  const { user } = await setupTestCase()
+  const client = createTestClient(user, [scope])
+
+  const created = await createArea(client, {
+    name: 'Single Version District',
+    externalId: 'area-withdraw-only-version-pcode',
+    effectiveFrom: '2099-01-01'
+  })
+
+  await expect(
+    client.administrativeAreas.withdrawVersion({
+      id: created.id,
+      versionId: created.versions[0].versionId
+    })
+  ).rejects.toMatchObject({
+    code: 'CONFLICT',
+    message: expect.stringContaining('only one version')
+  })
+
+  const row = await getClient()
+    .selectFrom('administrativeAreas')
+    .select(['versions'])
+    .where('id', '=', created.id)
+    .executeTakeFirstOrThrow()
+  expect(row.versions).toHaveLength(1)
+
+  const auditEntries = await getClient()
+    .selectFrom('auditLog')
+    .selectAll()
+    .where('operation', '=', 'administrativeAreas.withdrawVersion')
+    .execute()
+  expect(auditEntries).toHaveLength(0)
 })
 
 test('rejects withdrawing an already-effective INACTIVE version too — the check is date-based, not status-based', async () => {

--- a/packages/events/src/router/administrative-areas/index.ts
+++ b/packages/events/src/router/administrative-areas/index.ts
@@ -45,6 +45,17 @@ export function setAdministrativeAreasRoute(
 
 export const administrativeAreaRouter = router({
   list: userAndSystemProcedure
+    .meta({
+      openapi: {
+        summary: 'List administrative areas',
+        description:
+          'Retrieve a list of administrative areas based on provided filters.',
+        method: 'GET',
+        path: '/administrative-areas',
+        tags: ['Administrative areas'],
+        protect: true
+      }
+    })
     .input(
       z
         .object({

--- a/packages/events/src/router/locations/locations.withdrawVersion.test.ts
+++ b/packages/events/src/router/locations/locations.withdrawVersion.test.ts
@@ -138,6 +138,33 @@ test('rejects withdrawing a version whose effectiveFrom has already passed', asy
   expect(auditEntries).toHaveLength(0)
 })
 
+test('rejects withdrawing the only version a location has', async () => {
+  const { user } = await setupTestCase()
+  const client = createTestClient(user, [scope])
+
+  const created = await createLocation(client, {
+    name: 'Single Version Office',
+    externalId: 'withdraw-only-version-pcode',
+    effectiveFrom: '2099-01-01'
+  })
+
+  await expect(
+    client.locations.withdrawVersion({
+      id: created.id,
+      versionId: created.versions[0].versionId
+    })
+  ).rejects.toMatchObject({
+    code: 'CONFLICT',
+    message: expect.stringContaining('only one version')
+  })
+
+  const versionsInDb = await getVersionsFromDb(created.id)
+  expect(versionsInDb).toHaveLength(1)
+
+  const auditEntries = await getWithdrawAuditEntries()
+  expect(auditEntries).toHaveLength(0)
+})
+
 test('rejects withdrawing an already-effective INACTIVE version too — the check is date-based, not status-based', async () => {
   const { user } = await setupTestCase()
   const client = createTestClient(user, [scope])

--- a/packages/events/src/router/locations/locations.withdrawVersion.test.ts
+++ b/packages/events/src/router/locations/locations.withdrawVersion.test.ts
@@ -111,7 +111,7 @@ test('withdraws a pending future version and writes an audit entry', async () =>
   })
 })
 
-test('rejects withdrawing a version whose effectiveFrom has already passed', async () => {
+test('rejects withdrawing an already-effective version that is also the only version — the only-version check wins', async () => {
   const { user } = await setupTestCase()
   const client = createTestClient(user, [scope])
 
@@ -123,12 +123,13 @@ test('rejects withdrawing a version whose effectiveFrom has already passed', asy
   await expect(
     client.locations.withdrawVersion({
       id: created.id,
-      // The initial (creation) element is already in effect — 2024-01-01.
+      // The initial (creation) element is already in effect — 2024-01-01 —
+      // but it is also the only version, and that check takes precedence.
       versionId: created.versions[0].versionId
     })
   ).rejects.toMatchObject({
     code: 'CONFLICT',
-    message: expect.stringContaining('already in effect')
+    message: expect.stringContaining('only one version')
   })
 
   const versionsInDb = await getVersionsFromDb(created.id)

--- a/packages/events/src/service/locations/locations.ts
+++ b/packages/events/src/service/locations/locations.ts
@@ -486,6 +486,10 @@ export interface WithdrawnVersion {
  * Withdraws a pending (future-dated) version element by `versionId`.
  *
  * - unknown id, or no element with that `versionId` → NOT_FOUND
+ * - it is the only version the row has → CONFLICT (a row must always keep
+ *   at least one version; the `versions` column is non-empty by DB
+ *   constraint, so removing the last element would otherwise fail as an
+ *   unhandled NOT NULL violation instead of a clean API error)
  * - the element's `effectiveFrom` is today or in the past (no longer
  *   pending — it may already be in effect) → CONFLICT
  */
@@ -506,6 +510,13 @@ export async function withdrawVersionChecked({
     throw new TRPCError({
       code: 'NOT_FOUND',
       message: `${entityLabel} with id ${payload.id} has no version ${payload.versionId}`
+    })
+  }
+
+  if (versions.length === 1) {
+    throw new TRPCError({
+      code: 'CONFLICT',
+      message: `${entityLabel} with id ${payload.id} has only one version — withdrawing it would leave none`
     })
   }
 

--- a/packages/testland/e2e/testcases/events-rest-api/events-administrative-areas.spec.ts
+++ b/packages/testland/e2e/testcases/events-rest-api/events-administrative-areas.spec.ts
@@ -20,6 +20,27 @@ import { fetchClientAPI, NON_EXISTING_UUID } from './helpers'
 // file covers the administrative-area-specific wiring: parentId instead of
 // administrativeAreaId/locationType, and one representative case per verb.
 
+test.describe('GET /api/events/administrative-areas', () => {
+  let systemAdminToken: string
+
+  test.beforeAll(async () => {
+    systemAdminToken = await getToken(CREDENTIALS.NATIONAL_SYSTEM_ADMIN)
+  })
+
+  test('HTTP 200 with administrative areas payload', async () => {
+    const response = await fetchClientAPI(
+      '/api/events/administrative-areas',
+      'GET',
+      systemAdminToken
+    )
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(Array.isArray(body)).toBe(true)
+    expect(body.length).toBeGreaterThan(0)
+  })
+})
+
 test.describe('Administrative area write API (/api/events/administrative-areas)', () => {
   let systemAdminToken: string
   let registrarToken: string


### PR DESCRIPTION
**Problem**
- Withdrawing the only remaining version of a location or administrative area returned an unhandled `500` instead of a clean error.

**Root cause**
- `withdrawVersionChecked` only checked that the target version existed and was still pending — it never checked whether it was the last one.
- Removing it left `removeVersion`'s `jsonb_agg` aggregating over zero rows, which returns `NULL`, violating the `versions` column's non-empty constraint.

**Fix**
- Added a guard in `withdrawVersionChecked` that rejects withdrawing the last remaining version with a clean `CONFLICT`, before it reaches the DB.
- Exposed `administrativeAreas.list` as `GET /administrative-areas` (missing `openapi` meta), mirroring the existing locations REST list endpoint.

**Tests**
- Added regression tests for the last-version guard on both locations and administrative areas.
- Added an e2e REST test for `GET /api/events/administrative-areas`.
