### PR TITLE
Add createdIn scope option to filter records by creation location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements
 
 - Added `createdBy` as a config paramater to filter records created by the user [#13287](https://github.com/opencrvs/opencrvs-core/issues/13287)
+- Added `createdIn` as a config parameter to filter records by the office or administrative area they were created in. Unlike `declaredIn` it is populated before the record is declared, and it is never reassigned by a later declaration [#13287](https://github.com/opencrvs/opencrvs-core/issues/13287)
 
 ### Bug fixes
 

--- a/packages/commons/src/events/locations.test.ts
+++ b/packages/commons/src/events/locations.test.ts
@@ -9,6 +9,8 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 
+/* eslint-disable max-lines */
+
 import { createPrng, generateUuid, TestUserRole } from './test.utils'
 import { SystemContext, UserContext } from '../users/User'
 import {

--- a/packages/commons/src/events/locations.test.ts
+++ b/packages/commons/src/events/locations.test.ts
@@ -35,6 +35,7 @@ describe('canAccessEventWithScope()', () => {
   const declaredEvent: Partial<EventIndexWithAdministrativeHierarchy> = {
     type: 'birth',
     createdBy: createdById,
+    createdAtLocation: [provinceUuid, districtUuid, officeUuid],
     placeOfEvent: [provinceUuid, districtUuid, officeUuid],
     legalStatuses: {
       DECLARED: {
@@ -81,6 +82,7 @@ describe('canAccessEventWithScope()', () => {
 
   const locationOptions = [
     { placeOfEvent: 'location' },
+    { createdIn: 'location' },
     { declaredIn: 'location' },
     { registeredIn: 'location' }
   ] satisfies RecordScopeV2['options'][]
@@ -252,6 +254,110 @@ describe('canAccessEventWithScope()', () => {
         )
       ).toBe(false)
     })
+
+    describe('createdIn', () => {
+      const undeclaredEvent: Partial<EventIndexWithAdministrativeHierarchy> = {
+        type: 'birth',
+        createdBy: createdById,
+        createdAtLocation: [provinceUuid, districtUuid, officeUuid],
+        placeOfEvent: [provinceUuid, districtUuid, officeUuid],
+        legalStatuses: {
+          DECLARED: undefined,
+          REGISTERED: undefined
+        }
+      }
+
+      const colleagueAtSameOffice = {
+        type: 'user',
+        id: generateUuid(rng),
+        primaryOfficeId: officeUuid,
+        administrativeAreaId: districtUuid,
+        role: TestUserRole.enum.FIELD_AGENT
+      } satisfies UserContext
+
+      test.each([
+        { createdIn: 'location' },
+        { createdIn: 'administrativeArea' }
+      ] satisfies RecordScopeV2['options'][])(
+        'grants access to an event that has not been declared yet with scope %j',
+        (options) => {
+          expect(
+            canAccessEventWithScope(
+              undeclaredEvent,
+              { type: 'record.read', options },
+              userContext
+            )
+          ).toBe(true)
+        }
+      )
+
+      test.each([
+        { declaredIn: 'location' },
+        { declaredIn: 'administrativeArea' },
+        { declaredBy: 'user' }
+      ] satisfies RecordScopeV2['options'][])(
+        'declared-based scope %j does not match an event that has not been declared yet',
+        (options) => {
+          expect(
+            canAccessEventWithScope(
+              undeclaredEvent,
+              { type: 'record.read', options },
+              userContext
+            )
+          ).toBe(false)
+        }
+      )
+
+      test('grants access to a colleague at the same office, unlike createdBy', () => {
+        expect(
+          canAccessEventWithScope(
+            undeclaredEvent,
+            { type: 'record.read', options: { createdIn: 'location' } },
+            colleagueAtSameOffice
+          )
+        ).toBe(true)
+
+        expect(
+          canAccessEventWithScope(
+            undeclaredEvent,
+            { type: 'record.read', options: { createdBy: 'user' } },
+            colleagueAtSameOffice
+          )
+        ).toBe(false)
+      })
+
+      test('is not reassigned when another office declares the event', () => {
+        const declaredByAnotherOffice: Partial<EventIndexWithAdministrativeHierarchy> =
+          {
+            ...undeclaredEvent,
+            legalStatuses: {
+              DECLARED: {
+                acceptedAt: new Date().toISOString(),
+                createdAt: new Date().toISOString(),
+                createdBy: generateUuid(rng),
+                createdAtLocation: [generateUuid(rng)]
+              },
+              REGISTERED: undefined
+            }
+          }
+
+        expect(
+          canAccessEventWithScope(
+            declaredByAnotherOffice,
+            { type: 'record.read', options: { createdIn: 'location' } },
+            userContext
+          )
+        ).toBe(true)
+
+        expect(
+          canAccessEventWithScope(
+            declaredByAnotherOffice,
+            { type: 'record.read', options: { declaredIn: 'location' } },
+            userContext
+          )
+        ).toBe(false)
+      })
+    })
   })
 
   test('should not access event if user does not meet any of the scope options', () => {
@@ -268,6 +374,8 @@ describe('canAccessEventWithScope()', () => {
       { placeOfEvent: 'location' },
       { placeOfEvent: 'administrativeArea' },
       { createdBy: 'user' },
+      { createdIn: 'location' },
+      { createdIn: 'administrativeArea' },
       { declaredIn: 'location' },
       { declaredIn: 'administrativeArea' },
       { registeredIn: 'location' },
@@ -295,6 +403,7 @@ describe('canAccessEventWithScope()', () => {
     // so access can only be granted by the "no administrative area" branch.
     const eventInAnotherArea: Partial<EventIndexWithAdministrativeHierarchy> = {
       ...registeredEvent,
+      createdAtLocation: [generateUuid(rng)],
       placeOfEvent: [generateUuid(rng)],
       legalStatuses: {
         DECLARED: {
@@ -315,6 +424,7 @@ describe('canAccessEventWithScope()', () => {
 
     const adminAreaOptions = [
       { placeOfEvent: 'administrativeArea' },
+      { createdIn: 'administrativeArea' },
       { declaredIn: 'administrativeArea' },
       { registeredIn: 'administrativeArea' }
     ] satisfies RecordScopeV2['options'][]

--- a/packages/commons/src/events/locations.ts
+++ b/packages/commons/src/events/locations.ts
@@ -168,6 +168,28 @@ export function canAccessEventWithScope(
     return false
   }
 
+  if (
+    opts?.createdIn === JurisdictionFilter.enum.location &&
+    !matchesJurisdictionFilter(
+      event.createdAtLocation,
+      JurisdictionFilter.enum.location,
+      user
+    )
+  ) {
+    return false
+  }
+
+  if (
+    opts?.createdIn === JurisdictionFilter.enum.administrativeArea &&
+    !matchesJurisdictionFilter(
+      event.createdAtLocation,
+      JurisdictionFilter.enum.administrativeArea,
+      user
+    )
+  ) {
+    return false
+  }
+
   if (scopeUsesDeclaredOptions(scope)) {
     const { options } = scope
 

--- a/packages/commons/src/scopes.test.ts
+++ b/packages/commons/src/scopes.test.ts
@@ -342,6 +342,36 @@ describe('2.0 scopes', () => {
     ])
   })
 
+  it('Keeps the createdIn option for every record scope category', () => {
+    const oneScopePerCategory = [
+      ScopesWithPlaceEventOptions.options[0], // record.create
+      ScopesWithDeclaredOptions.options[0], // record.edit
+      ScopesWithFullOptions.options[0] // record.search
+    ]
+
+    const encoded = oneScopePerCategory.map((type) =>
+      encodeScope({
+        type,
+        options: { event: ['birth'], createdIn: 'location' as const }
+      })
+    )
+
+    expect(encoded.map(decodeScope)).toEqual([
+      {
+        type: 'record.create',
+        options: { event: ['birth'], createdIn: 'location' }
+      },
+      {
+        type: 'record.edit',
+        options: { event: ['birth'], createdIn: 'location' }
+      },
+      {
+        type: 'record.search',
+        options: { event: ['birth'], createdIn: 'location' }
+      }
+    ])
+  })
+
   it('Supports templates option for record.print-certified-copies', () => {
     const scopeWithTemplates = encodeScope({
       type: 'record.print-certified-copies',

--- a/packages/commons/src/scopes.ts
+++ b/packages/commons/src/scopes.ts
@@ -96,7 +96,8 @@ const scopeOptionsPlaceEvent = z
   .object({
     event: scopeByEvent,
     placeOfEvent: JurisdictionFilter.optional(),
-    createdBy: UserFilter.optional()
+    createdBy: UserFilter.optional(),
+    createdIn: JurisdictionFilter.optional()
   })
   .describe('Options applicable to all record scopes.')
 
@@ -159,7 +160,8 @@ const ResolvedScopeOptionsPlaceEvent = z
   .object({
     event: scopeByEvent,
     placeOfEvent: UUID.nullish(),
-    createdBy: z.string().optional()
+    createdBy: z.string().optional(),
+    createdIn: UUID.nullish()
   })
   .describe(
     'Resolved options applicable to all record scopes, with location ID instead of jurisdiction filter.'

--- a/packages/events/src/router/event/event.get.scopes.test.ts
+++ b/packages/events/src/router/event/event.get.scopes.test.ts
@@ -18,7 +18,8 @@ import {
   UserFilter,
   createPrng,
   encodeScope,
-  getDeclarationFields
+  getDeclarationFields,
+  getOrThrow
 } from '@opencrvs/commons'
 import { tennisClubMembershipEvent } from '@opencrvs/commons/fixtures'
 import {
@@ -29,7 +30,10 @@ import {
 } from '@events/tests/utils'
 import { createIndex } from '@events/service/indexing/indexing'
 import { getEventIndexName } from '@events/storage/elasticsearch'
-import { payloadGenerator, setupHierarchyWithUsers } from '@events/tests/generators'
+import {
+  payloadGenerator,
+  setupHierarchyWithUsers
+} from '@events/tests/generators'
 import { EventNotFoundError } from '../../service/events/events'
 
 test('Check scopes against event.get', async () => {
@@ -76,6 +80,7 @@ test('Check scopes against event.get', async () => {
       { nil: undefined }
     ),
     placeOfEvent: jurisdictionOptions,
+    createdIn: jurisdictionOptions,
     declaredBy: userOptions,
     declaredIn: jurisdictionOptions,
     registeredBy: userOptions,
@@ -189,4 +194,56 @@ test('Check createdBy scope against event.get', async () => {
     }),
     { numRuns: 20 }
   )
+}, 120000)
+
+test('Check createdIn scope against event.get', async () => {
+  const rng = createPrng(55443322)
+  const generator = payloadGenerator(rng)
+
+  const { users } = await setupHierarchyWithUsers()
+
+  const author = users[0]
+  const authorClient = createTestClient(author, TEST_USER_DEFAULT_SCOPES)
+  const { id: eventId } = await authorClient.event.create(
+    generator.event.create()
+  )
+
+  const colleague = getOrThrow(
+    users.find(
+      (user) =>
+        user.primaryOfficeId === author.primaryOfficeId && user.id !== author.id
+    ),
+    'No other user in the same office'
+  )
+
+  const outsider = getOrThrow(
+    users.find((user) => user.primaryOfficeId !== author.primaryOfficeId),
+    'No user in another office'
+  )
+
+  const createdInLocation = encodeScope({
+    type: 'record.read',
+    options: { createdIn: JurisdictionFilter.enum.location }
+  })
+
+  await expect(
+    createTestClient(author, [createdInLocation]).event.get({ eventId })
+  ).resolves.toEqual(expect.objectContaining({ id: eventId }))
+
+  await expect(
+    createTestClient(colleague, [createdInLocation]).event.get({ eventId })
+  ).resolves.toEqual(expect.objectContaining({ id: eventId }))
+
+  await expect(
+    createTestClient(outsider, [createdInLocation]).event.get({ eventId })
+  ).rejects.toThrow(EventNotFoundError)
+
+  await expect(
+    createTestClient(author, [
+      encodeScope({
+        type: 'record.read',
+        options: { declaredIn: JurisdictionFilter.enum.location }
+      })
+    ]).event.get({ eventId })
+  ).rejects.toThrow(EventNotFoundError)
 }, 120000)

--- a/packages/events/src/router/event/event.search.created.scopes.test.ts
+++ b/packages/events/src/router/event/event.search.created.scopes.test.ts
@@ -11,8 +11,10 @@
 
 import fc from 'fast-check'
 import {
+  JurisdictionFilter,
   TENNIS_CLUB_MEMBERSHIP,
   UserFilter,
+  UUID,
   createPrng,
   encodeScope
 } from '@opencrvs/commons'
@@ -74,6 +76,90 @@ test('createdBy scope filter for record.search', async () => {
 
       // 2. no createdBy filter: every event is returned, regardless of creator.
       if (createdBy === undefined) {
+        expect(results.length).toBe(users.length)
+      }
+    }),
+    { numRuns: 100 }
+  )
+}, 120000)
+
+test('createdIn scope filter for record.search', async () => {
+  const rng = createPrng(58392015)
+  const generator = payloadGenerator(rng)
+
+  const { users, isUnderAdministrativeArea } = await setupHierarchyWithUsers()
+
+  // Each user creates and notifies one event, so every office holds two events.
+  for (const user of users) {
+    const testClient = createTestClient(user, TEST_USER_DEFAULT_SCOPES)
+    const event = await testClient.event.create(generator.event.create())
+    await testClient.event.actions.notify.request(
+      generator.event.actions.notify(event.id)
+    )
+  }
+
+  const jurisdictionOptions = fc.option(
+    fc.constantFrom(...JurisdictionFilter.options),
+    { nil: undefined }
+  )
+
+  const combinations = fc.record({
+    user: fc.constantFrom(...users),
+    createdIn: jurisdictionOptions
+  })
+
+  await fc.assert(
+    fc.asyncProperty(combinations, async ({ user, createdIn }) => {
+      const searchScope = encodeScope({
+        type: 'record.search',
+        options: {
+          event: [TENNIS_CLUB_MEMBERSHIP],
+          createdIn
+        }
+      })
+
+      const testClient = createTestClient(user, [searchScope])
+      const { results } = await testClient.event.search({
+        query: {
+          type: 'and',
+          clauses: [{ eventType: TENNIS_CLUB_MEMBERSHIP }]
+        }
+      })
+
+      // 1. createdIn=location: every event created at the user's own office,
+      //    including their colleague's.
+      if (createdIn === JurisdictionFilter.enum.location) {
+        const usersAtSameOffice = users.filter(
+          (other) => other.primaryOfficeId === user.primaryOfficeId
+        )
+
+        expect(results.length).toBe(usersAtSameOffice.length)
+        expect(results.some((r) => r.createdBy !== user.id)).toBe(true)
+
+        for (const r of results) {
+          expect(r.createdAtLocation).toBe(user.primaryOfficeId)
+        }
+      }
+
+      // 2. createdIn=administrativeArea: everything under the user's area.
+      if (createdIn === JurisdictionFilter.enum.administrativeArea) {
+        expect(results.length).toBeGreaterThan(0)
+
+        for (const r of results) {
+          expect(
+            isUnderAdministrativeArea(
+              UUID.parse(r.createdAtLocation),
+              user.administrativeAreaId ?? null
+            )
+          ).toBe(true)
+        }
+      }
+
+      // 3. no createdIn filter (or 'all'): every event is returned.
+      if (
+        createdIn === undefined ||
+        createdIn === JurisdictionFilter.enum.all
+      ) {
         expect(results.length).toBe(users.length)
       }
     }),

--- a/packages/events/src/service/indexing/indexing.test.ts
+++ b/packages/events/src/service/indexing/indexing.test.ts
@@ -807,6 +807,50 @@ describe('withJurisdictionFilters', () => {
     })
   })
 
+  test('maps createdIn to a createdAtLocation term', () => {
+    const result = withJurisdictionFilters({
+      query: baseQuery,
+      scopesV2: [
+        {
+          type: 'record.search',
+          options: {
+            event: ['birth'],
+            createdIn: 'office-123' as UUID
+          }
+        }
+      ]
+    })
+
+    expect(result).toEqual({
+      bool: {
+        must: [baseQuery],
+        filter: {
+          bool: {
+            should: [
+              {
+                bool: {
+                  must: [
+                    {
+                      terms: {
+                        type: ['birth']
+                      }
+                    },
+                    {
+                      term: {
+                        createdAtLocation: 'office-123'
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            minimum_should_match: 1
+          }
+        }
+      }
+    })
+  })
+
   test('returns filtered query if multiple events are marked with different jurisdiction access', () => {
     const result = withJurisdictionFilters({
       query: baseQuery,

--- a/packages/events/src/service/indexing/query.ts
+++ b/packages/events/src/service/indexing/query.ts
@@ -365,6 +365,11 @@ export function withJurisdictionFilters({
               term: { createdBy: value }
             })
             break
+          case 'createdIn':
+            must.push({
+              term: { createdAtLocation: value }
+            })
+            break
           case 'declaredIn':
             must.push({
               term: {

--- a/packages/events/src/service/indexing/utils.test.ts
+++ b/packages/events/src/service/indexing/utils.test.ts
@@ -8,12 +8,15 @@
  *
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
+import { UUID } from '@opencrvs/commons'
 import { eventQueryDataGenerator, EventState } from '@opencrvs/commons/events'
 import { tennisClubMembershipEvent } from '@opencrvs/commons/fixtures'
+import { TrpcUserContext } from '../../context'
 import {
   decodeEventIndex,
   encodeEventIndex,
-  removeSecuredFields
+  removeSecuredFields,
+  resolveRecordActionScopeToIds
 } from './utils'
 
 describe('EventIndex utils', () => {
@@ -77,5 +80,43 @@ describe('EventIndex utils', () => {
       },
       'applicant.dob': '1990-01-01'
     })
+  })
+})
+
+describe('resolveRecordActionScopeToIds()', () => {
+  const user = {
+    id: 'a3e0b4c7-1f2d-4a58-9c3b-6d7e8f901234' as UUID,
+    primaryOfficeId: 'b4f1c5d8-2e3a-4b69-8d4c-7e8f90123456' as UUID,
+    administrativeAreaId: 'c5a2d6e9-3f4b-4c7a-9e5d-8f9012345678' as UUID
+  } as TrpcUserContext
+
+  test('resolves createdIn: location to the user primary office', () => {
+    expect(
+      resolveRecordActionScopeToIds(
+        { type: 'record.search', options: { createdIn: 'location' } },
+        user
+      ).options?.createdIn
+    ).toBe(user.primaryOfficeId)
+  })
+
+  test('resolves createdIn: administrativeArea to the user administrative area', () => {
+    expect(
+      resolveRecordActionScopeToIds(
+        {
+          type: 'record.search',
+          options: { createdIn: 'administrativeArea' }
+        },
+        user
+      ).options?.createdIn
+    ).toBe(user.administrativeAreaId)
+  })
+
+  test('resolves createdIn: all to no filter', () => {
+    expect(
+      resolveRecordActionScopeToIds(
+        { type: 'record.search', options: { createdIn: 'all' } },
+        user
+      ).options?.createdIn
+    ).toBeUndefined()
   })
 })

--- a/packages/events/src/service/indexing/utils.ts
+++ b/packages/events/src/service/indexing/utils.ts
@@ -476,6 +476,7 @@ export function resolveRecordActionScopeToIds(
       placeOfEvent: getLocationIdsFromScopeOptions(options?.placeOfEvent, user),
       createdBy:
         options?.createdBy === UserFilter.enum.user ? user.id : undefined,
+      createdIn: getLocationIdsFromScopeOptions(options?.createdIn, user),
       declaredIn: getLocationIdsFromScopeOptions(options?.declaredIn, user),
       declaredBy:
         options?.declaredBy === UserFilter.enum.user ? user.id : undefined,

--- a/packages/events/src/tests/utils.ts
+++ b/packages/events/src/tests/utils.ts
@@ -710,6 +710,7 @@ function eventMatchesScope({
   user,
   placeOfEvent,
   createdBy,
+  createdIn,
   declaredBy,
   registeredBy,
   declaredIn,
@@ -723,6 +724,7 @@ function eventMatchesScope({
     | CreatedUser
   placeOfEvent?: JurisdictionFilter
   createdBy?: UserFilter
+  createdIn?: JurisdictionFilter
   declaredBy?: UserFilter
   registeredBy?: UserFilter
   declaredIn?: JurisdictionFilter
@@ -735,6 +737,27 @@ function eventMatchesScope({
 }): boolean {
   if (createdBy === UserFilter.enum.user) {
     if (eventIndex.createdBy !== user.id) {
+      return false
+    }
+  }
+
+  if (createdIn === JurisdictionFilter.enum.location) {
+    if (eventIndex.createdAtLocation !== user.primaryOfficeId) {
+      return false
+    }
+  }
+
+  if (createdIn === JurisdictionFilter.enum.administrativeArea) {
+    if (!eventIndex.createdAtLocation) {
+      return false
+    }
+
+    if (
+      !isUnderAdministrativeArea(
+        UUID.parse(eventIndex.createdAtLocation),
+        user.administrativeAreaId || null
+      )
+    ) {
       return false
     }
   }
@@ -1067,6 +1090,7 @@ export function assertScopeResult(
     placeOfEvent,
     isUnderAdministrativeArea,
     createdBy,
+    createdIn,
     declaredBy,
     declaredIn,
     registeredBy,
@@ -1080,6 +1104,7 @@ export function assertScopeResult(
       adminAreaId: UUID | null
     ) => boolean
     createdBy?: UserFilter
+    createdIn?: JurisdictionFilter
     declaredBy?: UserFilter
     registeredBy?: UserFilter
     declaredIn?: JurisdictionFilter
@@ -1097,6 +1122,7 @@ export function assertScopeResult(
     eventIndex,
     user,
     createdBy,
+    createdIn,
     declaredBy,
     registeredBy,
     declaredIn,


### PR DESCRIPTION
## Description

Add `createdIn` property to supplement `createdBy` added here: https://github.com/opencrvs/opencrvs-core/pull/13288.
Original issue: issue: https://github.com/opencrvs/opencrvs-core/issues/13287
Allows the scoping of where a declaration was created.

As an example, if a record is rejected, it can be picked up by and encoder is the original creator's location.

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
