### PR TITLE
fix: Run differencial backup as non-root user after pgbackrest upgrade

### DIFF
--- a/charts/dependencies/files/postgres/postgres-backup-config.sh
+++ b/charts/dependencies/files/postgres/postgres-backup-config.sh
@@ -15,7 +15,7 @@ set -e
 common_config(){
 apt update -q
 apt upgrade -y -q
-apt install -y -q pgbackrest openssh-client
+apt install -y -q pgbackrest=2.59.0-1.pgdg13+1 openssh-client
 # Common configuration for backup and restore
 # Temporal directory required for pushing WAL files
 echo "Create pgbackrest temp directory with correct permissions"

--- a/charts/dependencies/templates/postgres-backup-cronjob-diff.yaml
+++ b/charts/dependencies/templates/postgres-backup-cronjob-diff.yaml
@@ -30,7 +30,7 @@ spec:
                 - -c
                 - |
                   kubectl exec -n {{ .Release.Namespace }} postgres-0 -- \
-                    pgbackrest --stanza="{{ .Values.postgres.backup.stanza }}" backup --type=diff
+                    su postgres -c 'pgbackrest --stanza="{{ .Values.postgres.backup.stanza }}" backup --type=diff'
           restartPolicy: OnFailure
 {{- end }}
 {{- end }}

--- a/charts/dependencies/templates/postgres-backup-cronjob-full.yaml
+++ b/charts/dependencies/templates/postgres-backup-cronjob-full.yaml
@@ -30,7 +30,7 @@ spec:
                 - -c
                 - |
                   kubectl exec -n {{ .Release.Namespace }} postgres-0 -- \
-                    pgbackrest --stanza="{{ .Values.postgres.backup.stanza }}" backup --type=full
+                    su postgres -c 'pgbackrest --stanza="{{ .Values.postgres.backup.stanza }}" backup --type=full'
           restartPolicy: OnFailure
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## Description

Reference release notes: https://pgbackrest.org/release.html#2.59.0

> IMPORTANT NOTE: Starting with this release, only the restore command may be run as root by default. Use allow-root to run other commands as root (though this is not recommended).

Postgres container didn't had fixed pgbackrest client version, as a result after upstream repository upgrade, backup server and database server become incompatible: https://github.com/opencrvs/opencrvs-testland-infrastructure/actions/runs/31007653528/job/92311571523

```
2026-08-05 12:55:35.749 P00   INFO: backup command begin 2.58.0: --config=/etc/pgbackrest/pgbackrest.conf --exec-id=69817-7bed5302 --log-level-console=info --pg1-path=/var/lib/postgresql/data --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-host=10.0.1.2 --repo1-host-user=backup --repo1-path=/home/backup/migration-production/postgres --repo1-retention-diff=7 --repo1-retention-full=1 --repo1-type=posix --stanza=main --type=full
2026-08-05 12:55:36.244 P00  ERROR: [039]: expected value '2.58.0' for greeting key 'version' but got '2.59.0'
                                    HINT: is the same version of pgBackRest installed on the local and remote host?
2026-08-05 12:55:36.244 P00   INFO: backup command end: aborted with exception [039]
```

Manual upgrade lead to issue with root user, see release notes:
```
2026-08-05 13:01:23.306 P00  ERROR: [031]: the 'backup' command must not be run as the root user
                                    HINT: running as root can create files that the regular user cannot access, causing later commands to fail.
                                    HINT: set the 'allow-root' option to allow running this command as root.
2026-08-05 13:01:23.306 P00   INFO: backup command end: aborted with exception [031]
```


## Testing

### Manual compatibility testing

Available versions on Postgres container (Debian GNU/Linux 13):
```
root@postgres-0:/# apt-cache policy pgbackrest
pgbackrest:
  Installed: (none)
  Candidate: 2.59.0-1.pgdg13+1
  Version table:
     2.59.0-1.pgdg13+1 500
        500 http://apt.postgresql.org/pub/repos/apt trixie-pgdg/main amd64 Packages
     2.58.0-1.pgdg13+1 500
        500 http://apt.postgresql.org/pub/repos/apt trixie-pgdg/main amd64 Packages
     2.55.1-1 500
        500 http://deb.debian.org/debian trixie/main amd64 Packages
```

Manual fixed version installation:
<img width="1080" height="498" alt="image" src="https://github.com/user-attachments/assets/7af784e9-2156-4ddb-9621-2ea25f8271c6" />

Execution as non-root user:
<img width="1448" height="342" alt="image" src="https://github.com/user-attachments/assets/2612d014-fb8c-4d3f-87f9-b099f4aaaab5" />


## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
