### PR TITLE
Merge #13370: fix: Run differencial backup as non-root user after pgbackrest upgrade

### DIFF
--- a/charts/dependencies/files/postgres/postgres-backup-config.sh
+++ b/charts/dependencies/files/postgres/postgres-backup-config.sh
@@ -14,7 +14,7 @@ set -e
 . "$(dirname "${BASH_SOURCE[0]}")/ensure-deb-utils.sh"
 
 common_config(){
-ensure_deb_utils "pgbackrest openssh-client" pgbackrest ssh || exit 1
+ensure_deb_utils "pgbackrest=2.59.0-1.pgdg13+1 openssh-client" pgbackrest ssh || exit 1
 # Common configuration for backup and restore
 # Temporal directory required for pushing WAL files
 echo "Create pgbackrest temp directory with correct permissions"

--- a/charts/dependencies/templates/postgres-backup-cronjob-diff.yaml
+++ b/charts/dependencies/templates/postgres-backup-cronjob-diff.yaml
@@ -31,7 +31,7 @@ spec:
                 - -c
                 - |
                   kubectl exec -n {{ .Release.Namespace }} postgres-0 -- \
-                    pgbackrest --stanza="{{ .Values.postgres.backup.stanza }}" backup --type=diff
+                    su postgres -c 'pgbackrest --stanza="{{ .Values.postgres.backup.stanza }}" backup --type=diff'
           restartPolicy: OnFailure
 {{- end }}
 {{- end }}

--- a/charts/dependencies/templates/postgres-backup-cronjob-full.yaml
+++ b/charts/dependencies/templates/postgres-backup-cronjob-full.yaml
@@ -31,7 +31,7 @@ spec:
                 - -c
                 - |
                   kubectl exec -n {{ .Release.Namespace }} postgres-0 -- \
-                    pgbackrest --stanza="{{ .Values.postgres.backup.stanza }}" backup --type=full
+                    su postgres -c 'pgbackrest --stanza="{{ .Values.postgres.backup.stanza }}" backup --type=full'
           restartPolicy: OnFailure
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## Description

Cherry-pick from https://github.com/opencrvs/opencrvs-core/pull/13370 with amend applied to v2.1.0

## Additional testing

Helm chart with changes successfully deployed on migration-production and migration-staging environments:

<img width="1038" height="582" alt="image" src="https://github.com/user-attachments/assets/e522c2bb-46b9-4b07-b385-48601c9e37ec" />

Backup job: https://github.com/opencrvs/opencrvs-testland-infrastructure/actions/runs/31084900809/job/92562030401
<img width="1658" height="834" alt="image" src="https://github.com/user-attachments/assets/ffd924da-3bea-4691-a365-82488d383431" />


Restore job: https://github.com/opencrvs/opencrvs-testland-infrastructure/actions/runs/31085063846/job/92562537718

<img width="1672" height="708" alt="image" src="https://github.com/user-attachments/assets/07b76fef-6f0c-4cb4-aa40-1a10c862a555" />


## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
