### PR TITLE
fix: remove custom actions from drafts

### DIFF
--- a/ACTIONS.md
+++ b/ACTIONS.md
@@ -38,6 +38,8 @@ Custom actions are non-core actions that are defined only in the country configu
 
 All custom actions are configurable.
 
+Custom actions are not available while an event is still in `CREATED` state, i.e. a draft. A draft is not indexed and is only reachable through its creator's drafts workqueue, and executing any action on an event deletes its drafts — so a custom action, which cannot change the status, would leave the event in `CREATED` with its declaration data destroyed and no way to find it again. The action is hidden in the client and rejected with HTTP 409 by the backend.
+
 <!-- TODO: add screenshot of custom action dialog here -->
 
 ## Action configurations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ A new `integration.audit.read` scope guards it; country configs must assign it t
 - Keep a number field's postfix/unit label (e.g. `Kilograms (kg)` on Weight at birth) on a single line instead of wrapping onto a second row [#13216](https://github.com/opencrvs/opencrvs-core/issues/13216)
 - Bust the locally cached data when a user's office or role changes, so stale drafts and records from the previous office no longer appear after the change
 - Stop showing an empty `Comment` section in the record audit history for archived records. Archiving from the action menu never asked for a comment, so the section only ever displayed a `-` placeholder. Records archived through the "mark as duplicate" flow still show the comment that was entered there [#13265](https://github.com/opencrvs/opencrvs-core/issues/13265)
+- Stop offering custom actions (e.g. `ESCALATE`) on a draft. Executing one deleted the draft while leaving the event undeclared, making the record impossible to find again [#13245](https://github.com/opencrvs/opencrvs-core/issues/13245)
 
 ## 2.0.0
 

--- a/packages/client/src/v2-events/features/workqueues/Actions/useCustomActionConfigs.ts
+++ b/packages/client/src/v2-events/features/workqueues/Actions/useCustomActionConfigs.ts
@@ -17,7 +17,7 @@ import {
   getOrThrow,
   isActionEnabled,
   isActionVisible,
-  filterActionsByFlags,
+  getAvailableActionsForEvent,
   isValidIcon,
   getAcceptedScopesByType,
   getAssignmentStatus,
@@ -73,13 +73,17 @@ export function useCustomActionConfigs(event: EventIndex): {
   }
 
   const customActionConfigs = useMemo(() => {
+    // The event's status and flags decide whether custom actions are available
+    // at all. The backend enforces the same list, so skipping this check would
+    // offer actions that fail with a 409.
+    if (!getAvailableActionsForEvent(event).includes(ActionType.CUSTOM)) {
+      return []
+    }
+
     return eventConfiguration.actions
       .filter(
         (action): action is CustomActionConfig =>
           action.type === ActionType.CUSTOM
-      )
-      .filter(
-        (action) => filterActionsByFlags([action.type], event.flags).length > 0
       )
       .filter(({ customActionType }) =>
         canAccessEventWithScopes(customActionType)

--- a/packages/commons/src/events/state/__snapshots__/availableActions.test.ts.snap
+++ b/packages/commons/src/events/state/__snapshots__/availableActions.test.ts.snap
@@ -40,7 +40,6 @@ exports[`getAvailableActionsForEvent() should return the correct actions for "CR
   "DECLARE",
   "NOTIFY",
   "DELETE",
-  "CUSTOM",
 ]
 `;
 

--- a/packages/commons/src/events/state/availableActions.test.ts
+++ b/packages/commons/src/events/state/availableActions.test.ts
@@ -26,6 +26,15 @@ describe('getAvailableActionsForEvent()', () => {
     })
   }
 
+  it(`should not allow CUSTOM for "${EventStatus.enum.CREATED}" status, since a custom action would destroy the draft`, () => {
+    expect(
+      getAvailableActionsForEvent({
+        status: EventStatus.enum.CREATED,
+        flags: []
+      } as unknown as EventIndex)
+    ).not.toContain(ActionType.CUSTOM)
+  })
+
   const REJECTABLE_STATUSES = [
     EventStatus.enum.NOTIFIED,
     EventStatus.enum.DECLARED

--- a/packages/commons/src/events/state/availableActions.ts
+++ b/packages/commons/src/events/state/availableActions.ts
@@ -18,14 +18,6 @@ import { EventStatus } from '../EventMetadata'
 import { Flag, InherentFlags } from '../Flag'
 
 const AVAILABLE_ACTIONS_BY_EVENT_STATUS = {
-  /**
-   * A CREATED event is a draft: it is not indexed, so it is only reachable
-   * through its creator's drafts workqueue, and executing any action on it
-   * deletes its drafts. A custom action cannot change the status, so it would
-   * leave the event in CREATED with its declaration data destroyed — the draft
-   * would vanish from the workqueue with no way to find it again. Custom
-   * actions are therefore not available until the event has been declared.
-   */
   [EventStatus.enum.CREATED]: [
     ActionType.READ,
     ActionType.DECLARE,

--- a/packages/commons/src/events/state/availableActions.ts
+++ b/packages/commons/src/events/state/availableActions.ts
@@ -18,12 +18,19 @@ import { EventStatus } from '../EventMetadata'
 import { Flag, InherentFlags } from '../Flag'
 
 const AVAILABLE_ACTIONS_BY_EVENT_STATUS = {
+  /**
+   * A CREATED event is a draft: it is not indexed, so it is only reachable
+   * through its creator's drafts workqueue, and executing any action on it
+   * deletes its drafts. A custom action cannot change the status, so it would
+   * leave the event in CREATED with its declaration data destroyed — the draft
+   * would vanish from the workqueue with no way to find it again. Custom
+   * actions are therefore not available until the event has been declared.
+   */
   [EventStatus.enum.CREATED]: [
     ActionType.READ,
     ActionType.DECLARE,
     ActionType.NOTIFY,
-    ActionType.DELETE,
-    ActionType.CUSTOM
+    ActionType.DELETE
   ],
   [EventStatus.enum.NOTIFIED]: [
     ActionType.READ,

--- a/packages/events/src/router/event/__snapshots__/event.actions.register.test.ts.snap
+++ b/packages/events/src/router/event/__snapshots__/event.actions.register.test.ts.snap
@@ -26,6 +26,6 @@ exports[`Request and confirmation flow > Synchronous confirmation flow > should 
 
 exports[`Validation error message contains all the offending fields 1`] = `[TRPCError: [{"message":"Invalid date field","id":"applicant.dob","value":"02-02"},{"message":"Please enter a valid date","id":"applicant.dob","value":"02-02"}]]`;
 
-exports[`can not register an event that is not first declared and validated 1`] = `[TRPCError: Action 'REGISTER' cannot be performed on an event in 'CREATED' state with [] flags. Available actions: READ, DECLARE, NOTIFY, DELETE, CUSTOM.]`;
+exports[`can not register an event that is not first declared and validated 1`] = `[TRPCError: Action 'REGISTER' cannot be performed on an event in 'CREATED' state with [] flags. Available actions: READ, DECLARE, NOTIFY, DELETE.]`;
 
 exports[`when mandatory field is invalid, conditional hidden fields are still skipped 1`] = `[TRPCError: [{"message":"Invalid date field","id":"applicant.dob","value":"02-1-2024"},{"message":"Please enter a valid date","id":"applicant.dob","value":"02-1-2024"}]]`;

--- a/packages/events/src/router/event/event.actions.custom.test.ts
+++ b/packages/events/src/router/event/event.actions.custom.test.ts
@@ -21,9 +21,7 @@ import {
 import {
   sanitizeForSnapshot,
   setupTestCase,
-  UNSTABLE_EVENT_FIELDS
-} from '@events/tests/utils'
-import {
+  UNSTABLE_EVENT_FIELDS,
   createTestClient,
   createCountryConfigClient
 } from '@events/tests/utils'
@@ -177,6 +175,39 @@ describe('event.actions.custom', () => {
         customActionType: 'INVALID_ACTION'
       })
     ).rejects.toMatchSnapshot()
+  })
+
+  test('returns HTTP409 if trying to execute an action on a draft, since it would destroy the draft', async () => {
+    const { user, generator } = await setupTestCase()
+    const client = createTestClient(user, [
+      encodeScope({
+        type: 'record.create',
+        options: { event: [TENNIS_CLUB_MEMBERSHIP] }
+      }),
+      encodeScope({
+        type: 'record.read',
+        options: { event: [TENNIS_CLUB_MEMBERSHIP] }
+      }),
+      `type=record.custom-action&event=${TENNIS_CLUB_MEMBERSHIP}&customActionTypes=${CUSTOM_ACTION_TYPE}`
+    ])
+
+    // The event is only created, never declared, so it stays in CREATED state.
+    const event = await client.event.create(generator.event.create())
+
+    await expect(
+      client.event.actions.custom.request({
+        type: ActionType.CUSTOM,
+        eventId: event.id,
+        transactionId: getUUID(),
+        customActionType: CUSTOM_ACTION_TYPE,
+        annotation: { notes: 'Confirmed membership' }
+      })
+    ).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: expect.stringContaining(
+        `Action 'CUSTOM' cannot be performed on an event in 'CREATED' state`
+      )
+    })
   })
 
   test('returns HTTP409 if trying to execute an action where the condition is not met', async () => {

--- a/packages/events/src/router/event/event.actions.custom.test.ts
+++ b/packages/events/src/router/event/event.actions.custom.test.ts
@@ -188,7 +188,13 @@ describe('event.actions.custom', () => {
         type: 'record.read',
         options: { event: [TENNIS_CLUB_MEMBERSHIP] }
       }),
-      `type=record.custom-action&event=${TENNIS_CLUB_MEMBERSHIP}&customActionTypes=${CUSTOM_ACTION_TYPE}`
+      encodeScope({
+        type: 'record.custom-action',
+        options: {
+          event: [TENNIS_CLUB_MEMBERSHIP],
+          customActionTypes: [CUSTOM_ACTION_TYPE]
+        }
+      })
     ])
 
     // The event is only created, never declared, so it stays in CREATED state.

--- a/packages/events/src/router/event/event.draft.test.ts
+++ b/packages/events/src/router/event/event.draft.test.ts
@@ -76,7 +76,7 @@ test('Throws error when creating a draft for invalid action', async () => {
       transactionId: 'trnx-id'
     })
   ).rejects.toThrow(
-    "Action 'REGISTER' cannot be performed on an event in 'CREATED' state with [] flags. Available actions: READ, DECLARE, NOTIFY, DELETE, CUSTOM"
+    "Action 'REGISTER' cannot be performed on an event in 'CREATED' state with [] flags. Available actions: READ, DECLARE, NOTIFY, DELETE"
   )
 })
 


### PR DESCRIPTION
## Description

[issue-13245-escalate-on-draft.webm](https://github.com/user-attachments/assets/47ee1f29-e42f-4017-95e1-cef99bd6637b)
>[!NOTE]
> I considered writing a migration to cleanup the orphan events that have no drafts tied to them but as it's a destructive action and not hurting the application too much for now, let's revisit that at a later time. One thing to note tho, changing a user's office can similarly leave orphan events with `CREATED` status as it removes all the drafts of a user but doesn't cleanup the events: 

https://github.com/opencrvs/opencrvs-core/blob/f63f9bd496c0fb170f3d171eb21a8b0008cea540/packages/events/src/service/users/api.ts#L240-L242

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [x] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
