### PR TITLE
fix: show error message for rate limit. Have a default

### DIFF
--- a/packages/countryconfig-template/src/translations/login.csv
+++ b/packages/countryconfig-template/src/translations/login.csv
@@ -10,6 +10,7 @@ error.errorPhoneNumberNotFound,Error message for phone number not found,Phone nu
 error.networkError,The error that appears when there is no internet connection,Unable to connect to server,Impossible de se connecter au serveur
 error.required.password,New password required,Invalid password,Le nouveau mot de passe n'est pas valide
 label.error,Generic error message for invalid form nput,Invalid input,Entrée invalide
+login.somethingWentWrong,Error toast message for general errors,Something went wrong. Please try again,Une erreur s'est produite. Veuillez réessayer
 login.clearForm,,Clear form,Effacer le formulaire
 login.codeSubmissionError,The error that appears when the user entered sms code is unauthorised,Incorrect verification code. Please try again,"Désolé, ce code n'a pas fonctionné."
 login.fieldMissing,The error if user doesn't fill all the field,Enter your username and password,Nom d'utilisateur/mot de passe requis

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -101,11 +101,11 @@ export async function createServer() {
     if (request.response instanceof RateLimitError) {
       return reply
         .response({
-          statusCode: 402,
+          statusCode: 429,
           error: 'Rate limit exceeded',
           message: request.response.message
         })
-        .code(402)
+        .code(429)
     }
 
     return reply.continue

--- a/packages/login/src/App.test.tsx
+++ b/packages/login/src/App.test.tsx
@@ -9,6 +9,9 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 import { createTestApp } from '@login/tests/util'
+import { rest } from 'msw'
+import { setupServer } from 'msw/node'
+import { act } from 'react'
 
 describe('Login app step one', () => {
   let app: any
@@ -43,5 +46,53 @@ describe('Login app step one', () => {
       .simulate('change', { target: { value: 'kennedy.mweene' } })
 
     app.find('input#password').simulate('change', { target: { value: 'test' } })
+  })
+})
+
+describe('Login error', () => {
+  it('shows rate limit error', async () => {
+    const server = setupServer(
+      rest.post('/api/auth/authenticate', (_, res, ctx) => {
+        return res(
+          ctx.status(429),
+          ctx.json({
+            statusCode: 429,
+            error: 'RATE_LIMIT_ERROR',
+            message: 'Rate limited'
+          })
+        )
+      })
+    )
+    server.listen()
+
+    try {
+      const { app } = await createTestApp()
+
+      app
+        .find('input#username')
+        .simulate('change', { target: { value: 'kennedy.mweene' } })
+      app
+        .find('input#password')
+        .simulate('change', { target: { value: 'test' } })
+
+      await act(async () => {
+        app.find('form#STEP_ONE').simulate('submit')
+        await new Promise((resolve) => setTimeout(resolve, 0))
+      })
+      app.update()
+
+      const toast = app.findWhere(
+        (node) =>
+          node.type() !== undefined &&
+          node
+            .text()
+            .includes(
+              'Too many login attempts. You can try again after one minute.'
+            )
+      )
+      expect(toast.exists()).toBe(true)
+    } finally {
+      server.close()
+    }
   })
 })

--- a/packages/login/src/i18n/messages/views/stepOneForm.ts
+++ b/packages/login/src/i18n/messages/views/stepOneForm.ts
@@ -69,6 +69,17 @@ const messagesToDefine: IStepOneFormMessages = {
     description:
       'The error that appears when the user entered details are forbidden'
   },
+  tooManyLoginAttemptError: {
+    id: 'login.tooManyLoginAttemptError',
+    defaultMessage:
+      'Too many login attempts. You can try again after one minute.',
+    description: 'Error shown when login attempt is limited by the system'
+  },
+  somethingWentWrong: {
+    id: 'login.somethingWentWrong',
+    defaultMessage: 'Something went wrong. Please try again.',
+    description: 'Error toast message for general errors'
+  },
   optionalLabel: {
     id: 'login.optionalLabel',
     defaultMessage: 'Optional',

--- a/packages/login/src/utils/authUtils.ts
+++ b/packages/login/src/utils/authUtils.ts
@@ -15,6 +15,7 @@ export const ERROR_CODE_FIELD_MISSING = 500
 export const ERROR_CODE_INVALID_CREDENTIALS = 401
 export const ERROR_CODE_FORBIDDEN_CREDENTIALS = 403
 export const ERROR_CODE_PHONE_NUMBER_VALIDATE = 503
+export const ERROR_CODE_RATE_LIMIT = 429
 
 export interface ITokenPayload {
   subject: string

--- a/packages/login/src/views/StepOne/StepOneContainer.tsx
+++ b/packages/login/src/views/StepOne/StepOneContainer.tsx
@@ -18,7 +18,7 @@ import {
   selectApplicationName
 } from '@login/login/selectors'
 import { useDispatch, useSelector } from 'react-redux'
-import { useIntl } from 'react-intl'
+import { IntlShape, useIntl } from 'react-intl'
 import { Field, Form } from 'react-final-form'
 import { Box, InputField, PasswordInput, TextInput } from '@opencrvs/components'
 import { messages } from '@login/i18n/messages/views/stepOneForm'
@@ -28,7 +28,8 @@ import {
   ERROR_CODE_FIELD_MISSING,
   ERROR_CODE_FORBIDDEN_CREDENTIALS,
   ERROR_CODE_INVALID_CREDENTIALS,
-  ERROR_CODE_PHONE_NUMBER_VALIDATE
+  ERROR_CODE_PHONE_NUMBER_VALIDATE,
+  ERROR_CODE_RATE_LIMIT
 } from '@login/utils/authUtils'
 import { IAuthenticationData } from '@login/utils/authApi'
 import * as actions from '@login/login/actions'
@@ -44,6 +45,23 @@ import { FORGOTTEN_ITEM, STEP_TWO } from '@login/navigation/routes'
 
 const userNameField = stepOneFields.username
 const passwordField = stepOneFields.password
+
+const getErrorMessage = (intl: IntlShape, errorCode: number) => {
+  switch (errorCode) {
+    case ERROR_CODE_FIELD_MISSING:
+      return intl.formatMessage(messages.fieldMissing)
+    case ERROR_CODE_INVALID_CREDENTIALS:
+      return intl.formatMessage(messages.submissionError)
+    case ERROR_CODE_FORBIDDEN_CREDENTIALS:
+      return intl.formatMessage(messages.forbiddenCredentialError)
+    case ERROR_CODE_PHONE_NUMBER_VALIDATE:
+      return intl.formatMessage(messages.phoneNumberFormat)
+    case ERROR_CODE_RATE_LIMIT:
+      return intl.formatMessage(messages.tooManyLoginAttemptError)
+    default:
+      return intl.formatMessage(messages.somethingWentWrong)
+  }
+}
 
 const UserNameInput = () => {
   const intl = useIntl()
@@ -172,14 +190,7 @@ export function StepOneContainer() {
 
       {submissionError && errorCode ? (
         <Toast type="error" onClose={() => dispatch(resetSubmissionError())}>
-          {errorCode === ERROR_CODE_FIELD_MISSING &&
-            intl.formatMessage(messages.fieldMissing)}
-          {errorCode === ERROR_CODE_INVALID_CREDENTIALS &&
-            intl.formatMessage(messages.submissionError)}
-          {errorCode === ERROR_CODE_FORBIDDEN_CREDENTIALS &&
-            intl.formatMessage(messages.forbiddenCredentialError)}
-          {errorCode === ERROR_CODE_PHONE_NUMBER_VALIDATE &&
-            intl.formatMessage(messages.phoneNumberFormat)}
+          {getErrorMessage(intl, errorCode)}
         </Toast>
       ) : (
         isOffline && (

--- a/packages/login/src/views/StepTwo/StepTwoContainer.tsx
+++ b/packages/login/src/views/StepTwo/StepTwoContainer.tsx
@@ -19,7 +19,6 @@ import { Text } from '@opencrvs/components/lib/Text'
 
 import * as actions from '@login/login/actions'
 import { IVerifyCodeNumbers, resetSubmissionError } from '@login/login/actions'
-import { ceil } from 'lodash'
 import { messages } from '@login/i18n/messages/views/stepTwoForm'
 import { useDispatch, useSelector } from 'react-redux'
 import { Box } from '@login/../../components/lib/Box'

--- a/packages/testland/src/translations/login.csv
+++ b/packages/testland/src/translations/login.csv
@@ -11,6 +11,7 @@ error.networkError,The error that appears when there is no internet connection,U
 error.required.password,New password required,Invalid password,Le nouveau mot de passe n'est pas valide
 label.error,Generic error message for invalid form nput,Invalid input,Entrée invalide
 login.clearForm,,Clear form,Effacer le formulaire
+login.somethingWentWrong,Error toast message for general errors,Something went wrong. Please try again,Une erreur s'est produite. Veuillez réessayer
 login.codeSubmissionError,The error that appears when the user entered sms code is unauthorised,Incorrect verification code. Please try again,"Désolé, ce code n'a pas fonctionné."
 login.fieldMissing,The error if user doesn't fill all the field,Enter your username and password,Nom d'utilisateur/mot de passe requis
 login.forbiddenCredentialError,The error that appears when the user entered details are forbidden,User is currently deactivated,L'utilisateur est actuellement désactivé.


### PR DESCRIPTION
## Description
- Use semantic HTTP error for rate limiting
- Show rate limit message error in login
- Create default message

<img width="1713" height="985" alt="error-429-login" src="https://github.com/user-attachments/assets/33edc36d-ed0b-4f8f-8833-696a05a6aec8" />

