### PR TITLE
e2e: Remove options count expectation in test case

### DIFF
--- a/packages/testland/e2e/testcases/jurisdiction/birth-form-jurisdiction-restrictions.spec.ts
+++ b/packages/testland/e2e/testcases/jurisdiction/birth-form-jurisdiction-restrictions.spec.ts
@@ -70,7 +70,6 @@ test.describe('Birth form - child place of birth jurisdiction restrictions', () 
     // `activeOnly`, so "Old Ibombo Community Clinic" — inactivated since
     // 2024-11-15 — is correctly excluded rather than listed.
     const options = await dropdown.locator('[role="list"] > li')
-    await expect(options).toHaveCount(2)
     await expect(options.nth(1)).toHaveText('Ibombo District Hospital')
     await expect(
       dropdown.getByText('Old Ibombo Community Clinic')


### PR DESCRIPTION
Remove expectation for options count in birth form test.

"opencrvs-core/packages/testland/e2e/testcases/advanced-search/10-search-location-versioning.spec.ts" adds a new location. So the count assertion is flaky depending on the order

## Description

Clearly describe what has been changed. Include relevant context or background.
Explain how the issue was fixed (if applicable) and the root cause.

Link this pull request to the GitHub issue (and optionally name the branch `ocrvs-<issue #>`)

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
