### PR TITLE
Content card sits flush against the navigation and the window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ A new `integration.audit.read` scope guards it; country configs must assign it t
 - Keep a number field's postfix/unit label (e.g. `Kilograms (kg)` on Weight at birth) on a single line instead of wrapping onto a second row [#13216](https://github.com/opencrvs/opencrvs-core/issues/13216)
 - Bust the locally cached data when a user's office or role changes, so stale drafts and records from the previous office no longer appear after the change
 - Stop showing an empty `Comment` section in the record audit history for archived records. Archiving from the action menu never asked for a comment, so the section only ever displayed a `-` placeholder. Records archived through the "mark as duplicate" flow still show the comment that was entered there [#13265](https://github.com/opencrvs/opencrvs-core/issues/13265)
+- Keep a 24px gutter beside a `Content` card at every width, so the workqueue and other card pages no longer sit flush against the side navigation and the browser window on screens narrower than the card's maximum [#13391](https://github.com/opencrvs/opencrvs-core/issues/13391)
 
 ## 2.0.0
 

--- a/packages/components/src/Content/Content.tsx
+++ b/packages/components/src/Content/Content.tsx
@@ -18,15 +18,22 @@ const Container = styled.div<{ size: ContentSize }>`
   border-radius: 4px;
   box-sizing: border-box;
   margin: 24px auto;
+  /*
+   * The 48px is the gutter. It has to come off the width rather than go on as
+   * a margin, because 'margin: auto' only shares out space that is left over:
+   * once the region is narrower than the card there is none, the margins
+   * compute to zero, and the card sits flush against the navigation and the
+   * window.
+   */
   max-width: ${({ size }) => {
     switch (size) {
       case 'large':
-        return '1140px'
+        return 'min(1140px, 100% - 48px)'
       case 'normal':
-        return '778px'
+        return 'min(778px, 100% - 48px)'
       case 'small':
       default:
-        return '568px'
+        return 'min(568px, 100% - 48px)'
     }
   }};
   border: 1px solid ${({ theme }) => theme.colors.grey300};


### PR DESCRIPTION
## Description

Closes #13391.

Fixes this bug:
<img width="1283" height="777" alt="Screenshot 2026-08-06 at 18 26 34" src="https://github.com/user-attachments/assets/c505ab07-109d-468c-b83e-5935ff9abce3" />


A `Content` card centres itself with `margin: 24px auto`. Auto margins only share out space that is *left over*, so once the region holding the card is narrower than the card's `max-width` there is none to share: both margins compute to zero and the card sits flush — hard against the side navigation on one edge and the browser window on the other.

The workqueue uses `ContentSize.LARGE` (1140px), so it does this at any browser width below 1140px plus the sidebar, which is most laptop screens.

No value of `margin` can fix it, because the problem is that there is nothing left to distribute. The gutter has to come off the width instead:

```diff
   max-width: ${({ size }) => {
     switch (size) {
       case 'large':
-        return '1140px'
+        return 'min(1140px, 100% - 48px)'
       case 'normal':
-        return '778px'
+        return 'min(778px, 100% - 48px)'
       case 'small':
       default:
-        return '568px'
+        return 'min(568px, 100% - 48px)'
     }
   }};
```

Below the cap the card is 48px narrower than its region and the existing auto margins split that into 24px a side. Above the cap nothing changes at all — the card is still capped and still centred, exactly as before. Mobile is untouched: the `md` breakpoint already sets `max-width: 100%` after this rule, so the card still goes full-bleed.

This is the same idiom `Frame.Layout` already uses for its multi-column branch (`min(1140px, 100% - 24px - 24px)`); it just applies it to the card itself, where it holds for every layout rather than one.

### Scope

The issue also proposed removing `Content`'s vertical margin so that containers own the spacing between their children. That is left alone. Testing on the version-select branch showed the vertical double-count no longer occurs in practice, and reproducing the 24px as a wrapper at every call site would have cost 23 new elements and a visual re-check of 30 screens to fix a fault that is not biting. If it resurfaces it is worth its own issue.

## Testing

- `packages/components`: `tsc --noEmit`, `lint:css` and `prettier --check` all clean.
- No consumer changes, so client and login are untouched.

Worth an eye on: the workqueue between roughly 1000px and 1400px wide, where the card was previously flush. Every other `Content` gains the same gutter at its own threshold. Vertical spacing is unchanged everywhere.

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests — typecheck, lint and format were run; the workqueue has **not** been looked at in a browser yet
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [x] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TC1rjmGpsC9gcqzCoi2P3
