### PR TITLE
Testland: let a registrar register their own late declaration

### DIFF
--- a/packages/testland/src/events/birth/index.ts
+++ b/packages/testland/src/events/birth/index.ts
@@ -420,6 +420,13 @@ export const birthEvent = defineConfig({
       },
       flags: [
         {
+          /*
+           * A late birth needs a second pair of eyes before it can be
+           * registered — except when a Local Registrar declared it, since they
+           * already hold the authority the approval would grant. Without this
+           * exemption a registrar cannot register their own late declaration
+           * at all, which makes the whole path untestable in Testland.
+           */
           id: 'approval-required-for-late-registration',
           operation: 'add',
           conditional: and(
@@ -429,7 +436,8 @@ export const birthEvent = defineConfig({
                 .days(BIRTH_LATE_REGISTRATION_TARGET_DAYS)
                 .inPast()
             ),
-            field('child.dob').isBefore().now()
+            field('child.dob').isBefore().now(),
+            not(user.hasRole('LOCAL_REGISTRAR'))
           )
         },
         {


### PR DESCRIPTION
## Description

In Testland, `REGISTER` on a birth is enabled only when the record carries `validated` and does **not** carry `approval-required-for-late-registration`:

```ts
conditional: and(
  flag('validated'),
  not(flag('approval-required-for-late-registration')),
  not(flag('escalated-to-provincial-registrar')),
  not(flag('escalated-to-registrar-general'))
)
```

`DECLARE` raises the late-registration flag for any child date of birth more than `BIRTH_LATE_REGISTRATION_TARGET_DAYS` (365) in the past. It now skips that when a Local Registrar is the one declaring.

## Why

A Local Registrar already holds the authority the approval would grant, so requiring someone else to approve their own declaration adds nothing.

Practically, it also makes the path testable. Any birth more than a year old could be declared and edited but never registered, whatever the role — so registering from the UI appeared broken, and no local test data could reach a registration unless the date of birth happened to be recent.

## Acceptance criteria

1. **GIVEN** a Local Registrar declares a birth with a date of birth over a year ago, **THEN** Register is enabled.
2. **GIVEN** any other role declares the same record, **THEN** the late-registration flag is raised and Register stays disabled pending approval.
3. **GIVEN** a birth within the last year, **THEN** behaviour is unchanged for every role.