### PR TITLE
Record tab: a registration shows no documents or signature

### DIFF
--- a/packages/client/src/v2-events/features/events/ReadOnlyView.tsx
+++ b/packages/client/src/v2-events/features/events/ReadOnlyView.tsx
@@ -21,6 +21,9 @@ import styled from 'styled-components'
 import {
   ActionType,
   applyDraftToEventIndex,
+  FieldConfig,
+  FieldType,
+  RecordForm,
   EventState,
   getActionAnnotationFields,
   getDeclaration,
@@ -70,6 +73,19 @@ const messages = defineMessages({
     description: 'Heading of the card on the Record tab'
   }
 })
+
+/**
+ * What an informant submits with a declaration and attests to by signing it.
+ * A registration can move on from that declaration through corrections the
+ * informant never confirmed, so none of it carries over.
+ */
+function isSupportingField(field: FieldConfig) {
+  return (
+    field.type === FieldType.FILE ||
+    field.type === FieldType.FILE_WITH_OPTIONS ||
+    field.type === FieldType.SIGNATURE
+  )
+}
 
 const OfflineMessageWrapper = styled.div`
   text-align: center;
@@ -121,7 +137,34 @@ function ReadonlyViewContent({ eventId }: { eventId: UUID }) {
   const intl = useIntl()
   const { formatMessage } = useIntlFormatMessageWithFlattenedParams()
 
-  const formConfig = getDeclaration(configuration)
+  /*
+   * A registration shows neither supporting documents nor the signature. The
+   * signature attests to the declaration as it stood, and a registration can
+   * be corrected afterwards without the informant seeing it. The documents
+   * stay reachable from the Documents tab.
+   *
+   * Filters the config rather than the values — Review decides whether to
+   * render the document viewer from the config alone.
+   */
+  const fullFormConfig = getDeclaration(configuration)
+
+  const formConfig = useMemo(() => {
+    if (selected?.form !== RecordForm.REGISTRATION) {
+      return fullFormConfig
+    }
+
+    return {
+      ...fullFormConfig,
+      pages: fullFormConfig.pages
+        .map((page) => ({
+          ...page,
+          fields: page.fields.filter((field) => !isSupportingField(field))
+        }))
+        .filter(({ fields }) => fields.length > 0)
+    }
+  }, [fullFormConfig, selected?.form])
+
+  const isRegistration = selected?.form === RecordForm.REGISTRATION
 
   const annotation = useMemo((): EventState | undefined => {
     // Collect annotations from all past non-READ actions that have annotation fields
@@ -166,6 +209,18 @@ function ReadonlyViewContent({ eventId }: { eventId: UUID }) {
 
   const { title, fields } = actionConfiguration.review
 
+  /*
+   * Only signatures, not the whole of isSupportingField. An annotation belongs
+   * to the action that captured it, so a file in one is evidence attached to
+   * that action — a correction request, say — and that evidence does belong to
+   * the registration, because the correction does. A signature captured this
+   * way is still the informant confirming their declaration, so it is subject
+   * to the same rule as the documents above.
+   */
+  const reviewFields = isRegistration
+    ? fields.filter(({ type }) => type !== FieldType.SIGNATURE)
+    : fields
+
   return (
     <ReviewComponent.Body
       readonlyMode
@@ -191,7 +246,7 @@ function ReadonlyViewContent({ eventId }: { eventId: UUID }) {
       }}
       form={eventStateWithDraft.declaration}
       formConfig={formConfig}
-      reviewFields={fields}
+      reviewFields={reviewFields}
       showValidationErrors={isLatest}
       title={formatMessage(title, eventStateWithDraft.declaration)}
       validatorContext={validatorContext}

--- a/packages/client/src/v2-events/features/events/components/DocumentViewer.tsx
+++ b/packages/client/src/v2-events/features/events/components/DocumentViewer.tsx
@@ -158,6 +158,7 @@ export function DocumentViewer({
   return (
     <ResponsiveDocumentViewer
       comparisonView={!!comparisonView}
+      data-testid="document-viewer"
       showInMobile={!!showInMobile}
     >
       <DocumentViewerComponent id="document_section" options={fileOptions}>


### PR DESCRIPTION
Closes #13369. Stacked on #13395 → #13388 — review those first, and retarget as they merge.

## Why

The signature is **the informant confirming the declaration as it stood when they signed it**. A registration can be corrected afterwards, and the informant neither saw those corrections nor attested to them — so carrying their signature onto the registration would claim they had. The supporting documents are evidence submitted for that same declaration, and do not stand as evidence for whatever the registration later became.

This holds whether or not a given record has actually been corrected. The question is what the attestation *covers*, not whether it still happens to match.

Every document stays reachable from the Documents tab whatever version is selected. This is about what a registration **is**, not about withholding anything.

## What this does

| Selected form | Document preview | Supporting document rows | Signature |
|---|---|---|---|
| Notification | shown, as attached to that version | shown | shown |
| Declaration | shown, as attached to that version | shown | shown |
| **Registration** | **hidden** | **hidden** | **hidden** |

## Notification and declaration needed no work

Their documents already come from the version snapshot, so an earlier declaration shows the documents as they stood at that edit rather than today's set. That falls out of the prefix fold in #13388.

## Filtering the config, not the values

`Review` decides whether to render the document viewer from `formConfig.pages` alone, never from the form values:

```ts
const pageIdsWithFile = formConfig.pages
  .filter(({ fields }) =>
    fields.some(({ type }) => type === FieldType.FILE || type === FieldType.FILE_WITH_OPTIONS)
  )
```

So blanking the file values would leave an empty viewer standing. Filtering the config removes the left-column document rows and the right-column preview together, and needs no change to `Review` — which the declare, edit, correct, print-certificate and dedup flows all share.

## Annotations drop only the signature

The annotation review fields get a narrower filter than the declaration form, on purpose. An annotation belongs to the action that captured it, so a **file** in one is evidence attached to that action — a correction request, say — and that evidence *does* belong to the registration, because the correction does. A **signature** captured as an annotation is still the informant confirming their declaration, so the rule above applies to it.

## Testing

- `packages/client` — 326 pass, typecheck clean, lint clean
- Added a `data-testid` to the document viewer's root so its absence can be asserted

## Note on scope

This is a **view rule, not a data rule**. `REGISTER` does not clear file or signature fields, so a registration's declaration state still holds every reference — this only stops them rendering. Anything else reading that state, such as a certificate template or an export, still sees them. If "a registration carries no informant attestation" should hold at the data level, that is a much larger change to the action model and needs its own issue.

## Note on `check-missing-translation`

Failing on every open PR from every author, and on develop's own `event.summary.redacted`. The check compares against `opencrvs-countryconfig`, but testland now ships inside core. This stack's keys are in `packages/testland/src/translations/client.csv`.
