### PR TITLE
fix: make seal action only available on registered events

### DIFF
--- a/packages/testland/src/events/birth/index.ts
+++ b/packages/testland/src/events/birth/index.ts
@@ -1268,7 +1268,7 @@ export const birthEvent = defineConfig({
       conditionals: [
         {
           type: ConditionalType.SHOW,
-          conditional: not(flag('sealed'))
+          conditional: and(status('REGISTERED'), not(flag('sealed')))
         }
       ],
       flags: [{ id: 'sealed', operation: 'add' }],


### PR DESCRIPTION
## Description

[ocrvs-13300-seal-fix-scripted.webm](https://github.com/user-attachments/assets/66ec1141-3a2c-4e73-94b9-97e4dc05d0b0)

>[!NOTE]
> Didn't add any e2e test for this intentionally as it felt overkill, plus QA team is reviewing which e2e flows they want anyways.

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
