### PR TITLE
fix: Remove direct calls to events service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Archiving a NOTIFIED (incomplete) record used to clear `InherentFlags.INCOMPLETE
 - Updates Kubernetes node networking and firewall configuration for multi-node clusters with private node communication [#353](https://github.com/opencrvs/infrastructure/pull/353)
 - Enable OpenTelemetry for Traefik and NGINX [#10685](https://github.com/opencrvs/opencrvs-core/issues/10685)
 - Reduce the amount of data sent to Elasticsearch by dropping unused and duplicate fields during Metricbeat processing [#10978](https://github.com/opencrvs/opencrvs-core/issues/10978)
+- Remove direct calls to events service [#13399](https://github.com/opencrvs/opencrvs-core/issues/13399)
 
 ### New features
 

--- a/charts/opencrvs-services/templates/_domain-helper.tpl
+++ b/charts/opencrvs-services/templates/_domain-helper.tpl
@@ -6,7 +6,7 @@
 
 {{- define "render-opencrvs-host-matchers" -}}
 {{- $root := . -}}
-{{- $service_names := list "register" "login" "gateway" "events" "countryconfig" "metabase" -}}
+{{- $service_names := list "register" "login" "gateway" "countryconfig" "metabase" -}}
 {{- $host_matchers := list (printf "Host(`%s`)" $root.Values.hostname) -}}
 {{- range $service_name := $service_names -}}
 {{- $host := include "render-external-subdomain" (dict "service_name" $service_name "Values" $root.Values) -}}

--- a/charts/opencrvs-services/templates/events-deployment.yaml
+++ b/charts/opencrvs-services/templates/events-deployment.yaml
@@ -1,33 +1,4 @@
 ---
-apiVersion: traefik.io/v1alpha1
-kind: IngressRoute
-metadata:
-  name: events-route
-spec:
-  entryPoints:
-  {{- if or .Values.ingress.ssl_enabled .Values.ingress.tls_resolver }}
-    - websecure
-  {{- end }}
-  {{- if or .Values.ingress.tls_resolver (not .Values.ingress.ssl_enabled) }}
-    - web
-  {{- end }}
-  routes:
-  - match: 'Host(`{{ include "render-external-subdomain" (dict "service_name" "events" "Values" .Values) }}`)'
-    kind: Rule
-    services:
-    - name: events
-      namespace: {{ .Release.Namespace }}
-      port: {{ .Values.events.port }}
-    middlewares:
-      - name: sts-and-basic-response-headers
-  {{- if .Values.ingress.tls_resolver }}
-  tls:
-    certResolver: {{ .Values.ingress.tls_resolver }}
-  {{- else if .Values.ingress.tls_secret_name }}
-  tls:
-    secretName: {{ .Values.ingress.tls_secret_name }}
-  {{- end }}
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/packages/utilities/scripts/opencrvs-validate.sh
+++ b/packages/utilities/scripts/opencrvs-validate.sh
@@ -528,7 +528,7 @@ EOF
 
 check_events_service_status() {
   local check_name="Events service status"
-  local url="https://events.${DOMAIN}/health/ready"
+  local url="http://events:5555/health/ready"
   local response_file
   local curl_output
   local curl_status
@@ -690,7 +690,6 @@ configure_public_domains() {
     "login.$DOMAIN"
     "register.$DOMAIN"
     "countryconfig.$DOMAIN"
-    "events.$DOMAIN"
     "metabase.$DOMAIN"
     "$minio_url"
   )


### PR DESCRIPTION
## Description

Related issue: https://github.com/opencrvs/opencrvs-core/issues/13399

Goal of this PR is to remove events service from OpenCRVS application frontend

See e2e test results: https://github.com/opencrvs/e2e/actions/runs/31468091001

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
