### PR TITLE
fix: Drop not used labels and tags from the index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Archiving a NOTIFIED (incomplete) record used to clear `InherentFlags.INCOMPLETE
 - Advanced search keeps records at renamed or inactivated offices, facilities and admin areas findable — filters list historical names and, for offices/facilities, inactivated locations [#13146](https://github.com/opencrvs/opencrvs-core/issues/13146)
 - Updates Kubernetes node networking and firewall configuration for multi-node clusters with private node communication [#353](https://github.com/opencrvs/infrastructure/pull/353)
 - Enable OpenTelemetry for Traefik and NGINX [#10685](https://github.com/opencrvs/opencrvs-core/issues/10685)
+- Reduce the amount of data sent to Elasticsearch by dropping unused and duplicate fields during Metricbeat processing [#10978](https://github.com/opencrvs/opencrvs-core/issues/10978)
 
 ### New features
 

--- a/charts/dependencies/files/beats/metricbeat.yml
+++ b/charts/dependencies/files/beats/metricbeat.yml
@@ -47,6 +47,36 @@ processors:
       target: ''
       fields:
         host.name: ${NODE_NAME}
+  - drop_fields:
+      fields:
+        - agent
+        - ecs
+        - input
+        - host.ip
+        - host.mac
+        - host.os
+        - host.architecture
+        - host.containerized
+        - log.file.device_id
+        - log.file.inode
+        - log.file.fingerprint
+        - log.offset
+        - kubernetes.node.uid
+        - kubernetes.namespace_uid
+        - kubernetes.namespace_labels
+        - kubernetes.node.labels
+        - kubernetes.pod.uid
+        - container.id
+        - stream
+        - event.timezone
+        - pid
+        - req.remotePort
+        - container.runtime
+        - time
+        - kubernetes.node.name
+        - kubernetes.container.name
+        - kubernetes.labels.pod-template-hash
+        - level
 
 #========================== Elasticsearch output ===============================
 output.elasticsearch:


### PR DESCRIPTION
## Description

Related issue: https://github.com/opencrvs/opencrvs-core/issues/10978

Related PR: https://github.com/opencrvs/opencrvs-core/pull/12972

Goal of this PR is to reduce index size by dropping fields not used for filtering or search.

## Testing

- Record size before optimisation: 6.1K
- Record size after optimisation: 4.3K
- Estimated % optimisation: 30%
- Daily index size before optimisation: 500Mb
- Estimated daily index size after optimisation: 350Mb
- Size for 30 days period before: 15G
- Estimated Size for 30 days period after: 10G


Testing environment: https://kibana.qa.opencrvs.dev/app/discover

Example record before optimisation: 
[record-before-cleanup.json](https://github.com/user-attachments/files/30935149/record-before-cleanup.json)

Example record after optimisation: 
[record-after-cleanup.json](https://github.com/user-attachments/files/30935160/record-after-cleanup.json)


## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
