### PR TITLE
ci: one static required check for lint-and-test

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -669,3 +669,39 @@ jobs:
       # commons and events are built first (cache hits when warm)
       - name: Build toolkit and dependencies
         run: pnpm exec nx run @opencrvs/toolkit:build
+
+  required-checks:
+    name: Required checks
+    # The single context branch protection requires from this workflow.
+    #
+    # Per-job names cannot be required directly any more: `nx affected`
+    # makes the `test` matrix dynamic, and a matrix job that is skipped is
+    # skipped before its matrix expands. Either way the check runs for
+    # unselected entries are never created, so a required context named
+    # after one of them waits for a status that will never be reported and
+    # blocks the PR forever. A skipped *non-matrix* job does report, as
+    # "success" — which is exactly why this job tolerates `skipped` below
+    # and fails only on real failures.
+    needs:
+      - setup
+      - test
+      - countryconfig-template
+      - prepare-client-tests
+      - lint-client
+      - test-storybook
+      - test-client
+      - lint-knip
+      - build-toolkit
+    # `always()`, or a skipped dependency would skip this job too and take
+    # the gate down with it
+    if: always()
+    runs-on: ubuntu-26.04
+    permissions: {}
+    steps:
+      # For a matrix dependency, `result` is the aggregate: `failure` if
+      # any entry failed.
+      - name: Fail unless every dependency succeeded or was skipped
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "One or more required jobs failed or were cancelled."
+          exit 1


### PR DESCRIPTION
Add an aggregate `Required checks` job that always reports and fails only on real failures, so protection can require one static context instead of 21 dynamic ones.