### PR TITLE
fix(documents): only let the uploader replace their own file

### DIFF
--- a/packages/documents/src/features/uploadDocument/handler.test.ts
+++ b/packages/documents/src/features/uploadDocument/handler.test.ts
@@ -21,12 +21,14 @@ jest.mock('../../minio/client', () => {
     __esModule: true,
     minioClient: {
       putObject: (...args: unknown[]) => minioPutMock(...args),
-      statObject: (...args: unknown[]) => {
-        minioStatMock(...args)
-        return true
-      }
+      statObject: (...args: unknown[]) => minioStatMock(...args)
     }
   }
+})
+
+/** What Minio throws when the object is not in the bucket. */
+const objectNotFound = Object.assign(new Error('Not found'), {
+  code: 'NotFound'
 })
 
 describe('fileExistsHandler', () => {
@@ -40,7 +42,7 @@ describe('fileExistsHandler', () => {
 
   beforeEach(async () => {
     minioPutMock.mockClear()
-    minioStatMock.mockClear()
+    minioStatMock.mockReset().mockReturnValue({ metaData: {} })
     server = await createServer()
   })
 
@@ -172,7 +174,8 @@ describe('fileUploadHandler', () => {
 
   beforeEach(async () => {
     minioPutMock.mockClear()
-    minioStatMock.mockClear()
+    // By default the key is free, which is the ordinary case for a new upload.
+    minioStatMock.mockReset().mockRejectedValue(objectNotFound)
     server = await createServer()
   })
 
@@ -251,6 +254,45 @@ describe('fileUploadHandler', () => {
     expect(filename).toBe(`${transactionId}.txt`)
 
     expect(res.statusCode).toBe(200)
+  })
+
+  const uploadTo = (transactionId: string) => {
+    const body =
+      `--${boundary}${CRLF}` +
+      createFormProperty('transactionId', transactionId) +
+      `--${boundary}${CRLF}` +
+      createFormProperty('file', 'test upload', 'file') +
+      `--${boundary}--${CRLF}`
+
+    return server.server.inject({
+      method: 'POST',
+      url: '/files',
+      payload: Buffer.from(body, 'utf8'),
+      headers: {
+        'Content-Type': `multipart/form-data; boundary=${boundary}`,
+        authorization: `Bearer ${token}`
+      }
+    })
+  }
+
+  it('refuses to replace a file uploaded by someone else', async () => {
+    minioStatMock.mockResolvedValue({
+      metaData: { 'created-by': 'another-user' }
+    })
+
+    const res = await uploadTo('transaction-3')
+
+    expect(res.statusCode).toBe(403)
+    expect(minioPutMock).not.toHaveBeenCalled()
+  })
+
+  it('lets the original uploader replace their own file', async () => {
+    minioStatMock.mockResolvedValue({ metaData: { 'created-by': '123123' } })
+
+    const res = await uploadTo('transaction-4')
+
+    expect(res.statusCode).toBe(200)
+    expect(minioPutMock).toHaveBeenCalled()
   })
 })
 

--- a/packages/documents/src/features/uploadDocument/handler.ts
+++ b/packages/documents/src/features/uploadDocument/handler.ts
@@ -20,7 +20,7 @@ import {
 import { fromBuffer } from 'file-type'
 import { v4 as uuid } from 'uuid'
 
-import { badRequest, notFound } from '@hapi/boom'
+import { badRequest, forbidden } from '@hapi/boom'
 import { Readable } from 'stream'
 import { z } from 'zod'
 export interface IDocumentPayload {
@@ -60,6 +60,21 @@ const Payload = z.object({
 })
 
 /**
+ * @returns the object's metadata, or null when it does not exist.
+ */
+async function statObjectIfExists(documentPath: DocumentPath) {
+  try {
+    return await minioClient.statObject(MINIO_BUCKET, documentPath)
+  } catch (error) {
+    if ((error as { code?: string }).code === 'NotFound') {
+      return null
+    }
+
+    throw error
+  }
+}
+
+/**
  * V2 version of the file upload handler.
  */
 export async function fileUploadHandler(
@@ -78,6 +93,20 @@ export async function fileUploadHandler(
   const filePath = (
     path ? joinUrlPaths(path, filename) : filename
   ) as DocumentPath
+
+  /*
+   * The caller chooses the path, so an upload to a key that already exists
+   * would replace its contents and take over `created-by` — which then also
+   * satisfies the ownership check in deleteDocument. Replacing a file requires
+   * the same ownership that deleting one does.
+   */
+  const existing = await statObjectIfExists(filePath)
+
+  if (existing && existing.metaData['created-by'] !== userId) {
+    throw forbidden(
+      `request failed: user with id ${userId} does not have permission to replace this document`
+    )
+  }
 
   await minioClient.putObject(MINIO_BUCKET, filePath, file, {
     'created-by': userId,
@@ -102,25 +131,16 @@ export async function fileExistsHandler(
 
   const documentPath = DocumentPath.parse(filePath)
 
-  let stat
-
-  try {
-    stat = await minioClient.statObject(MINIO_BUCKET, documentPath)
-  } catch (error) {
-    if ((error as { code?: string }).code === 'NotFound') {
-      return h
-        .response(
-          `request failed: document ${documentPath} does not exist in bucket ${MINIO_BUCKET}`
-        )
-        .code(404)
-    }
-
-    throw error
-  }
+  const stat = await statObjectIfExists(documentPath)
 
   if (!stat) {
-    return notFound('File not found')
+    return h
+      .response(
+        `request failed: document ${documentPath} does not exist in bucket ${MINIO_BUCKET}`
+      )
+      .code(404)
   }
+
   return h.response().code(200)
 }
 


### PR DESCRIPTION
The caller chooses the upload path, and nothing checked whether the key was already taken. Uploading to a known key replaced its contents and reset `created-by` to the caller, which then also satisfied the ownership check in deleteDocument — so knowing a key was enough to both tamper with a document and then remove it.

Require the same ownership to replace a file that deleting one already requires. Fresh keys are unaffected, and re-uploading under the same transaction id still works for the original uploader, which is what retries and offline replays do.