### PR TITLE
fix(events): match email, mobile and username exactly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ A new `integration.audit.read` scope guards it; country configs must assign it t
 - Stop showing an empty `Comment` section in the record audit history for archived records. Archiving from the action menu never asked for a comment, so the section only ever displayed a `-` placeholder. Records archived through the "mark as duplicate" flow still show the comment that was entered there [#13265](https://github.com/opencrvs/opencrvs-core/issues/13265)
 - Stop `/auth/verifyUser` from revealing whether a submitted email or mobile number belongs to a registered account, and stop the username-reminder flow from returning the account's security-question key with no proof the caller controls the mailbox — see "Breaking changes" above for the required country-config migration [#12861](https://github.com/opencrvs/opencrvs-core/issues/12861)
 - Stop offering custom actions (e.g. `ESCALATE`) on a draft. Executing one deleted the draft while leaving the event undeclared, making the record impossible to find again [#13245](https://github.com/opencrvs/opencrvs-core/issues/13245)
+- Stop reporting an email or mobile number as already in use when it is merely contained in an existing one. Duplicate and existence checks on users matched substrings, so creating a user with the email `a@x.com` was rejected as a duplicate of an existing `ba@x.com`. Email, mobile and username now match whole values; email and username stay case-insensitive in effect. [#11207](https://github.com/opencrvs/opencrvs-core/issues/11207)
 
 ## 2.0.0
 

--- a/packages/events/src/router/initialisation/initialisation.user.create.test.ts
+++ b/packages/events/src/router/initialisation/initialisation.user.create.test.ts
@@ -225,6 +225,50 @@ test('Throws error when creating user with existing mobile', async () => {
   )
 })
 
+test('Does not report a username as taken when it is only a prefix of an existing one', async () => {
+  await systemInitialisationTestSetup()
+
+  const client = createInitialisationTestClient()
+  const eventsDb = getClient()
+
+  await client.locations.set(locationPayload)
+  const location = await eventsDb
+    .selectFrom('locations')
+    .selectAll()
+    .executeTakeFirstOrThrow()
+
+  await expect(
+    client.users.create({
+      email: 'j.campbell2@opencrvs.org',
+      role: 'admin',
+      name: { firstname: 'Jane', surname: 'Campbell' },
+      primaryOfficeId: location.id,
+      username: 'j.campbell2'
+    })
+  ).resolves.toBeDefined()
+
+  // The seed job skips an initial user whose username this search reports as
+  // already existing.
+  const existing = await client.users.search({
+    username: 'j.campbell',
+    count: 1,
+    skip: 0,
+    sortOrder: 'asc'
+  })
+
+  expect(existing).toEqual([])
+
+  await expect(
+    client.users.create({
+      email: 'j.campbell@opencrvs.org',
+      role: 'admin',
+      name: { firstname: 'John', surname: 'Campbell' },
+      primaryOfficeId: location.id,
+      username: 'j.campbell'
+    })
+  ).resolves.toBeDefined()
+})
+
 test('Creates user with active status when status is provided', async () => {
   await systemInitialisationTestSetup()
   const client = createInitialisationTestClient()

--- a/packages/events/src/router/user/user.changeEmail.test.ts
+++ b/packages/events/src/router/user/user.changeEmail.test.ts
@@ -127,4 +127,32 @@ describe('user.changeEmail', () => {
       })
     ).rejects.toMatchObject({ code: 'CONFLICT' })
   })
+
+  test("allows an email that is only a substring of another user's email", async () => {
+    const { users } = await setupTestCase()
+    const client1 = createTestClient(users[0])
+    const client2 = createTestClient(users[1])
+
+    const longerEmail = 'bshared@test.example'
+    const nonce1 = await requestEmailChange(client1, longerEmail)
+    await client1.user.changeEmail({
+      userId: users[0].id,
+      email: longerEmail,
+      nonce: nonce1,
+      verifyCode: VERIFY_CODE
+    })
+
+    // 'shared@test.example' is a substring of 'bshared@test.example'
+    const shorterEmail = 'shared@test.example'
+    const nonce2 = await requestEmailChange(client2, shorterEmail)
+    await client2.user.changeEmail({
+      userId: users[1].id,
+      email: shorterEmail,
+      nonce: nonce2,
+      verifyCode: VERIFY_CODE
+    })
+
+    const updatedUser = await client2.user.get(users[1].id)
+    expect(updatedUser).toMatchObject({ email: shorterEmail })
+  })
 })

--- a/packages/events/src/router/user/user.changePhone.test.ts
+++ b/packages/events/src/router/user/user.changePhone.test.ts
@@ -10,6 +10,7 @@
  */
 
 import { createTestClient, setupTestCase } from '@events/tests/utils'
+import { updateUserById } from '@events/storage/postgres/events/users'
 
 // TWO_FA_ENABLED is false in the test environment, so the verification
 // code is always the default one
@@ -89,6 +90,25 @@ describe('user.changePhone', () => {
         verifyCode: '999999'
       })
     ).rejects.toMatchObject({ code: 'BAD_REQUEST' })
+  })
+
+  test('rejects a phone number another user already has', async () => {
+    const { user, users } = await setupTestCase()
+    const [, secondUser] = users
+
+    await updateUserById(secondUser.id, { mobile: '01711111111' })
+
+    const client = createTestClient(user)
+    const nonce = await requestPhoneChange(client)
+
+    await expect(
+      client.user.changePhone({
+        userId: user.id,
+        phoneNumber: '01711111111',
+        nonce,
+        verifyCode: VERIFY_CODE
+      })
+    ).rejects.toMatchObject({ code: 'CONFLICT' })
   })
 
   test("cannot change another user's phone number", async () => {

--- a/packages/events/src/router/user/user.create.test.ts
+++ b/packages/events/src/router/user/user.create.test.ts
@@ -170,6 +170,65 @@ test('Throws error when creating user with existing email', async () => {
   )
 })
 
+test('Allows creating a user whose email is a substring of an existing email', async () => {
+  const { user } = await setupTestCase()
+
+  const client = createTestClient(user, [
+    encodeScope({
+      type: 'user.create'
+    })
+  ])
+
+  await expect(
+    client.user.create({
+      email: 'ba@x.com',
+      role: 'admin',
+      name: { firstname: 'given1', surname: 'family1' },
+      primaryOfficeId: user.primaryOfficeId
+    })
+  ).resolves.toBeDefined()
+
+  // 'a@x.com' is a substring of 'ba@x.com' but a different address
+  await expect(
+    client.user.create({
+      email: 'a@x.com',
+      role: 'admin',
+      name: { firstname: 'given2', surname: 'family2' },
+      primaryOfficeId: user.primaryOfficeId
+    })
+  ).resolves.toBeDefined()
+})
+
+test('Throws error when creating user with an existing email in different case', async () => {
+  const { user } = await setupTestCase()
+
+  const client = createTestClient(user, [
+    encodeScope({
+      type: 'user.create'
+    })
+  ])
+
+  await expect(
+    client.user.create({
+      email: 'casing+123@opencrvs.org',
+      role: 'admin',
+      name: { firstname: 'given1', surname: 'family1' },
+      primaryOfficeId: user.primaryOfficeId
+    })
+  ).resolves.toBeDefined()
+
+  await expect(
+    client.user.create({
+      email: 'CASING+123@OPENCRVS.ORG',
+      role: 'admin',
+      name: { firstname: 'given2', surname: 'family2' },
+      primaryOfficeId: user.primaryOfficeId
+    })
+  ).rejects.toThrowError(
+    new TRPCError({ code: 'CONFLICT', message: 'DUPLICATE_EMAIL' })
+  )
+})
+
 test('Persists custom data field when provided', async () => {
   const { user } = await setupTestCase()
 

--- a/packages/events/src/router/user/user.requestEmailChange.test.ts
+++ b/packages/events/src/router/user/user.requestEmailChange.test.ts
@@ -113,6 +113,18 @@ describe('user.requestEmailChange', () => {
       ).rejects.toMatchObject({ code: 'CONFLICT' })
     })
 
+    test("does not throw CONFLICT when the requested email is only a substring of another user's", async () => {
+      const { users } = await setupTestCase()
+      const client2 = createTestClient(users[1])
+
+      // A substring of user1's seeded `user-${id}@test.example`
+      const nearMiss = `${users[0].id}@test.example`
+
+      await expect(
+        client2.user.requestEmailChange({ email: nearMiss })
+      ).resolves.toHaveProperty('nonce')
+    })
+
     test('does not throw CONFLICT when the email belongs to the requesting user', async () => {
       const { users } = await setupTestCase()
       const client1 = createTestClient(users[0])

--- a/packages/events/src/router/user/user.search.test.ts
+++ b/packages/events/src/router/user/user.search.test.ts
@@ -100,20 +100,34 @@ test('filters by status', async () => {
   expect(deactivated).toHaveLength(users.length - active.length)
 })
 
-test('filters by email (case-insensitive partial match)', async () => {
+test('filters by email (exact match, case-insensitive)', async () => {
   const { user } = await setupTestCase()
   const client = createTestClient(user, withSearchAll)
 
+  // The seeder gives every user the email `user-${id}@test.example`
   const results = await client.user.search({
     ...defaultSearch,
-    email: user.id.toUpperCase()
+    email: `USER-${user.id}@TEST.EXAMPLE`
   })
 
   expect(results).toHaveLength(1)
   expect(results[0].id).toBe(user.id)
 })
 
-test('filters by username (case-insensitive partial match)', async () => {
+test('does not match an email that merely contains the search term', async () => {
+  const { user } = await setupTestCase()
+  const client = createTestClient(user, withSearchAll)
+
+  // A substring of the seeded `user-${id}@test.example`
+  const results = await client.user.search({
+    ...defaultSearch,
+    email: `${user.id}@test.example`
+  })
+
+  expect(results).toEqual([])
+})
+
+test('filters by username (exact match, case-insensitive)', async () => {
   const { user } = await setupTestCase()
   const client = createTestClient(user, withSearchAll)
 
@@ -121,14 +135,43 @@ test('filters by username (case-insensitive partial match)', async () => {
 
   const results = await client.user.search({
     ...defaultSearch,
-    username: 'U.NIQUEUSE'
+    username: 'U.NIQUEUSER'
   })
 
   expect(results).toHaveLength(1)
   expect(results[0].id).toBe(user.id)
 })
 
-test('filters by mobile (partial match)', async () => {
+test('does not match a username the search term is only a prefix of', async () => {
+  const { user } = await setupTestCase()
+  const client = createTestClient(user, withSearchAll)
+
+  await updateUsernameById(user.id, `j.campbell2`)
+
+  const results = await client.user.search({
+    ...defaultSearch,
+    username: 'j.campbell'
+  })
+
+  expect(results).toEqual([])
+})
+
+test('filters by mobile (exact match)', async () => {
+  const { user } = await setupTestCase()
+  const client = createTestClient(user, withSearchAll)
+
+  await updateUserById(user.id, { mobile: '+447911123456' })
+
+  const results = await client.user.search({
+    ...defaultSearch,
+    mobile: '+447911123456'
+  })
+
+  expect(results).toHaveLength(1)
+  expect(results[0].id).toBe(user.id)
+})
+
+test('does not match a mobile that merely contains the search term', async () => {
   const { user } = await setupTestCase()
   const client = createTestClient(user, withSearchAll)
 
@@ -139,8 +182,7 @@ test('filters by mobile (partial match)', async () => {
     mobile: '7911123'
   })
 
-  expect(results).toHaveLength(1)
-  expect(results[0].id).toBe(user.id)
+  expect(results).toEqual([])
 })
 
 test('respects count and skip for pagination', async () => {

--- a/packages/events/src/router/user/user.update.test.ts
+++ b/packages/events/src/router/user/user.update.test.ts
@@ -183,6 +183,22 @@ test('throws CONFLICT with DUPLICATE_EMAIL if email is already in use by another
   )
 })
 
+test("allows update when the email is only a substring of another user's email", async () => {
+  const { user, users } = await setupTestCase()
+  const [, secondUser] = users
+
+  await updateUserById(secondUser.id, { email: 'ba@x.com' })
+
+  const client = createTestClient(user, [USER_EDIT_SCOPE])
+
+  await expect(
+    client.user.update({
+      ...generateUpdateInput(user),
+      email: 'a@x.com'
+    })
+  ).resolves.not.toThrow()
+})
+
 test("allows update when mobile is the same user's own mobile", async () => {
   const { user } = await setupTestCase()
   await updateUserById(user.id, { mobile: '01812345678' })

--- a/packages/events/src/storage/postgres/events/users.ts
+++ b/packages/events/src/storage/postgres/events/users.ts
@@ -256,24 +256,24 @@ function buildSearchUsersBaseQuery(
       'locations.administrativeAreaId'
     ])
 
+  /*
+   * Emails and usernames are lowercase in storage, so lowercasing the input
+   * keeps matching case-insensitive. Mobile numbers are stored verbatim.
+   */
   if (input.username) {
     query = query.where(
       'userCredentials.username',
-      'ilike',
-      `%${input.username.toLowerCase()}%`
+      '=',
+      input.username.toLowerCase()
     )
   }
 
   if (input.mobile) {
-    query = query.where('users.mobile', 'ilike', `%${input.mobile}%`)
+    query = query.where('users.mobile', '=', input.mobile)
   }
 
   if (input.email) {
-    query = query.where(
-      'users.email',
-      'ilike',
-      `%${input.email.toLowerCase()}%`
-    )
+    query = query.where('users.email', '=', input.email.toLowerCase())
   }
 
   if (input.status) {


### PR DESCRIPTION
## Description

Use exact match when searching users with username, email or mobile so that `j.cam` does not match against `j.cambell`. create/update users had a hard gate which refuses the action if existing match is found, the previous logic denied quite a few valid cases.

Part of #11207 stack

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [x] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly