### PR TITLE
fix(client): use normal content size in EventOverview Summary tab

### DIFF
--- a/packages/client/src/v2-events/features/workqueues/EventOverview/EventOverview.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/EventOverview.tsx
@@ -86,7 +86,7 @@ function EventOverviewFull({ event }: { event: EventDocument }) {
           name={''}
         />
       )}
-      size={ContentSize.LARGE}
+      size={ContentSize.NORMAL}
       title={title}
       titleColor={event.id ? 'copy' : 'grey600'}
     >
@@ -148,7 +148,7 @@ function EventOverviewProtected({ eventIndex }: { eventIndex: EventIndex }) {
           name={''}
         />
       )}
-      size={ContentSize.LARGE}
+      size={ContentSize.NORMAL}
       title={title}
       titleColor={eventIndex.id ? 'copy' : 'grey600'}
     >


### PR DESCRIPTION
Renders the event summary `Content` at `ContentSize.NORMAL` instead of `ContentSize.LARGE`, in both the full and PII-protected overview variants. As per design