### PR TITLE
fix: Implement service account support

### DIFF
--- a/.github/workflows/build-images-from-branch.yml
+++ b/.github/workflows/build-images-from-branch.yml
@@ -117,7 +117,7 @@ jobs:
         uses: Wandalen/wretry.action@v3.8.0
         with:
           attempt_limit: 3
-          action: docker/build-push-action@v6
+          action: docker/build-push-action@v7
           with: |
             file: packages/Dockerfile.base
             provenance: false
@@ -201,7 +201,7 @@ jobs:
         uses: Wandalen/wretry.action@v3.8.0
         with:
           attempt_limit: 3
-          action: docker/build-push-action@v6
+          action: docker/build-push-action@v7
           with: |
             file: packages/${{ matrix.service }}/Dockerfile
             build-args: |
@@ -296,7 +296,7 @@ jobs:
         uses: Wandalen/wretry.action@v3.8.0
         with:
           attempt_limit: 3
-          action: docker/build-push-action@v6
+          action: docker/build-push-action@v7
           with: |
             file: packages/testland/Dockerfile.assets
             provenance: false
@@ -325,7 +325,7 @@ jobs:
         uses: Wandalen/wretry.action@v3.8.0
         with:
           attempt_limit: 3
-          action: docker/build-push-action@v6
+          action: docker/build-push-action@v7
           with: |
             file: packages/countryconfig-template/Dockerfile
             context: packages/countryconfig-template
@@ -335,7 +335,7 @@ jobs:
         uses: Wandalen/wretry.action@v3.8.0
         with:
           attempt_limit: 3
-          action: docker/build-push-action@v6
+          action: docker/build-push-action@v7
           with: |
             file: packages/countryconfig-template/Dockerfile.assets
             context: packages/countryconfig-template

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Archiving a NOTIFIED (incomplete) record used to clear `InherentFlags.INCOMPLETE
 - Reduce the amount of data sent to Elasticsearch by dropping unused and duplicate fields during Metricbeat processing [#10978](https://github.com/opencrvs/opencrvs-core/issues/10978)
 - Remove direct calls to events service [#13399](https://github.com/opencrvs/opencrvs-core/issues/13399)
 - Record review, event summaries, team lists, settings and the duplicate comparison now draw their label-and-value rows from one shared component, so they present consistently and screen readers announce each value together with its row and column heading [#4024](https://github.com/opencrvs/opencrvs-core/issues/4024)
+- Added Service account support for Managed Kubernetes [#13324](https://github.com/opencrvs/opencrvs-core/issues/13324)
 
 ### New features
 

--- a/charts/opencrvs-services/README.md
+++ b/charts/opencrvs-services/README.md
@@ -377,6 +377,21 @@ helm upgrade --install opencrvs oci://ghcr.io/opencrvs/opencrvs-services \
             <td>Number of PODs not available while deployment within ReplicaSet</td>
         </tr>
         <tr>
+            <td>service_account.create</td>
+            <td>true</td>
+            <td>Create Kubernetes ServiceAccount resources for OpenCRVS workloads. Each workload gets its own ServiceAccount. Configuration is available per workload as well, add <code>&ltservice_name&gt.service_account.&ltkey&gt</code>. For more information see <a href="#service-accounts">Service accounts</a>.</td>
+        </tr>
+        <tr>
+            <td>service_account.annotations</td>
+            <td>{}</td>
+            <td>Annotations applied to all workload ServiceAccounts. Per-workload annotations override global annotations with the same key.</td>
+        </tr>
+        <tr>
+            <td>service_account.automount_service_account_token</td>
+            <td>true</td>
+            <td>Controls <code>automountServiceAccountToken</code> on generated ServiceAccounts and workload Pod specs. Can be overridden per workload.</td>
+        </tr>
+        <tr>
             <td>resources</td>
             <td>{}</td>
             <td>Resources allocated to OpenCRVS microservices (Kubernetes PODs). Properties in this section could be defined per microservice as well.</td>
@@ -432,6 +447,16 @@ helm upgrade --install opencrvs oci://ghcr.io/opencrvs/opencrvs-services \
             <td>Use default OpenCRVS login/password or generate random values</td>
         </tr>
         <tr>
+            <td>deployment_jobs.service_account.name</td>
+            <td>deployment-jobs</td>
+            <td>Common ServiceAccount name used by Helm pre/post deployment jobs.</td>
+        </tr>
+        <tr>
+            <td>deployment_jobs.service_account.annotations</td>
+            <td>{}</td>
+            <td>Annotations applied to the common ServiceAccount used by Helm pre/post deployment jobs.</td>
+        </tr>
+        <tr>
             <td>on_restore_cronjob.enabled</td>
             <td><pre>false</pre></td>
             <td>Special cronjob for OpenCRVS maintenance after database restore. Job runs reindex and postgres passwords update.</td>
@@ -443,6 +468,62 @@ helm upgrade --install opencrvs oci://ghcr.io/opencrvs/opencrvs-services \
         </tr>
     </tbody>
 </table>
+
+# Service accounts
+
+OpenCRVS Helm chart creates a Kubernetes ServiceAccount for each regular workload and injects the matching `serviceAccountName` into the workload Pod spec.
+
+By default, ServiceAccount names match workload names:
+
+- `auth`
+- `client`
+- `countryconfig`
+- `dashboards`, when `dashboards.enabled` is `true`
+- `documents`
+- `events`
+- `gateway`
+- `login`
+- `data-cleanup`, when `data_cleanup.enabled` is `true`
+- `on-db-restore-cronjob`, when `on_restore_cronjob.enabled` is `true`
+
+Helm pre/post deployment jobs use one shared ServiceAccount named `deployment-jobs` by default. This includes validation, datastore setup, data migration, data seed, and Elasticsearch reindex jobs.
+
+**Example: global annotations**
+
+```yaml
+service_account:
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/opencrvs-default
+```
+
+**Example: workload-specific annotations**
+
+```yaml
+auth:
+  service_account:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/opencrvs-auth
+```
+
+**Example: deployment job annotations**
+
+```yaml
+deployment_jobs:
+  service_account:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/opencrvs-deployment-jobs
+```
+
+If ServiceAccounts are managed outside of this chart, set `service_account.create` to `false` and provide matching existing ServiceAccounts in the namespace. A custom name can be set per workload:
+
+```yaml
+service_account:
+  create: false
+
+auth:
+  service_account:
+    name: existing-auth-service-account
+```
 
 # Authentication configuration
 

--- a/charts/opencrvs-services/templates/_service-account-helper.tpl
+++ b/charts/opencrvs-services/templates/_service-account-helper.tpl
@@ -1,0 +1,68 @@
+{{/*
+Renders the service account name for a workload.
+*/}}
+{{- define "service-account-name" -}}
+{{- $service_name := .service_name -}}
+{{- $service_key_name := ( $service_name | replace "-" "_" ) -}}
+{{- $service_values := index .Values $service_key_name | default dict -}}
+{{- $service_account := $service_values.service_account | default dict -}}
+{{- $service_account.name | default $service_name -}}
+{{- end }}
+
+{{/*
+Renders service account fields for a Pod spec.
+*/}}
+{{- define "pod-service-account-values-helper" -}}
+{{- $service_name := .service_name -}}
+{{- $service_key_name := ( $service_name | replace "-" "_" ) -}}
+{{- $global := .Values.service_account | default dict -}}
+{{- $service_values := index .Values $service_key_name | default dict -}}
+{{- $service_account := $service_values.service_account | default dict }}
+serviceAccountName: {{ include "service-account-name" . | quote }}
+{{- if hasKey $service_account "automount_service_account_token" }}
+automountServiceAccountToken: {{ index $service_account "automount_service_account_token" }}
+{{- else if hasKey $global "automount_service_account_token" }}
+automountServiceAccountToken: {{ index $global "automount_service_account_token" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Renders a ServiceAccount resource for a workload.
+*/}}
+{{- define "service-account-helper" -}}
+{{- $service_name := .service_name -}}
+{{- $service_key_name := ( $service_name | replace "-" "_" ) -}}
+{{- $global := .Values.service_account | default dict -}}
+{{- $service_values := index .Values $service_key_name | default dict -}}
+{{- $service_account := $service_values.service_account | default dict -}}
+{{- $create := true -}}
+{{- if hasKey $global "create" -}}
+{{- $create = index $global "create" -}}
+{{- end -}}
+{{- if hasKey $service_account "create" -}}
+{{- $create = index $service_account "create" -}}
+{{- end -}}
+{{- if $create }}
+{{- $annotations := dict -}}
+{{- if $global.annotations -}}
+{{- $annotations = mergeOverwrite $annotations $global.annotations -}}
+{{- end -}}
+{{- if $service_account.annotations -}}
+{{- $annotations = mergeOverwrite $annotations $service_account.annotations -}}
+{{- end }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "service-account-name" . | quote }}
+  {{- if $annotations }}
+  annotations:
+    {{- toYaml $annotations | nindent 4 }}
+  {{- end }}
+{{- if hasKey $service_account "automount_service_account_token" }}
+automountServiceAccountToken: {{ index $service_account "automount_service_account_token" }}
+{{- else if hasKey $global "automount_service_account_token" }}
+automountServiceAccountToken: {{ index $global "automount_service_account_token" }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/opencrvs-services/templates/auth-deployment.yaml
+++ b/charts/opencrvs-services/templates/auth-deployment.yaml
@@ -19,6 +19,7 @@ spec:
         service_name: opencrvs_auth
     spec:
       {{- include "opencrvs.imagePullSecrets" (dict "root" . "service" .Values.auth) | nindent 6 }}
+      {{- include "pod-service-account-values-helper" (dict "service_name" "auth" "Values" .Values) | nindent 6 }}
       containers:
         - image: {{ include "opencrvs.image" (dict "root" . "service" .Values.auth) }}
           imagePullPolicy: {{ .Values.auth.image.pullPolicy | default .Values.platform.imagePullPolicy }}
@@ -79,6 +80,8 @@ spec:
         - secret:
             secretName: {{ .Release.Name }}-key-tls
           name: private-key
+
+{{- include "service-account-helper" (dict "service_name" "auth" "Values" .Values) }}
 
 {{- include "service-helper" (dict "service_name" "auth" "Values" .Values) }}
 

--- a/charts/opencrvs-services/templates/client-deployment.yaml
+++ b/charts/opencrvs-services/templates/client-deployment.yaml
@@ -50,6 +50,7 @@ spec:
         service_name: opencrvs_client
     spec:
       {{- include "opencrvs.imagePullSecrets" (dict "root" . "service" .Values.client) | nindent 6 }}
+      {{- include "pod-service-account-values-helper" (dict "service_name" "client" "Values" .Values) | nindent 6 }}
       containers:
         - image: {{ include "opencrvs.image" (dict "root" . "service" .Values.client) }}
           imagePullPolicy: {{ .Values.client.image.pullPolicy | default .Values.platform.imagePullPolicy }}
@@ -96,6 +97,8 @@ spec:
             name: {{ $config_name }}
       {{- end }}
       {{- end }}
+
+{{- include "service-account-helper" (dict "service_name" "client" "Values" .Values) }}
 
 {{- include "service-helper" (dict "service_name" "client" "Values" .Values) }}
 

--- a/charts/opencrvs-services/templates/countryconfig-deployment.yaml
+++ b/charts/opencrvs-services/templates/countryconfig-deployment.yaml
@@ -74,6 +74,7 @@ spec:
         service_name: opencrvs_countryconfig
     spec:
       {{- include "opencrvs.imagePullSecrets" (dict "root" . "service" .Values.countryconfig) | nindent 6 }}
+      {{- include "pod-service-account-values-helper" (dict "service_name" "countryconfig" "Values" .Values) | nindent 6 }}
       containers:
         - name: countryconfig
           image: {{ include "opencrvs.image" (dict "root" . "service" .Values.countryconfig) | quote }}
@@ -129,6 +130,8 @@ spec:
                 path: public-key.pem
             name: {{ .Release.Name }}-cert-tls
           name: public-key
+
+{{- include "service-account-helper" (dict "service_name" "countryconfig" "Values" .Values) }}
 
 {{- include "service-helper" (dict "service_name" "countryconfig" "Values" .Values) }}
 

--- a/charts/opencrvs-services/templates/dashboards-deployment.yaml
+++ b/charts/opencrvs-services/templates/dashboards-deployment.yaml
@@ -48,6 +48,7 @@ spec:
         app: dashboards
     spec:
       {{- include "opencrvs.imagePullSecrets" (dict "root" . "service" .Values.dashboards) | nindent 6 }}
+      {{- include "pod-service-account-values-helper" (dict "service_name" "dashboards" "Values" .Values) | nindent 6 }}
       initContainers:
         - name: copy-assets
           image: {{ include "opencrvs.image" (dict "root" . "service" .Values.countryconfig) }}-assets
@@ -127,11 +128,13 @@ spec:
       volumes:
         - name: assets
           emptyDir: {}
+
+{{- include "service-account-helper" (dict "service_name" "dashboards" "Values" .Values) }}
+
 {{- include "service-helper" (dict "service_name" "dashboards" "Values" .Values) }}
 
 {{- include "hpa-helper" (dict "service_name" "dashboards" "Values" .Values) }}
 
 {{- include "pdb-helper" (dict "service_name" "dashboards" "Values" .Values) }}
-
 
 {{- end }}

--- a/charts/opencrvs-services/templates/data-cleanup-job.yaml
+++ b/charts/opencrvs-services/templates/data-cleanup-job.yaml
@@ -13,6 +13,7 @@ spec:
         app: data-cleanup
     spec:
       {{- include "opencrvs.imagePullSecrets" (dict "root" . "service" .Values.postgres) | nindent 6 }}
+      {{- include "pod-service-account-values-helper" (dict "service_name" "deployment-jobs" "Values" .Values) | nindent 6 }}
       containers:
         - name: cleanup-postgres
           image: {{ include "opencrvs.imageReference" .Values.postgres }}
@@ -129,4 +130,5 @@ spec:
           {{- end }}
           {{- include "render-env-vars" (dict "service_name" "data_cleanup" "Values" .Values) }}
       restartPolicy: "OnFailure"
+
 {{- end }}

--- a/charts/opencrvs-services/templates/data-migration-analytics-job.yaml
+++ b/charts/opencrvs-services/templates/data-migration-analytics-job.yaml
@@ -15,6 +15,7 @@ spec:
         app: data-migration-analytics
     spec:
       {{- include "opencrvs.imagePullSecrets" (dict "root" . "service" .Values.countryconfig) | nindent 6 }}
+      {{- include "pod-service-account-values-helper" (dict "service_name" "deployment-jobs" "Values" .Values) | nindent 6 }}
       initContainers:
         - name: copy-assets
           image: {{ include "opencrvs.image" (dict "root" . "service" .Values.countryconfig) }}-assets

--- a/charts/opencrvs-services/templates/data-migration-job.yaml
+++ b/charts/opencrvs-services/templates/data-migration-job.yaml
@@ -18,6 +18,7 @@ spec:
         app: migration
     spec:
       {{- include "opencrvs.imagePullSecrets" (dict "root" . "service" .Values.data_migration) | nindent 6 }}
+      {{- include "pod-service-account-values-helper" (dict "service_name" "deployment-jobs" "Values" .Values) | nindent 6 }}
       containers:
         - name: migration
           image: {{ include "opencrvs.image" (dict "root" . "service" .Values.data_migration) }}

--- a/charts/opencrvs-services/templates/data-seed-job.yaml
+++ b/charts/opencrvs-services/templates/data-seed-job.yaml
@@ -17,6 +17,7 @@ spec:
         app: data-seed
     spec:
       {{- include "opencrvs.imagePullSecrets" (dict "root" . "service" .Values.data_seed) | nindent 6 }}
+      {{- include "pod-service-account-values-helper" (dict "service_name" "deployment-jobs" "Values" .Values) | nindent 6 }}
       containers:
         - name: data-seed
           image: {{ include "opencrvs.image" (dict "root" . "service" .Values.data_seed) }}
@@ -47,4 +48,5 @@ spec:
           {{- end }}
           {{- include "render-env-vars" (dict "service_name" "data_seed" "Values" .Values) }}
       restartPolicy: "OnFailure"
+
 {{- end }}

--- a/charts/opencrvs-services/templates/documents-deployment.yaml
+++ b/charts/opencrvs-services/templates/documents-deployment.yaml
@@ -20,6 +20,7 @@ spec:
         service_name: opencrvs_documents
     spec:
       {{- include "opencrvs.imagePullSecrets" (dict "root" . "service" .Values.documents) | nindent 6 }}
+      {{- include "pod-service-account-values-helper" (dict "service_name" "documents" "Values" .Values) | nindent 6 }}
       containers:
         - image: {{ include "opencrvs.image" (dict "root" . "service" .Values.documents) }}
           imagePullPolicy: {{ .Values.documents.image.pullPolicy | default .Values.platform.imagePullPolicy }}
@@ -70,6 +71,8 @@ spec:
                 path: public-key.pem
             name: {{ .Release.Name }}-cert-tls
           name: public-key
+
+{{- include "service-account-helper" (dict "service_name" "documents" "Values" .Values) }}
 
 {{- include "service-helper" (dict "service_name" "documents" "Values" .Values) }}
 

--- a/charts/opencrvs-services/templates/elasticsearch-on-deploy.yaml
+++ b/charts/opencrvs-services/templates/elasticsearch-on-deploy.yaml
@@ -15,6 +15,7 @@ spec:
         app: elasticsearch-on-deploy
     spec:
       {{- include "opencrvs.imagePullSecrets" (dict "root" . "service" .Values.utilities) | nindent 6 }}
+      {{- include "pod-service-account-values-helper" (dict "service_name" "deployment-jobs" "Values" .Values) | nindent 6 }}
       containers:
         - name: elasticsearch-on-deploy
           command: ["/scripts/setup.sh"]

--- a/charts/opencrvs-services/templates/elasticsearch-reindex-job.yaml
+++ b/charts/opencrvs-services/templates/elasticsearch-reindex-job.yaml
@@ -16,6 +16,7 @@ spec:
         app: elasticsearch-reindex
     spec:
       {{- include "elasticsearch-reindex.imagePullSecrets" . | nindent 6 }}
+      {{- include "pod-service-account-values-helper" (dict "service_name" "deployment-jobs" "Values" .Values) | nindent 6 }}
       initContainers:
       {{- include "elasticsearch-reindex.initContainerSpec" . | nindent 8 }}
       containers:

--- a/charts/opencrvs-services/templates/events-deployment.yaml
+++ b/charts/opencrvs-services/templates/events-deployment.yaml
@@ -20,6 +20,7 @@ spec:
         service_name: opencrvs_events
     spec:
       {{- include "opencrvs.imagePullSecrets" (dict "root" . "service" .Values.events) | nindent 6 }}
+      {{- include "pod-service-account-values-helper" (dict "service_name" "events" "Values" .Values) | nindent 6 }}
       containers:
         - name: events
           image: {{ include "opencrvs.image" (dict "root" . "service" .Values.events) }}
@@ -69,6 +70,8 @@ spec:
             items:
               - key: public-key.pem
                 path: public-key.pem
+
+{{- include "service-account-helper" (dict "service_name" "events" "Values" .Values) }}
 
 {{- include "service-helper" (dict "service_name" "events" "Values" .Values) }}
 

--- a/charts/opencrvs-services/templates/gateway-deployment.yaml
+++ b/charts/opencrvs-services/templates/gateway-deployment.yaml
@@ -50,6 +50,7 @@ spec:
         service.name: opencrvs_gateway
     spec:
       {{- include "opencrvs.imagePullSecrets" (dict "root" . "service" .Values.gateway) | nindent 6 }}
+      {{- include "pod-service-account-values-helper" (dict "service_name" "gateway" "Values" .Values) | nindent 6 }}
       containers:
         - name: gateway
           image: {{ include "opencrvs.image" (dict "root" . "service" .Values.gateway) }}
@@ -106,6 +107,8 @@ spec:
                 path: public-key.pem
             name: {{ .Release.Name }}-cert-tls
           name: public-key
+
+{{- include "service-account-helper" (dict "service_name" "gateway" "Values" .Values) }}
 
 {{- include "service-helper" (dict "service_name" "gateway" "Values" .Values) }}
 

--- a/charts/opencrvs-services/templates/login-deployment.yaml
+++ b/charts/opencrvs-services/templates/login-deployment.yaml
@@ -46,6 +46,7 @@ spec:
         app: login
     spec:
       {{- include "opencrvs.imagePullSecrets" (dict "root" . "service" .Values.login) | nindent 6 }}
+      {{- include "pod-service-account-values-helper" (dict "service_name" "login" "Values" .Values) | nindent 6 }}
       containers:
         - name: login
           image: {{ include "opencrvs.image" (dict "root" . "service" .Values.login) }}
@@ -90,6 +91,8 @@ spec:
             name: {{ $config_name }}
       {{- end }}
       {{- end }}
+
+{{- include "service-account-helper" (dict "service_name" "login" "Values" .Values) }}
 
 {{- include "service-helper" (dict "service_name" "login" "Values" .Values) }}
 

--- a/charts/opencrvs-services/templates/postgres-on-deploy-job.yaml
+++ b/charts/opencrvs-services/templates/postgres-on-deploy-job.yaml
@@ -15,6 +15,7 @@ spec:
         app: postgres-on-deploy
     spec:
       {{- include "opencrvs.imagePullSecrets" (dict "root" . "service" .Values.dashboards) | nindent 6 }}
+      {{- include "pod-service-account-values-helper" (dict "service_name" "deployment-jobs" "Values" .Values) | nindent 6 }}
       containers:
         {{- include "postgres-on-deploy.containerSpec" . | nindent 8 }}
         {{- include "render-env-vars" (dict "service_name" "postgres_on_deploy" "Values" .Values) }}

--- a/charts/opencrvs-services/templates/postgres-on-restore-cronjob.yaml
+++ b/charts/opencrvs-services/templates/postgres-on-restore-cronjob.yaml
@@ -22,6 +22,7 @@ spec:
             job-type: restore
         spec:
           {{- include "elasticsearch-reindex.imagePullSecrets" . | nindent 10 }}
+          {{- include "pod-service-account-values-helper" (dict "service_name" "deployment-jobs" "Values" .Values) | nindent 10 }}
           restartPolicy: OnFailure
           initContainers:
           {{- include "elasticsearch-reindex.initContainerSpec" . | nindent 12 }}
@@ -32,4 +33,3 @@ spec:
             {{- include "postgres-on-deploy.volumes" . | nindent 10 }}
             {{- include "elasticsearch-reindex.volumes" . | nindent 10 }}
 {{- end }}
-

--- a/charts/opencrvs-services/templates/service-accounts.yaml
+++ b/charts/opencrvs-services/templates/service-accounts.yaml
@@ -1,0 +1,1 @@
+{{- include "service-account-helper" (dict "service_name" "deployment-jobs" "Values" .Values "hook" true) }}

--- a/charts/opencrvs-services/templates/validate-postdeploy-job.yaml
+++ b/charts/opencrvs-services/templates/validate-postdeploy-job.yaml
@@ -19,6 +19,7 @@ spec:
         helm.sh/revision: {{ .Release.Revision | quote }}
     spec:
       {{- include "opencrvs.imagePullSecrets" (dict "root" . "service" .Values.utilities) | nindent 6 }}
+      {{- include "pod-service-account-values-helper" (dict "service_name" "deployment-jobs" "Values" .Values) | nindent 6 }}
       containers:
         {{- include "opencrvs-validate.containerSpec" (dict "root" . "mode" "postdeploy") | nindent 8 }}
       restartPolicy: "Never"

--- a/charts/opencrvs-services/templates/validate-predeploy-job.yaml
+++ b/charts/opencrvs-services/templates/validate-predeploy-job.yaml
@@ -19,6 +19,7 @@ spec:
         helm.sh/revision: {{ .Release.Revision | quote }}
     spec:
       {{- include "opencrvs.imagePullSecrets" (dict "root" . "service" .Values.utilities) | nindent 6 }}
+      {{- include "pod-service-account-values-helper" (dict "service_name" "deployment-jobs" "Values" .Values) | nindent 6 }}
       containers:
         {{- include "opencrvs-validate.containerSpec" (dict "root" . "mode" "predeploy") | nindent 8 }}
       restartPolicy: "Never"

--- a/charts/opencrvs-services/values.yaml
+++ b/charts/opencrvs-services/values.yaml
@@ -186,6 +186,15 @@ pdb:
   enabled: true
   minAvailable: 50%
 
+# ServiceAccount configuration.
+# By default, the chart creates one ServiceAccount per workload.
+# Override annotations globally here, or per workload under
+# <workload>.service_account.annotations.
+service_account:
+  create: true
+  annotations: {}
+  automount_service_account_token: true
+
 # Resources allocated to OpenCRVS microservices (Kubernetes PODs):
 resources:
   memoryRequest: '128Mi'
@@ -391,6 +400,14 @@ events:
 
 ##############################################################
 # One time jobs:
+# Common service account for Helm pre/post deployment jobs.
+deployment_jobs:
+  service_account:
+    name: deployment-jobs
+    annotations:
+      "helm.sh/hook": pre-install,pre-upgrade
+      "helm.sh/hook-weight": "-10"
+      "helm.sh/hook-delete-policy": before-hook-creation
 
 # data_migration: Job to migrate datastores while deployment
 data_migration:

--- a/packages/countryconfig-template/.github/workflows/publish-to-dockerhub.yml
+++ b/packages/countryconfig-template/.github/workflows/publish-to-dockerhub.yml
@@ -79,7 +79,7 @@ jobs:
           fi
 
       - name: Build and push countryconfig image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           push: true
           provenance: false
@@ -88,7 +88,7 @@ jobs:
             ${{ secrets.DOCKERHUB_ACCOUNT}}/${{ secrets.DOCKERHUB_REPO }}:${{ steps.country_config.outputs.version }}
 
       - name: Build and push assets image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           push: true
           provenance: false


### PR DESCRIPTION
## Description

Related issue: https://github.com/opencrvs/opencrvs-core/issues/13324

Goal of this PR is to give cloud native deployments a flexibility to manage access to managed components by providing service account mapping.

E/g: Instead of giving access to postges or redis database to all Kubernetes virtual machine, access can be granted to particular Pods only as a result attach surface will be reduced significantly.

## Testing

See e2e workflow results

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
