### PR TITLE
test(e2e): QA-testrail specs for death pages 1-4

### DIFF
--- a/packages/testland/e2e/testcases/qa-testrail-testcases/Birth-Death form/death-form/1.death-event-declaration.spec.ts
+++ b/packages/testland/e2e/testcases/qa-testrail-testcases/Birth-Death form/death-form/1.death-event-declaration.spec.ts
@@ -1,0 +1,398 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+import { expect, test } from '@playwright/test'
+import { login, waitForActionResponses } from '../../../../helpers'
+import { selectLocationOption } from '../helpers'
+import { trackAndDeleteCreatedEvents } from '../../../test-data/eventDeletion'
+
+/*
+ * QA case: "Death event declaration" - full walkthrough of the death
+ * declaration form, page by page, plus the Save & Exit / Exit / Delete
+ * declaration actions available from any page. Mirrors
+ * ../birth/1.birth-event-declaration.spec.ts structurally; death's page
+ * order is Deceased -> Event details -> Informant -> Spouse -> Documents
+ * (packages/testland/src/events/death/forms/declaration.ts:64-72), and the
+ * death review page has no Alpha print button (DEATH_DECLARATION_REVIEW
+ * only has review.comment/review.signature, unlike birth's review.print).
+ */
+
+// Edge-case deceased name (birth sample-data sheet's sample 5: an ordinal
+// suffix) - reused here since the sheet has no death-specific sample data.
+const DECEASED_NAME = { firstname: 'Richard the 3rd', surname: 'Doppler' }
+
+trackAndDeleteCreatedEvents()
+
+test('Death event declaration', async ({ page }) => {
+  await test.step('1. Click the + (Plus) sign', async () => {
+    await login(page)
+
+    await page.click('#header-new-event')
+    await expect(page.getByText('New Declaration')).toBeVisible()
+  })
+
+  await test.step('2. Validate event selection page', async () => {
+    /*
+     * Expected result: should show radio buttons of the events, a
+     * Continue button and an Exit button.
+     */
+    await expect(page.getByLabel('Death')).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Continue' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Exit' })).toBeVisible()
+
+    await page.getByRole('button', { name: 'Continue' }).click()
+    /*
+     * Expected result: "Please select the type of event"
+     */
+    await expect(
+      page.getByText('Please select the type of event')
+    ).toBeVisible()
+
+    await page.getByLabel('Death').click()
+    await page.getByRole('button', { name: 'Continue' }).click()
+
+    /*
+     * Expected result: should navigate to the "Introduction" page
+     */
+    await expect(
+      page.getByText(
+        'Introduce the death registration process to the informant'
+      )
+    ).toBeVisible()
+  })
+
+  await test.step('3. Validate "Introduction" page', async () => {
+    /*
+     * Expected result: should show Continue, Exit, Save & exit and the
+     * 3-dot menu (delete option)
+     */
+    await expect(page.getByRole('button', { name: 'Continue' })).toBeVisible()
+    await expect(
+      page.getByRole('button', { name: 'Exit', exact: true })
+    ).toBeVisible()
+    await expect(
+      page.getByRole('button', { name: 'Save & Exit' })
+    ).toBeVisible()
+
+    await page.locator('#event-menu-dropdownMenu').click()
+    await expect(
+      page
+        .locator('#event-menu-dropdownMenu')
+        .getByRole('listitem')
+        .filter({ hasText: 'Delete declaration' })
+    ).toBeVisible()
+    await page.locator('#event-menu-dropdownMenu').click()
+
+    /*
+     * Expected result: verbiage of death event introduction
+     */
+    await expect(
+      page.getByText('I am going to help you make a declaration of death.')
+    ).toBeVisible()
+    await expect(
+      page.getByText(
+        'As the legal Informant it is important that all the information provided by you is accurate.'
+      )
+    ).toBeVisible()
+
+    await page.getByRole('button', { name: 'Continue' }).click()
+
+    /*
+     * Expected result: should navigate to the "Deceased details" page
+     */
+    await expect(page.getByText("Deceased's details")).toBeVisible()
+  })
+
+  await test.step('4. Validate "Deceased Details" page', async () => {
+    await expect(page.getByRole('button', { name: 'Continue' })).toBeVisible()
+    await expect(
+      page.getByRole('button', { name: 'Exit', exact: true })
+    ).toBeVisible()
+    await expect(
+      page.getByRole('button', { name: 'Save & Exit' })
+    ).toBeVisible()
+
+    await page.locator('#firstname').fill(DECEASED_NAME.firstname)
+    await page.locator('#surname').fill(DECEASED_NAME.surname)
+    await page.locator('#deceased____gender').click()
+    await page.getByText('Male', { exact: true }).click()
+
+    const dob = new Date()
+    dob.setDate(dob.getDate() - 365 * 40)
+    const [dyyyy, dmm, ddd] = dob.toISOString().split('T')[0].split('-')
+    await page.getByPlaceholder('dd').fill(ddd)
+    await page.getByPlaceholder('mm').fill(dmm)
+    await page.getByPlaceholder('yyyy').fill(dyyyy)
+
+    await page.locator('#province').click()
+    await selectLocationOption(page, 'Central')
+    await page.locator('#district').click()
+    await selectLocationOption(page, 'Ibombo')
+    await page.locator('#village').click()
+
+    await page.getByRole('button', { name: 'Continue' }).click()
+
+    /*
+     * Expected result: should navigate to the "Event details" page
+     */
+    await expect(page.getByText('Event details')).toBeVisible()
+  })
+
+  await test.step('5. Validate "Event Details" page', async () => {
+    await expect(page.getByRole('button', { name: 'Continue' })).toBeVisible()
+    await expect(
+      page.getByRole('button', { name: 'Exit', exact: true })
+    ).toBeVisible()
+    await expect(
+      page.getByRole('button', { name: 'Save & Exit' })
+    ).toBeVisible()
+
+    const dateOfDeath = new Date()
+    dateOfDeath.setDate(dateOfDeath.getDate() - 10)
+    const [yyyy, mm, dd] = dateOfDeath.toISOString().split('T')[0].split('-')
+    await page.getByPlaceholder('dd').fill(dd)
+    await page.getByPlaceholder('mm').fill(mm)
+    await page.getByPlaceholder('yyyy').fill(yyyy)
+
+    await page.locator('#eventDetails____placeOfDeath').click()
+    await page.getByText('Health Institution', { exact: true }).click()
+    await page
+      .locator('#searchable-select-eventDetails____deathLocation input')
+      .fill('ib')
+    await page.getByText('Ibombo District Hospital').click()
+
+    await page.getByRole('button', { name: 'Continue' }).click()
+
+    /*
+     * Expected result: should navigate to the "Informant details" page
+     */
+    await expect(page.getByText("Informant's details")).toBeVisible()
+  })
+
+  await test.step('6. Validate "Informant details" page', async () => {
+    await expect(page.getByText('Informant Type')).toBeVisible()
+    await expect(page.getByText('Phone number')).toBeVisible()
+    await expect(page.getByText('Email')).toBeVisible()
+
+    /*
+     * Note: per-page "Continue" does not block on empty required fields -
+     * it navigates straight through instead of showing inline errors.
+     * Required-field validation for this page is covered separately via
+     * the Review page (see e.g. 2.validate-deceaseds-details-page.spec.ts).
+     */
+    await page.locator('#informant____relation').click()
+    await page.getByText('Spouse', { exact: true }).click()
+    await page.locator('#informant____email').fill('spouse@opencrvs.dev')
+    await page.getByRole('button', { name: 'Continue' }).click()
+
+    /*
+     * Expected result: should navigate to the "Spouse details" page
+     */
+    await expect(
+      page.getByText('Spouse details', { exact: true })
+    ).toBeVisible()
+  })
+
+  await test.step('7. Validate "Spouse details" page', async () => {
+    await expect(
+      page.getByText('Spouse details', { exact: true })
+    ).toBeVisible()
+
+    await page.locator('#firstname').fill('Aisha')
+    await page.locator('#surname').fill('Doppler')
+    await page.getByPlaceholder('dd').fill('01')
+    await page.getByPlaceholder('mm').fill('01')
+    await page.getByPlaceholder('yyyy').fill('1985')
+
+    await page.getByRole('button', { name: 'Continue' }).click()
+
+    /*
+     * Expected result: should navigate to the "Supporting documents" page
+     */
+    await expect(
+      page.getByText('Upload supporting documents', { exact: true })
+    ).toBeVisible()
+  })
+
+  await test.step('8. Validate "Supporting document" page', async () => {
+    await expect(
+      page.getByText('Upload supporting documents', { exact: true })
+    ).toBeVisible()
+
+    await page.getByRole('button', { name: 'Continue' }).click()
+
+    /*
+     * Expected result: should navigate to the "Review" page
+     */
+    await expect(page).toHaveURL(/\/review/)
+  })
+
+  await test.step('9. Validate "Review" page', async () => {
+    /*
+     * Expected result: should show the Review declaration block and the
+     * Action menu (Save & Exit, Exit and Delete declaration - no Alpha
+     * print button on the death review page)
+     */
+    await expect(page.getByTestId('deceased.name-value')).toContainText(
+      `${DECEASED_NAME.firstname} ${DECEASED_NAME.surname}`
+    )
+    await page.getByRole('button', { name: 'Action', exact: true }).click()
+    await expect(
+      page.getByText('Save & Exit', { exact: true })
+    ).toBeVisible()
+    await expect(page.getByText('Delete declaration')).toBeVisible()
+    await page.getByRole('button', { name: 'Action', exact: true }).click()
+  })
+
+  await test.step('10. Validate "Save & Exit" button', async () => {
+    // On the review page, Save & Exit is reached through the "Action"
+    // dropdown (unlike the pre-review pages, which show it as a direct
+    // top-bar button).
+    await page.getByRole('button', { name: 'Action', exact: true }).click()
+    await page.getByText('Save & Exit', { exact: true }).click()
+
+    /*
+     * Expected result: modal with title "Save & exit?", the helper text
+     * below, and Cancel/Confirm buttons.
+     */
+    await expect(
+      page.getByRole('heading', { name: 'Save & exit?' })
+    ).toBeVisible()
+    await expect(
+      page.getByText(
+        'All inputted data will be kept secure for future editing. Are you ready to save any changes to this declaration form?'
+      )
+    ).toBeVisible()
+
+    await page.getByRole('button', { name: 'Cancel' }).click()
+    /*
+     * Expected result: should close the modal
+     */
+    await expect(
+      page.getByRole('heading', { name: 'Save & exit?' })
+    ).toBeHidden()
+
+    await page.getByRole('button', { name: 'Action', exact: true }).click()
+    await page.getByText('Save & Exit', { exact: true }).click()
+    await waitForActionResponses(page, ['event.draft.create'], async () => {
+      await page.getByRole('button', { name: 'Confirm' }).click()
+    })
+
+    /*
+     * Expected result: the declaration is saved as a draft
+     */
+    await page.getByText('Drafts').click()
+    await expect(page.locator('#content-name')).toHaveText('Drafts')
+  })
+})
+
+test('Validate "Exit" button', async ({ page }) => {
+  await test.step('11.1 Open the "Exit" modal', async () => {
+    await login(page)
+    await page.click('#header-new-event')
+    await page.getByLabel('Death').click()
+    await page.getByRole('button', { name: 'Continue' }).click()
+    await page.getByRole('button', { name: 'Exit', exact: true }).click()
+
+    /*
+     * Expected result: modal with title "Exit without saving changes?"
+     */
+    await expect(
+      page.getByRole('heading', { name: 'Exit without saving changes?' })
+    ).toBeVisible()
+    await expect(
+      page.getByText(
+        'You have unsaved changes on your declaration form. Are you sure you want to exit without saving?'
+      )
+    ).toBeVisible()
+  })
+
+  await test.step('11.2 Click Cancel', async () => {
+    await page.getByRole('button', { name: 'Cancel' }).click()
+
+    /*
+     * Expected result: should close the modal
+     */
+    await expect(
+      page.getByRole('heading', { name: 'Exit without saving changes?' })
+    ).toBeHidden()
+  })
+
+  await test.step('11.3 Click Confirm', async () => {
+    await page.getByRole('button', { name: 'Exit', exact: true }).click()
+    await page.getByRole('button', { name: 'Confirm' }).click()
+
+    /*
+     * Expected result: no draft is saved
+     */
+    await expect(
+      page.getByTestId('search-result').getByText('Assigned to you')
+    ).toBeVisible()
+  })
+})
+
+test('Validate "Delete declaration" button', async ({ page }) => {
+  await test.step('12.1 Open the "Delete draft?" modal', async () => {
+    await login(page)
+    await page.click('#header-new-event')
+    await page.getByLabel('Death').click()
+    await page.getByRole('button', { name: 'Continue' }).click()
+
+    await page.locator('#event-menu-dropdownMenu').click()
+    await page
+      .locator('#event-menu-dropdownMenu')
+      .getByRole('listitem')
+      .filter({ hasText: 'Delete declaration' })
+      .click()
+
+    /*
+     * Expected result: modal with title "Delete draft?"
+     */
+    await expect(
+      page.getByRole('heading', { name: 'Delete draft?' })
+    ).toBeVisible()
+    await expect(
+      page.getByText('Are you sure you want to delete this declaration?')
+    ).toBeVisible()
+  })
+
+  await test.step('12.2 Click Cancel', async () => {
+    await page.getByRole('button', { name: 'Cancel' }).click()
+
+    /*
+     * Expected result: should close the modal
+     */
+    await expect(
+      page.getByRole('heading', { name: 'Delete draft?' })
+    ).toBeHidden()
+  })
+
+  await test.step('12.3 Click Confirm', async () => {
+    await page.locator('#event-menu-dropdownMenu').click()
+    await page
+      .locator('#event-menu-dropdownMenu')
+      .getByRole('listitem')
+      .filter({ hasText: 'Delete declaration' })
+      .click()
+
+    const deleteResponse = page.waitForResponse(
+      (response) => response.url().includes('event.delete') && response.ok()
+    )
+    await page.getByRole('button', { name: 'Confirm' }).click()
+    await deleteResponse
+
+    /*
+     * Expected result: no draft is saved
+     */
+    await expect(
+      page.getByTestId('search-result').getByText('Assigned to you')
+    ).toBeVisible()
+  })
+})

--- a/packages/testland/e2e/testcases/qa-testrail-testcases/Birth-Death form/death-form/2.validate-deceaseds-details-page.spec.ts
+++ b/packages/testland/e2e/testcases/qa-testrail-testcases/Birth-Death form/death-form/2.validate-deceaseds-details-page.spec.ts
@@ -1,0 +1,411 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+import { test, expect, type Page } from '@playwright/test'
+import { goToSection, login } from '../../../../helpers'
+import { selectLocationOption } from '../helpers'
+import { REQUIRED_VALIDATION_ERROR } from '../../../birth/helpers'
+import { trackAndDeleteCreatedEvents } from '../../../test-data/eventDeletion'
+
+/*
+ * QA case: "Validate the deceased's details page"
+ * (packages/testland/src/events/death/forms/pages/deceased.ts)
+ */
+
+const openDeathDeclaration = async (page: Page) => {
+  await page.click('#header-new-event')
+  await page.getByLabel('Death').click()
+  await page.getByRole('button', { name: 'Continue' }).click()
+  await page.getByRole('button', { name: 'Continue' }).click()
+  await expect(page.getByText("Deceased's details")).toBeVisible()
+}
+
+trackAndDeleteCreatedEvents()
+
+test("Validate the deceased's details page", async ({ page }) => {
+  await login(page)
+  await openDeathDeclaration(page)
+
+  await test.step('1. Validate "First Name(s)" text field', async () => {
+    for (const name of ['Richard the 3rd', 'John_Peter', 'John-Peter', "O'Neill"]) {
+      await test.step(`Accept non-English/special-character name: ${name}`, async () => {
+        await page.locator('#firstname').fill(name)
+        await page.getByRole('heading', { name: 'Death' }).click()
+
+        await expect(page.locator('#firstname_error')).toBeHidden()
+      })
+    }
+
+    await test.step('Enter more than 32 English characters is clipped', async () => {
+      const LONG_NAME = 'Ovuvuevuevue Enyetuenwuevue Ugbemugbem Osas'
+      await page.locator('#firstname').fill(LONG_NAME)
+      await page.getByRole('heading', { name: 'Death' }).click()
+
+      await expect(page.locator('#firstname')).toHaveValue(
+        LONG_NAME.slice(0, 32)
+      )
+      await page.locator('#firstname').fill('Rakibul')
+    })
+
+    await test.step('Reject a name containing an invalid character', async () => {
+      await page.locator('#firstname').fill('John@Peter')
+      await page.locator('#surname').fill('Doppler')
+
+      /*
+       * Expected result: "Input contains invalid characters. Please use
+       * only letters (a-z, A-Z), numbers (0-9), hyphens (-) and
+       * apostrophes(')" - the NAME field's validator error is suppressed
+       * on this page itself (a composite/nested field type) and only
+       * surfaces on the review row.
+       */
+      await goToSection(page, 'review')
+      await expect(
+        page
+          .locator('[data-testid="deceased.name-value"]')
+          .getByText(
+            "Input contains invalid characters. Please use only letters (a-z, A-Z), numbers (0-9), hyphens (-) and apostrophes(')"
+          )
+      ).toBeVisible()
+
+      await page.getByTestId('change-button-deceased.name').click()
+      await page.getByRole('button', { name: 'Continue' }).click()
+      await page.locator('#firstname').fill('Rakibul')
+    })
+  })
+
+  await test.step('2. Validate "Last name" text field', async () => {
+    const LONG_NAME = 'Ovuvuevuevue Enyetuenwuevue Ugbemugbem Osas'
+    await page.locator('#surname').fill(LONG_NAME)
+    await page.getByRole('heading', { name: 'Death' }).click()
+
+    /*
+     * Expected result: should not accept more than 32 characters
+     */
+    await expect(page.locator('#surname')).toHaveValue(LONG_NAME.slice(0, 32))
+    await page.locator('#surname').fill('Islam')
+  })
+
+  await test.step('3. Validate the Sex dropdown field', async () => {
+    for (const sex of ['Male', 'Female', 'Unknown']) {
+      await test.step(`Select dropdown value: ${sex}`, async () => {
+        await page.locator('#deceased____gender').click()
+        await page.getByText(sex, { exact: true }).click()
+
+        await expect(
+          page.locator('#deceased____gender', { hasText: sex })
+        ).toBeVisible()
+      })
+    }
+  })
+
+  await test.step('4. Validate the DOB field', async () => {
+    await test.step('Enter a valid past date and focus out', async () => {
+      await page.getByPlaceholder('dd').fill('01')
+      await page.getByPlaceholder('mm').fill('01')
+      await page.getByPlaceholder('yyyy').fill('1960')
+      await page.getByRole('heading', { name: 'Death' }).click()
+
+      await expect(page.locator('#deceased____dob_error')).toBeHidden()
+    })
+
+    await test.step('Enter a future date', async () => {
+      const futureDate = new Date()
+      futureDate.setDate(futureDate.getDate() + 1)
+      const [yyyy, mm, dd] = futureDate.toISOString().split('T')[0].split('-')
+
+      await page.getByPlaceholder('dd').fill(dd)
+      await page.getByPlaceholder('mm').fill(mm)
+      await page.getByPlaceholder('yyyy').fill(yyyy)
+      await page.getByRole('heading', { name: 'Death' }).click()
+
+      /*
+       * Expected result: "Must be a valid Birthdate"
+       */
+      await expect(page.locator('#deceased____dob_error')).toHaveText(
+        'Must be a valid Birthdate'
+      )
+
+      // Restore a valid past date for the rest of the flow
+      await page.getByPlaceholder('dd').fill('01')
+      await page.getByPlaceholder('mm').fill('01')
+      await page.getByPlaceholder('yyyy').fill('1960')
+      await page.getByRole('heading', { name: 'Death' }).click()
+      await expect(page.locator('#deceased____dob_error')).toBeHidden()
+    })
+  })
+
+  await test.step('5. Validate the "Nationality" drop-down field', async () => {
+    await page.locator('#deceased____nationality').click()
+    await page.getByText('Holy See', { exact: true }).click()
+
+    await expect(page.locator('#deceased____nationality')).toContainText(
+      'Holy See'
+    )
+    await page.locator('#deceased____nationality').click()
+    /*
+     * Scoped to the open dropdown's own option list - a bare page-wide
+     * getByText('Farajaland') also matches the "Country" field's own
+     * single-value badge further down the (still-rendered) address
+     * section, since Farajaland is that field's default too.
+     */
+    await page
+      .locator('.react-select__option')
+      .getByText('Farajaland', { exact: true })
+      .click()
+  })
+
+  await test.step('6-7. Validate "Proof of identity" and "National ID"', async () => {
+    for (const idType of ['Passport', 'Birth Registration Number', 'National ID']) {
+      await page.locator('#deceased____idType').click()
+      await page.getByText(idType, { exact: true }).click()
+
+      /*
+       * Expected result: should show Document No. for every ID type
+       */
+      await expect(page.getByText('ID Number')).toBeVisible()
+    }
+
+    await test.step('Enter less than 10 digits', async () => {
+      await page.locator('#deceased____nid').fill('123456789')
+      await page.getByRole('heading', { name: 'Death' }).click()
+
+      await expect(
+        page.getByText(
+          'The national ID can only be numeric and must be 10 digits long',
+          { exact: true }
+        )
+      ).toBeVisible()
+    })
+
+    await test.step('Enter 10 digits', async () => {
+      await page.locator('#deceased____nid').fill('1234567890')
+      await page.getByRole('heading', { name: 'Death' }).click()
+
+      await expect(
+        page.getByText(
+          'The national ID can only be numeric and must be 10 digits long',
+          { exact: true }
+        )
+      ).not.toBeVisible()
+    })
+
+    await test.step('Enter more than 10 digits', async () => {
+      await page.locator('#deceased____nid').fill('12345678901')
+      await page.getByRole('heading', { name: 'Death' }).click()
+
+      await expect(
+        page.getByText(
+          'The national ID can only be numeric and must be 10 digits long',
+          { exact: true }
+        )
+      ).toBeVisible()
+
+      await page.locator('#deceased____nid').fill('1234567890')
+    })
+  })
+
+  await test.step('8. Validate Passport/Birth Registration Number field', async () => {
+    await page.locator('#deceased____idType').click()
+    await page.getByText('Passport', { exact: true }).click()
+    await page.locator('#deceased____passport').fill('P1234567')
+    await page.getByRole('heading', { name: 'Death' }).click()
+
+    await expect(page.locator('#deceased____passport_error')).toBeHidden()
+
+    await page.locator('#deceased____idType').click()
+    await page.getByText('National ID', { exact: true }).click()
+    await page.locator('#deceased____nid').fill('1234567890')
+  })
+
+  await test.step('9. Validate the "Marital Status" drop-down field', async () => {
+    await page.locator('#deceased____maritalStatus').click()
+    await page.getByText('Widowed', { exact: true }).click()
+
+    await expect(page.locator('#deceased____maritalStatus')).toContainText(
+      'Widowed'
+    )
+  })
+
+  await test.step('10. Validate "No. of dependants" field', async () => {
+    await page.locator('#deceased____numberOfDependants').fill('2')
+    await expect(
+      page.locator('#deceased____numberOfDependants_error')
+    ).toBeHidden()
+
+    /*
+     * Expected result: should accept NULL as it is an optional field
+     */
+    await page.locator('#deceased____numberOfDependants').fill('')
+    await expect(
+      page.locator('#deceased____numberOfDependants_error')
+    ).toBeHidden()
+  })
+
+  await test.step('11. Validate the Residence section', async () => {
+    await expect(page.locator('#country')).toHaveText('Farajaland')
+    await page.locator('#province').click()
+    await selectLocationOption(page, 'Central')
+    await page.locator('#district').click()
+    await selectLocationOption(page, 'Ibombo')
+    await page.locator('#village').click()
+
+    await page.locator('#town').fill('Klow')
+    await page.locator('#residentialArea').fill('Downtown')
+    await page.locator('#street').fill('Main street')
+    await page.locator('#number').fill('12')
+    await page.locator('#zipCode').fill('1200')
+
+    await expect(
+      page.locator('#searchable-select-province .react-select__single-value')
+    ).toHaveText('Central')
+    await expect(page.locator('#town')).toHaveValue('Klow')
+  })
+
+  await test.step('12. Click "Continue"', async () => {
+    await page.getByRole('button', { name: 'Continue' }).click()
+
+    /*
+     * Expected result: users will redirect to the Event details page
+     */
+    await expect(page.getByText('Event details')).toBeVisible()
+  })
+})
+
+test("Validate the deceased's details page - required field validation and NID uniqueness", async ({
+  page
+}) => {
+  await login(page)
+  await openDeathDeclaration(page)
+
+  await test.step('Leave every field null and check the required errors on Review', async () => {
+    await goToSection(page, 'review')
+
+    await expect(
+      page
+        .locator('[data-testid="deceased.name-value"]')
+        .getByText(REQUIRED_VALIDATION_ERROR)
+    ).toBeVisible()
+    await expect(
+      page
+        .locator('[data-testid="deceased.gender-value"]')
+        .getByText(REQUIRED_VALIDATION_ERROR)
+    ).toBeVisible()
+    await expect(
+      page
+        .locator('[data-testid="deceased.dob-value"]')
+        .getByText(REQUIRED_VALIDATION_ERROR)
+    ).toBeVisible()
+    /*
+     * Unlike the scalar fields above, an empty ADDRESS field fails its own
+     * `isValidAdministrativeLeafLevel()` validator rather than the generic
+     * required check, so its review row shows "Invalid input" instead of
+     * "Required for registration" (see deceased.ts's address field
+     * validation message, id: 'error.invalidInput').
+     */
+    await expect(
+      page
+        .locator('[data-testid="deceased.address-value"]')
+        .getByText('Invalid input')
+    ).toBeVisible()
+  })
+
+  await test.step("Entering the same National ID as the informant's is rejected as non-unique", async () => {
+    await page.getByTestId('change-button-deceased.name').click()
+    await page.getByRole('button', { name: 'Continue' }).click()
+
+    await page.locator('#deceased____idType').click()
+    await page.getByText('National ID', { exact: true }).click()
+    await page.locator('#deceased____nid').fill('1122334455')
+    await page.getByRole('button', { name: 'Continue' }).click()
+
+    // Continue through Event details to the Informant page
+    await expect(page.getByText('Event details')).toBeVisible()
+    await page.getByPlaceholder('dd').fill('01')
+    await page.getByPlaceholder('mm').fill('01')
+    await page.getByPlaceholder('yyyy').fill(String(new Date().getFullYear()))
+    await page.locator('#eventDetails____placeOfDeath').click()
+    await page.getByText('Health Institution', { exact: true }).click()
+    await page
+      .locator('#searchable-select-eventDetails____deathLocation input')
+      .fill('ib')
+    await page.getByText('Ibombo District Hospital').click()
+    await page.getByRole('button', { name: 'Continue' }).click()
+
+    await expect(page.getByText("Informant's details")).toBeVisible()
+    await page.locator('#informant____relation').click()
+    await page.getByText('Son', { exact: true }).click()
+    await page.locator('#informant____idType').click()
+    await page.getByText('National ID', { exact: true }).click()
+    await page.locator('#informant____nid').fill('1122334455')
+    await page.getByRole('heading', { name: 'Death' }).click()
+
+    /*
+     * Expected result: "National id must be unique"
+     */
+    await expect(
+      page.getByText('National id must be unique', { exact: true })
+    ).toBeVisible()
+  })
+})
+
+test("Validate the deceased's details page - age and DOB format validators", async ({
+  page
+}) => {
+  await login(page)
+  await openDeathDeclaration(page)
+
+  await test.step('"Exact date of birth unknown" - age outside 0-120 is rejected', async () => {
+    await page.getByText('Exact date of birth unknown').click()
+
+    await page.locator('#deceased____age').fill('150')
+    await page.getByRole('heading', { name: 'Death' }).click()
+
+    /*
+     * Expected result: "Age must be between 0 and 120"
+     */
+    await expect(page.locator('#deceased____age_error')).toHaveText(
+      'Age must be between 0 and 120'
+    )
+
+    // Uncheck "unknown" so the DOB fields are used for the next step
+    await page.getByText('Exact date of birth unknown').click()
+  })
+
+  await test.step('Date of birth later than the date of death is rejected', async () => {
+    const dob = new Date()
+    dob.setDate(dob.getDate() - 5)
+    const [dyyyy, dmm, ddd] = dob.toISOString().split('T')[0].split('-')
+    await page.getByPlaceholder('dd').fill(ddd)
+    await page.getByPlaceholder('mm').fill(dmm)
+    await page.getByPlaceholder('yyyy').fill(dyyyy)
+    await page.getByRole('button', { name: 'Continue' }).click()
+
+    // ...but the date of death is set earlier than that DOB
+    await expect(page.getByText('Event details')).toBeVisible()
+    const dateOfDeath = new Date()
+    dateOfDeath.setDate(dateOfDeath.getDate() - 10)
+    const [yyyy, mm, dd] = dateOfDeath.toISOString().split('T')[0].split('-')
+    await page.getByPlaceholder('dd').fill(dd)
+    await page.getByPlaceholder('mm').fill(mm)
+    await page.getByPlaceholder('yyyy').fill(yyyy)
+    await page.getByRole('heading', { name: 'Death' }).click()
+
+    await goToSection(page, 'review')
+
+    /*
+     * Expected result: "Date of birth must be before the date of death"
+     */
+    await expect(
+      page
+        .locator('[data-testid="deceased.dob-value"]')
+        .getByText('Date of birth must be before the date of death')
+    ).toBeVisible()
+  })
+})

--- a/packages/testland/e2e/testcases/qa-testrail-testcases/Birth-Death form/death-form/3.validate-death-details-page.spec.ts
+++ b/packages/testland/e2e/testcases/qa-testrail-testcases/Birth-Death form/death-form/3.validate-death-details-page.spec.ts
@@ -1,0 +1,334 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+import { test, expect, type Page } from '@playwright/test'
+import { goToSection, login } from '../../../../helpers'
+import { REQUIRED_VALIDATION_ERROR } from '../../../birth/helpers'
+import { trackAndDeleteCreatedEvents } from '../../../test-data/eventDeletion'
+
+/*
+ * QA case: "Validate Death details page" - the QA doc's "Event details"
+ * page (packages/testland/src/events/death/forms/pages/eventDetails.ts),
+ * including its cause-of-death gating into either a plain Description
+ * textarea (Lay reported/Verbal autopsy) or the separate ICD-10
+ * causeOfDeathDetails page (Physician/Medically Certified).
+ */
+
+const beginAtEventDetailsPage = async (page: Page) => {
+  await login(page)
+  await page.click('#header-new-event')
+  await page.getByLabel('Death').click()
+  await page.getByRole('button', { name: 'Continue' }).click()
+  await page.getByRole('button', { name: 'Continue' }).click()
+
+  await page.locator('#firstname').fill('Richard')
+  await page.locator('#surname').fill('Doppler')
+
+  /*
+   * The deceased's own DOB must be fixed for the "Date of death must be
+   * after the deceased's birth date" validation (further below) to have
+   * a known value to compare against.
+   */
+  await page.getByPlaceholder('dd').fill('01')
+  await page.getByPlaceholder('mm').fill('01')
+  await page.getByPlaceholder('yyyy').fill('1960')
+
+  await page.getByRole('button', { name: 'Continue' }).click()
+
+  await expect(page.getByText('Event details')).toBeVisible()
+}
+
+trackAndDeleteCreatedEvents()
+
+test('Validate Death details page', async ({ page }) => {
+  await beginAtEventDetailsPage(page)
+
+  await test.step('1. Validate the Date of Death field', async () => {
+    const yesterday = new Date()
+    yesterday.setDate(yesterday.getDate() - 1)
+    const [yyyy, mm, dd] = yesterday.toISOString().split('T')[0].split('-')
+
+    await page.getByPlaceholder('dd').fill(dd)
+    await page.getByPlaceholder('mm').fill(mm)
+    await page.getByPlaceholder('yyyy').fill(yyyy)
+    await page.getByRole('heading', { name: 'Death' }).click()
+
+    /*
+     * Expected result: should accept the DOD date
+     */
+    await expect(page.locator('#eventDetails____date_error')).toBeHidden()
+
+    await test.step('Enter a future date', async () => {
+      const futureDate = new Date()
+      futureDate.setDate(futureDate.getDate() + 1)
+      const [fyyyy, fmm, fdd] = futureDate.toISOString().split('T')[0].split('-')
+
+      await page.getByPlaceholder('dd').fill(fdd)
+      await page.getByPlaceholder('mm').fill(fmm)
+      await page.getByPlaceholder('yyyy').fill(fyyyy)
+      await page.getByRole('heading', { name: 'Death' }).click()
+
+      /*
+       * Expected result: "Must be a valid date"
+       */
+      await expect(page.locator('#eventDetails____date_error')).toHaveText(
+        'Must be a valid date'
+      )
+
+      // Restore a valid past date before the next check
+      await page.getByPlaceholder('dd').fill(dd)
+      await page.getByPlaceholder('mm').fill(mm)
+      await page.getByPlaceholder('yyyy').fill(yyyy)
+      await page.getByRole('heading', { name: 'Death' }).click()
+      await expect(page.locator('#eventDetails____date_error')).toBeHidden()
+    })
+
+    await test.step("Enter a date of death before the deceased's DOB", async () => {
+      await page.getByPlaceholder('dd').fill('01')
+      await page.getByPlaceholder('mm').fill('01')
+      await page.getByPlaceholder('yyyy').fill('1959')
+      await page.getByRole('heading', { name: 'Death' }).click()
+
+      /*
+       * Expected result: "Date of death must be after the deceased's
+       * birth date"
+       */
+      await expect(page.locator('#eventDetails____date_error')).toHaveText(
+        "Date of death must be after the deceased's birth date"
+      )
+
+      // Restore a valid date of death for the rest of the flow
+      await page.getByPlaceholder('dd').fill(dd)
+      await page.getByPlaceholder('mm').fill(mm)
+      await page.getByPlaceholder('yyyy').fill(yyyy)
+      await page.getByRole('heading', { name: 'Death' }).click()
+      await expect(page.locator('#eventDetails____date_error')).toBeHidden()
+    })
+  })
+
+  await test.step('2-3. Validate "Place of death"', async () => {
+    await test.step('Select "Health Institution" and enter a facility', async () => {
+      await page.locator('#eventDetails____placeOfDeath').click()
+      await page.getByText('Health Institution', { exact: true }).click()
+
+      await expect(
+        page.locator('#eventDetails____deathLocation')
+      ).toBeVisible()
+
+      await page
+        .locator('#searchable-select-eventDetails____deathLocation input')
+        .fill('ib')
+      await page.getByText('Ibombo District Hospital').click()
+
+      await expect(
+        page.locator(
+          '#searchable-select-eventDetails____deathLocation .react-select__single-value'
+        )
+      ).toHaveText('Ibombo District Hospital')
+    })
+
+    await test.step("Select \"Deceased's usual place of residence\"", async () => {
+      await page.locator('#eventDetails____placeOfDeath').click()
+      await page
+        .getByText("Deceased's usual place of residence", { exact: true })
+        .click()
+
+      /*
+       * Expected result: no separate address block is shown - the
+       * deceased's own residence (collected on the deceased's details
+       * page) is reused
+       */
+      await expect(
+        page.locator('#eventDetails____deathLocation')
+      ).toBeHidden()
+      await expect(
+        page.locator('#eventDetails____deathLocationOther-form-input')
+      ).toBeHidden()
+    })
+
+    await test.step('Select "Other" and enter an address', async () => {
+      await page.locator('#eventDetails____placeOfDeath').click()
+      await page.getByText('Other', { exact: true }).click()
+
+      await expect(
+        page.locator('#eventDetails____deathLocationOther-form-input')
+      ).toBeVisible()
+      await expect(page.locator('#country')).toHaveText('Farajaland')
+
+      /*
+       * This field's `allowedLocations` is scoped to the user's own
+       * jurisdiction (packages/testland/src/events/death/forms/pages/
+       * eventDetails.ts's deathLocationOther config) - with only one
+       * valid choice, province/district render pre-filled and locked
+       * rather than as an open combobox, unlike the other address fields
+       * in this suite.
+       */
+      await expect(
+        page.locator('#searchable-select-province .react-select__single-value')
+      ).toHaveText('Central')
+      await expect(
+        page.locator('#searchable-select-district .react-select__single-value')
+      ).toHaveText('Ibombo')
+      await page.locator('#town').fill('Klow')
+      await page.locator('#residentialArea').fill('Downtown')
+      await page.locator('#street').fill('Main street')
+      await page.locator('#number').fill('12')
+      await page.locator('#zipCode').fill('1200')
+    })
+  })
+
+  await test.step('4. Validate "Manner of death"', async () => {
+    await page.locator('#eventDetails____mannerOfDeath').click()
+    await page.getByText('Natural causes', { exact: true }).click()
+
+    await expect(page.locator('#eventDetails____mannerOfDeath')).toContainText(
+      'Natural causes'
+    )
+  })
+
+  await test.step('5-6. Validate "Cause of death has been established" and its Source', async () => {
+    await test.step('Leave the checkbox unchecked hides Source of cause of death', async () => {
+      await expect(
+        page.getByText('Source of cause of death')
+      ).toBeHidden()
+    })
+
+    await test.step('Checking it shows "Source of cause of death"', async () => {
+      await page.getByText('Cause of death has been established').click()
+
+      await expect(page.getByText('Source of cause of death')).toBeVisible()
+    })
+
+    await test.step('Selecting "Lay reported" shows the plain Description field', async () => {
+      await page.locator('#eventDetails____sourceCauseDeath').click()
+      await page.getByText('Lay reported', { exact: true }).click()
+
+      // Not { exact: true } - the label renders as "Description *".
+      await expect(page.getByText('Description')).toBeVisible()
+      await page.locator('#eventDetails____description').fill('Fell ill suddenly.')
+    })
+
+    await test.step('Selecting "Physician" instead routes to the ICD-10 cause-of-death page', async () => {
+      await page.locator('#eventDetails____sourceCauseDeath').click()
+      await page.getByText('Physician', { exact: true }).click()
+
+      /*
+       * Expected result: "Description" field hides - the ICD-10 page is
+       * used instead
+       */
+      await expect(page.getByText('Description', { exact: true })).toBeHidden()
+    })
+  })
+
+  await test.step('7. Click "Continue" and fill the ICD-10 cause-of-death page', async () => {
+    await page.getByRole('button', { name: 'Continue' }).click()
+
+    /*
+     * Expected result: navigates to the Cause of death details page
+     */
+    await expect(page.getByText('A. Cause of death')).toBeVisible()
+
+    await test.step('Selecting "Other" and entering text with a semicolon shows "Must not contain semicolon(s)"', async () => {
+      await page
+        .locator('#causeOfDeathDetails____causeOfDeathA____symptom____one')
+        .click()
+      await page.getByText('Other', { exact: true }).click()
+
+      await expect(
+        page.locator(
+          '#causeOfDeathDetails____causeOfDeathA____symptom____one____other'
+        )
+      ).toBeVisible()
+
+      await page
+        .locator(
+          '#causeOfDeathDetails____causeOfDeathA____symptom____one____other'
+        )
+        .fill('Sepsis; unspecified')
+      await page.getByRole('heading', { name: 'Death' }).click()
+
+      /*
+       * Expected result: "Must not contain semicolon(s)"
+       */
+      await expect(
+        page.locator(
+          '#causeOfDeathDetails____causeOfDeathA____symptom____one____other_error'
+        )
+      ).toHaveText('Must not contain semicolon(s)')
+    })
+
+    // Real ICD-10 term already proven against the lookup API in
+    // death/declaration/death-declaration-1.spec.ts:65,192-198.
+    await page
+      .locator('#causeOfDeathDetails____causeOfDeathA____symptom____one')
+      .fill('Sepsis, unspecified')
+    await page.getByText('Sepsis, unspecified', { exact: true }).click()
+    await page
+      .locator('#causeOfDeathDetails____causeOfDeathA____interval')
+      .fill('2')
+    await page
+      .locator('#causeOfDeathDetails____causeOfDeathA____interval-form-input')
+      .getByTestId('select__unit')
+      .click()
+    await page.getByText('Days', { exact: true }).click()
+
+    await page.getByRole('button', { name: 'Continue' }).click()
+
+    /*
+     * Expected result: navigates to the Informant details page
+     */
+    await expect(page.getByText("Informant's details")).toBeVisible()
+  })
+})
+
+test('Validate Death details page - required field validation', async ({
+  page
+}) => {
+  await beginAtEventDetailsPage(page)
+
+  await goToSection(page, 'review')
+
+  /*
+   * Expected result: "Required for registration" for date of death and
+   * place of death
+   */
+  await expect(
+    page
+      .locator('[data-testid="eventDetails.date-value"]')
+      .getByText(REQUIRED_VALIDATION_ERROR)
+  ).toBeVisible()
+  await expect(
+    page.locator('[data-testid="eventDetails.placeOfDeath-value"]')
+  ).toHaveText(REQUIRED_VALIDATION_ERROR)
+})
+
+test('Validate Death details page - deathLocationOther incomplete address validation', async ({
+  page
+}) => {
+  await beginAtEventDetailsPage(page)
+
+  await page.locator('#eventDetails____placeOfDeath').click()
+  await page.getByText('Other', { exact: true }).click()
+
+  await goToSection(page, 'review')
+
+  /*
+   * Expected result: "Invalid input" - province/district are pre-filled
+   * and locked to the user's own jurisdiction, but no village was ever
+   * selected, so the address falls short of the required leaf
+   * administrative level (see eventDetails.ts's deathLocationOther field
+   * validation, id: 'error.invalidInput').
+   */
+  await expect(
+    page
+      .locator('[data-testid="eventDetails.deathLocationOther-value"]')
+      .getByText('Invalid input')
+  ).toBeVisible()
+})

--- a/packages/testland/e2e/testcases/qa-testrail-testcases/Birth-Death form/death-form/4.validate-informant-details-page-when-spouse.spec.ts
+++ b/packages/testland/e2e/testcases/qa-testrail-testcases/Birth-Death form/death-form/4.validate-informant-details-page-when-spouse.spec.ts
@@ -1,0 +1,144 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+import { test, expect, type Page } from '@playwright/test'
+import { login } from '../../../../helpers'
+import { trackAndDeleteCreatedEvents } from '../../../test-data/eventDeletion'
+
+/*
+ * QA case: "Validate the informant details page when informant is Spouse" -
+ * when the informant IS the spouse, none of informant's own person-fields
+ * (name/dob/nationality/idType/etc.) render on the informant page - only
+ * relation/phone/email - because that identity is captured on the Spouse
+ * page instead (packages/testland/src/events/death/forms/pages/informant.ts,
+ * `informantOtherThanSpouse` gate).
+ */
+
+const beginAtInformantPage = async (page: Page) => {
+  await login(page)
+  await page.click('#header-new-event')
+  await page.getByLabel('Death').click()
+  await page.getByRole('button', { name: 'Continue' }).click()
+  await page.getByRole('button', { name: 'Continue' }).click()
+
+  await page.locator('#firstname').fill('Richard')
+  await page.locator('#surname').fill('Doppler')
+  await page.getByRole('button', { name: 'Continue' }).click()
+
+  const dateOfDeath = new Date()
+  dateOfDeath.setDate(dateOfDeath.getDate() - 5)
+  const [yyyy, mm, dd] = dateOfDeath.toISOString().split('T')[0].split('-')
+  await page.getByPlaceholder('dd').fill(dd)
+  await page.getByPlaceholder('mm').fill(mm)
+  await page.getByPlaceholder('yyyy').fill(yyyy)
+  await page.locator('#eventDetails____placeOfDeath').click()
+  await page.getByText('Health Institution', { exact: true }).click()
+  await page
+    .locator('#searchable-select-eventDetails____deathLocation input')
+    .fill('ib')
+  await page.getByText('Ibombo District Hospital').click()
+  await page.getByRole('button', { name: 'Continue' }).click()
+
+  await expect(page.getByText("Informant's details")).toBeVisible()
+}
+
+trackAndDeleteCreatedEvents()
+
+test('Validate the informant details page when informant is Spouse', async ({
+  page
+}) => {
+  await beginAtInformantPage(page)
+
+  await test.step('1. Validate "Informant details" page contents and select Spouse', async () => {
+    await expect(page.getByText('Informant Type')).toBeVisible()
+    await expect(page.getByText('Phone number')).toBeVisible()
+    await expect(page.getByText('Email')).toBeVisible()
+
+    /*
+     * Note: per-page "Continue" does not block on empty required fields -
+     * it navigates straight through instead of showing inline errors.
+     * Required-field validation for this page is covered separately via
+     * the Review page (see e.g. 2.validate-deceaseds-details-page.spec.ts).
+     */
+    await page.locator('#informant____relation').click()
+    await page.getByText('Spouse', { exact: true }).click()
+
+    /*
+     * Expected result: should not add any other field
+     */
+    await expect(page.locator('#firstname')).toBeHidden()
+    await expect(page.locator('#informant____nationality')).toBeHidden()
+    await expect(page.locator('#informant____idType')).toBeHidden()
+  })
+
+  await test.step('2. Validate the "Phone number" field', async () => {
+    await test.step('Leave the field as null and continue', async () => {
+      await page.locator('#informant____phoneNo').fill('')
+      await page.getByRole('heading', { name: 'Death' }).click()
+
+      /*
+       * Expected result: optional field, no validation error
+       */
+      await expect(page.locator('#informant____phoneNo_error')).toBeHidden()
+    })
+
+    await test.step('Enter a number not starting with 0', async () => {
+      await page.locator('#informant____phoneNo').fill('1234567890')
+      await page.getByRole('heading', { name: 'Death' }).click()
+
+      await expect(page.locator('#informant____phoneNo_error')).toHaveText(
+        'Must be a valid 10 digit number that starts with 0(7|9)'
+      )
+    })
+
+    await test.step('Enter a number with the wrong length', async () => {
+      await page.locator('#informant____phoneNo').fill('07123')
+      await page.getByRole('heading', { name: 'Death' }).click()
+
+      await expect(page.locator('#informant____phoneNo_error')).toHaveText(
+        'Must be a valid 10 digit number that starts with 0(7|9)'
+      )
+    })
+
+    await test.step('Enter a valid 10 digit number starting with 0', async () => {
+      await page.locator('#informant____phoneNo').fill('0712345678')
+      await page.getByRole('heading', { name: 'Death' }).click()
+
+      await expect(page.locator('#informant____phoneNo_error')).toBeHidden()
+    })
+  })
+
+  await test.step('3. Validate the "Email" field', async () => {
+    await test.step('Enter an invalid email address', async () => {
+      await page.locator('#informant____email').fill('not-an-email')
+      await page.getByRole('heading', { name: 'Death' }).click()
+
+      await expect(page.locator('#informant____email_error')).toBeVisible()
+    })
+
+    await test.step('Enter a valid email address', async () => {
+      await page.locator('#informant____email').fill('spouse@opencrvs.dev')
+      await page.getByRole('heading', { name: 'Death' }).click()
+
+      await expect(page.locator('#informant____email_error')).toBeHidden()
+    })
+  })
+
+  await test.step('4. Click "Continue"', async () => {
+    await page.getByRole('button', { name: 'Continue' }).click()
+
+    /*
+     * Expected result: should navigate to the Spouse details page
+     */
+    await expect(
+      page.getByText('Spouse details', { exact: true })
+    ).toBeVisible()
+  })
+})

--- a/packages/testland/e2e/testcases/qa-testrail-testcases/Birth-Death form/helpers.ts
+++ b/packages/testland/e2e/testcases/qa-testrail-testcases/Birth-Death form/helpers.ts
@@ -1,0 +1,26 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+import { Page } from '@playwright/test'
+
+/*
+ * Local copy of e2e/utils.ts's selectLocationOption, scoped to this folder
+ * only (not editing the shared utils.ts). The shared version's plain
+ * getByText(locationName) does a substring match, which is ambiguous for
+ * "Ibombo" - it also matches the option list's "Ibombo-north (old)" and
+ * "Ibombo-south (new)" entries, causing a strict-mode violation. This
+ * version disambiguates with an exact match.
+ */
+export async function selectLocationOption(page: Page, locationName: string) {
+  await page
+    .locator('[id^="locationOption"]')
+    .getByText(locationName, { exact: true })
+    .click()
+}


### PR DESCRIPTION
## Summary
- Adds Playwright e2e specs mapping 1:1 to death-declaration QA-testrail cases 1-4 (death event declaration, Deceased's details, Death details, Informant's details when informant is Spouse)
- Part 3 of 4 PRs covering birth 1-8 / death 1-8 QA-testrail coverage, split to stay within the repo's ~1000-1500 LOC/PR guideline

## Test plan
- [x] Lint clean (`eslint`)
- [x] Typecheck clean (no new errors introduced)
- [x] All specs pass against `e2e.opencrvs.dev` (`--workers=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)