### PR TITLE
chore: add separate hospital clerk for qa

### DIFF
--- a/packages/testland/src/data-seeding/employees/source/default-employees.csv
+++ b/packages/testland/src/data-seeding/employees/source/default-employees.csv
@@ -56,4 +56,4 @@ CRVS_OFFICE_QmAyxAJkxiJ,Kalusha,Cwalya,HOSPITAL_CLERK,0911111112,k.cwalya,kalush
 CRVS_OFFICE_QmAyxAJkxiJ,Hakainde,Habazoka,HEALTH_ADMINISTRATOR,0911111119,h.habazoka,kalushabwalya17+91@gmail.com,test
 CRVS_OFFICE_DC5stjQ45n3,Joseph,Banda,LOCAL_REGISTRAR,0940000003,j.banda,kalushabwalya17+44@gmail.com,test
 CRVS_OFFICE_OldIbomboRegOffice,Daniel,Henry,LOCAL_REGISTRAR,0940000002,d.henry,kalushabwalya17+43@gmail.com,test
-CRVS_OFFICE_W1zgTm2kGWP,Madam,Regression,QA_HOSPITAL_CLERK,0911111112,m.regression,kalushabwalya17+451@gmail.com,test
+CRVS_OFFICE_W1zgTm2kGWP,Madam,Regression,QA_HOSPITAL_CLERK,0911114112,m.regression,kalushabwalya17+451@gmail.com,test

--- a/packages/testland/src/data-seeding/employees/source/default-employees.csv
+++ b/packages/testland/src/data-seeding/employees/source/default-employees.csv
@@ -56,3 +56,4 @@ CRVS_OFFICE_QmAyxAJkxiJ,Kalusha,Cwalya,HOSPITAL_CLERK,0911111112,k.cwalya,kalush
 CRVS_OFFICE_QmAyxAJkxiJ,Hakainde,Habazoka,HEALTH_ADMINISTRATOR,0911111119,h.habazoka,kalushabwalya17+91@gmail.com,test
 CRVS_OFFICE_DC5stjQ45n3,Joseph,Banda,LOCAL_REGISTRAR,0940000003,j.banda,kalushabwalya17+44@gmail.com,test
 CRVS_OFFICE_OldIbomboRegOffice,Daniel,Henry,LOCAL_REGISTRAR,0940000002,d.henry,kalushabwalya17+43@gmail.com,test
+CRVS_OFFICE_W1zgTm2kGWP,Madam,Regression,QA_HOSPITAL_CLERK,0911111112,m.regression,kalushabwalya17+451@gmail.com,test

--- a/packages/testland/src/data-seeding/roles/roles.ts
+++ b/packages/testland/src/data-seeding/roles/roles.ts
@@ -292,5 +292,25 @@ export const roles: Role[] = [
       { type: 'record.print-certified-copies', options: { placeOfEvent: 'location' } },
       { type: 'record.correct', options: { placeOfEvent: 'location' } }
     ])
+  },
+  {
+    id: 'QA_HOSPITAL_CLERK',
+    label: {
+      defaultMessage: 'QA Hospital Official',
+      description: 'Name for user role QA Hospital Official. Used for regression testing',
+      id: 'userRole.hospitalClerk'
+    },
+    scopes: defineScopes([
+      { type: 'user.read-only-my-audit' },
+      { type: 'record.search', options: { placeOfEvent: 'location', flags: { noneOf: ['sealed'] } } },
+      { type: 'workqueue', options: { ids: ['assigned-to-you', 'recent', 'pending-attestation', 'pending-updates'] } },
+      { type: 'record.create', options: { placeOfEvent: 'location' } },
+      { type: 'record.read', options: { event: ['birth', 'death', 'adoption', 'tennis-club-membership'], notifiedIn: 'location', flags: { noneOf: ['sealed'] } } },
+      { type: 'record.edit', options: { status: ['NOTIFIED'] } },
+      { type: 'record.notify', options: { placeOfEvent: 'location' } },
+      { type: 'record.declare', options: { placeOfEvent: 'location' } },
+      { type: 'record.edit', options: { event: ['birth', 'death', 'adoption'], notifiedBy: 'user' } },
+      { type: 'record.print-certified-copies', options: { templates: ['v2.tennis-club-membership-certificate-alpha'], registeredIn: 'location' } }
+    ])
   }
 ]


### PR DESCRIPTION
## Description
1. https://github.com/opencrvs/opencrvs-core/issues/13263 changed hospital clerk permissions
2. https://github.com/opencrvs/opencrvs-core/issues/13156 qa needs those permissions
3. create separate role `QA_HOSPITAL_CLERK` and user `m.regression`

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
