### PR TITLE
feat: Implement Network policies to OpenCRVS pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,7 @@ Until the removal, behaviour depends on the environment, so the change surfaces 
 - `pnpm dev` now runs the MOSIP stack alongside the rest of core, so local registrations exercise the same MOSIP path as a real deployment. The testland `NO_MOSIP` escape hatch is gone — it only ever short-circuited local development, and production already defaulted to `false`.
 - Record review, event summaries, team lists, settings and the duplicate comparison now draw their label-and-value rows from one shared component, so they present consistently and screen readers announce each value together with its row and column heading [#4024](https://github.com/opencrvs/opencrvs-core/issues/4024)
 - Added Service account support for Managed Kubernetes [#13324](https://github.com/opencrvs/opencrvs-core/issues/13324)
+- Implement Network policies to OpenCRVS pods [#13284](https://github.com/opencrvs/opencrvs-core/issues/13284)
 
 ### New features
 

--- a/charts/dependencies/Chart.yaml
+++ b/charts/dependencies/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opencrvs-dependencies-chart
 description: Dependencies required by OpenCRVS
 type: application
-version: v2.1.0
+version: v2.1.0-ocrvs-13284
 appVersion: v2.1.0

--- a/charts/dependencies/README.md
+++ b/charts/dependencies/README.md
@@ -27,22 +27,122 @@ Any particular service within this helm chart can be disabled by setting `<servi
 
 ## Global configuration options
 
-| Parameter               | Type   | Default        | Description                                                                                                                                                                                    |
-| ----------------------- | ------ | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| hostname                | string | farajaland.dev | All chart services will be available under specified domain. Exposed services are MinIO and Kibana, if Monitoring is enabled                                                                   |
-| ingress.ssl_enabled     | bool   | false          | Enable or disable https endpoint, by default all http traffic is routed to https                                                                                                               |
-| ingress.tls_resolver    | string | ` `            | If traefik was deployed with custom resolver, please define resolver name here. Resolver will be attached to Traefik CRD IngressRoute, otherwise default Traefik SSL Certificate will be used. |
-| ingress.tls_secret_name | string | ` `            | Secret with custom SSL Certificate for IngressRoute, check traefik documentation for details. Otherwise default Traefik SSL Certificate will be used.                                          |
-| timezone                | string | ` `            | Time zone for a backup and restore CronJobs, by default local time zone is used from server                                                                                                    |
-| storage_type            | string | `pvc`          | Kubernetes storage type, available options are `pvc` or `host_path`. More information are at [Storage Configuration](#storage-configuration)                                                   |
-| platform.imagePullSecrets | list | `[]`         | Pod-level image pull secrets applied to all workloads in this chart. Use this when images are stored in private registries.                                                                    |
-| node_selector           | dict   | `{}`           | Label selector for datastore nodes, usually used to keep data persistent                                                                                                                       |
-| monitoring.enabled      | bool   | `false`        | Enable or disable monitoring, see [Monitoring](#monitoring)                                                                                                                                    |
-| priority_class.enabled  | bool   | `false`        | Enable or disable priority class for datastores. Enabling this option will avoid unnecessary pod eviction.                                                                                     |
-| backup.enabled          | bool   | `true`         | Enable or disable data backup. Please check [Backup configuration](#backup-configuration) for more options. Usually this option is enabled on Production environment                           |
-| restore.enabled         | bool   | `true`         | Enable or disable data restore. Please check [Restore configuration](#restore-configuration) for more options. Usually this option is enabled on Staging environment                           |
-| utilities.image.repository | string | `ghcr.io/opencrvs/ocrvs-utilities` | Shared utilities image repository used by helper jobs and init containers.                                                                                     |
-| utilities.image.tag     | string | `v2.1.0`       | Shared utilities image tag used by helper jobs and init containers.                                                                                                                            |
+| Parameter                           | Type   | Default                            | Description                                                                                                                                                                                                                                                    |
+| ----------------------------------- | ------ | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| hostname                            | string | farajaland.dev                     | All chart services will be available under specified domain. Exposed services are MinIO and Kibana, if Monitoring is enabled                                                                                                                                   |
+| ingress.ssl_enabled                 | bool   | false                              | Enable or disable https endpoint, by default all http traffic is routed to https                                                                                                                                                                               |
+| ingress.tls_resolver                | string | ` `                                | If traefik was deployed with custom resolver, please define resolver name here. Resolver will be attached to Traefik CRD IngressRoute, otherwise default Traefik SSL Certificate will be used.                                                                 |
+| ingress.tls_secret_name             | string | ` `                                | Secret with custom SSL Certificate for IngressRoute, check traefik documentation for details. Otherwise default Traefik SSL Certificate will be used.                                                                                                          |
+| network_policy.enabled              | bool   | `true`                             | Render Kubernetes NetworkPolicy resources for dependency workloads. Requires a CNI provider that enforces NetworkPolicy.                                                                                                                                       |
+| network_policy.ingress_mode         | string | `deny`                             | Baseline policy for ingress to dependency pods: `deny` (default, requires another NetworkPolicy to allow it), `private` (allow only RFC1918 private ranges), or `full` (unrestricted).                                                                         |
+| network_policy.egress_mode          | string | `deny`                             | Baseline policy for egress from dependency pods. Same modes as `ingress_mode`, applied to egress. DNS (53) is always allowed except in `full` mode.                                                                                                            |
+| network_policy.allow_same_namespace | bool   | `true`                             | Allow dependency pods in the same namespace to communicate with each other.                                                                                                                                                                                    |
+| network_policy.allowed_namespaces   | list   | `[]`                               | Namespaces allowed to reach dependency pods (e.g. the opencrvs-services namespace). When set, dependency pods accept ingress on any port from every pod in each listed namespace, so the OpenCRVS application keeps working once ingress is denied by default. |
+| timezone                            | string | ` `                                | Time zone for a backup and restore CronJobs, by default local time zone is used from server                                                                                                                                                                    |
+| storage_type                        | string | `pvc`                              | Kubernetes storage type, available options are `pvc` or `host_path`. More information are at [Storage Configuration](#storage-configuration)                                                                                                                   |
+| platform.imagePullSecrets           | list   | `[]`                               | Pod-level image pull secrets applied to all workloads in this chart. Use this when images are stored in private registries.                                                                                                                                    |
+| node_selector                       | dict   | `{}`                               | Label selector for datastore nodes, usually used to keep data persistent                                                                                                                                                                                       |
+| monitoring.enabled                  | bool   | `false`                            | Enable or disable monitoring, see [Monitoring](#monitoring)                                                                                                                                                                                                    |
+| priority_class.enabled              | bool   | `false`                            | Enable or disable priority class for datastores. Enabling this option will avoid unnecessary pod eviction.                                                                                                                                                     |
+| backup.enabled                      | bool   | `true`                             | Enable or disable data backup. Please check [Backup configuration](#backup-configuration) for more options. Usually this option is enabled on Production environment                                                                                           |
+| restore.enabled                     | bool   | `true`                             | Enable or disable data restore. Please check [Restore configuration](#restore-configuration) for more options. Usually this option is enabled on Staging environment                                                                                           |
+| utilities.image.repository          | string | `ghcr.io/opencrvs/ocrvs-utilities` | Shared utilities image repository used by helper jobs and init containers.                                                                                                                                                                                     |
+| utilities.image.tag                 | string | `v2.1.0`                           | Shared utilities image tag used by helper jobs and init containers.                                                                                                                                                                                            |
+
+## Network Policies
+
+The chart can render Kubernetes `NetworkPolicy` resources for dependency workloads. This requires a CNI provider that enforces NetworkPolicy — set `network_policy.enabled: false` on clusters without one.
+
+When enabled, the chart can render:
+
+- a default deny ingress and/or egress policy for dependency pods, per `ingress_mode`/`egress_mode`
+- an allow-private-ingress and/or allow-private-egress policy (RFC1918 ranges only), when `ingress_mode`/`egress_mode` is `private`
+- a same-namespace allow policy, enabled by default
+- an allow-ingress-namespaces policy, when `network_policy.allowed_namespaces` is set and `ingress_mode` is not `full`
+- a DNS egress allow policy for TCP/UDP port 53, unless `egress_mode` is `full`
+- service-specific rules defined under `<service>.network_policy.rules`
+- operator-provided service rules defined under `<service>.network_policy.custom_rules`
+- an ingress and/or egress rule for a service, when `<service>.network_policy.ingress_mode`/`egress_mode` is set to `private` or `full`
+
+`network_policy.ingress_mode`/`egress_mode` each take one of three values, both at the global level and per-service under `<service>.network_policy`:
+
+- `deny` (default) — nothing is allowed beyond same-namespace/`allowed_namespaces`/per-service rules.
+- `private` — additionally allow traffic to/from RFC1918 private ranges (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`), blocking the public internet either way.
+- `full` — no baseline policy at all; unrestricted.
+
+The same-namespace allow policy is intended as a practical first hardening step: dependency pods can still communicate inside the chart namespace, while unexpected cross-namespace and external traffic is blocked unless explicitly allowed.
+
+`<service>.network_policy.ingress_mode`/`egress_mode` are a shortcut for opting one service into `private` or `full` access without writing out an ingress/egress rule under `rules`/`custom_rules` — independent of the global `network_policy.ingress_mode`/`egress_mode`, which control whether the chart-wide baseline policies are rendered at all. For ingress, `private`/`full` accept traffic from RFC1918 ranges/any source respectively, scoped to the service's own `port` value; it renders nothing if `port` is not set, rather than silently opening every port. For egress, `private`/`full` accept traffic to RFC1918 ranges/any destination on any port, since a service's own port doesn't describe what it calls out to.
+
+The dependencies chart and the opencrvs-services chart are typically deployed to separate namespaces (see the default `*.host` values in `charts/opencrvs-services/values.yaml`, e.g. `redis-0.redis.opencrvs-deps-dev.svc.cluster.local`). While `network_policy.ingress_mode` is `deny` (the default), application pods (auth, gateway, events, etc.) can no longer reach Postgres, Elasticsearch, MinIO or Redis unless the opencrvs-services release namespace is listed in `network_policy.allowed_namespaces`. This rule allows all ports from every pod in each listed namespace, rather than requiring a separate rule per service/port pair.
+
+Example:
+
+```yaml
+network_policy:
+  allowed_namespaces:
+    - opencrvs-production
+```
+
+Service-specific rules follow Kubernetes `NetworkPolicy.spec` syntax, except `podSelector` is generated by the chart from the service `app_label`.
+
+Example — open ingress for a service's own port, custom egress via `rules`:
+
+```yaml
+minio:
+  network_policy:
+    rules:
+      - name: allow-console-ingress
+        policyTypes:
+          - Ingress
+        ingress:
+          - ports:
+              - protocol: TCP
+                port: 3536 # console; API (3535) is not opened here
+      - name: allow-package-repo-egress
+        policyTypes:
+          - Egress
+        egress:
+          - to:
+              - ipBlock:
+                  cidr: 0.0.0.0/0
+            ports:
+              - protocol: TCP
+                port: 80
+              - protocol: TCP
+                port: 443 # apk mirrors are sometimes HTTP-only, so both are opened
+```
+
+Each rule must define `name`; the chart uses it to generate deterministic `NetworkPolicy` resource names. `ingress_mode: full` is a shortcut for the same shape, but only supports a single port (the service's `port` value) — write a `rules` entry instead when a service listens on more than one port, as MinIO does.
+
+For backup and restore jobs, external backup server access must be allowed explicitly. Standard Kubernetes `NetworkPolicy` supports IP blocks, pod selectors, namespace selectors, and ports; it does not support DNS/FQDN destinations.
+
+To handle this, the chart computes an `ipBlock` egress rule (`<host>/32`, TCP port 22) for Postgres and MinIO directly from the resolved backup/restore host (`backup.host`, `restore.host`, `postgres.backup.host`, `postgres.restore.host`, `minio.backup.host`, `minio.restore.host`), rendered only when the corresponding `backup.enabled`/`restore.enabled` flag is true. **This requires the host value to be a literal IP address** — if you configure a DNS hostname instead, the generated `ipBlock.cidr` will be invalid and the policy will not match traffic to that host.
+
+### Service connections
+
+Applies once `network_policy.enabled: true`. Every dependency pod always accepts traffic from its own namespace (`allow_same_namespace`) and from any namespace listed in `allowed_namespaces`, and may always egress to DNS (53). The table below shows what each service allows **beyond** that baseline, per its current `values.yaml` configuration:
+
+| Service                                                | Port(s)                    | Extra ingress                                             | Extra egress                                                                                               |
+| ------------------------------------------------------ | -------------------------- | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| Postgres                                               | 5432                       | any source (`ingress_mode: full`)                         | 80, 443 (package installs); backup/restore host:22 when backup/restore enabled                             |
+| Elasticsearch                                          | 9200                       | any source (`ingress_mode: full`)                         | —                                                                                                          |
+| Redis                                                  | 6379                       | any source (`ingress_mode: full`)                         | —                                                                                                          |
+| MinIO                                                  | 3535 (API), 3536 (console) | 3536 only, any source (`rules`) — API stays baseline-only | 80, 443 (package installs); backup/restore host:22 when backup/restore enabled                             |
+| Kibana                                                 | 5601                       | any source (`ingress_mode: full`)                         | —                                                                                                          |
+| Filebeat, Metricbeat, Logstash, APM Server, Elastalert | —                          | —                                                         | —                                                                                                          |
+| backup-runner (differential backup/restore jobs)       | —                          | —                                                         | any port, RFC1918 private ranges only (Kubernetes API server, for `kubectl exec`/`scale`/`delete`/`apply`) |
+
+`ingress_mode: full` opens a service to any source, not just Traefik — narrow it with an explicit `rules` entry (e.g. a `namespaceSelector` for `traefik`), or use `ingress_mode: private` to restrict to RFC1918 ranges, if `full` is too broad for your deployment.
+
+Postgres and MinIO also get an unconditional `allow-package-repo-egress` rule (`0.0.0.0/0:80,443`) so that runtime package installation (see [Air-Gap Installation](#air-gap-installation)) keeps working when egress is denied by default — port 80 is included since some apt/apk mirrors are HTTP-only. This rule is intentionally broad: it also permits port 80/443 egress to other pods/namespaces in the cluster, not just the internet. Elasticsearch does not get this rule since it has no backup path and installs no packages at runtime in this chart.
+
+Differential-type backup/restore automation (`postgres-on-deploy`, `postgres-backup-diff`, `postgres-backup-full`, `postgres-restore`, `minio-backup`, `minio-restore`) drives the actual backup/restore by issuing `kubectl exec`/`scale`/`delete`/`apply` against the Kubernetes API server — it never talks to the Postgres/MinIO pods over the network directly, since `kubectl exec` is proxied through the API server. These pods are labeled `app: backup-runner` (not `app: postgres`/`app: minio`) and get their own unconditional `backup-runner-allow-egress` rule for that access, rather than relying on incidental coverage from the package-repo rule.
+
+`backup-runner-allow-egress` intentionally allows all ports, not just 443. The `kubernetes` Service in the `default` namespace exposes port 443, but many CNIs enforce egress `NetworkPolicy` against the _post-DNAT_ destination — i.e. the API server's real `targetPort` (commonly 6443 on kubeadm-style clusters), not the Service's port — so a rule scoped to `port: 443` can silently fail to match. Run `kubectl get endpoints kubernetes -n default` to see the actual port on your cluster if you'd rather scope this down.
+
+The destination is scoped to RFC1918 private ranges (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`) rather than `0.0.0.0/0`, since the only legitimate destination is the API server (a ClusterIP, pod IP, or node IP — always private in a normally-networked cluster) and these pods have no reason to reach the public internet. **If your cluster's nodes have a public IP as their primary interface** (common on bare VPS-style setups without a private VPC network) and the CNI enforces policy against the post-DNAT node IP rather than the ClusterIP, this scoping could exclude the API server — check with `kubectl get nodes -o wide` (INTERNAL-IP vs EXTERNAL-IP) and `kubectl get endpoints kubernetes -n default -o wide` before relying on it, and fall back to `0.0.0.0/0` if needed. These pods are already privileged (their `backup-runner` ServiceAccount can `exec`/`scale`/`delete` arbitrary pods via RBAC), so the extra egress breadth of `0.0.0.0/0` wouldn't add meaningful risk beyond what their RBAC already grants — the private-range scoping here is defense in depth, not a hard requirement.
+
 ## Postgres
 
 Postgres configuration section for Helm values.yaml
@@ -83,46 +183,46 @@ This section allows you to configure the postgres deployment within your infrast
 
 This section allows you to configure the deployment and authentication settings for Elasticsearch.
 
-| Key                     | Type    | Example               | Description                                                                                                                                  |
-| ----------------------- | ------- | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| image.repository        | string  | `docker.elastic.co/elasticsearch/elasticsearch` | Elasticsearch Docker image repository.                                                                                 |
-| image.tag               | string  | `8.19.15`            | Elasticsearch Docker image tag.                                                                                                               |
-| enabled                 | boolean | true                  | Enable or disable the Elasticsearch deployment.                                                                                              |
-| use_default_credentials | boolean | true                  | Deploy Elasticsearch without enabled authentication.                                                                                         |
-| storage_type            | string  | `global storage_type` | Optional Elasticsearch-specific override for the Kubernetes storage type. Available options are `pvc` or `host_path`. If not set, the global `storage_type` value is used. |
-| pvc.storage_class       | string  | `n/a`                 | StorageClass name used for dynamic volume provisioning                                                                                       |
-| pvc.storage_size        | string  | 10Gi                  | Persistent volume claim size for Postgres data volume                                                                                        |
-| pvc.access_mode         | string  | ReadWriteOnce         | Kubernetes PVC access mode                                                                                                                   |
-| host_data_path          | string  | `/data/elasticsearch` | Path to persistent data on the host when `storage_type` is `host_path`.                                                                     |
-| node_selector           | dict    | `{}`                  | Label selector for datastore nodes, usually used to keep data persistent                                                                     |
+| Key                     | Type    | Example                                         | Description                                                                                                                                                                |
+| ----------------------- | ------- | ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| image.repository        | string  | `docker.elastic.co/elasticsearch/elasticsearch` | Elasticsearch Docker image repository.                                                                                                                                     |
+| image.tag               | string  | `8.19.15`                                       | Elasticsearch Docker image tag.                                                                                                                                            |
+| enabled                 | boolean | true                                            | Enable or disable the Elasticsearch deployment.                                                                                                                            |
+| use_default_credentials | boolean | true                                            | Deploy Elasticsearch without enabled authentication.                                                                                                                       |
+| storage_type            | string  | `global storage_type`                           | Optional Elasticsearch-specific override for the Kubernetes storage type. Available options are `pvc` or `host_path`. If not set, the global `storage_type` value is used. |
+| pvc.storage_class       | string  | `n/a`                                           | StorageClass name used for dynamic volume provisioning                                                                                                                     |
+| pvc.storage_size        | string  | 10Gi                                            | Persistent volume claim size for Postgres data volume                                                                                                                      |
+| pvc.access_mode         | string  | ReadWriteOnce                                   | Kubernetes PVC access mode                                                                                                                                                 |
+| host_data_path          | string  | `/data/elasticsearch`                           | Path to persistent data on the host when `storage_type` is `host_path`.                                                                                                    |
+| node_selector           | dict    | `{}`                                            | Label selector for datastore nodes, usually used to keep data persistent                                                                                                   |
 
 ## MinIO
 
 ### Configuration options
 
-| Key                     | Type   | Default value                   | Description                                                                                                                                  |
-| ----------------------- | ------ | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| enabled                 | bool   | true                            | Enable or disable minio service                                                                                                              |
-| image.repository        | string | `quay.io/minio/minio`           | MinIO Docker image repository.                                                                                                               |
-| image.tag               | string | `RELEASE.2025-06-13T11-33-47Z`  | MinIO Docker image tag.                                                                                                                      |
-| use_default_credentials | bool   | true                            | Default credentials for MinIO are username `minioadmin` and password `minioadmin`.                                                           |
+| Key                     | Type   | Default value                   | Description                                                                                                                                                        |
+| ----------------------- | ------ | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| enabled                 | bool   | true                            | Enable or disable minio service                                                                                                                                    |
+| image.repository        | string | `quay.io/minio/minio`           | MinIO Docker image repository.                                                                                                                                     |
+| image.tag               | string | `RELEASE.2025-06-13T11-33-47Z`  | MinIO Docker image tag.                                                                                                                                            |
+| use_default_credentials | bool   | true                            | Default credentials for MinIO are username `minioadmin` and password `minioadmin`.                                                                                 |
 | storage_type            | string | `global storage_type`           | Optional MinIO-specific override for the Kubernetes storage type. Available options are `pvc` or `host_path`. If not set, the global `storage_type` value is used. |
-| pvc.storage_class       | string | `n/a`                           | StorageClass name used for dynamic volume provisioning                                                                                       |
-| pvc.storage_size        | string | 10Gi                            | Persistent volume claim size for Postgres data volume                                                                                        |
-| pvc.access_mode         | string | ReadWriteOnce                   | Kubernetes PVC access mode                                                                                                                   |
-| host_data_path          | string | `/data/minio`                   | Path to persistent data on the host when `storage_type` is `host_path`.                                                                      |
-| node_selector           | dict   | `{}`                            | Label selector for datastore nodes, usually used to keep data persistent                                                                     |
-| backup.{}               | dict   | `{}`                            | Backup configuration section, for more information please check `values.yaml` and **Backup section** in this README                          |
-| backup.enabled          | string | `false`                         | Backup enabled or disabled, section has higher priority over global `backup` section                                                         |
-| backup.type             | string | `dump`                          | `dump` is a full filesystem dump, `differential` is rsync from MinIO filesystem on remote backup server                                      |
-| backup.server_secret    | string | `backup-server-ssh-credentials` | Name of the Kubernetes secret with backup server credentials                                                                                 |
-| backup.schedule         | string | `0 1 * * *`                     | Time to run backup job, if not defined then value from `backup.schedule` is used                                                             |
-| backup.server_dir       | string | `n/a`                           | Directory on backup server for encrypted archive backups or filesystem rsync. Uses global value if not set                                   |
-| restore.{}              | dict   | `{}`                            | Restore configuration section, for more information please check `values.yaml` and **Restore section** in this README                        |
-| restore.enabled         | string | `false`                         | Enables restore functionality; section overrides global `restore` settings.                                                                  |
-| restore.type            | string | `dump`                          | Restore method: `dump` (from encrypted archive) or `differential` (same as for backup)                                                       |
-| restore.server_secret   | string | `backup-server-ssh-credentials` | Name of the Kubernetes secret with backup server credentials, usually backup server is used for restore, thats why credentials are shared    |
-| restore.schedule        | string | `0 3 * * *`                     | Restore cronjob schedule, if not defined then value from `restore.schedule` is used                                                          |
+| pvc.storage_class       | string | `n/a`                           | StorageClass name used for dynamic volume provisioning                                                                                                             |
+| pvc.storage_size        | string | 10Gi                            | Persistent volume claim size for Postgres data volume                                                                                                              |
+| pvc.access_mode         | string | ReadWriteOnce                   | Kubernetes PVC access mode                                                                                                                                         |
+| host_data_path          | string | `/data/minio`                   | Path to persistent data on the host when `storage_type` is `host_path`.                                                                                            |
+| node_selector           | dict   | `{}`                            | Label selector for datastore nodes, usually used to keep data persistent                                                                                           |
+| backup.{}               | dict   | `{}`                            | Backup configuration section, for more information please check `values.yaml` and **Backup section** in this README                                                |
+| backup.enabled          | string | `false`                         | Backup enabled or disabled, section has higher priority over global `backup` section                                                                               |
+| backup.type             | string | `dump`                          | `dump` is a full filesystem dump, `differential` is rsync from MinIO filesystem on remote backup server                                                            |
+| backup.server_secret    | string | `backup-server-ssh-credentials` | Name of the Kubernetes secret with backup server credentials                                                                                                       |
+| backup.schedule         | string | `0 1 * * *`                     | Time to run backup job, if not defined then value from `backup.schedule` is used                                                                                   |
+| backup.server_dir       | string | `n/a`                           | Directory on backup server for encrypted archive backups or filesystem rsync. Uses global value if not set                                                         |
+| restore.{}              | dict   | `{}`                            | Restore configuration section, for more information please check `values.yaml` and **Restore section** in this README                                              |
+| restore.enabled         | string | `false`                         | Enables restore functionality; section overrides global `restore` settings.                                                                                        |
+| restore.type            | string | `dump`                          | Restore method: `dump` (from encrypted archive) or `differential` (same as for backup)                                                                             |
+| restore.server_secret   | string | `backup-server-ssh-credentials` | Name of the Kubernetes secret with backup server credentials, usually backup server is used for restore, thats why credentials are shared                          |
+| restore.schedule        | string | `0 3 * * *`                     | Restore cronjob schedule, if not defined then value from `restore.schedule` is used                                                                                |
 
 ### MinIO Credentials
 

--- a/charts/dependencies/templates/_network-policy-helper.tpl
+++ b/charts/dependencies/templates/_network-policy-helper.tpl
@@ -1,0 +1,95 @@
+{{- define "network-policy-rules" -}}
+{{- if .Values.network_policy.enabled -}}
+{{- $service_name := .service_name -}}
+{{- $root := .Values -}}
+{{- $service_key := $service_name | replace "-" "_" -}}
+{{- $service_values := index $root $service_key | default dict -}}
+{{- $network_policy := $service_values.network_policy | default dict -}}
+{{- $appLabel := $network_policy.app_label | default $service_name -}}
+{{- $default_rules := $network_policy.rules | default list -}}
+{{- $custom_rules := $network_policy.custom_rules | default list -}}
+{{- $rules := concat $default_rules $custom_rules -}}
+
+{{- $ingress_mode := $network_policy.ingress_mode | default "deny" -}}
+{{- $egress_mode := $network_policy.egress_mode | default "deny" -}}
+{{- $private_cidrs := list "10.0.0.0/8" "172.16.0.0/12" "192.168.0.0/16" -}}
+
+{{- if and (ne $ingress_mode "deny") $service_values.port }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ printf "%s-allow-ingress" $service_name | trunc 63 | trimSuffix "-" }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ $appLabel | quote }}
+  policyTypes:
+    - Ingress
+  ingress:
+{{- if eq $ingress_mode "private" }}
+    - from:
+        {{- range $private_cidrs }}
+        - ipBlock:
+            cidr: {{ . }}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: {{ $service_values.port }}
+{{- else }}
+    - ports:
+        - protocol: TCP
+          port: {{ $service_values.port }}
+{{- end }}
+{{- end }}
+
+{{- if ne $egress_mode "deny" }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ printf "%s-allow-egress" $service_name | trunc 63 | trimSuffix "-" }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ $appLabel | quote }}
+  policyTypes:
+    - Egress
+  egress:
+{{- if eq $egress_mode "private" }}
+    - to:
+        {{- range $private_cidrs }}
+        - ipBlock:
+            cidr: {{ . }}
+        {{- end }}
+{{- else }}
+    - {}
+{{- end }}
+{{- end }}
+
+{{- range $rule := $rules }}
+{{- if not $rule.name }}
+{{- fail (printf "network_policy rule for service %s must define name" $service_name) }}
+{{- end }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ printf "%s-%s" $service_name $rule.name | trunc 63 | trimSuffix "-" }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ $appLabel | quote }}
+  policyTypes:
+{{ toYaml $rule.policyTypes | indent 4 }}
+{{- if $rule.ingress }}
+  ingress:
+{{ toYaml $rule.ingress | indent 4 }}
+{{- end }}
+{{- if $rule.egress }}
+  egress:
+{{ toYaml $rule.egress | indent 4 }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/dependencies/templates/apm-server.yaml
+++ b/charts/dependencies/templates/apm-server.yaml
@@ -58,4 +58,6 @@ spec:
       - name: config
         configMap:
           name: {{ .Values.apm_server.custom_config_configmap | default "apm-server-config" }}
+
+{{ include "network-policy-rules" (dict "service_name" "apm-server" "Values" .Values) }}
 {{- end }}

--- a/charts/dependencies/templates/elastalert.yaml
+++ b/charts/dependencies/templates/elastalert.yaml
@@ -125,4 +125,6 @@ spec:
           configMap:
             name: {{ .Values.elastalert.custom_rules_configmap }}
       {{- end }}
+
+{{ include "network-policy-rules" (dict "service_name" "elastalert" "Values" .Values) }}
 {{- end }}

--- a/charts/dependencies/templates/elasticsearch.yaml
+++ b/charts/dependencies/templates/elasticsearch.yaml
@@ -130,4 +130,6 @@ spec:
             path: {{ .Values.elasticsearch.host_data_path }}
             type: DirectoryOrCreate
       {{- end }}
+
+{{ include "network-policy-rules" (dict "service_name" "elasticsearch"  "Values" .Values) }}
 {{- end }}

--- a/charts/dependencies/templates/filebeat.yaml
+++ b/charts/dependencies/templates/filebeat.yaml
@@ -114,4 +114,6 @@ subjects:
   - kind: ServiceAccount
     name: filebeat
     namespace: {{ .Release.Namespace }}
+
+{{ include "network-policy-rules" (dict "service_name" "filebeat" "Values" .Values) }}
 {{- end }}

--- a/charts/dependencies/templates/kibana-on-deploy.yaml
+++ b/charts/dependencies/templates/kibana-on-deploy.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   template:
     metadata:

--- a/charts/dependencies/templates/kibana.yaml
+++ b/charts/dependencies/templates/kibana.yaml
@@ -26,6 +26,7 @@ spec:
   tls:
     secretName: {{ .Values.ingress.tls_secret_name }}
   {{- end }}
+
 ---
 apiVersion: v1
 kind: Service
@@ -40,6 +41,7 @@ spec:
       name: http
   selector:
     app: kibana
+
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -150,4 +152,6 @@ spec:
           configMap:
             name: elasticsearch-scripts
             defaultMode: 0755
+
+{{ include "network-policy-rules" (dict "service_name" "kibana"  "Values" .Values) }}
 {{- end }}

--- a/charts/dependencies/templates/logstash.yaml
+++ b/charts/dependencies/templates/logstash.yaml
@@ -68,4 +68,6 @@ spec:
       - name: logstash-configmap
         configMap:
           name: logstash-configmap
+
+{{ include "network-policy-rules" (dict "service_name" "logstash" "Values" .Values) }}
 {{- end }}

--- a/charts/dependencies/templates/metricbeat.yaml
+++ b/charts/dependencies/templates/metricbeat.yaml
@@ -193,4 +193,6 @@ subjects:
 - kind: ServiceAccount
   name: metricbeat
   namespace: {{ .Release.Namespace }}
+
+{{ include "network-policy-rules" (dict "service_name" "metricbeat" "Values" .Values) }}
 {{- end }}

--- a/charts/dependencies/templates/minio-backup-cronjob.yaml
+++ b/charts/dependencies/templates/minio-backup-cronjob.yaml
@@ -90,6 +90,9 @@ kind: Job
 {{- end }}
 metadata:
   name: minio-backup
+  labels:
+    app: backup-runner
+    job-type: backup
 spec:
   {{ if .Values.backup.cronjob }}
   schedule: {{ default .Values.backup.schedule .Values.minio.backup.schedule }}
@@ -100,6 +103,10 @@ spec:
     spec:
   {{- end }}
       template:
+        metadata:
+          labels:
+            app: backup-runner
+            job-type: backup
         spec:
           {{- include "opencrvs.imagePullSecrets" (dict "root" . "service" .Values.minio) | nindent 10 }}
           serviceAccountName: backup-runner

--- a/charts/dependencies/templates/minio-restore-cronjob.yaml
+++ b/charts/dependencies/templates/minio-restore-cronjob.yaml
@@ -90,6 +90,9 @@ kind: Job
 {{- end }}
 metadata:
   name: minio-restore
+  labels:
+    app: backup-runner
+    job-type: restore
 spec:
   {{ if .Values.restore.cronjob }}
   schedule: {{ default .Values.restore.schedule .Values.minio.restore.schedule }}
@@ -100,6 +103,10 @@ spec:
     spec:
   {{- end }}
       template:
+        metadata:
+          labels:
+            app: backup-runner
+            job-type: restore
         spec:
           {{- include "opencrvs.imagePullSecrets" (dict "root" . "service" .Values.minio) | nindent 10 }}
           serviceAccountName: backup-runner

--- a/charts/dependencies/templates/minio.yaml
+++ b/charts/dependencies/templates/minio.yaml
@@ -201,4 +201,6 @@ spec:
               - key: ssh_key
                 path: id_rsa
       {{- end }}
+
+{{ include "network-policy-rules" (dict "service_name" "minio"  "Values" .Values) }}
 {{- end }}

--- a/charts/dependencies/templates/network-policy.yaml
+++ b/charts/dependencies/templates/network-policy.yaml
@@ -1,0 +1,172 @@
+{{/*
+This file contains generic network policies applied widely within namespace
+without relation to particular services
+*/}}
+{{- if .Values.network_policy.enabled }}
+{{- $ingress_mode := .Values.network_policy.ingress_mode | default "deny" -}}
+{{- $egress_mode := .Values.network_policy.egress_mode | default "deny" -}}
+{{- $deny_ingress := ne $ingress_mode "full" -}}
+{{- $deny_egress := ne $egress_mode "full" -}}
+{{- $private_cidrs := list "10.0.0.0/8" "172.16.0.0/12" "192.168.0.0/16" -}}
+
+{{- if or $deny_ingress $deny_egress }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-default-deny
+spec:
+  podSelector: {}
+  policyTypes:
+  {{- if $deny_ingress }}
+    - Ingress
+  {{- end }}
+  {{- if $deny_egress }}
+    - Egress
+  {{- end }}
+{{- if eq $ingress_mode "deny" }}
+  ingress: []
+{{- end }}
+{{- if eq $ingress_mode "private" }}
+  ingress:
+    - from:
+        {{- range $private_cidrs }}
+        - ipBlock:
+            cidr: {{ . }}
+        {{- end }}
+{{- end }}
+{{- if eq $egress_mode "deny" }}
+  egress: []
+{{- end }}
+{{- if eq $egress_mode "private" }}
+  egress:
+    - to:
+        {{- range $private_cidrs }}
+        - ipBlock:
+            cidr: {{ . }}
+        {{- end }}
+{{- end }}
+{{- end }}
+
+{{- if and .Values.network_policy.allow_same_namespace (or $deny_ingress $deny_egress) }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-allow-same-namespace
+spec:
+  podSelector: {}
+  policyTypes:
+  {{- if $deny_ingress }}
+    - Ingress
+  {{- end }}
+  {{- if $deny_egress }}
+    - Egress
+  {{- end }}
+{{- if $deny_ingress }}
+  ingress:
+    - from:
+        - podSelector: {}
+{{- end }}
+{{- if $deny_egress }}
+  egress:
+    - to:
+        - podSelector: {}
+{{- end }}
+{{- end }}
+
+{{- if and $deny_ingress .Values.network_policy.allowed_namespaces }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-allow-ingress-namespaces
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        {{- range .Values.network_policy.allowed_namespaces }}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ . }}
+        {{- end }}
+{{- end }}
+
+{{- if $deny_egress }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-allow-dns
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+{{- end }}
+
+{{/*
+Backup and restore server egress rules.
+
+Standard Kubernetes NetworkPolicy egress peers only support ipBlock,
+podSelector and namespaceSelector - not DNS/FQDN destinations. Postgres and
+MinIO connect to the backup/restore server over SSH (port 22), so the rules
+below assume *.host values are literal IP addresses and build a /32 ipBlock
+from them.
+*/}}
+{{- $any_backup_restore_enabled := false }}
+{{- range $app := list "postgres" "minio" }}
+{{- range $type := list "backup" "restore" }}
+{{- if eq (include (printf "%s.%s_enabled" $app $type) $) "true" }}
+{{- $any_backup_restore_enabled = true }}
+{{- $host := default (index $.Values $type "host") (index $.Values $app $type "host") }}
+{{- if $host }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ $app }}-allow-{{ $type }}-server-egress
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ $app }}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: {{ printf "%s/32" $host }}
+      ports:
+        - protocol: TCP
+          port: 22
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- if $any_backup_restore_enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: backup-runner-allow-egress
+spec:
+  podSelector:
+    matchLabels:
+      app: backup-runner
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+{{- end }}
+
+{{- end }}

--- a/charts/dependencies/templates/postgres-backup-cronjob-diff.yaml
+++ b/charts/dependencies/templates/postgres-backup-cronjob-diff.yaml
@@ -9,6 +9,9 @@ kind: Job
 {{- end }}
 metadata:
   name: postgres-backup-diff
+  labels:
+    app: backup-runner
+    job-type: backup
 spec:
   {{ if .Values.backup.cronjob }}
   schedule: {{ .Values.postgres.backup.schedule.differential }}
@@ -19,6 +22,10 @@ spec:
     spec:
   {{- end }}
       template:
+        metadata:
+          labels:
+            app: backup-runner
+            job-type: backup
         spec:
           {{- include "opencrvs.imagePullSecrets" (dict "root" . "service" .Values.postgres) | nindent 10 }}
           serviceAccountName: backup-runner

--- a/charts/dependencies/templates/postgres-backup-cronjob-full.yaml
+++ b/charts/dependencies/templates/postgres-backup-cronjob-full.yaml
@@ -9,6 +9,9 @@ kind: Job
 {{- end }}
 metadata:
   name: postgres-backup-full
+  labels:
+    app: backup-runner
+    job-type: backup
 spec:
   {{ if .Values.backup.cronjob }}
   schedule: {{ .Values.postgres.backup.schedule.full }}
@@ -19,6 +22,10 @@ spec:
     spec:
   {{- end }}
       template:
+        metadata:
+          labels:
+            app: backup-runner
+            job-type: backup
         spec:
           {{- include "opencrvs.imagePullSecrets" (dict "root" . "service" .Values.postgres) | nindent 10 }}
           serviceAccountName: backup-runner

--- a/charts/dependencies/templates/postgres-on-deploy-job.yaml
+++ b/charts/dependencies/templates/postgres-on-deploy-job.yaml
@@ -5,11 +5,19 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: postgres-on-deploy
+  labels:
+    app: backup-runner
+    job-type: backup
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   template:
+    metadata:
+      labels:
+        app: backup-runner
+        job-type: backup
     spec:
       {{- include "opencrvs.imagePullSecrets" (dict "root" . "service" .Values.postgres) | nindent 6 }}
       serviceAccountName: backup-runner

--- a/charts/dependencies/templates/postgres-restore-cronjob.yaml
+++ b/charts/dependencies/templates/postgres-restore-cronjob.yaml
@@ -99,6 +99,9 @@ kind: Job
 {{- end }}
 metadata:
   name: postgres-restore
+  labels:
+    app: backup-runner
+    job-type: restore
 spec:
   {{- if .Values.restore.cronjob }}
   schedule: {{ default .Values.restore.schedule .Values.postgres.restore.schedule }}
@@ -109,6 +112,10 @@ spec:
     spec:
   {{- end }}
       template:
+        metadata:
+          labels:
+            app: backup-runner
+            job-type: restore
         spec:
           {{- include "opencrvs.imagePullSecrets" (dict "root" . "service" .Values.postgres) | nindent 10 }}
           serviceAccountName: backup-runner
@@ -138,7 +145,7 @@ spec:
                   kubectl exec postgres-restore-runner -- \
                     rm -rf /var/lib/postgresql/data/*
                   kubectl exec postgres-restore-runner -- \
-                    pgbackrest --stanza="{{ .Values.postgres.backup.stanza }}" restore --delta --force || exit 1
+                    su postgres -c 'pgbackrest --stanza="{{ .Values.postgres.backup.stanza }}" restore --delta --force' || exit 1
                   kubectl scale statefulset postgres --replicas=1
               volumeMounts:
                 - mountPath: /manifests

--- a/charts/dependencies/templates/postgres.yaml
+++ b/charts/dependencies/templates/postgres.yaml
@@ -196,4 +196,7 @@ spec:
               - key: ssh_key
                 path: id_rsa
       {{- end }}
+
+{{ include "network-policy-rules" (dict "service_name" "postgres"  "Values" .Values) }}
+
 {{- end }}

--- a/charts/dependencies/templates/redis.yaml
+++ b/charts/dependencies/templates/redis.yaml
@@ -69,4 +69,6 @@ spec:
           configMap:
             name: redis-opencrvs-conf
       {{- end }}
+
+{{ include "network-policy-rules" (dict "service_name" "redis" "Values" .Values) }}
 {{- end }}

--- a/charts/dependencies/values.yaml
+++ b/charts/dependencies/values.yaml
@@ -20,6 +20,34 @@ ingress:
   # Resolver will be attached to Traefik CRD IngressRoute
   tls_resolver: ''
 
+# Kubernetes NetworkPolicy configuration for dependency workloads.
+network_policy:
+  # Render NetworkPolicy resources. Requires a CNI provider that enforces
+  # NetworkPolicy - set to false on clusters without one.
+  enabled: true
+  # Baseline policy for ingress to dependency pods. One of:
+  # - deny: deny ingress unless another NetworkPolicy allows it (default).
+  # - private: allow ingress only from RFC1918 private ranges
+  #            (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16).
+  # - full: no baseline policy; ingress is unrestricted.
+  ingress_mode: deny
+  # Baseline policy for egress from dependency pods. Same modes as
+  # ingress_mode, applied to egress instead. DNS (TCP/UDP 53) is always
+  # allowed regardless of mode, except when full.
+  egress_mode: deny
+  # Allow dependency pods in this namespace to communicate with each other.
+  # This keeps the chart practical while blocking unexpected cross-namespace
+  # and external traffic by default.
+  allow_same_namespace: true
+  # Namespaces allowed to reach dependency pods. Only takes effect when
+  # ingress_mode is not "full". Dependency pods accept ingress on any port
+  # from every pod in each listed namespace (e.g. auth/gateway reaching
+  # redis/postgres/elasticsearch/minio from the opencrvs-services
+  # namespace). Required for the OpenCRVS application to keep working while
+  # ingress is denied by default, since the two charts are typically
+  # deployed to separate namespaces.
+  allowed_namespaces: []
+
 # Kubernetes storage type, available options are `pvc` or `host_path`
 storage_type: pvc
 
@@ -52,6 +80,31 @@ postgres:
   image:
     repository: postgres
     tag: 17.6
+  port: 5432
+  network_policy:
+    app_label:
+    ingress_mode: private
+    # FIXME: In future releases replace postgres image to more robust
+    # version with all required utilities installed and drop allow-package-repo-egress rule
+    # Chart-provided rules for this service. Postgres installs
+    # openssh-client/rsync/pgbackrest packages at runtime (see Air-Gap
+    # Installation in README.md); apt keeps package repositories
+    # reachable even when egress is denied by default. Some apt mirrors are
+    # HTTP-only, so both 80 and 443 are opened.
+    rules:
+      - name: allow-package-repo-egress
+        policyTypes:
+          - Egress
+        egress:
+          - to:
+              - ipBlock:
+                  cidr: 0.0.0.0/0
+            ports:
+              - protocol: TCP
+                port: 80
+              - protocol: TCP
+                port: 443
+
   # By default postgres is deployed with authentication enabled user/password: postgres/postgres
   use_default_credentials: true
   # postgres databases and users to create, if `use_default_credentials` is set to `false`.
@@ -142,14 +195,16 @@ postgres:
     # Host:
     # host: backup server hostname or IP
 
-
 # Elasticsearch Configuration
 elasticsearch:
+  # Enable Elasticsearch deployment.
+  enabled: true
   image:
     repository: docker.elastic.co/elasticsearch/elasticsearch
     tag: 8.19.15
-  # Enable Elasticsearch deployment.
-  enabled: true
+  port: 9200
+  network_policy:
+    ingress_mode: private
   # By default Elasticsearch is deployed without authentication enabled.
   use_default_credentials: true
   admin_user_secret_name: elasticsearch-admin-user
@@ -196,11 +251,17 @@ apm_server:
   image:
     repository: docker.elastic.co/apm/apm-server
     tag: 8.19.15
+  port: 8200
 
 kibana:
   image:
     repository: docker.elastic.co/kibana/kibana
     tag: 8.19.15
+  port: 5601
+
+  network_policy:
+    ingress_mode: private
+
   users_secret: kibana-users-secret
   # Configmap for custom configuration file
   # custom_config_configmap: kibana-custom-config
@@ -269,6 +330,39 @@ minio:
   image:
     repository: quay.io/minio/minio
     tag: RELEASE.2025-06-13T11-33-47Z
+  port: 3535
+  network_policy:
+    ingress_mode: private
+    rules:
+      # FIXME: See comment on postgres service
+      # FIXME: MinIO listens on two ports (API: 3535, Console: 3536), but
+      # network_policy.ingress_mode only scopes to the service's single `port`
+      # value (API here) - it can't express "console only". Ingress for the
+      # console is opened explicitly below instead; the API port keeps relying
+      # on allow_same_namespace / allowed_namespaces for internal access.
+      - name: allow-console-ingress
+        policyTypes:
+          - Ingress
+        ingress:
+          - ports:
+              - protocol: TCP
+                port: 3536
+      # MinIO installs packages such as openssh/rsync/minio-client at
+      # runtime (see Air-Gap Installation in README.md); apk keeps package
+      # repositories reachable even when egress is denied by default. Some
+      # apk mirrors are HTTP-only, so both 80 and 443 are opened.
+      - name: allow-package-repo-egress
+        policyTypes:
+          - Egress
+        egress:
+          - to:
+              - ipBlock:
+                  cidr: 0.0.0.0/0
+            ports:
+              - protocol: TCP
+                port: 80
+              - protocol: TCP
+                port: 443
 
   # Use default credentials (username: minioadmin, password: minioadmin).
   # Highly discouraged for production environments—see official docs:
@@ -337,6 +431,9 @@ redis:
   image:
     repository: redis
     tag: '8'
+  port: 6379
+  network_policy:
+    ingress_mode: private
   # By default Redis is deployed without authentication enabled.
   # auth_mode:
   #   - disabled: no authentication

--- a/charts/opencrvs-mosip/templates/network-policy.yaml
+++ b/charts/opencrvs-mosip/templates/network-policy.yaml
@@ -1,0 +1,29 @@
+{{/*
+This chart has no default-deny NetworkPolicy of its own, but its pods are
+typically deployed into the same namespace as the opencrvs-services chart,
+whose "*-default-deny" policy uses podSelector: {} and therefore matches
+every pod in the namespace, these included. This rule exempts
+esignet-mock/mosip-api/mosip-mock from that default-deny by explicitly
+allowing all ingress and egress for them.
+*/}}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: mosip-allow-all
+spec:
+  podSelector:
+    matchExpressions:
+      - key: app
+        operator: In
+        values:
+          - esignet-mock
+          - mosip-api
+          - mosip-mock
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - {}
+  egress:
+    - {}

--- a/charts/opencrvs-services/Chart.yaml
+++ b/charts/opencrvs-services/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opencrvs-services
 description: OpenCRVS Services
 type: application
-version: v2.1.0
+version: v2.1.0-ocrvs-13284
 appVersion: v2.1.0

--- a/charts/opencrvs-services/README.md
+++ b/charts/opencrvs-services/README.md
@@ -312,6 +312,51 @@ helm upgrade --install opencrvs oci://ghcr.io/opencrvs/opencrvs-services \
         <td>Default <code>imagePullPolicy</code> applied to all OpenCRVS service containers. Leave unset to use Kubernetes' own tag-based default (<code>IfNotPresent</code> for versioned tags, <code>Always</code> for <code>:latest</code>). Environments deploying a floating tag (e.g. <code>develop</code>) should set this to <code>Always</code>, otherwise nodes keep serving whatever image was first cached under that tag. Can be overridden at service level.</td>
         </tr>
         <tr>
+            <th>NetworkPolicy configuration</th>
+            <th></th>
+            <th>Optional Kubernetes NetworkPolicy resources for OpenCRVS workloads.</th>
+        </tr>
+        <tr>
+            <td>network_policy.enabled</td>
+            <td>true</td>
+            <td>Render NetworkPolicy resources. Requires a CNI provider that enforces NetworkPolicy — set to false on clusters without one.</td>
+        </tr>
+        <tr>
+            <td>network_policy.ingress_mode</td>
+            <td>deny</td>
+            <td>Baseline policy for ingress to OpenCRVS pods: <code>deny</code> (default, requires another NetworkPolicy to allow it), <code>private</code> (allow only RFC1918 private ranges), or <code>full</code> (unrestricted).</td>
+        </tr>
+        <tr>
+            <td>network_policy.egress_mode</td>
+            <td>private</td>
+            <td>Baseline policy for egress from OpenCRVS pods. Same modes as <code>ingress_mode</code>, applied to egress instead (DNS on TCP/UDP 53 stays allowed except in <code>full</code> mode). Defaults to <code>private</code> rather than <code>deny</code> so pods can reach the dependencies chart and other in-VPC services without every deployment having to enumerate <code>allowed_namespaces</code> up front; services needing real internet (e.g. <code>countryconfig</code>) opt out individually via their own <code>network_policy.egress_mode: full</code> — see "Hardening" in this README.</td>
+        </tr>
+        <tr>
+            <td>network_policy.allow_same_namespace</td>
+            <td>true</td>
+            <td>Allow OpenCRVS pods in the release namespace to communicate with each other.</td>
+        </tr>
+        <tr>
+            <td>network_policy.allowed_namespaces</td>
+            <td>[]</td>
+            <td>List of namespaces OpenCRVS pods are allowed to reach. Only takes effect when <code>egress_mode</code> is not <code>full</code>. Grants egress on any port to every pod in each listed namespace (e.g. the dependencies chart's namespace) — see "Hardening" in this README.</td>
+        </tr>
+        <tr>
+            <td>&lt;service&gt;.network_policy.rules</td>
+            <td>[]</td>
+            <td>Chart-provided service-specific NetworkPolicy rules. Rules use Kubernetes NetworkPolicy spec syntax, except <code>podSelector</code> is generated from <code>app_label</code>.</td>
+        </tr>
+        <tr>
+            <td>&lt;service&gt;.network_policy.custom_rules</td>
+            <td>[]</td>
+            <td>Operator-provided service-specific NetworkPolicy rules appended to chart-provided rules.</td>
+        </tr>
+        <tr>
+            <td>&lt;service&gt;.network_policy.ingress_mode / egress_mode</td>
+            <td>deny</td>
+            <td>Same <code>deny</code>/<code>private</code>/<code>full</code> modes as the global flags, applied per service instead of writing an ingress/egress rule under <code>rules</code>/<code>custom_rules</code>. For ingress, <code>private</code>/<code>full</code> accept from RFC1918 ranges/any source respectively, scoped to the service's own <code>port</code>; renders nothing if <code>port</code> is not set, rather than silently opening every port. For egress, <code>private</code>/<code>full</code> accept to RFC1918 ranges/any destination on any port, since a service's own port doesn't describe what it calls out to. Independent of the global <code>network_policy.ingress_mode</code>/<code>egress_mode</code>, which control whether the chart-wide baseline policies are rendered at all — <code>countryconfig</code> uses <code>egress_mode: full</code> to keep public-internet egress for its SMTP/SMS integrations regardless of the global mode.</td>
+        </tr>
+        <tr>
             <th>Common Service properties</th>
             <th></th>
             <th>Properties listed below can be defined for any service</th>
@@ -539,6 +584,102 @@ auth:
   service_account:
     name: existing-auth-service-account
 ```
+
+# Network Policies
+
+NetworkPolicy resources require a CNI provider that enforces Kubernetes
+NetworkPolicy — set `network_policy.enabled=false` on clusters without one.
+
+When `network_policy.enabled=true`, the chart can render (resource names are
+prefixed with the Helm release name, e.g. `<release>-default-deny`, so
+multiple releases in the same namespace don't collide):
+
+- `<release>-default-deny`, which denies ingress and/or egress for OpenCRVS workloads, per `ingress_mode`/`egress_mode`.
+- `<release>-allow-private-ingress`/`<release>-allow-private-egress`, when `ingress_mode`/`egress_mode` is `private`, allowing traffic to/from RFC1918 private ranges only.
+- `<release>-allow-same-namespace`, which allows OpenCRVS pods in the same namespace to communicate with each other.
+- `<release>-allow-egress-namespaces`, when `network_policy.allowed_namespaces` is set and `egress_mode` is not `full`, which allows egress on any port to every pod in each listed namespace.
+- `<release>-allow-dns`, which allows egress to any DNS server on TCP and UDP port 53, unless `egress_mode` is `full`.
+- Service-specific policies from `<service>.network_policy.rules` and `<service>.network_policy.custom_rules`.
+- An ingress and/or egress policy for a service, when `<service>.network_policy.ingress_mode`/`egress_mode` is set to `private` or `full`.
+
+`network_policy.ingress_mode`/`egress_mode` each take one of three values:
+
+- `deny` — nothing is allowed beyond same-namespace/`allowed_namespaces`/per-service rules. Default for `ingress_mode`.
+- `private` — additionally allow traffic to/from RFC1918 private ranges (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`), blocking the public internet either way. Default for `egress_mode`.
+- `full` — no baseline policy at all; unrestricted.
+
+Rules under `custom_rules` are appended to chart-provided `rules`, so operators can
+add site-specific ingress or egress without replacing service defaults.
+
+`<service>.network_policy.ingress_mode`/`egress_mode` are a shortcut for opting
+one service into `private` or `full` access, without writing an ingress/egress
+rule under `rules`/`custom_rules`. For ingress, `private`/`full` accept traffic
+from RFC1918 ranges/any source respectively, scoped to the service's own `port`
+value; it renders nothing if `port` is not set, rather than silently opening
+every port. For egress, `private`/`full` accept traffic to RFC1918 ranges/any
+destination on any port, since a service's own port doesn't describe what it
+calls out to. Both are independent of the global `network_policy.ingress_mode`/
+`egress_mode`, which control whether the chart-wide baseline policies are
+rendered at all.
+
+`client`, `gateway` and `login` are the OpenCRVS entry points reached directly by
+end users and external clients, so their `allow-ingress` rule intentionally accepts
+traffic from any namespace or client on their service port, rather than being
+scoped to a specific source namespace. `countryconfig` and `dashboards` remain
+scoped to ingress from the `traefik` namespace only.
+
+## Hardening
+
+`ingress_mode` defaults to `deny` and `egress_mode` defaults to `private` —
+OpenCRVS pods can reach RFC1918 private destinations (the dependencies chart,
+other in-VPC services) but not the public internet, without every deployment
+having to enumerate `allowed_namespaces` up front. `countryconfig` is the one
+service that genuinely needs public internet by default (SMTP and SMS gateway
+integrations point at arbitrary external hosts configured via env vars/secrets,
+not fixed IPs a private-range rule could cover), so it carries its own
+`network_policy.egress_mode: full` regardless of the global `egress_mode`.
+
+For a fully locked-down deployment, set `egress_mode: deny` and list every
+namespace OpenCRVS pods actually need in `allowed_namespaces` — otherwise auth,
+gateway, events, etc. lose access to Postgres, Elasticsearch, MinIO and Redis
+the moment the private-range baseline goes away too.
+
+The dependencies chart and this chart are typically deployed to separate namespaces
+(see the default `*.host` values in `values.yaml`, e.g.
+`redis-0.redis.opencrvs-deps-dev.svc.cluster.local`), so at minimum that namespace
+must be listed. `allowed_namespaces` is the egress-side counterpart to
+`network_policy.allowed_namespaces` in the dependencies chart, which must separately
+list this chart's namespace to grant the matching ingress — both sides need setting
+for traffic to actually flow.
+
+```yaml
+network_policy:
+  egress_mode: deny
+  allowed_namespaces:
+    - opencrvs-deps-production
+    - traefik
+```
+
+`allowed_namespaces` grants egress on **any port** to every pod in each listed
+namespace — it's a namespace-level trust boundary, not a per-service/per-port
+allowlist. If you need tighter control over what a specific service can reach,
+add a scoped `custom_rules` entry for that service instead (see the `rules` example
+above) and leave `allowed_namespaces` empty. The same applies to `countryconfig`:
+if its blanket `egress_mode: full` is broader than you'd like, replace it with a
+`custom_rules` entry scoped to your specific SMTP/SMS provider IPs instead.
+
+### Service connections
+
+Applies once `network_policy.enabled: true`. Every OpenCRVS pod always accepts traffic from its own namespace (`allow_same_namespace`). With the default `egress_mode: private`, egress is also allowed to DNS (53) and any RFC1918 private range; `countryconfig` additionally has unrestricted egress. The table below shows what each service allows **beyond** that baseline, per its current `values.yaml` configuration:
+
+| Service                                                                                                                                                           | Port             | Extra ingress                                             |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | --------------------------------------------------------- |
+| client, gateway, login                                                                                                                                            | 3000, 7070, 3020 | any source (`rules: allow-ingress`) — public entry points |
+| countryconfig                                                                                                                                                     | 3040             | `traefik` namespace only (`rules: from-traefik`)          |
+| dashboards (disabled by default)                                                                                                                                  | 4444             | `traefik` namespace only (`rules: from-traefik`)          |
+| auth, config, documents, events, migration, data-migration-analytics, data-cleanup, data-seed, elasticsearch-on-deploy, elasticsearch-reindex, postgres-on-deploy | —                | —                                                         |
+
+Only `countryconfig` defines an extra egress rule (`network_policy.egress_mode: full` — unrestricted, for its SMTP/SMS integrations); every other service relies solely on the shared `egress_mode`/`allowed_namespaces` baseline above to reach the dependencies chart.
 
 # Authentication configuration
 

--- a/charts/opencrvs-services/templates/_network-policy-helper.tpl
+++ b/charts/opencrvs-services/templates/_network-policy-helper.tpl
@@ -1,0 +1,95 @@
+{{- define "network-policy-rules" -}}
+{{- if .Values.network_policy.enabled -}}
+{{- $service_name := .service_name -}}
+{{- $root := .Values -}}
+{{- $service_key := .service_key | default ($service_name | replace "-" "_") -}}
+{{- $service_values := index $root $service_key | default dict -}}
+{{- $network_policy := $service_values.network_policy | default dict -}}
+{{- $appLabel := $network_policy.app_label | default $service_name -}}
+{{- $default_rules := $network_policy.rules | default list -}}
+{{- $custom_rules := $network_policy.custom_rules | default list -}}
+{{- $rules := concat $default_rules $custom_rules -}}
+
+{{- $ingress_mode := $network_policy.ingress_mode | default "deny" -}}
+{{- $egress_mode := $network_policy.egress_mode | default "deny" -}}
+{{- $private_cidrs := list "10.0.0.0/8" "172.16.0.0/12" "192.168.0.0/16" -}}
+
+{{- if and (ne $ingress_mode "deny") $service_values.port }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ printf "%s-allow-ingress" $service_name | trunc 63 | trimSuffix "-" }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ $appLabel | quote }}
+  policyTypes:
+    - Ingress
+  ingress:
+{{- if eq $ingress_mode "private" }}
+    - from:
+        {{- range $private_cidrs }}
+        - ipBlock:
+            cidr: {{ . }}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: {{ $service_values.port }}
+{{- else }}
+    - ports:
+        - protocol: TCP
+          port: {{ $service_values.port }}
+{{- end }}
+{{- end }}
+
+{{- if ne $egress_mode "deny" }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ printf "%s-allow-egress" $service_name | trunc 63 | trimSuffix "-" }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ $appLabel | quote }}
+  policyTypes:
+    - Egress
+  egress:
+{{- if eq $egress_mode "private" }}
+    - to:
+        {{- range $private_cidrs }}
+        - ipBlock:
+            cidr: {{ . }}
+        {{- end }}
+{{- else }}
+    - {}
+{{- end }}
+{{- end }}
+
+{{- range $rule := $rules }}
+{{- if not $rule.name }}
+{{- fail (printf "network_policy rule for service %s must define name" $service_name) }}
+{{- end }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ printf "%s-%s" $service_name $rule.name | trunc 63 | trimSuffix "-" }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ $appLabel | quote }}
+  policyTypes:
+{{ toYaml $rule.policyTypes | indent 4 }}
+{{- if $rule.ingress }}
+  ingress:
+{{ toYaml $rule.ingress | indent 4 }}
+{{- end }}
+{{- if $rule.egress }}
+  egress:
+{{ toYaml $rule.egress | indent 4 }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/opencrvs-services/templates/auth-deployment.yaml
+++ b/charts/opencrvs-services/templates/auth-deployment.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -83,6 +84,8 @@ spec:
           name: private-key
 
 {{- include "service-account-helper" (dict "service_name" "auth" "Values" .Values) }}
+
+{{- include "network-policy-rules" (dict "service_name" "auth" "Values" .Values) }}
 
 {{- include "service-helper" (dict "service_name" "auth" "Values" .Values) }}
 

--- a/charts/opencrvs-services/templates/client-deployment.yaml
+++ b/charts/opencrvs-services/templates/client-deployment.yaml
@@ -101,6 +101,8 @@ spec:
 
 {{- include "service-account-helper" (dict "service_name" "client" "Values" .Values) }}
 
+{{- include "network-policy-rules" (dict "service_name" "client" "Values" .Values) }}
+
 {{- include "service-helper" (dict "service_name" "client" "Values" .Values) }}
 
 {{- include "hpa-helper" (dict "service_name" "client" "Values" .Values) }}

--- a/charts/opencrvs-services/templates/countryconfig-deployment.yaml
+++ b/charts/opencrvs-services/templates/countryconfig-deployment.yaml
@@ -136,6 +136,8 @@ spec:
 
 {{- include "service-account-helper" (dict "service_name" "countryconfig" "Values" .Values) }}
 
+{{- include "network-policy-rules" (dict "service_name" "countryconfig" "Values" .Values) }}
+
 {{- include "service-helper" (dict "service_name" "countryconfig" "Values" .Values) }}
 
 {{- include "hpa-helper" (dict "service_name" "countryconfig" "Values" .Values) }}

--- a/charts/opencrvs-services/templates/dashboards-deployment.yaml
+++ b/charts/opencrvs-services/templates/dashboards-deployment.yaml
@@ -132,6 +132,8 @@ spec:
 
 {{- include "service-account-helper" (dict "service_name" "dashboards" "Values" .Values) }}
 
+{{- include "network-policy-rules" (dict "service_name" "dashboards" "Values" .Values) }}
+
 {{- include "service-helper" (dict "service_name" "dashboards" "Values" .Values) }}
 
 {{- include "hpa-helper" (dict "service_name" "dashboards" "Values" .Values) }}

--- a/charts/opencrvs-services/templates/data-cleanup-job.yaml
+++ b/charts/opencrvs-services/templates/data-cleanup-job.yaml
@@ -3,14 +3,14 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   labels:
-    app: data-cleanup
+    app: deployment-jobs
   name: data-cleanup
   namespace: {{ .Release.Namespace }}
 spec:
   template:
     metadata:
       labels:
-        app: data-cleanup
+        app: deployment-jobs
     spec:
       {{- include "opencrvs.imagePullSecrets" (dict "root" . "service" .Values.postgres) | nindent 6 }}
       {{- include "pod-service-account-values-helper" (dict "service_name" "deployment-jobs" "Values" .Values) | nindent 6 }}
@@ -130,5 +130,7 @@ spec:
           {{- end }}
           {{- include "render-env-vars" (dict "service_name" "data_cleanup" "Values" .Values) }}
       restartPolicy: "OnFailure"
+
+{{ include "network-policy-rules" (dict "service_name" "data-cleanup" "Values" .Values) }}
 
 {{- end }}

--- a/charts/opencrvs-services/templates/data-migration-analytics-job.yaml
+++ b/charts/opencrvs-services/templates/data-migration-analytics-job.yaml
@@ -6,13 +6,13 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "3"
   labels:
-    app: data-migration-analytics
+    app: deployment-jobs
   name: data-migration-analytics
 spec:
   template:
     metadata:
       labels:
-        app: data-migration-analytics
+        app: deployment-jobs
     spec:
       {{- include "opencrvs.imagePullSecrets" (dict "root" . "service" .Values.countryconfig) | nindent 6 }}
       {{- include "pod-service-account-values-helper" (dict "service_name" "deployment-jobs" "Values" .Values) | nindent 6 }}

--- a/charts/opencrvs-services/templates/data-migration-job.yaml
+++ b/charts/opencrvs-services/templates/data-migration-job.yaml
@@ -9,13 +9,13 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "2"
   labels:
-    app: migration
+    app: deployment-jobs
   name: {{ .Values.data_migration.job_name | default "data-migration" }}
 spec:
   template:
     metadata:
       labels:
-        app: migration
+        app: deployment-jobs
     spec:
       {{- include "opencrvs.imagePullSecrets" (dict "root" . "service" .Values.data_migration) | nindent 6 }}
       {{- include "pod-service-account-values-helper" (dict "service_name" "deployment-jobs" "Values" .Values) | nindent 6 }}
@@ -45,3 +45,5 @@ spec:
               value: "{{ .Values.postgres.host }}:{{ .Values.postgres.port }}"
           {{- include "render-env-vars" (dict "service_name" "data_migration" "Values" .Values) }}
       restartPolicy: "OnFailure"
+
+{{ include "network-policy-rules" (dict "service_name" "deployment-jobs" "Values" .Values) }}

--- a/charts/opencrvs-services/templates/data-seed-job.yaml
+++ b/charts/opencrvs-services/templates/data-seed-job.yaml
@@ -7,14 +7,14 @@ metadata:
     "helm.sh/hook": post-install
     "helm.sh/hook-weight": "3"
   labels:
-    app: data-seed
+    app: deployment-jobs
   name: data-seed
   namespace: {{ .Release.Namespace }}
 spec:
   template:
     metadata:
       labels:
-        app: data-seed
+        app: deployment-jobs
     spec:
       {{- include "opencrvs.imagePullSecrets" (dict "root" . "service" .Values.data_seed) | nindent 6 }}
       {{- include "pod-service-account-values-helper" (dict "service_name" "deployment-jobs" "Values" .Values) | nindent 6 }}
@@ -48,5 +48,7 @@ spec:
           {{- end }}
           {{- include "render-env-vars" (dict "service_name" "data_seed" "Values" .Values) }}
       restartPolicy: "OnFailure"
+
+{{ include "network-policy-rules" (dict "service_name" "deployment-jobs" "Values" .Values) }}
 
 {{- end }}

--- a/charts/opencrvs-services/templates/documents-deployment.yaml
+++ b/charts/opencrvs-services/templates/documents-deployment.yaml
@@ -75,6 +75,8 @@ spec:
 
 {{- include "service-account-helper" (dict "service_name" "documents" "Values" .Values) }}
 
+{{- include "network-policy-rules" (dict "service_name" "documents" "Values" .Values) }}
+
 {{- include "service-helper" (dict "service_name" "documents" "Values" .Values) }}
 
 {{- include "hpa-helper" (dict "service_name" "documents" "Values" .Values) }}

--- a/charts/opencrvs-services/templates/elasticsearch-on-deploy.yaml
+++ b/charts/opencrvs-services/templates/elasticsearch-on-deploy.yaml
@@ -6,13 +6,13 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "1"
   labels:
-    app: elasticsearch-on-deploy
+    app: deployment-jobs
   name: elasticsearch-on-deploy
 spec:
   template:
     metadata:
       labels:
-        app: elasticsearch-on-deploy
+        app: deployment-jobs
     spec:
       {{- include "opencrvs.imagePullSecrets" (dict "root" . "service" .Values.utilities) | nindent 6 }}
       {{- include "pod-service-account-values-helper" (dict "service_name" "deployment-jobs" "Values" .Values) | nindent 6 }}
@@ -48,4 +48,7 @@ spec:
             name: elasticsearch-on-update-script
             defaultMode: 0755
       restartPolicy: "OnFailure"
+
+{{ include "network-policy-rules" (dict "service_name" "deployment-jobs" "Values" .Values) }}
+
 {{- end }}

--- a/charts/opencrvs-services/templates/elasticsearch-reindex-job.yaml
+++ b/charts/opencrvs-services/templates/elasticsearch-reindex-job.yaml
@@ -6,14 +6,14 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "4"
   labels:
-    app: elasticsearch-reindex
+    app: deployment-jobs
   name: elasticsearch-reindex
   namespace: {{ .Release.Namespace }}
 spec:
   template:
     metadata:
       labels:
-        app: elasticsearch-reindex
+        app: deployment-jobs
     spec:
       {{- include "elasticsearch-reindex.imagePullSecrets" . | nindent 6 }}
       {{- include "pod-service-account-values-helper" (dict "service_name" "deployment-jobs" "Values" .Values) | nindent 6 }}
@@ -24,4 +24,7 @@ spec:
       restartPolicy: "OnFailure"
       volumes:
       {{- include "elasticsearch-reindex.volumes" . | nindent 8 }}
+
+{{ include "network-policy-rules" (dict "service_name" "deployment-jobs" "Values" .Values) }}
+
 {{- end }}

--- a/charts/opencrvs-services/templates/events-deployment.yaml
+++ b/charts/opencrvs-services/templates/events-deployment.yaml
@@ -74,6 +74,8 @@ spec:
 
 {{- include "service-account-helper" (dict "service_name" "events" "Values" .Values) }}
 
+{{- include "network-policy-rules" (dict "service_name" "events" "Values" .Values) }}
+
 {{- include "service-helper" (dict "service_name" "events" "Values" .Values) }}
 
 {{- include "hpa-helper" (dict "service_name" "events" "Values" .Values) }}

--- a/charts/opencrvs-services/templates/gateway-deployment.yaml
+++ b/charts/opencrvs-services/templates/gateway-deployment.yaml
@@ -111,6 +111,8 @@ spec:
 
 {{- include "service-account-helper" (dict "service_name" "gateway" "Values" .Values) }}
 
+{{- include "network-policy-rules" (dict "service_name" "gateway" "Values" .Values) }}
+
 {{- include "service-helper" (dict "service_name" "gateway" "Values" .Values) }}
 
 {{- include "hpa-helper" (dict "service_name" "gateway" "Values" .Values) }}

--- a/charts/opencrvs-services/templates/login-deployment.yaml
+++ b/charts/opencrvs-services/templates/login-deployment.yaml
@@ -34,6 +34,7 @@ kind: Deployment
 metadata:
   labels:
     app: login
+    service_name: login
   name: login
 spec:
   replicas: {{ .Values.login.replicas | default 1 }}
@@ -45,6 +46,7 @@ spec:
     metadata:
       labels:
         app: login
+        service_name: login
     spec:
       {{- include "opencrvs.imagePullSecrets" (dict "root" . "service" .Values.login) | nindent 6 }}
       {{- include "pod-service-account-values-helper" (dict "service_name" "login" "Values" .Values) | nindent 6 }}
@@ -94,6 +96,8 @@ spec:
       {{- end }}
 
 {{- include "service-account-helper" (dict "service_name" "login" "Values" .Values) }}
+
+{{- include "network-policy-rules" (dict "service_name" "login" "Values" .Values) }}
 
 {{- include "service-helper" (dict "service_name" "login" "Values" .Values) }}
 

--- a/charts/opencrvs-services/templates/network-policy.yaml
+++ b/charts/opencrvs-services/templates/network-policy.yaml
@@ -1,0 +1,111 @@
+{{- if .Values.network_policy.enabled }}
+{{- $ingress_mode := .Values.network_policy.ingress_mode | default "deny" -}}
+{{- $egress_mode := .Values.network_policy.egress_mode | default "deny" -}}
+{{- $deny_ingress := ne $ingress_mode "full" -}}
+{{- $deny_egress := ne $egress_mode "full" -}}
+{{- $private_cidrs := list "10.0.0.0/8" "172.16.0.0/12" "192.168.0.0/16" -}}
+
+{{- if or $deny_ingress $deny_egress }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-default-deny
+spec:
+  podSelector: {}
+  policyTypes:
+  {{- if $deny_ingress }}
+    - Ingress
+  {{- end }}
+  {{- if $deny_egress }}
+    - Egress
+  {{- end }}
+{{- if eq $ingress_mode "deny" }}
+  ingress: []
+{{- end }}
+{{- if eq $ingress_mode "private" }}
+  ingress:
+    - from:
+        {{- range $private_cidrs }}
+        - ipBlock:
+            cidr: {{ . }}
+        {{- end }}
+{{- end }}
+{{- if eq $egress_mode "deny" }}
+  egress: []
+{{- end }}
+{{- if eq $egress_mode "private" }}
+  egress:
+    - to:
+        {{- range $private_cidrs }}
+        - ipBlock:
+            cidr: {{ . }}
+        {{- end }}
+{{- end }}
+{{- end }}
+
+{{- if and .Values.network_policy.allow_same_namespace (or $deny_ingress $deny_egress) }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-allow-same-namespace
+spec:
+  podSelector: {}
+  policyTypes:
+  {{- if $deny_ingress }}
+    - Ingress
+  {{- end }}
+  {{- if $deny_egress }}
+    - Egress
+  {{- end }}
+{{- if $deny_ingress }}
+  ingress:
+    - from:
+        - podSelector: {}
+{{- end }}
+{{- if $deny_egress }}
+  egress:
+    - to:
+        - podSelector: {}
+{{- end }}
+{{- end }}
+
+{{- if and $deny_egress .Values.network_policy.allowed_namespaces }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-allow-egress-namespaces
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        {{- range .Values.network_policy.allowed_namespaces }}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ . }}
+        {{- end }}
+{{- end }}
+
+{{- if $deny_egress }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-allow-dns
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+{{- end }}
+
+{{- end }}

--- a/charts/opencrvs-services/templates/postgres-on-deploy-job.yaml
+++ b/charts/opencrvs-services/templates/postgres-on-deploy-job.yaml
@@ -6,13 +6,13 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "1"
   labels:
-    app: postgres-on-deploy
+    app: deployment-jobs
   name: postgres-on-deploy
 spec:
   template:
     metadata:
       labels:
-        app: postgres-on-deploy
+        app: deployment-jobs
     spec:
       {{- include "opencrvs.imagePullSecrets" (dict "root" . "service" .Values.dashboards) | nindent 6 }}
       {{- include "pod-service-account-values-helper" (dict "service_name" "deployment-jobs" "Values" .Values) | nindent 6 }}
@@ -22,3 +22,5 @@ spec:
       restartPolicy: "OnFailure"
       volumes:
         {{- include "postgres-on-deploy.volumes" . | nindent 8 }}
+
+{{ include "network-policy-rules" (dict "service_name" "deployment-jobs" "Values" .Values) }}

--- a/charts/opencrvs-services/templates/postgres-on-restore-cronjob.yaml
+++ b/charts/opencrvs-services/templates/postgres-on-restore-cronjob.yaml
@@ -5,7 +5,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   labels:
-    app: common
+    app: deployment-jobs
     job-type: restore
   name: on-db-restore-cronjob
 spec:
@@ -18,7 +18,7 @@ spec:
       template:
         metadata:
           labels:
-            app: common
+            app: deployment-jobs
             job-type: restore
         spec:
           {{- include "elasticsearch-reindex.imagePullSecrets" . | nindent 10 }}
@@ -32,4 +32,7 @@ spec:
           volumes:
             {{- include "postgres-on-deploy.volumes" . | nindent 10 }}
             {{- include "elasticsearch-reindex.volumes" . | nindent 10 }}
+
+{{ include "network-policy-rules" (dict "service_name" "deployment-jobs" "Values" .Values) }}
+
 {{- end }}

--- a/charts/opencrvs-services/templates/validate-postdeploy-job.yaml
+++ b/charts/opencrvs-services/templates/validate-postdeploy-job.yaml
@@ -7,7 +7,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "5"
   labels:
-    app: validate-postdeploy
+    app: deployment-jobs
   name: validate-postdeploy
 spec:
   backoffLimit: 0
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       labels:
-        app: validate-postdeploy
+        app: deployment-jobs
         helm.sh/revision: {{ .Release.Revision | quote }}
     spec:
       {{- include "opencrvs.imagePullSecrets" (dict "root" . "service" .Values.utilities) | nindent 6 }}

--- a/charts/opencrvs-services/templates/validate-predeploy-job.yaml
+++ b/charts/opencrvs-services/templates/validate-predeploy-job.yaml
@@ -7,7 +7,7 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "0"
   labels:
-    app: validate-predeploy
+    app: deployment-jobs
   name: validate-predeploy
 spec:
   backoffLimit: 0
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       labels:
-        app: validate-predeploy
+        app: deployment-jobs
         helm.sh/revision: {{ .Release.Revision | quote }}
     spec:
       {{- include "opencrvs.imagePullSecrets" (dict "root" . "service" .Values.utilities) | nindent 6 }}

--- a/charts/opencrvs-services/values.yaml
+++ b/charts/opencrvs-services/values.yaml
@@ -148,6 +148,40 @@ ingress:
   # Generate SSL Certificate by TLS resolver instead of using default traefik Certificate
   tls_resolver: ''
 
+# Kubernetes NetworkPolicy configuration for OpenCRVS workloads.
+# Requires a CNI provider that enforces Kubernetes NetworkPolicy.
+network_policy:
+  # Render NetworkPolicy resources. Requires a CNI provider that enforces
+  # NetworkPolicy - set to false on clusters without one.
+  enabled: true
+  # Baseline policy for ingress to OpenCRVS pods. One of:
+  # - deny: deny ingress unless another NetworkPolicy allows it (default).
+  # - private: allow ingress only from RFC1918 private ranges
+  #            (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16).
+  # - full: no baseline policy; ingress is unrestricted.
+  ingress_mode: deny
+  # Baseline policy for egress from OpenCRVS pods. Same modes as
+  # ingress_mode, applied to egress instead. Defaults to "private" rather
+  # than "deny": OpenCRVS pods need to reach the dependencies chart's
+  # namespace (see allowed_namespaces below) and typically nothing else
+  # outside the cluster/VPC, so private strikes a safe-by-default balance
+  # without requiring every deployment to enumerate allowed_namespaces up
+  # front. Services that genuinely need public internet (e.g. countryconfig,
+  # for SMTP/SMS provider integrations) opt out individually via their own
+  # network_policy.egress_mode: full; see "Hardening" in README.md.
+  egress_mode: private
+  # Allow OpenCRVS pods in this namespace to communicate with each other.
+  # This keeps the chart practical while blocking unexpected cross-namespace
+  # and external traffic by default.
+  allow_same_namespace: true
+  # Namespaces OpenCRVS pods are allowed to reach. Only takes effect when
+  # egress_mode is not "full". Required for the OpenCRVS application to
+  # keep working once egress is denied by default (e.g. auth/gateway
+  # reaching redis/postgres/elasticsearch/minio), since the dependencies
+  # chart is typically deployed to a separate namespace. See "Hardening"
+  # in README.md.
+  allowed_namespaces: []
+
 # See kubernetes documentation for more information on service types:
 # https://kubernetes.io/docs/concepts/services-networking/service/
 service_type: ClusterIP
@@ -284,6 +318,8 @@ auth:
     # tag: v2.0.0
 
 client:
+  network_policy:
+    ingress_mode: private
   port: 3000
   image:
     name: ocrvs-client
@@ -316,6 +352,14 @@ countryconfig:
     name: opencrvs/ocrvs-countryconfig
     tag: v2.0.0
   port: 3040
+  network_policy:
+    # countryconfig needs public-internet egress regardless of the global
+    # network_policy.egress_mode: it integrates with per-country SMTP
+    # servers and SMS gateways (e.g. Infobip) at arbitrary external hosts
+    # configured via env vars/secrets, not fixed IPs a private-range or
+    # namespace-scoped rule could cover.
+    egress_mode: full
+    ingress_mode: private
 
 dashboards:
   enabled: false
@@ -323,8 +367,10 @@ dashboards:
     name: metabase
     repository: metabase
     tag: v0.56.4
-  use_default_credentials: true
   port: 4444
+  network_policy:
+    ingress_mode: private
+  use_default_credentials: true
   env:
     METABASE_DATABASE_SSL: false
     OPENCRVS_METABASE_MAP_NAME: Farajaland
@@ -347,10 +393,12 @@ gateway:
   port: 7070
   image:
     name: ocrvs-gateway
-
+  network_policy:
+    ingress_mode: private
   env:
     CHECK_INVALID_TOKEN: 'true'
     CONFIG_SMS_CODE_EXPIRY_SECONDS: '600'
+    CONFIG_TOKEN_EXPIRY_SECONDS: '604800'
     COUNTRY: FAR
     DISABLE_RATE_LIMIT: 'false'
     LANGUAGES: 'en,fr'
@@ -359,6 +407,8 @@ login:
   port: 3020
   image:
     name: ocrvs-login
+  network_policy:
+    ingress_mode: private
   # login is an nginx docker image
   # nginx_conf_d_configmaps:
   #     List of Configmap names to store custom configuration:
@@ -414,6 +464,9 @@ events:
 deployment_jobs:
   service_account:
     name: deployment-jobs
+    network_policy:
+      ingress_mode: deny
+      egress_mode: full
     annotations:
       'helm.sh/hook': pre-install,pre-upgrade
       'helm.sh/hook-weight': '-10'


### PR DESCRIPTION
# Description

Related Documentation: https://app.gitbook.com/o/zub8C4BetmW3a9Bj4Cd4/s/SSLwN6XKBBaNBtMjawLL/~/edit/~/changes/XeubioF4tiShH17JQJ6T/technical/guides/installation/advanced-topics/ingress-egress-access

Related issue: https://github.com/opencrvs/opencrvs-core/issues/13284


> Postgres and MinIO Differential backup still require access to public repo to install ssh, rsync, pgbackrest packages. OpenCRVS will get Air-gap installation mode in release v2.1 that will solve external dependencies installation, see https://github.com/opencrvs/opencrvs-core/tree/develop/charts/dependencies#air-gap-installation, but this mode required custom images for MinIO and Postgres, we will keep this option to integrators.

Key Items covered by PR:

- Add optional Kubernetes `NetworkPolicy` support to the `dependencies` and `opencrvs-services` charts (`network_policy.enabled`), default-deny with explicit per-service opt-ins via `rules`/`custom_rules` or the simpler `ingress_mode`/`egress_mode` flags.
- Cross-namespace access between the two charts (typically deployed to separate namespaces) is controlled by `network_policy.allowed_namespaces` on each side.
- Postgres/MinIO get dedicated egress rules for backup/restore server access (derived from existing backup/restore host config) and package-repo installs.
- Differential backup/restore jobs (`kubectl exec`/`scale`/`delete`/`apply` against the API server) run under their own `app: backup-runner` label with dedicated egress, instead of sharing the Postgres/MinIO pods' label and rules.
- Along the way, fixed unrelated pre-existing bugs: missing privilege drop in pgBackRest automation, malformed pod-template `labels` on several backup/restore Jobs, and a missing `helm.sh/hook-delete-policy` that meant the stanza-create hook wasn't actually recreated on upgrade.


# Testing

## Dependencies

Check README.md for more information which connections are allowed

All communications are denied by `opencrvs-deps-default-deny` rule

Target cluster: tmp-master (Hetzner)

### Default rules

Only default rules were applied (backup is enabled):
<img width="536" height="273" alt="image" src="https://github.com/user-attachments/assets/3a6798b3-b692-4f99-8e64-4457e30608d6" />


### Connectivity test within namespace

`opencrvs-deps-allow-same-namespace` rule is responsible for communication inside namespace, all to all connections are allowed

E/g connection Kibana -> Postgres (`curl -v telnet://postgres:5432`):
<img width="690" height="148" alt="image" src="https://github.com/user-attachments/assets/21c647db-772f-4ce4-905f-d3921d312a09" />


### Connectivity test ingress

Rules responsible for ingress traffic:
- elasticsearch-allow-ingress
- kibana-allow-ingress
- minio-allow-console-ingress
- minio-allow-package-repo-egress
- postgres-allow-ingress
- redis-allow-ingress

By default ingress connections are allowed from Any external or internal service to particular ports only. Potential attacher may open additional port or exploit existing process, but attack surface is limited only to "legal" ports.

E/g: Connection countryconfig -> postgres:

<img width="1129" height="121" alt="image" src="https://github.com/user-attachments/assets/d5dcfa15-df4b-4b40-bc66-d1bb5dd4d596" />

### Connectivity test egress

Rules responsible for egress traffic:
- opencrvs-deps-allow-dns
- postgres-allow-https-egress
- minio-allow-https-egress

Connection from minio pod to random server on 80 port:
<img width="936" height="288" alt="image" src="https://github.com/user-attachments/assets/b58000f9-adec-44d1-835e-7548e0edc8a5" />

Connection from minio pod to backup server on 22 port:
<img width="418" height="70" alt="image" src="https://github.com/user-attachments/assets/c2c55e18-be29-4414-8bdb-11f9e511619d" />

Connection from minio pod to random (existing) server on 22 port:
<img width="463" height="66" alt="image" src="https://github.com/user-attachments/assets/33395ff0-e802-4987-b96a-b08d79fca6d1" />

### Custom rules

Custom rule added for minio service like in previous example with random (existing) server:
```yaml
minio:
  network_policy:
    custom_rules:
      - name: access-friends
        policyTypes:
          - Egress
        egress:
          - to:
              - ipBlock:
                  cidr: 10.1.0.3/32
            ports:
              - protocol: TCP
                port: 22
```

<img width="797" height="567" alt="image" src="https://github.com/user-attachments/assets/a46b2776-5506-410a-88c4-7271f619f28c" />


### Backup test
<img width="1887" height="299" alt="image" src="https://github.com/user-attachments/assets/4808a3d1-700b-4127-a512-993ee50bd14e" />


## OpenCRVS services

### Default rules

<img width="612" height="195" alt="image" src="https://github.com/user-attachments/assets/91579887-85ed-46d9-8e5a-6c92a379234a" />


### Connectivity test within namespace

1. Create pod with `curl` utility
2. Test connection to auth service

<img width="1380" height="683" alt="image" src="https://github.com/user-attachments/assets/60d1c66d-5b4d-460b-8294-8509fa7cb0b4" />


### Connectivity test ingress

On e2e environment successfully hit home page URL: https://ocrvs-13284.e2e-k8s.opencrvs.dev/


### Connectivity test egress

1. Create pod with `curl` utility
2. Test connection to postgres service

<img width="1065" height="120" alt="image" src="https://github.com/user-attachments/assets/2500bee5-f0d2-45e0-bb5d-280f83a5c996" />

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
