### PR TITLE
fix: Move backup_host away from secret into variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,15 @@ The MOSIP integration used to be released from its own `opencrvs/mosip` reposito
 
 For the integration's own release history prior to this move, see [`packages/mosip-api/CHANGELOG.md`](https://github.com/opencrvs/opencrvs-core/blob/develop/packages/mosip-api/CHANGELOG.md).
 
+#### Backup/restore host moved out of the SSH secret into a plain variable
+
+`BACKUP_HOST` / `PGBACKREST_REPO1_HOST` for the minio and postgres backup/restore charts used to be read from the `host` key of the backup-server SSH credentials secret. Since a hostname isn't sensitive, it's now read from `.Values.backup.host` / `.Values.restore.host` instead, populated from the `BACKUP_HOST` / `RESTORE_HOST` GitHub environment variables.
+
+- **Restore fails if `RESTORE_HOST` is not defined.** Environments that had restore configured before this change carried the host inside the SSH secret; on upgrade, if `RESTORE_HOST` isn't set the restore job has no host to connect to.
+- **Operators must run `yarn environment:init` for every environment that uses backup or restore (e.g. staging)** before deploying this change, so `BACKUP_HOST`/`RESTORE_HOST` get populated as GitHub environment variables.
+
+[#13502](https://github.com/opencrvs/opencrvs-core/pull/13502)
+
 ### Improvements
 
 - User avatars are now drawn by OpenCRVS itself rather than fetched from the third-party service `ui-avatars.com`. Previously each avatar sent the user's full name to that service and showed nothing at all offline; initials are now rendered locally, so avatars work offline and no user's name leaves the country's deployment [#3769](https://github.com/opencrvs/opencrvs-core/issues/3769)

--- a/charts/dependencies/files/postgres/postgres-backup-config.sh
+++ b/charts/dependencies/files/postgres/postgres-backup-config.sh
@@ -14,7 +14,7 @@ set -e
 . "$(dirname "${BASH_SOURCE[0]}")/ensure-deb-utils.sh"
 
 common_config(){
-ensure_deb_utils "pgbackrest=2.59.0-1.pgdg13+1 openssh-client" pgbackrest ssh || exit 1
+ensure_deb_utils "pgbackrest={{ .Values.postgres.pgbackrest_version }}* openssh-client" pgbackrest ssh || exit 1
 # Common configuration for backup and restore
 # Temporal directory required for pushing WAL files
 echo "Create pgbackrest temp directory with correct permissions"

--- a/charts/dependencies/templates/minio-backup-cronjob.yaml
+++ b/charts/dependencies/templates/minio-backup-cronjob.yaml
@@ -57,10 +57,7 @@ spec:
                       name: {{ .Values.backup.backup_server_secret }}
                       key: user
                 - name: BACKUP_HOST
-                  valueFrom:
-                    secretKeyRef:
-                      name: {{ .Values.backup.backup_server_secret }}
-                      key: host
+                  value: {{ default .Values.backup.host .Values.minio.backup.host }}
                 - name: BACKUP_REMOTE_DIR
                   value: "{{ .Values.minio.backup_server_dir | default .Values.backup.backup_server_dir }}"
               {{- include "render-env-vars" (dict "service_name" "backup" "Values" .Values) | nindent 4 }}

--- a/charts/dependencies/templates/minio-restore-cronjob.yaml
+++ b/charts/dependencies/templates/minio-restore-cronjob.yaml
@@ -57,10 +57,7 @@ spec:
                       name: {{ .Values.restore.backup_server_secret }}
                       key: user
                 - name: BACKUP_HOST
-                  valueFrom:
-                    secretKeyRef:
-                      name: {{ .Values.restore.backup_server_secret }}
-                      key: host
+                  value: {{ default .Values.restore.host .Values.minio.restore.host }}
                 - name: BACKUP_REMOTE_DIR
                   value: {{ default .Values.restore.backup_server_dir .Values.minio.backup_server_dir }}
               {{- include "render-env-vars" (dict "service_name" "restore" "Values" .Values) | nindent 4 }}

--- a/charts/dependencies/templates/minio.yaml
+++ b/charts/dependencies/templates/minio.yaml
@@ -157,14 +157,11 @@ spec:
                 {{- end }}
                   key: user
             - name: BACKUP_HOST
-              valueFrom:
-                secretKeyRef:
-                {{- if (eq (include "minio.backup_enabled" .) "true") }}
-                  name: {{ default .Values.backup.backup_server_secret .Values.minio.backup.server_secret}}
-                {{- else }}
-                  name: {{ default .Values.restore.backup_server_secret .Values.minio.restore.server_secret}}
-                {{- end }}
-                  key: host
+              {{- if (eq (include "minio.backup_enabled" .) "true") }}
+              value: {{ default .Values.backup.host .Values.minio.backup.host }}
+              {{- else }}
+              value: {{ default .Values.restore.host .Values.minio.restore.host }}
+              {{- end }}
             - name: BACKUP_REMOTE_DIR
               {{- if (eq (include "minio.backup_enabled" .) "true") }}
               value: {{ default .Values.backup.backup_server_dir .Values.minio.backup.server_dir }}

--- a/charts/dependencies/templates/postgres-backup-cronjob-dump.yaml
+++ b/charts/dependencies/templates/postgres-backup-cronjob-dump.yaml
@@ -66,10 +66,7 @@ spec:
                       name: {{ .Values.backup.backup_server_secret }}
                       key: user
                 - name: BACKUP_HOST
-                  valueFrom:
-                    secretKeyRef:
-                      name: {{ default .Values.backup.backup_server_secret .Values.postgres.backup.server_secret }}
-                      key: host
+                  value: {{ default .Values.backup.host .Values.postgres.backup.host }}
                 - name: BACKUP_REMOTE_DIR
                   value: {{ default .Values.backup.backup_server_dir .Values.postgres.backup.server_dir }}
               {{- include "render-env-vars" (dict "service_name" "backup" "Values" .Values) | nindent 4 }}

--- a/charts/dependencies/templates/postgres-restore-cronjob.yaml
+++ b/charts/dependencies/templates/postgres-restore-cronjob.yaml
@@ -65,10 +65,7 @@ spec:
                       name: {{ .Values.restore.backup_server_secret }}
                       key: user
                 - name: BACKUP_HOST
-                  valueFrom:
-                    secretKeyRef:
-                      name: {{ .Values.restore.backup_server_secret }}
-                      key: host
+                  value: {{ default .Values.restore.host .Values.postgres.restore.host }}
                 - name: BACKUP_REMOTE_DIR
                   value: {{ default .Values.restore.backup_server_dir .Values.postgres.restore.server_dir }}
               {{- include "render-env-vars" (dict "service_name" "restore" "Values" .Values) | nindent 4 }}

--- a/charts/dependencies/templates/postgres-restore-job-configmap.yaml
+++ b/charts/dependencies/templates/postgres-restore-job-configmap.yaml
@@ -28,7 +28,7 @@ data:
             for utility in pgbackrest ssh; do
               command -v "$utility" >/dev/null 2>&1 || missing="$missing $utility"
             done
-            if [ -n "$missing" ] && { ! apt update || ! apt install -y pgbackrest openssh-client; }; then
+            if [ -n "$missing" ] && { ! apt update || ! apt install -y pgbackrest={{ .Values.postgres.pgbackrest_version }}* openssh-client; }; then
               echo "[ERROR] Missing utilities:$missing" >&2
               echo "[ERROR] Automatic installation failed. Ensure the container can access its package repositories, or include the required packages in the base image for air-gapped deployments." >&2
               exit 1

--- a/charts/dependencies/templates/postgres-restore-job-configmap.yaml
+++ b/charts/dependencies/templates/postgres-restore-job-configmap.yaml
@@ -63,10 +63,7 @@ data:
                 name: {{ default .Values.postgres.restore.server_secret .Values.restore.backup_server_secret }}
                 key: user
           - name: PGBACKREST_REPO1_HOST
-            valueFrom:
-              secretKeyRef:
-                name: {{ default .Values.postgres.restore.server_secret .Values.restore.backup_server_secret }}
-                key: host
+            value: {{ default .Values.restore.host .Values.postgres.restore.host }}
           - name: PGBACKREST_REPO1_TYPE
             value: posix
           - name: PGBACKREST_REPO1_CIPHER_TYPE

--- a/charts/dependencies/templates/postgres-scripts-configmap.yaml
+++ b/charts/dependencies/templates/postgres-scripts-configmap.yaml
@@ -5,7 +5,7 @@ data:
 {{ .Files.Get "files/common/backup-functions.sh" | indent 8 }}
 {{- range $path, $file := .Files.Glob "files/postgres/*" }}
     {{ base $path }}: |
-{{ toString $file | indent 8 }}
+{{ tpl (toString $file) $ | indent 8 }}
 {{- end }}
 kind: ConfigMap
 metadata:

--- a/charts/dependencies/templates/postgres.yaml
+++ b/charts/dependencies/templates/postgres.yaml
@@ -124,10 +124,7 @@ spec:
                   name: {{ default .Values.postgres.backup.server_secret .Values.backup.backup_server_secret }}
                   key: user
             - name: PGBACKREST_REPO1_HOST
-              valueFrom:
-                secretKeyRef:
-                  name: {{ default .Values.postgres.backup.server_secret .Values.backup.backup_server_secret }}
-                  key: host
+              value: {{ default .Values.backup.host .Values.postgres.backup.host }}
             - name: PGBACKREST_REPO1_TYPE
               value: posix
             - name: PGBACKREST_REPO1_CIPHER_TYPE

--- a/charts/dependencies/values.yaml
+++ b/charts/dependencies/values.yaml
@@ -102,6 +102,9 @@ postgres:
     # Both dump and differential flows can reuse this Secret.
     server_secret: backup-server-ssh-credentials
 
+    # Host:
+    # host: backup server hostname or IP
+
     # Secret holding the pgBackRest repository encryption passphrase.
     # Encryption is always enabled; cipher type is fixed in templates
     # (e.g. repo1-cipher-type=aes-256-cbc).
@@ -131,6 +134,10 @@ postgres:
     # schedule: "0 3 * * *"   # daily at 03:00
     # encryption_secret: restore-encryption-secret
     # server_secret: backup-server-ssh-credentials
+
+    # Host:
+    # host: backup server hostname or IP
+
 
 # Elasticsearch Configuration
 elasticsearch:
@@ -290,6 +297,9 @@ minio:
     # Name of the Kubernetes secret containing backup server SSH credentials.
     # server_secret: backup-server-ssh-credentials
 
+    # Host:
+    # host: backup server hostname or IP
+
     # Cron schedule to run backup job (format: "MIN HOUR DAY MONTH WEEKDAY").
     # schedule: "0 1 * * *"
 
@@ -308,6 +318,9 @@ minio:
 
     # Name of the Kubernetes secret containing backup server SSH credentials.
     # server_secret: backup-server-ssh-credentials
+
+    # Host:
+    # host: backup server hostname or IP
 
     # Cron schedule for restore job.
     # schedule: "0 3 * * *"
@@ -351,6 +364,10 @@ backup:
   # - host, hostname / IP of backup server
   # - ssh_key, ssh key for passwordless connection
   backup_server_secret: backup-server-ssh-credentials
+
+  # Host:
+  # host: backup server hostname or IP
+
   backup_server_dir: /home/backup/demo
   backup_encryption_secret: backup-encryption-secret
 
@@ -370,6 +387,10 @@ restore:
   # - host, hostname / IP of backup server
   # - ssh_key, ssh key for passwordless connection
   backup_server_secret: backup-server-ssh-credentials
+
+  # Host:
+  # host: backup server hostname or IP
+
   # backup_server_dir: /home/backup/demo
   backup_encryption_secret: restore-encryption-secret
 

--- a/charts/dependencies/values.yaml
+++ b/charts/dependencies/values.yaml
@@ -83,6 +83,10 @@ postgres:
     # Requested persistent storage size
     storage_size: '10Gi'
 
+  # pgBackRest version (major.minor.hotfix). Single source of truth for both
+  # backup/restore scripts
+  pgbackrest_version: 2.59.0
+
   # Backup section
   backup:
     # Enable/Disable backup

--- a/packages/toolkit/src/environment/setup-environment.ts
+++ b/packages/toolkit/src/environment/setup-environment.ts
@@ -24,6 +24,11 @@ async function select<Value = string>(options: any): Promise<Value> {
   return inquirer.select(options)
 }
 
+async function input(options: any): Promise<string> {
+  const inquirer = await import('@inquirer/prompts')
+  return inquirer.input(options)
+}
+
 import {
   Secret,
   Variable,
@@ -572,6 +577,9 @@ ALL_QUESTIONS.push(
     'ENVIRONMENT',
     existingValues
   )?.value
+  let restoreHost =
+    findExistingValue('RESTORE_HOST', 'VARIABLE', 'ENVIRONMENT', existingValues)
+      ?.value || ''
   let restoreType =
     findExistingValue(
       'RESTORE_ENVIRONMENT_MODE',
@@ -655,6 +663,10 @@ ALL_QUESTIONS.push(
           value: 'differential'
         }
       ]
+    })
+    restoreHost = await input({
+      message: 'What is the host/IP address of the restore backup server?',
+      default: restoreHost
     })
   } else {
     log(kleur.bold().green('✔'), kleur.bold().yellow('Restore is disabled'))
@@ -1015,6 +1027,22 @@ ALL_QUESTIONS.push(
         existingValues
       ),
       scope: 'ENVIRONMENT' as const
+    },
+    {
+      type: 'VARIABLE' as const,
+      name: 'RESTORE_HOST',
+      value: answerOrExisting(
+        restoreHost,
+        findExistingValue('RESTORE_HOST', 'VARIABLE', 'ENVIRONMENT', existingValues),
+        (val) => val || ''
+      ),
+      didExist: findExistingValue(
+        'RESTORE_HOST',
+        'VARIABLE',
+        'ENVIRONMENT',
+        existingValues
+      ),
+      scope: 'ENVIRONMENT' as const
     }
   ]
 
@@ -1330,12 +1358,14 @@ ALL_QUESTIONS.push(
     // Hardcode like this blocks us from being generic:
     // https://github.com/opencrvs/opencrvs-core/issues/11171
     two_fa_enabled: environment !== 'production' ? false : true,
-    backup_enabled: configureBackup ? true : false,
+    traefik_mode: traefikConfOption,
     restore_enabled: restoreEnvironmentName ? true : false,
     restore_environment_name: restoreEnvironmentName || '',
     restore_type: restoreType,
-    traefik_mode: traefikConfOption,
-    backup_type: backupType
+    restore_host: restoreHost || '',
+    backup_enabled: configureBackup ? true : false,
+    backup_type: backupType,
+    backup_host: backupHost || ''
   })
   let addon_message =
     kubeWorkerNodes.length > 0 || configureBackup

--- a/packages/toolkit/src/environment/templates/charts-values/dependencies/values.yaml
+++ b/packages/toolkit/src/environment/templates/charts-values/dependencies/values.yaml
@@ -69,6 +69,7 @@ backup:
   schedule: "0 1 * * *"
   backup_server_secret: backup-server-ssh-credentials
   backup_server_dir: /home/backup/{{env}}
+  host: {{backup_host}}
 
 
 # Restore configuration
@@ -78,3 +79,4 @@ restore:
   backup_server_secret: backup-server-ssh-credentials
   backup_server_dir: /home/backup/{{restore_environment_name}}
   backup_encryption_secret: restore-encryption-secret
+  host: {{restore_host}}


### PR DESCRIPTION
## Description

Goal of this PR is to prepare Dependencies helm chart to work with NetworkPolicies in scope of https://github.com/opencrvs/opencrvs-core/issues/13284. Backup host IP address should be passed as plain text for proper traffic isolation.

Motivation to keep this PR away from Networking Policy implementation is because of additional complexity we would like to avoid.


`BACKUP_HOST` / `PGBACKREST_REPO1_HOST` for the minio and postgres backup/restore charts were previously read from the `host` key of the backup-server SSH secret. That value isn't sensitive, so it's moved out of the secret into a plain Helm value instead (`.Values.backup.host` / `.Values.restore.host`, with service-specific overrides for minio/postgres).

Changes:
- `charts/dependencies/templates/{minio,minio-backup-cronjob,minio-restore-cronjob,postgres,postgres-backup-cronjob-dump,postgres-restore-cronjob,postgres-restore-job-configmap}.yaml`: host env vars now set via `value:` instead of `secretKeyRef`
- `charts/dependencies/values.yaml`: documents the new `host` key alongside existing `server_secret` fields
- `packages/toolkit/src/environment/setup-environment.ts`:
  - includes `backup_host` in the generated environment answers
  - adds a new `restoreHost` prompt when configuring restore, stored as the `RESTORE_HOST` GitHub environment variable (same pattern as `RESTORE_ENVIRONMENT_NAME`)
  - passes `restore_host` through to the generated chart values, filling `restore.host` in the environment's `values.yaml`

Not related included fix:
- Pin pgBackRest to fixed version in helm chart values

See related PRs: 
- https://github.com/opencrvs/infrastructure/pull/367
- https://github.com/opencrvs/opencrvs-core/pull/13497


## Testing

Restore test:

```
NB01NSTL012:~ vmudryi$ k logs -f pr-qgtgd
pod/postgres-restore-runner created
statefulset.apps/postgres scaled
pod/postgres-restore-runner condition met
Waiting for container initialization
pgBackRest 2.59.0
2026-08-21 08:55:52.533 P00   INFO: restore command begin 2.59.0: --config=/etc/pgbackrest/pgbackrest.conf --delta --exec-id=267-c57b5e53 --force --log-level-console=info --pg1-path=/var/lib/postgresql/data --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-host=10.0.1.2 --repo1-host-user=backup --repo1-path=/home/backup/migration-production/postgres --repo1-type=posix --stanza=main
2026-08-21 08:55:53.044 P00   INFO: repo1: restore backup set 20260816-010001F_20260821-010001D, recovery will start at 2026-08-21 01:00:01
2026-08-21 08:55:53.047 P00   INFO: remove invalid files/links/paths from '/var/lib/postgresql/data'
2026-08-21 08:55:54.565 P00   INFO: write updated /var/lib/postgresql/data/postgresql.auto.conf
2026-08-21 08:55:54.570 P00   INFO: restore global/pg_control (performed last to ensure aborted restores cannot be started)
2026-08-21 08:55:54.571 P00   INFO: restore size = 49.3MB, file total = 1382
2026-08-21 08:55:54.571 P00   INFO: restore command end: completed successfully (2041ms)
statefulset.apps/postgres scaled
NB01NSTL012:~ vmudryi$ 
```

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
