### PR TITLE
QA testrail e2e: Core actions (notify, declare, register) and helpers

### DIFF
--- a/.claude/skills/qa-testrail-testcases/SKILL.md
+++ b/.claude/skills/qa-testrail-testcases/SKILL.md
@@ -1,0 +1,382 @@
+---
+name: qa-testrail-testcases
+description: Convert a section from the regression TestRail workbook/JSON into a Playwright e2e spec under packages/testland/e2e/testcases/qa-testrail-testcases/, following this repo's e2e conventions.
+---
+
+# QA TestRail testcases → Playwright e2e specs
+
+Goal: turn manually-written regression test cases into automated Playwright
+specs living under `packages/testland/e2e/testcases/qa-testrail-testcases/`,
+in the same style as the rest of `packages/testland/e2e/testcases/`.
+
+Typical trigger phrasing: "automate the Escalate section from Custom
+actions", "write the e2e tests for the Login suite's <section> section",
+"do the next section in qa-testrail-testcases".
+
+## Terminology — suite vs. section
+
+- A **test suite** = the value of the `Test Suite`/`test_suite` column, e.g.
+  "Custom actions", "Login", "Assign-Unassign", "Versioning of
+  Administrative Structure".
+- A **section** = the value of the `Section`/`section` column. One suite
+  contains many sections (e.g. "Custom actions" contains Validate, Escalate,
+  Attestation, Seal-Unseal).
+- A **test case** = one row within a section (`Test Case Title` / `Steps` /
+  `Expected Result`).
+
+So "write me tests for the Validate section of Custom actions" means: find
+the "Custom actions" suite, find "Validate" within it, and automate every
+row grouped under that section. If the user names only a section without a
+suite, either infer the suite from context (e.g. they're clearly continuing
+work on a suite folder already in progress) or list the available suite
+names and ask — don't guess when a section name could plausibly live in more
+than one suite.
+
+## Folder isolation — never edit outside this folder, fork only on real changes
+
+Everything this skill writes or edits must stay inside
+`packages/testland/e2e/testcases/qa-testrail-testcases/`. Never modify a file
+outside that folder (`e2e/helpers.ts`, `e2e/constants.ts`, `e2e/utils.ts`,
+`e2e/testcases/birth/helpers.ts`, `e2e/testcases/test-data/*.ts`, etc.) —
+only import from them.
+
+This folder's own `helpers.ts` / `constants.ts` / `utils.ts` exist **only**
+for logic that genuinely differs from (or has no equivalent in) the
+canonical files. The rule for every method a new spec needs:
+
+- **Unchanged** — import it directly in the spec file from its canonical
+  location (e.g. `formatV2ChildName`/`getIdByName` from
+  `e2e/testcases/birth/helpers.ts`, `login`/`goToSection`/`joinValuesWith`
+  from `e2e/helpers.ts`, `createDeclaration`/`getDeclaration` (rename on
+  import, e.g. `as createBirthDeclaration`) from
+  `e2e/testcases/test-data/birth-declaration.ts` or `death-declaration.ts`,
+  `CREDENTIALS`/`GATEWAY_HOST` from `e2e/constants.ts`, `selectAction` from
+  `e2e/utils.ts`). Do **not** re-export it through this folder's local files
+  as a barrel/shim — import it at the point of use.
+- **Needs even a tiny behavior change** to make a new test work — write a
+  local version in this folder's `helpers.ts`/`utils.ts` instead (a genuine
+  fork, not a copy of the whole canonical file), and import that local
+  version everywhere it's needed within this folder. Note in a short comment
+  what's different from the canonical version and why, so a future pass
+  doesn't mistake it for an accidental duplicate.
+- If a local fork's own dependencies (helpers it calls internally) are
+  themselves unchanged, import those from canonical too, inside the local
+  file - don't duplicate them just because they're needed by a fork.
+
+Current example of this pattern: `helpers.ts` in this folder keeps only
+`openRecordByTitle` (adds `.first()` to the row locator - some workqueues
+here can render more than one matching row), `searchFromSearchBar` (forked
+only because it must call the local `openRecordByTitle`), and
+`createDuplicateDeathDeclaration` (no canonical equivalent - fixes
+`deceased.idType`/`nid` defaults so two calls reliably collide under the
+dedup config). `utils.ts` keeps only its forked `ensureAssignedToUser`
+(adds a `toPass` retry with a settle wait - a single point-in-time read of
+`assignedTo-value` was flaky here). Everything else these files used to
+duplicate (createBirthDeclaration, createDeathDeclaration,
+createDuplicateBirthDeclaration, login, getToken, triggerDeclarationAction,
+validateActionMenuButton, fillDate, fillChildDetails, openBirthDeclaration,
+drawSignature, uploadImageToSection, printAndExpectPopup, getLocations,
+getAdministrativeAreas, getIdByName, formatName, joinValuesWith,
+selectAction, CREDENTIALS, GATEWAY_HOST, etc.) was deleted from this
+folder and is imported straight from its canonical file by whichever spec
+needs it.
+
+## Step 1 — Read the source
+
+Source files, both under
+`packages/testland/e2e/testcases/qa-testrail-testcases/manual test cases/regression/`:
+- `regression_test_v2_1_web_online_4_cleaned.xlsx` — one sheet ("Regression
+  Tests"), columns `Test Suite | Section | Test Case Title | Steps |
+  Expected Result`.
+- `regression_tests.json` — a pre-parsed export of that sheet: a flat array
+  of ~190 rows shaped like:
+
+  ```json
+  {
+    "id": "TC-0007",
+    "test_suite": "Birth and Death forms",
+    "section": "Birth form",
+    "title": "Validate Mothers details page",
+    "steps": ["...", "..."],
+    "expected_results": ["...", "..."],
+    "aligned": false,
+    "raw_steps": "1. ...\n\n2. ...",
+    "raw_expected_result": "1. ...\n\n2. ..."
+  }
+  ```
+
+**Treat `regression_tests.json` as the primary source** — it's already split
+into `steps`/`expected_results` arrays, so there's no merged-cell
+forward-filling or manual re-parsing to do. Only open the raw `.xlsx` if a
+row is still unclear after reading the JSON (use `read_xlsx.py`, same as
+below, with sheet name `"Regression Tests"`).
+
+The JSON is ~600KB — **never read it whole with the Read tool.** Use the
+shipped filter script to pull out just the suite/section you're working on:
+
+```bash
+# List every (test_suite, section) pair, to check exact spelling/casing
+python3 .claude/skills/qa-testrail-testcases/scripts/filter_regression.py \
+  "packages/testland/e2e/testcases/qa-testrail-testcases/manual test cases/regression/regression_tests.json" \
+  --list
+
+# Filter to one suite (optionally one section within it), written to a file
+python3 .claude/skills/qa-testrail-testcases/scripts/filter_regression.py \
+  "packages/testland/e2e/testcases/qa-testrail-testcases/manual test cases/regression/regression_tests.json" \
+  "Custom actions" /tmp/ca-escalate.json --section "Escalate"
+```
+
+If you ever need the raw `.xlsx` directly (e.g. to double check a mojibake'd
+cell), the same zero-dependency reader works — no `xlsx`/`exceljs` npm
+package or `openpyxl` is installed in this repo's tooling, don't try to
+install one:
+
+```bash
+python3 .claude/skills/qa-testrail-testcases/scripts/read_xlsx.py \
+  "packages/testland/e2e/testcases/qa-testrail-testcases/manual test cases/regression/regression_test_v2_1_web_online_4_cleaned.xlsx" \
+  "Regression Tests" /tmp/regression-raw.json --group
+```
+
+Notes:
+- **Check `aligned` on every row before zipping `steps[]` with
+  `expected_results[]`.** When `aligned` is `false` (25 of 189 rows as of
+  writing), the two arrays don't line up 1:1 — the source spreadsheet's step
+  and result numbering didn't match. For those rows, read `raw_steps` /
+  `raw_expected_result` as prose instead. The filter script flags which rows
+  in its output are unaligned.
+- There's no `e2eMapping`/hint column in this source — the folder/file
+  convention in Step 2 is the only guidance for where a spec goes.
+- `id` (`TC-XXXX`) is unique per row — useful for cross-checking against the
+  workbook and for citing in your Step 6 report, but don't embed it in the
+  generated spec (test titles/comments stay in the same untagged style as
+  the existing specs).
+
+## Step 2 — Ground yourself in the existing code before writing anything
+
+Don't write assertions from the spreadsheet text alone — it's a
+human-authored QA doc, not a spec, and can be internally inconsistent (see
+"judgment calls" below). Cross-check against:
+
+- **Folder/file convention** — apply this algorithm every time:
+  1. **Suite folder**: `packages/testland/e2e/testcases/qa-testrail-testcases/<suite name, lowercased, as written in the Test Suite column>/`
+     (e.g. "Custom actions" → folder `custom actions/`). Create it if it
+     doesn't exist yet.
+  2. **Section folder**: inside the suite folder, one folder per section,
+     slugified (lowercase, spaces → hyphens) from the `Section` value, e.g.
+     `Validate` → `validate/`, `Seal-Unseal` → `seal-unseal/`. Create it if
+     it doesn't exist yet.
+  3. **Suite abbreviation**: a short lowercase prefix for the suite, e.g.
+     "Custom actions" → `ca`. **Always check for files already sitting in
+     the suite folder first and reuse whatever prefix they use** — never
+     invent a second prefix for the same suite. Only derive a fresh one
+     (initials of the suite's significant words, skipping connectors like
+     "and"/"of"/"&") when the suite folder is empty/new.
+  4. **File name**: `<suite-abbrev>-<section-slug>.spec.ts` for the first
+     (and usually only) file covering that section, e.g.
+     `ca-validate.spec.ts`. If a section's test cases are too many/varied to
+     sensibly fit in one file, split across multiple files and suffix the
+     second and later ones with a number: `<suite-abbrev>-<section-slug>-2.spec.ts`,
+     `-3.spec.ts`, etc. (the first file stays unnumbered).
+  5. This gives, in full:
+     `packages/testland/e2e/testcases/qa-testrail-testcases/<suite name>/<section-slug>/<suite-abbrev>-<section-slug>[-N].spec.ts`.
+- **Check for an existing stub first** — a target file may already exist
+  (possibly empty, or a `.gitkeep` placeholder folder) rather than needing
+  creation from scratch. Read before writing.
+- `packages/testland/e2e/HOW-TO-WRITE-A-TEST.md` and `README.md` — the
+  anti-flakiness rules are mandatory, not optional style: use
+  `openRecordByTitle` to select a record from a workqueue (never a raw
+  click), `ensureAssignedToUser` before acting on a record,
+  `triggerDeclarationAction` / `waitForCorrectionAction` to fire+confirm an
+  action (they wait on the real network responses), never an arbitrary
+  `page.waitForTimeout`.
+- Shared helpers — read before reimplementing anything: `packages/testland/e2e/helpers.ts`,
+  `e2e/utils.ts`, `e2e/constants.ts` (has `CREDENTIALS`, the seeded
+  usernames, and environment URLs), `e2e/mobile-helpers.ts`.
+- `e2e/testcases/test-data/birth-declaration.ts`, `death-declaration.ts` (and
+  the `-with-father-brother` / `-with-mother-father` variants) — seed
+  records via the tRPC API (`createDeclaration`) instead of driving the
+  whole form, unless the test case is specifically about form-filling
+  behavior.
+- **`ActionType.NOTIFY` needs a `record.notify`-scoped token — most roles
+  don't have it.** Per Farajaland's default role seed
+  (`packages/testland/src/data-seeding/roles/roles.ts`), only
+  `CREDENTIALS.HOSPITAL_OFFICIAL`/`HOSPITAL_OFFICIAL_OTHER` and
+  `CREDENTIALS.COMMUNITY_LEADER` carry `record.notify` — Registration
+  Officer, Registrar, and every other seeded role do not, and calling
+  `createDeclaration(token, undefined, ActionType.NOTIFY)` (or the raw
+  `event.actions.notify.request.mutate`) with one of those tokens throws
+  `TRPCClientError: FORBIDDEN` (this is enforced server-side via
+  `ACTION_SCOPE_MAP` in `packages/commons/src/events/scopes.ts`, not a bug).
+  When a test needs "role X inherits a record that was notified", notify
+  with a Hospital Official/Community Leader token and only switch to role
+  X's token for the *subsequent* API calls (assign — unrestricted — and
+  reject, declare, register, etc., whichever scope role X actually holds).
+- `e2e/testcases/birth/helpers.ts` and `e2e/testcases/print-certificate/birth/helpers.ts` —
+  shared utilities living under a misleadingly specific path
+  (`openRecordByTitle`, `formatV2ChildName`, `getAdministrativeAreas`,
+  `getIdByName`, etc. are used repo-wide, not just for birth).
+- Search `e2e/testcases/` for specs that already exercise the same
+  action/workqueue/flag — especially `custom-actions-and-flags/`,
+  `jurisdiction/`, `action-menu/`. They're ground truth for real locators,
+  copy text, and behavior, and are usually more reliable than the
+  spreadsheet's "Expected Result" column.
+- **Jurisdiction ("within their jurisdiction") cases**: visibility/permission
+  is resolved from the **creating user's own `primaryOfficeId`**
+  (`createdAtLocation` passed to `createDeclaration` is silently ignored for
+  a normal user token — only honored for a system/integration token). To
+  produce a record "outside" a district, create it with a token from a user
+  actually based there (e.g. `CREDENTIALS.REGISTRATION_OFFICER_PUALULA`),
+  not just by overriding the birth/death location form fields. Mirror
+  `jurisdiction/administrative-area-restrictions.spec.ts`.
+- When exact copy text, field ids, or SHOW/ENABLE conditionals matter, read
+  the event config directly: `packages/testland/src/events/birth/index.ts`,
+  `.../death/index.ts`. **Don't assume birth and death share copy for "the
+  same" action** — they're configured independently and can drift (e.g.
+  death's `VALIDATE_DECLARATION` supportingCopy was found still saying
+  "Approving this declaration confirms..." — a copy-paste leftover from
+  Approve). When source, spreadsheet, and sibling event disagree, that's a
+  signal to flag a possible product bug rather than silently picking one.
+
+## Step 3 — Confirm live behavior when still uncertain
+
+For anything not confidently pinned down by source + existing specs (exact
+modal copy, whether a field is required, action menu contents/ordering after
+a given action, etc.), check the real app instead of guessing:
+
+- URL: `https://register.qa.opencrvs.dev/` — this is the deployed `CLIENT_URL`
+  for `DOMAIN=qa.opencrvs.dev`, matching `packages/testland/e2e/constants.ts`.
+- Login: username + password, then a 6-digit verification code. Password is
+  `TEST_USER_PASSWORD` (`'test'`) from `constants.ts`; the code is always
+  `000000` in this environment (see `getAuthTokens` in `e2e/helpers.ts` — the
+  harness hardcodes it, and it works identically when logging in by hand).
+- Usernames: any value from the `CREDENTIALS` map in `e2e/constants.ts`, e.g.
+  `f.katongo` (Registration Officer, Ibombo), `k.mweene` (Registrar, Ibombo),
+  `m.owen` (Provincial Registrar), `c.lungu` (Registrar General),
+  `m.simbaya` (Registration Officer, Pualula — useful for jurisdiction
+  cases). Pick whichever role the test case is actually about.
+- Drive it with the `playwright-cli` skill or the `mcp__playwright__*`
+  browser tools: navigate, snapshot, click through the exact flow the test
+  case describes, and read off the true copy/labels/test-ids before encoding
+  them into assertions. **In this environment `playwright-cli` isn't
+  installed globally** — invoke it as `npx --yes @playwright/cli@latest
+  <command>` (e.g. `npx --yes @playwright/cli@latest open <url>`). If the
+  first call complains the skill doesn't match the tool version, run `npx
+  --yes @playwright/cli@latest install --skills` once to sync it, then
+  continue normally. Verified working end-to-end (login → 6-digit code →
+  PIN setup → profile check) against `register.qa.opencrvs.dev` as
+  Community Leader (`g.phiri`).
+- **This is a shared, persistent QA environment**, not a throwaway sandbox.
+  Read-only exploration and assigning/validating your own freshly-created
+  throwaway declaration is fine. Be careful firing hard-to-reverse actions
+  (Register, Revoke, Archive, delete) against records you didn't create —
+  other people or scheduled test runs may depend on their state. Prefer
+  creating your own declaration to poke at over acting on unrelated existing
+  records.
+
+## Step 4 — Write the spec
+
+Follow the conventions already established in sibling files (see Step 2).
+In short: `test.step(...)` blocks per sub-scenario, the `CREDENTIALS` map for
+logins, API-seeded declarations for anything not specifically about
+form-filling, `openRecordByTitle` / `ensureAssignedToUser` /
+`triggerDeclarationAction` / `selectAction` / `searchFromSearchBar` /
+`switchEventTab` for interaction, `getByTestId('status-value' | 'flags-value')`
+for record state, and `#action-Dropdown-Content li` `.allTextContents()` for
+action-menu contents.
+
+**`Assign`/`Unassign` in the source data means "whichever applies", not
+"both appear together".** The regression workbook/JSON has already been
+normalized so that any expected-result list needing this is written as the
+combined `Assign/Unassign` (see e.g. the Archive section's expected results)
+— if you ever find a row that still lists them as two separate items in the
+same action-menu list (that combination can't both be true for one record),
+that's a leftover the normalization missed: fix the wording in both
+`regression_tests.json` (plain JSON string edit) and the `.xlsx` (there's no
+shared-strings table in this workbook — the cell text lives inline in
+`xl/worksheets/sheet1.xml`; edit that XML entry directly inside the zip with
+Python's stdlib `zipfile`, no `openpyxl` needed) so the next person reading
+either source doesn't hit the same ambiguity. In the spec itself, assert only
+the one real action ('Assign' when unassigned, 'Unassign' when assigned) —
+never both.
+
+**Two behaviors of this app's action system catch nearly every new spec —
+check for both on every `test.step` that follows a `triggerDeclarationAction`
+/ `selectAction` confirm:**
+
+1. **Every action navigates the user out of the record view.** Confirming
+   an action (Archive, Register, Reject, Declare/Notify/Register "with
+   edits", etc.) sends the client back to the workqueue/search-result the
+   record was opened from — the record's own overview page is gone by the
+   time the action's response resolves. **Never assert `status-value` /
+   `flags-value` / the action menu on the same page right after the
+   trigger** — first re-find the record (`searchFromSearchBar(page, name)`,
+   or click the relevant workqueue button then `openRecordByTitle`), *then*
+   assert. This applies even inside a shared helper that wraps
+   `triggerDeclarationAction` (e.g. an `archiveAndAssertActions`-style
+   function) — the re-navigation has to happen inside the helper, before any
+   assertion, not just at call sites. (Exception: `Cancel`-ing a
+   confirmation modal never navigates anywhere, so checking the still-open
+   record right after a Cancel is fine.)
+2. **The Audit tab stays empty until the record is assigned to the viewing
+   user.** Most actions leave the record unassigned afterwards (that's *why*
+   the post-action menu shows `Assign`, not `Unassign`), so
+   `switchEventTab(page, 'Audit')` needs an `ensureAssignedToUser(page, ...)`
+   call immediately before it — even if the record was assigned earlier in
+   the same test, re-check after every re-navigation from rule 1. Checking
+   `status-value`/`flags-value` does **not** require assignment; only the
+   Audit tab's content does.
+
+Both of these were found (as 3 failing tests) in the Archive section's specs
+after they'd already passed review — treat them as load-bearing, not
+optional polish.
+
+**Switching users on the same `page` mid-test**: two separate things need to
+both be right, or the client is left in a half-navigated state (symptoms:
+`refreshToken` intermittently undefined, navigation to `CLIENT_URL` hanging,
+or a later step failing to find the search bar because login never actually
+finished) — this was hit and fixed while automating "Escalate", not
+theoretical:
+1. **Always `logout(page)` immediately before `login(page, ...)` when
+   switching to a different user on the same `page`.** This matches the
+   established pattern (e.g. `archival/archive-and-unarchive.spec.ts`,
+   `birth/save-and-delete-drafts.spec.ts`) — it forces a clean transition
+   through the login app instead of racing the client's own "detect the
+   refreshToken belongs to a different user, refetch their offline data"
+   logic. Only the very first login of a test (nothing to log out of yet)
+   skips this.
+2. **`skipPin` is per-*user*, not per-browser** — the client stores each
+   user's PIN in IndexedDB keyed by their `userID` (`packages/client/src/views/PIN/CreatePin.tsx`,
+   `packages/client/src/declarations/index.ts`), and that storage persists
+   for the rest of the test regardless of `logout()` (logout only clears the
+   current session pointer, not `USER_DATA`). So pass `skipPin: true` **only
+   when the exact same role has already logged in earlier in this same
+   test** (a genuine repeat) — never for a role's first appearance, even if
+   other roles logged in before it. Get this backwards (e.g. `true` for
+   every login after the first, regardless of who) and the first-time user
+   gets stuck on a PIN-creation screen the test never fills in.
+
+## Step 5 — Verify before calling it done
+
+- Typecheck **only the new file's presence in the output** — the whole
+  package (`pnpm run test:compilation` from `packages/testland`) currently
+  has pre-existing, unrelated failures from a stale `@opencrvs/toolkit`
+  build (`@opencrvs/toolkit/conditionals` missing exports, etc.). Run it,
+  then confirm none of the reported errors reference your new file's path —
+  don't try to fix the pre-existing ones.
+- Lint the new file specifically:
+  `pnpm exec eslint -c eslint.config.js "<path to the new spec>"` (run from
+  `packages/testland`).
+- Running the spec against a live stack (`pnpm e2e-dev` locally, or
+  `NODE_TLS_REJECT_UNAUTHORIZED=0 DOMAIN=<env>.opencrvs.dev pnpm e2e` per the
+  e2e README) is ideal but optional — call it out as unverified if no stack
+  is available in the current session.
+
+## Step 6 — Report back
+
+Include: which suite/section/rows were covered (cite the `TC-XXXX` ids even
+though they're not in the spec file itself) and where the file was written;
+any judgment call made because the spreadsheet was ambiguous or
+self-contradictory, with reasoning (note if a row had `aligned: false` and
+needed the raw prose fields instead of the parsed arrays); and any suspected
+product bugs discovered while cross-checking source vs. spreadsheet vs. live
+app.

--- a/.claude/skills/qa-testrail-testcases/SKILL.md
+++ b/.claude/skills/qa-testrail-testcases/SKILL.md
@@ -243,8 +243,12 @@ For anything not confidently pinned down by source + existing specs (exact
 modal copy, whether a field is required, action menu contents/ordering after
 a given action, etc.), check the real app instead of guessing:
 
-- URL: `https://register.qa.opencrvs.dev/` — this is the deployed `CLIENT_URL`
-  for `DOMAIN=qa.opencrvs.dev`, matching `packages/testland/e2e/constants.ts`.
+- URL: `https://register.e2e.opencrvs.dev/` — this is the deployed
+  `CLIENT_URL` for `DOMAIN=e2e.opencrvs.dev`, matching
+  `packages/testland/e2e/constants.ts`. The suite falls back to
+  `qa.opencrvs.dev` automatically (via `e2e/global-setup.ts`) if
+  `e2e.opencrvs.dev` doesn't respond — if the app seems to be behaving
+  unexpectedly, check which domain the run actually resolved to.
 - Login: username + password, then a 6-digit verification code. Password is
   `TEST_USER_PASSWORD` (`'test'`) from `constants.ts`; the code is always
   `000000` in this environment (see `getAuthTokens` in `e2e/helpers.ts` — the
@@ -263,9 +267,10 @@ a given action, etc.), check the real app instead of guessing:
   first call complains the skill doesn't match the tool version, run `npx
   --yes @playwright/cli@latest install --skills` once to sync it, then
   continue normally. Verified working end-to-end (login → 6-digit code →
-  PIN setup → profile check) against `register.qa.opencrvs.dev` as
-  Community Leader (`g.phiri`).
-- **This is a shared, persistent QA environment**, not a throwaway sandbox.
+  PIN setup → profile check) against `register.qa.opencrvs.dev` (the
+  environment in use before the e2e.opencrvs.dev switch — behavior should be
+  identical) as Community Leader (`g.phiri`).
+- **This is a shared, persistent environment**, not a throwaway sandbox.
   Read-only exploration and assigning/validating your own freshly-created
   throwaway declaration is fine. Be careful firing hard-to-reverse actions
   (Register, Revoke, Archive, delete) against records you didn't create —

--- a/.claude/skills/qa-testrail-testcases/scripts/filter_regression.py
+++ b/.claude/skills/qa-testrail-testcases/scripts/filter_regression.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""
+Filters regression_tests.json (the pre-parsed export of the regression
+workbook) by test_suite and, optionally, section — writing just the matching
+rows to a file. The full file is ~600KB / ~190 rows; always filter through
+this script rather than reading it whole with the Read tool.
+
+Usage:
+  # List every (test_suite, section) pair present, in file order
+  python3 filter_regression.py "<path-to-regression_tests.json>" --list
+
+  # Write every row for a suite
+  python3 filter_regression.py "<path-to-regression_tests.json>" "<Test Suite>" out.json
+
+  # Write only the rows for one section within a suite
+  python3 filter_regression.py "<path-to-regression_tests.json>" "<Test Suite>" out.json --section "<Section>"
+
+Matching on test_suite/section is case-insensitive and exact (not
+substring) — run --list first if unsure of exact spelling/casing.
+
+Each row already has `steps`/`expected_results` arrays split out. When a
+row's `aligned` field is false, those two arrays don't line up 1:1 (the
+source spreadsheet numbered them inconsistently) — for those rows, read
+`raw_steps`/`raw_expected_result` as prose instead of zipping the arrays.
+This script flags which written rows are unaligned so you don't miss it.
+"""
+import sys
+import json
+
+
+def main():
+    args = sys.argv[1:]
+    if not args:
+        print(__doc__)
+        sys.exit(1)
+
+    path = args[0]
+    with open(path, encoding='utf-8') as f:
+        data = json.load(f)
+
+    if '--list' in args:
+        seen = []
+        for row in data:
+            key = (row['test_suite'], row['section'])
+            if key not in seen:
+                seen.append(key)
+        for suite, section in seen:
+            print(f"{suite} -> {section}")
+        return
+
+    suite, out_path = args[1], args[2]
+    section = None
+    if '--section' in args:
+        section = args[args.index('--section') + 1]
+
+    matches = [
+        row for row in data
+        if row['test_suite'].strip().lower() == suite.strip().lower()
+        and (section is None or row['section'].strip().lower() == section.strip().lower())
+    ]
+
+    with open(out_path, 'w', encoding='utf-8') as f:
+        json.dump(matches, f, ensure_ascii=False, indent=2)
+
+    unaligned = [row['id'] for row in matches if not row.get('aligned', True)]
+    print(f"{len(matches)} matching rows written to {out_path}")
+    if unaligned:
+        print(
+            f"WARNING: {len(unaligned)} row(s) have aligned=false: {', '.join(unaligned)}"
+        )
+        print(
+            "For these, read raw_steps/raw_expected_result as prose instead of "
+            "zipping steps[]/expected_results[]."
+        )
+    if not matches:
+        print("No matches — re-run with --list to check exact suite/section spelling.")
+
+
+if __name__ == '__main__':
+    main()

--- a/.claude/skills/qa-testrail-testcases/scripts/read_xlsx.py
+++ b/.claude/skills/qa-testrail-testcases/scripts/read_xlsx.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""
+Reads a .xlsx workbook without any third-party dependency (no `xlsx`/`exceljs`
+npm package or `openpyxl` is installed in this repo's tooling). An .xlsx file
+is a zip of XML parts, so this uses only the stdlib: zipfile + xml.etree.
+
+Usage:
+  # 1. List sheet (tab) names in the workbook
+  python3 read_xlsx.py "<path-to-workbook.xlsx>"
+
+  # 2. Dump one sheet's rows as JSON to a file (always write to a file, not
+  #    stdout — on Windows the console is cp1252 and will throw
+  #    UnicodeEncodeError on the em-dashes/checkmarks/curly-quotes these
+  #    sheets contain).
+  python3 read_xlsx.py "<path-to-workbook.xlsx>" "<Sheet Name>" out.json
+
+  # 3. Same, but also group rows into sections (see note below) and emit
+  #    [{ section, cases: [{ title, steps, expected, e2eMapping }] }, ...]
+  python3 read_xlsx.py "<path-to-workbook.xlsx>" "<Sheet Name>" out.json --group
+
+Note on "Section": in these sheets, Section is a merged cell — only the
+first row of a section has a non-empty Section value; subsequent rows
+belong to the same section until the next non-empty Section value. Rows
+without --group give you the raw grid; --group forward-fills Section and
+buckets rows under it (assuming the header row is
+Section/Title/Steps (Step)/Steps (Expected Result)/e2e mapping).
+"""
+import sys
+import zipfile
+import re
+import json
+from xml.etree import ElementTree as ET
+
+NS = {
+    'main': 'http://schemas.openxmlformats.org/spreadsheetml/2006/main',
+    'r': 'http://schemas.openxmlformats.org/officeDocument/2006/relationships'
+}
+
+
+def col_to_index(cell_ref):
+    letters = re.match(r'([A-Z]+)', cell_ref).group(1)
+    idx = 0
+    for c in letters:
+        idx = idx * 26 + (ord(c) - ord('A') + 1)
+    return idx - 1
+
+
+def load_shared_strings(z):
+    if 'xl/sharedStrings.xml' not in z.namelist():
+        return []
+    root = ET.fromstring(z.read('xl/sharedStrings.xml'))
+    return [
+        ''.join(t.text or '' for t in si.findall('.//main:t', NS))
+        for si in root.findall('main:si', NS)
+    ]
+
+
+def load_sheet_map(z):
+    wb_root = ET.fromstring(z.read('xl/workbook.xml'))
+    sheets = [
+        (
+            sheet.get('name'),
+            sheet.get('{http://schemas.openxmlformats.org/officeDocument/2006/relationships}id')
+        )
+        for sheet in wb_root.findall('.//main:sheets/main:sheet', NS)
+    ]
+    rels_root = ET.fromstring(z.read('xl/_rels/workbook.xml.rels'))
+    rid_to_target = {rel.get('Id'): rel.get('Target') for rel in rels_root}
+    return [(name, rid_to_target.get(rid)) for name, rid in sheets]
+
+
+def read_sheet_rows(z, sheet_path, shared_strings):
+    sheet_path = sheet_path.lstrip('/')
+    if not sheet_path.startswith('xl/'):
+        sheet_path = 'xl/' + sheet_path
+    sheet_root = ET.fromstring(z.read(sheet_path))
+
+    rows_data = []
+    for row in sheet_root.findall('.//main:sheetData/main:row', NS):
+        row_cells = {}
+        max_col = 0
+        for c in row.findall('main:c', NS):
+            col_idx = col_to_index(c.get('r'))
+            max_col = max(max_col, col_idx)
+            cell_type = c.get('t')
+            v = c.find('main:v', NS)
+            is_elem = c.find('main:is', NS)
+            value = ''
+            if is_elem is not None:
+                value = ''.join(t.text or '' for t in is_elem.findall('.//main:t', NS))
+            elif v is not None:
+                value = shared_strings[int(v.text)] if cell_type == 's' else (v.text or '')
+            row_cells[col_idx] = value
+        rows_data.append([row_cells.get(i, '') for i in range(max_col + 1)])
+    return rows_data
+
+
+def group_by_section(rows):
+    header, *data_rows = rows
+    grouped = []
+    current = None
+    for row in data_rows:
+        row = row + [''] * (len(header) - len(row))
+        record = dict(zip(header, row))
+        if record.get('Section', '').strip():
+            current = {'section': record['Section'].strip(), 'cases': []}
+            grouped.append(current)
+        if current is None:
+            continue
+        if not any(v.strip() for v in record.values() if isinstance(v, str)):
+            continue
+        current['cases'].append({
+            'title': record.get('Title', ''),
+            'steps': record.get('Steps (Step)', ''),
+            'expected': record.get('Steps (Expected Result)', ''),
+            'e2eMapping': record.get('e2e mapping', '')
+        })
+    return grouped
+
+
+def main():
+    path = sys.argv[1]
+    sheet_name_filter = sys.argv[2] if len(sys.argv) > 2 else None
+    out_path = sys.argv[3] if len(sys.argv) > 3 else None
+    group = '--group' in sys.argv[4:]
+
+    z = zipfile.ZipFile(path)
+    shared_strings = load_shared_strings(z)
+    sheets = load_sheet_map(z)
+
+    if sheet_name_filter is None:
+        print("Sheets found:")
+        for name, target in sheets:
+            print(f"  {name} -> {target}")
+        return
+
+    target_sheet = next(
+        (target for name, target in sheets
+         if name.strip().lower() == sheet_name_filter.strip().lower()),
+        None
+    )
+    if not target_sheet:
+        print(f"Sheet '{sheet_name_filter}' not found")
+        sys.exit(1)
+
+    rows = read_sheet_rows(z, target_sheet, shared_strings)
+    output_obj = group_by_section(rows) if group else rows
+    output = json.dumps(output_obj, ensure_ascii=False)
+
+    if out_path:
+        with open(out_path, 'w', encoding='utf-8') as f:
+            f.write(output)
+    else:
+        sys.stdout.buffer.write(output.encode('utf-8'))
+
+
+if __name__ == '__main__':
+    main()

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "private": true,
   "os": [
     "darwin",
-    "linux"
+    "linux",
+    "win32"
   ],
   "engines": {
     "node": "22.x.x"

--- a/packages/testland/.gitignore
+++ b/packages/testland/.gitignore
@@ -42,6 +42,8 @@ graphql.schema.json
 /blob-report/
 /playwright/.cache/
 notebooks
+/.playwright-cli/
+/.playwright-mcp/ 
 
 ctrf/
 

--- a/packages/testland/e2e/constants.ts
+++ b/packages/testland/e2e/constants.ts
@@ -8,7 +8,7 @@
  *
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
-export const DOMAIN = process.env.DOMAIN || 'farajaland-e2e.opencrvs.dev'
+export const DOMAIN = process.env.DOMAIN || 'qa.opencrvs.dev'
 export const SCHEME = process.env.SCHEME || 'https'
 export const LOGIN_URL =
   process.env.NODE_ENV === 'development'

--- a/packages/testland/e2e/constants.ts
+++ b/packages/testland/e2e/constants.ts
@@ -8,7 +8,7 @@
  *
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
-export const DOMAIN = process.env.DOMAIN || 'qa.opencrvs.dev'
+export const DOMAIN = process.env.DOMAIN || 'e2e.opencrvs.dev'
 export const SCHEME = process.env.SCHEME || 'https'
 export const LOGIN_URL =
   process.env.NODE_ENV === 'development'

--- a/packages/testland/e2e/global-setup.ts
+++ b/packages/testland/e2e/global-setup.ts
@@ -1,0 +1,53 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+
+const PRIMARY_DOMAIN = 'e2e.opencrvs.dev'
+const FALLBACK_DOMAIN = 'qa.opencrvs.dev'
+const HEALTH_CHECK_TIMEOUT_MS = 5000
+
+async function isReachable(domain: string): Promise<boolean> {
+  try {
+    // Gateway's /ping is a public, no-auth health check - any HTTP response
+    // (even a 5xx from a degraded sub-service) means DNS/TLS/networking to
+    // the environment are working, which is all this check cares about.
+    await fetch(`https://gateway.${domain}/ping`, {
+      signal: AbortSignal.timeout(HEALTH_CHECK_TIMEOUT_MS)
+    })
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Resolves which shared environment testland e2e specs run against when
+ * DOMAIN isn't explicitly set. e2e.opencrvs.dev is the primary target, but
+ * the suite falls back to qa.opencrvs.dev if e2e.opencrvs.dev doesn't
+ * respond (e.g. mid-deploy or down). An explicit DOMAIN env var always wins
+ * and skips this check entirely.
+ *
+ * Runs once in the main test-runner process before workers are spawned, so
+ * mutating process.env here is inherited by every worker.
+ */
+export default async function globalSetup() {
+  if (process.env.DOMAIN) {
+    return
+  }
+
+  if (await isReachable(PRIMARY_DOMAIN)) {
+    process.env.DOMAIN = PRIMARY_DOMAIN
+  } else {
+    console.warn(
+      `[global-setup] ${PRIMARY_DOMAIN} did not respond within ${HEALTH_CHECK_TIMEOUT_MS}ms - falling back to ${FALLBACK_DOMAIN}.`
+    )
+    process.env.DOMAIN = FALLBACK_DOMAIN
+  }
+}

--- a/packages/testland/e2e/testcases/qa-testrail-testcases/constants.ts
+++ b/packages/testland/e2e/testcases/qa-testrail-testcases/constants.ts
@@ -1,0 +1,21 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+/**
+ * Reserved for constants specific to
+ * packages/testland/e2e/testcases/qa-testrail-testcases/ that differ from,
+ * or don't exist in, the canonical e2e/constants.ts.
+ *
+ * Every constant this suite currently needs (DOMAIN, CREDENTIALS,
+ * GATEWAY_HOST, etc.) is unchanged from the canonical file, so nothing is
+ * re-exported here - import those directly from '../../constants' (from
+ * this folder) or the equivalent relative path from a suite's spec file.
+ * See the qa-testrail-testcases skill for the full rule.
+ */

--- a/packages/testland/e2e/testcases/qa-testrail-testcases/event lifecycle (core actions)/declare/el-declare.spec.ts
+++ b/packages/testland/e2e/testcases/qa-testrail-testcases/event lifecycle (core actions)/declare/el-declare.spec.ts
@@ -22,7 +22,11 @@ import {
   createDeclaration as createDeathDeclaration,
   type Declaration as DeathDeclaration
 } from '../../../../testcases/test-data/death-declaration'
-import { fillDate, formatV2ChildName } from '../../../../testcases/birth/helpers'
+import {
+  fillDate,
+  formatV2ChildName,
+  openBirthDeclaration
+} from '../../../../testcases/birth/helpers'
 import {
   getToken,
   goToSection,
@@ -66,10 +70,7 @@ test('Verify user unable to declare incomplete record', async ({ page }) => {
   })
 
   await test.step('Start an incomplete birth declaration', async () => {
-    await page.click('#header-new-event')
-    await page.getByLabel('Birth').click()
-    await page.getByRole('button', { name: 'Continue' }).click()
-    await page.getByRole('button', { name: 'Continue' }).click()
+    await openBirthDeclaration(page)
 
     await page.locator('#firstname').fill(childName.firstNames)
     await page.locator('#surname').fill(childName.familyName)
@@ -184,7 +185,7 @@ test('Verify Registration Officer can declare a previously NOTIFIED birth record
 // Known issue: When CL notifies a death record, the 'Attestation required' flag is added.
 // Which shouldn't have. If fixed it'll pass.
 
-test.skip('Verify Community Leader can declare their own previously NOTIFIED death record via edit', async ({  // Known issue: When CL notifies a death record, the 'Attestation required' flag is added. Which shouldn't have. If fixed it'll pass.
+test.skip('Verify Community Leader can declare their own previously NOTIFIED death record via edit', async ({
   page
 }) => {
   test.setTimeout(180_000)

--- a/packages/testland/e2e/testcases/qa-testrail-testcases/event lifecycle (core actions)/declare/el-declare.spec.ts
+++ b/packages/testland/e2e/testcases/qa-testrail-testcases/event lifecycle (core actions)/declare/el-declare.spec.ts
@@ -1,0 +1,247 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+import { test, expect } from '@playwright/test'
+import { faker } from '@faker-js/faker'
+import { ActionType } from '@opencrvs/toolkit/events'
+import { CREDENTIALS } from '../../../../constants'
+import { ensureAssignedToUser } from '../../utils'
+import { selectAction } from '../../../../utils'
+import {
+  createDeclaration as createBirthDeclaration,
+  type Declaration as BirthDeclaration
+} from '../../../../testcases/test-data/birth-declaration'
+import {
+  createDeclaration as createDeathDeclaration,
+  type Declaration as DeathDeclaration
+} from '../../../../testcases/test-data/death-declaration'
+import { fillDate, formatV2ChildName } from '../../../../testcases/birth/helpers'
+import {
+  getToken,
+  goToSection,
+  joinValuesWith,
+  login,
+  switchEventTab,
+  triggerDeclarationAction,
+  validateActionMenuButton
+} from '../../../../helpers'
+import { openRecordByTitle } from '../../helpers'
+
+const formatV2DeceasedName = (declaration: {
+  'deceased.name': { firstname: string; surname: string }
+  [key: string]: any
+}) =>
+  joinValuesWith([
+    declaration['deceased.name'].firstname,
+    declaration['deceased.name'].surname
+  ])
+
+// Community Leader and Hospital Official (notify-only, see el-notify.spec.ts) are
+// already exercised there for the incomplete-record case, including the
+// disabled 'Declare' action. Here we cover the roles that create declarations
+// directly (Registration Officer and Registrar).
+
+// TestRail TC-0057: Verify user unable to declare incomplete record
+test('Verify user unable to declare incomplete record', async ({ page }) => {
+  test.setTimeout(180_000)
+
+  const childName = {
+    firstNames: faker.person.firstName(),
+    familyName: faker.person.lastName()
+  }
+  const deceasedName = {
+    firstNames: faker.person.firstName(),
+    familyName: faker.person.lastName()
+  }
+
+  await test.step('Login as Registration Officer', async () => {
+    await login(page, CREDENTIALS.REGISTRATION_OFFICER)
+  })
+
+  await test.step('Start an incomplete birth declaration', async () => {
+    await page.click('#header-new-event')
+    await page.getByLabel('Birth').click()
+    await page.getByRole('button', { name: 'Continue' }).click()
+    await page.getByRole('button', { name: 'Continue' }).click()
+
+    await page.locator('#firstname').fill(childName.firstNames)
+    await page.locator('#surname').fill(childName.familyName)
+
+    await goToSection(page, 'review')
+  })
+
+  await test.step("Action menu has 'Declare' (disabled) for the incomplete birth declaration", async () => {
+    await validateActionMenuButton(page, 'Declare', false)
+  })
+
+  await test.step('Start an incomplete death declaration', async () => {
+    await page.getByTestId('exit-button').click()
+    await page.getByRole('button', { name: 'Confirm', exact: true }).click()
+
+    await page.click('#header-new-event')
+    await page.getByLabel('Death').click()
+    await page.getByRole('button', { name: 'Continue' }).click()
+    await page.getByRole('button', { name: 'Continue' }).click()
+
+    await page.locator('#firstname').fill(deceasedName.firstNames)
+    await page.locator('#surname').fill(deceasedName.familyName)
+
+    await goToSection(page, 'review')
+  })
+
+  await test.step("Action menu has 'Declare' (disabled) for the incomplete death declaration", async () => {
+    await validateActionMenuButton(page, 'Declare', false)
+  })
+})
+
+// TestRail TC-0058: Verify user can declare previously NOTIFIED records
+// (1 of 2 e2e tests in this file covering this test case - the birth/RO
+// variant; see the death/Community Leader variant below)
+test('Verify Registration Officer can declare a previously NOTIFIED birth record via edit', async ({
+  page
+}) => {
+  test.setTimeout(300_000)
+
+  let declaration: BirthDeclaration
+
+  await test.step('Community Leader notifies a birth record via API', async () => {
+    const token = await getToken(CREDENTIALS.COMMUNITY_LEADER)
+    // The default NOTIFY declaration deliberately omits mother.nid/mother.dob
+    // (see the comment in createDeclaration), leaving the record incomplete
+    // for Declare until it is edited - matching the workflow the spreadsheet
+    // describes.
+    const res = await createBirthDeclaration(
+      token,
+      undefined,
+      ActionType.NOTIFY
+    )
+    declaration = res.declaration
+  })
+
+  await test.step('Login as Registration Officer', async () => {
+    await login(page, CREDENTIALS.REGISTRATION_OFFICER)
+  })
+
+  await test.step('Notifications workqueue lists the notified record', async () => {
+    await page.getByText('Notifications').click()
+    await openRecordByTitle(page, formatV2ChildName(declaration))
+  })
+
+  await test.step('Assign and start editing', async () => {
+    await ensureAssignedToUser(page, CREDENTIALS.REGISTRATION_OFFICER)
+    await selectAction(page, 'Edit')
+    await goToSection(page, 'review')
+  })
+
+  await test.step("'Declare with edits' is disabled while mother's date of birth/ID are still missing", async () => {
+    await validateActionMenuButton(page, 'Declare with edits', false)
+  })
+
+  await test.step("Fill in mother's missing date of birth and ID", async () => {
+    await page.getByTestId('change-button-mother.dob').click()
+    await fillDate(page, { dd: '15', mm: '06', yyyy: '1998' })
+    await page.locator('#mother____nid').fill(faker.string.numeric(10))
+
+    await page.getByRole('button', { name: 'Go to review' }).click()
+  })
+
+  await test.step("'Declare with edits' is enabled once required information is complete", async () => {
+    await validateActionMenuButton(page, 'Declare with edits', true)
+  })
+
+  await test.step('Declare with edits', async () => {
+    await triggerDeclarationAction(page, 'Declare with edits')
+  })
+
+  await test.step('Record is Declared, with Edited and Declared audit entries', async () => {
+    await page.getByText('Recent').click()
+    await openRecordByTitle(page, formatV2ChildName(declaration))
+    await ensureAssignedToUser(page, CREDENTIALS.REGISTRATION_OFFICER)
+
+    await expect(page.getByTestId('status-value')).toHaveText('Declared')
+
+    await switchEventTab(page, 'Audit')
+    await expect(
+      page.getByRole('button', { name: 'Edited', exact: true })
+    ).toBeVisible()
+    await expect(
+      page.getByRole('button', { name: 'Declared', exact: true })
+    ).toBeVisible()
+  })
+})
+
+// TestRail TC-0058: Verify user can declare previously NOTIFIED records
+// (2 of 2 e2e tests in this file covering this test case - the death/CL
+// variant; see the birth/Registration Officer variant above)
+//
+// Known issue: When CL notifies a death record, the 'Attestation required' flag is added.
+// Which shouldn't have. If fixed it'll pass.
+
+test.skip('Verify Community Leader can declare their own previously NOTIFIED death record via edit', async ({  // Known issue: When CL notifies a death record, the 'Attestation required' flag is added. Which shouldn't have. If fixed it'll pass.
+  page
+}) => {
+  test.setTimeout(180_000)
+
+  let declaration: DeathDeclaration
+
+  await test.step('Community Leader notifies a death record via API', async () => {
+    const token = await getToken(CREDENTIALS.COMMUNITY_LEADER)
+    const res = await createDeathDeclaration(
+      token,
+      undefined,
+      ActionType.NOTIFY
+    )
+    declaration = res.declaration
+  })
+
+  await test.step('Login as Community Leader', async () => {
+    await login(page, CREDENTIALS.COMMUNITY_LEADER)
+  })
+
+  await test.step('Own notified record is found in Recent', async () => {
+    await page.getByText('Recent').click()
+    await openRecordByTitle(page, formatV2DeceasedName(declaration))
+
+    await expect(page.getByTestId('status-value')).toHaveText('Notified')
+  })
+
+  await test.step('Assign and start editing', async () => {
+    await ensureAssignedToUser(page, CREDENTIALS.COMMUNITY_LEADER)
+    await selectAction(page, 'Edit')
+  })
+
+  await test.step('Make a change and go back to review', async () => {
+    await goToSection(page, 'review')
+    await page.getByTestId('change-button-informant.email').click()
+    await page.locator('#informant____email').fill(faker.internet.email())
+    await page.getByRole('button', { name: 'Go to review' }).click()
+  })
+
+  await test.step('Declare with edits', async () => {
+    await validateActionMenuButton(page, 'Declare with edits', true)
+    await triggerDeclarationAction(page, 'Declare with edits')
+  })
+
+  await test.step('Record is Declared, with Edited and Declared audit entries', async () => {
+    await page.getByText('Recent').click()
+    await openRecordByTitle(page, formatV2DeceasedName(declaration))
+
+    await expect(page.getByTestId('status-value')).toHaveText('Declared')
+
+    await ensureAssignedToUser(page, CREDENTIALS.COMMUNITY_LEADER)
+    await switchEventTab(page, 'Audit')
+    await expect(
+      page.getByRole('button', { name: 'Edited', exact: true })
+    ).toBeVisible()
+    await expect(
+      page.getByRole('button', { name: 'Declared', exact: true })
+    ).toBeVisible()
+  })
+})

--- a/packages/testland/e2e/testcases/qa-testrail-testcases/event lifecycle (core actions)/notify/el-notify.spec.ts
+++ b/packages/testland/e2e/testcases/qa-testrail-testcases/event lifecycle (core actions)/notify/el-notify.spec.ts
@@ -1,0 +1,272 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+import { test, expect } from '@playwright/test'
+import { faker } from '@faker-js/faker'
+import { CREDENTIALS } from '../../../../constants'
+import { ensureAssignedToUser } from '../../utils'
+import { fillDate } from '../../../../testcases/birth/helpers'
+import {
+  formatName,
+  goToSection,
+  login,
+  switchEventTab,
+  triggerDeclarationAction,
+  validateActionMenuButton
+} from '../../../../helpers'
+import { openRecordByTitle } from '../../helpers'
+
+// Community Leader is used for both events throughout this file: unlike
+// Hospital Official (notify-only, see roles.ts), Community Leader holds both
+// record.notify and record.declare, so the Action menu actually renders a
+// (disabled, while incomplete) 'Declare' item to assert against — matching
+// what the spreadsheet's "if 'Declare' button is available" phrasing implies.
+
+// TestRail TC-0055: Verify user can notify complete record
+test('Verify user can notify complete record', async ({ page }) => {
+  test.setTimeout(180_000)
+
+  const childName = {
+    firstNames: faker.person.firstName('female'),
+    familyName: faker.person.lastName()
+  }
+  const motherName = {
+    firstNames: faker.person.firstName('female'),
+    familyName: faker.person.lastName()
+  }
+  const deceasedName = {
+    firstNames: faker.person.firstName('male'),
+    familyName: faker.person.lastName()
+  }
+  const spouseName = {
+    firstNames: faker.person.firstName('female'),
+    familyName: faker.person.lastName()
+  }
+
+  await test.step('Login as Community Leader', async () => {
+    await login(page, CREDENTIALS.COMMUNITY_LEADER)
+  })
+
+  await test.step('Fill a complete birth declaration', async () => {
+    await page.click('#header-new-event')
+    await page.getByLabel('Birth').click()
+    await page.getByRole('button', { name: 'Continue' }).click()
+    await page.getByRole('button', { name: 'Continue' }).click()
+
+    await page.locator('#firstname').fill(childName.firstNames)
+    await page.locator('#surname').fill(childName.familyName)
+    await page.locator('#child____gender').click()
+    await page.getByText('Female', { exact: true }).click()
+    await fillDate(page, { dd: '05', mm: '08', yyyy: '2026' })
+    await page.locator('#child____placeOfBirth').click()
+    await page.getByText('Residential address', { exact: true }).click()
+    // Country/province/district/village default to the informant's own
+    // office location (Farajaland/Central/Ibombo/Klow), so no address
+    // fields need to be touched here or on the mother's/spouse's pages.
+    await page.getByRole('button', { name: 'Continue' }).click()
+
+    await page.locator('#informant____relation').click()
+    await page.getByText('Mother', { exact: true }).click()
+    await page.locator('#informant____email').fill('mother@example.com')
+    await page.getByRole('button', { name: 'Continue' }).click()
+
+    await page.locator('#firstname').fill(motherName.firstNames)
+    await page.locator('#surname').fill(motherName.familyName)
+    await fillDate(page, { dd: '15', mm: '06', yyyy: '1998' })
+    await page.locator('#mother____idType').click()
+    await page.getByText('National ID', { exact: true }).click()
+    await page.locator('#mother____nid').fill(faker.string.numeric(10))
+    await page.getByRole('button', { name: 'Continue' }).click()
+
+    await page.getByLabel("Father's details are not available").check()
+    await page.locator('#father____reason').fill('Father is missing.')
+    await page.getByRole('button', { name: 'Continue' }).click()
+
+    // Documents page has no required uploads.
+    await goToSection(page, 'review')
+  })
+
+  await test.step('Action menu shows Notify for the complete birth declaration', async () => {
+    await validateActionMenuButton(page, 'Notify', true)
+  })
+
+  await test.step('Notify the complete birth declaration', async () => {
+    await triggerDeclarationAction(page, 'Notify')
+  })
+
+  await test.step('Complete birth declaration is Notified, with an audit entry', async () => {
+    await page.getByText('Recent').click()
+    await openRecordByTitle(page, formatName(childName))
+    await ensureAssignedToUser(page, CREDENTIALS.COMMUNITY_LEADER)
+
+    await expect(page.getByTestId('status-value')).toHaveText('Notified')
+
+    await switchEventTab(page, 'Audit')
+    await page.getByRole('button', { name: 'Notified', exact: true }).click()
+    const modal = page.getByTestId('event-history-modal')
+    await expect(modal.getByText('Gift Phiri')).toBeVisible()
+    await page.locator('#close-dialog').click()
+    await page.getByTestId('exit-event').click()
+  })
+
+  await test.step('Fill a complete death declaration', async () => {
+    await page.click('#header-new-event')
+    await page.getByLabel('Death').click()
+    await page.getByRole('button', { name: 'Continue' }).click()
+    await page.getByRole('button', { name: 'Continue' }).click()
+
+    await page.locator('#firstname').fill(deceasedName.firstNames)
+    await page.locator('#surname').fill(deceasedName.familyName)
+    await page.locator('#deceased____gender').click()
+    await page.getByText('Male', { exact: true }).click()
+    await fillDate(page, { dd: '10', mm: '05', yyyy: '1970' })
+    await page.locator('#deceased____idType').click()
+    await page.getByText('National ID', { exact: true }).click()
+    await page.locator('#deceased____nid').fill(faker.string.numeric(10))
+    await page.getByRole('button', { name: 'Continue' }).click()
+
+    await fillDate(page, { dd: '01', mm: '08', yyyy: '2026' })
+    await page.locator('#eventDetails____placeOfDeath').click()
+    await page
+      .getByText("Deceased's usual place of residence", { exact: true })
+      .click()
+    await page.getByRole('button', { name: 'Continue' }).click()
+
+    await page.locator('#informant____relation').click()
+    await page.getByText('Spouse', { exact: true }).click()
+    await page.locator('#informant____email').fill('spouse@example.com')
+    await page.getByRole('button', { name: 'Continue' }).click()
+
+    await page.locator('#firstname').fill(spouseName.firstNames)
+    await page.locator('#surname').fill(spouseName.familyName)
+    await fillDate(page, { dd: '20', mm: '02', yyyy: '1972' })
+    await page.locator('#spouse____idType').click()
+    await page.getByText('None', { exact: true }).click()
+    // "Same as deceased's usual place of residence?" defaults to Yes.
+    await page.getByRole('button', { name: 'Continue' }).click()
+
+    // Documents page has no required uploads.
+    await goToSection(page, 'review')
+  })
+
+  await test.step('Action menu shows Notify for the complete death declaration', async () => {
+    await validateActionMenuButton(page, 'Notify', true)
+  })
+
+  await test.step('Notify the complete death declaration', async () => {
+    await triggerDeclarationAction(page, 'Notify')
+  })
+
+  await test.step('Complete death declaration is Notified, with an audit entry', async () => {
+    await page.getByText('Recent').click()
+    await openRecordByTitle(page, formatName(deceasedName))
+    await ensureAssignedToUser(page, CREDENTIALS.COMMUNITY_LEADER)
+
+    await expect(page.getByTestId('status-value')).toHaveText('Notified')
+
+    await switchEventTab(page, 'Audit')
+    await page.getByRole('button', { name: 'Notified', exact: true }).click()
+    const modal = page.getByTestId('event-history-modal')
+    await expect(modal.getByText('Gift Phiri')).toBeVisible()
+    await page.locator('#close-dialog').click()
+  })
+})
+
+// TestRail TC-0056: Verify user can notify completely blank record
+test('Verify user can notify completely blank record', async ({ page }) => {
+  test.setTimeout(180_000)
+
+  const childName = {
+    firstNames: faker.person.firstName(),
+    familyName: faker.person.lastName()
+  }
+  const deceasedName = {
+    firstNames: faker.person.firstName(),
+    familyName: faker.person.lastName()
+  }
+
+  await test.step('Login as Community Leader', async () => {
+    await login(page, CREDENTIALS.COMMUNITY_LEADER)
+  })
+
+  await test.step('Start a birth declaration with only the child’s name filled in', async () => {
+    await page.click('#header-new-event')
+    await page.getByLabel('Birth').click()
+    await page.getByRole('button', { name: 'Continue' }).click()
+    await page.getByRole('button', { name: 'Continue' }).click()
+
+    await page.locator('#firstname').fill(childName.firstNames)
+    await page.locator('#surname').fill(childName.familyName)
+
+    // Every other field (sex, DOB, place of birth, informant, mother,
+    // father) is left blank — Continue is allowed to proceed regardless;
+    // required-field validation only surfaces as "Required" text on review.
+    await goToSection(page, 'review')
+  })
+
+  await test.step('Action menu still shows Notify; Declare is disabled while incomplete', async () => {
+    await validateActionMenuButton(page, 'Notify', true)
+    await validateActionMenuButton(page, 'Declare', false)
+  })
+
+  await test.step('Notify the blank birth declaration', async () => {
+    await triggerDeclarationAction(page, 'Notify')
+  })
+
+  await test.step('Blank birth declaration is Notified, with an audit entry', async () => {
+    await page.getByText('Recent').click()
+    await openRecordByTitle(page, formatName(childName))
+    await ensureAssignedToUser(page, CREDENTIALS.COMMUNITY_LEADER)
+
+    await expect(page.getByTestId('status-value')).toHaveText('Notified')
+
+    await switchEventTab(page, 'Audit')
+    await page.getByRole('button', { name: 'Notified', exact: true }).click()
+    const modal = page.getByTestId('event-history-modal')
+    await expect(modal.getByText('Gift Phiri')).toBeVisible()
+    await page.locator('#close-dialog').click()
+    await page.getByTestId('exit-event').click()
+  })
+
+  await test.step('Start a death declaration with only the deceased’s name filled in', async () => {
+    await page.click('#header-new-event')
+    await page.getByLabel('Death').click()
+    await page.getByRole('button', { name: 'Continue' }).click()
+    await page.getByRole('button', { name: 'Continue' }).click()
+
+    await page.locator('#firstname').fill(deceasedName.firstNames)
+    await page.locator('#surname').fill(deceasedName.familyName)
+
+    await goToSection(page, 'review')
+  })
+
+  await test.step('Action menu still shows Notify; Declare is disabled while incomplete', async () => {
+    await validateActionMenuButton(page, 'Notify', true)
+    await validateActionMenuButton(page, 'Declare', false)
+  })
+
+  await test.step('Notify the blank death declaration', async () => {
+    await triggerDeclarationAction(page, 'Notify')
+  })
+
+  await test.step('Blank death declaration is Notified, with an audit entry', async () => {
+    await page.getByText('Recent').click()
+    await openRecordByTitle(page, formatName(deceasedName))
+    await ensureAssignedToUser(page, CREDENTIALS.COMMUNITY_LEADER)
+
+    await expect(page.getByTestId('status-value')).toHaveText('Notified')
+
+    await switchEventTab(page, 'Audit')
+    await page.getByRole('button', { name: 'Notified', exact: true }).click()
+    const modal = page.getByTestId('event-history-modal')
+    await expect(modal.getByText('Gift Phiri')).toBeVisible()
+    await page.locator('#close-dialog').click()
+  })
+})

--- a/packages/testland/e2e/testcases/qa-testrail-testcases/event lifecycle (core actions)/notify/el-notify.spec.ts
+++ b/packages/testland/e2e/testcases/qa-testrail-testcases/event lifecycle (core actions)/notify/el-notify.spec.ts
@@ -12,7 +12,10 @@ import { test, expect } from '@playwright/test'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../../constants'
 import { ensureAssignedToUser } from '../../utils'
-import { fillDate } from '../../../../testcases/birth/helpers'
+import {
+  fillDate,
+  openBirthDeclaration
+} from '../../../../testcases/birth/helpers'
 import {
   formatName,
   goToSection,
@@ -55,10 +58,7 @@ test('Verify user can notify complete record', async ({ page }) => {
   })
 
   await test.step('Fill a complete birth declaration', async () => {
-    await page.click('#header-new-event')
-    await page.getByLabel('Birth').click()
-    await page.getByRole('button', { name: 'Continue' }).click()
-    await page.getByRole('button', { name: 'Continue' }).click()
+    await openBirthDeclaration(page)
 
     await page.locator('#firstname').fill(childName.firstNames)
     await page.locator('#surname').fill(childName.familyName)
@@ -197,10 +197,7 @@ test('Verify user can notify completely blank record', async ({ page }) => {
   })
 
   await test.step('Start a birth declaration with only the child’s name filled in', async () => {
-    await page.click('#header-new-event')
-    await page.getByLabel('Birth').click()
-    await page.getByRole('button', { name: 'Continue' }).click()
-    await page.getByRole('button', { name: 'Continue' }).click()
+    await openBirthDeclaration(page)
 
     await page.locator('#firstname').fill(childName.firstNames)
     await page.locator('#surname').fill(childName.familyName)

--- a/packages/testland/e2e/testcases/qa-testrail-testcases/event lifecycle (core actions)/register/el-register.spec.ts
+++ b/packages/testland/e2e/testcases/qa-testrail-testcases/event lifecycle (core actions)/register/el-register.spec.ts
@@ -1,0 +1,181 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+import { test, expect } from '@playwright/test'
+import { ActionType } from '@opencrvs/toolkit/events'
+import { CREDENTIALS } from '../../../../constants'
+import { ensureAssignedToUser } from '../../utils'
+import { selectAction } from '../../../../utils'
+import {
+  createDeclaration as createBirthDeclaration,
+  type Declaration as BirthDeclaration
+} from '../../../../testcases/test-data/birth-declaration'
+import {
+  createDeclaration as createDeathDeclaration,
+  type Declaration as DeathDeclaration
+} from '../../../../testcases/test-data/death-declaration'
+import { formatV2ChildName } from '../../../../testcases/birth/helpers'
+import { getToken, joinValuesWith, login } from '../../../../helpers'
+import { openRecordByTitle, searchFromSearchBar } from '../../helpers'
+
+const formatV2DeceasedName = (declaration: {
+  'deceased.name': { firstname: string; surname: string }
+  [key: string]: any
+}) =>
+  joinValuesWith([
+    declaration['deceased.name'].firstname,
+    declaration['deceased.name'].surname
+  ])
+
+// TestRail TC-0071: Validate 'Register?' modal
+// (1 of 2 e2e tests in this file covering this test case - birth events)
+test("Validate the 'Register?' modal for birth events", async ({ page }) => {
+  test.setTimeout(180_000)
+
+  let declaration: BirthDeclaration
+
+  await test.step('Registrar declares a birth record via API (auto-validated)', async () => {
+    const token = await getToken(CREDENTIALS.REGISTRAR)
+    const res = await createBirthDeclaration(
+      token,
+      undefined,
+      ActionType.DECLARE
+    )
+    declaration = res.declaration
+  })
+
+  await test.step('Login as Registrar and assign the record', async () => {
+    await login(page, CREDENTIALS.REGISTRAR)
+    await page.getByText('Pending registration').click()
+    await openRecordByTitle(page, formatV2ChildName(declaration))
+    await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
+  })
+
+  const confirmButton = page.getByRole('button', { name: 'Confirm' })
+  const cancelButton = page.getByRole('button', { name: 'Cancel' })
+
+  await test.step('Open the Register modal and inspect its contents', async () => {
+    await selectAction(page, 'Register')
+
+    await expect(page.getByText('Register?', { exact: true })).toBeVisible()
+    await expect(
+      page.getByText(
+        'Registering this birth event will create an official civil registration record. Please ensure all details are correct before proceeding.'
+      )
+    ).toBeVisible()
+    await expect(page.getByText('WARNING!', { exact: false })).toBeVisible()
+
+    await expect(
+      page.getByText('Supporting documents reviewed?')
+    ).toBeVisible()
+    await expect(page.getByText('Register book number')).toBeVisible()
+    await expect(page.getByText('Register page number')).toBeVisible()
+    await expect(page.getByText('Additional comments')).toBeVisible()
+    await expect(cancelButton).toBeVisible()
+  })
+
+  await test.step("Confirm is disabled until 'Supporting documents reviewed?' is answered", async () => {
+    await expect(confirmButton).toBeDisabled()
+  })
+
+  await test.step("Selecting an option for 'Supporting documents reviewed?' enables Confirm", async () => {
+    await page.locator('#documents-verified').click()
+    await page.locator('.react-select__option', { hasText: /^Yes$/ }).click()
+
+    await expect(confirmButton).toBeEnabled()
+  })
+
+  await test.step('Cancel closes the modal without registering', async () => {
+    await cancelButton.click()
+    await expect(page.getByText('Register?', { exact: true })).not.toBeVisible()
+    await expect(page.getByTestId('status-value')).toHaveText('Declared')
+  })
+
+  await test.step('Confirm registers the record', async () => {
+    await selectAction(page, 'Register')
+    await page.locator('#documents-verified').click()
+    await page.locator('.react-select__option', { hasText: /^Yes$/ }).click()
+
+    const registerResponse = page.waitForResponse(
+      (res) => res.url().includes('event.actions.register') && res.ok()
+    )
+    await page.getByRole('button', { name: 'Confirm' }).click()
+    await registerResponse
+
+    // Register navigates the user out of the record view - re-find it.
+    await searchFromSearchBar(page, formatV2ChildName(declaration))
+    await expect(page.getByTestId('status-value')).toHaveText('Registered')
+  })
+})
+
+// TestRail TC-0071: Validate 'Register?' modal
+// (2 of 2 e2e tests in this file covering this test case - death events)
+test("Validate the 'Register?' modal for death events", async ({ page }) => {
+  test.setTimeout(180_000)
+
+  let declaration: DeathDeclaration
+
+  await test.step('Registrar declares a death record via API (auto-validated)', async () => {
+    const token = await getToken(CREDENTIALS.REGISTRAR)
+    const res = await createDeathDeclaration(
+      token,
+      undefined,
+      ActionType.DECLARE
+    )
+    declaration = res.declaration
+  })
+
+  await test.step('Login as Registrar and assign the record', async () => {
+    await login(page, CREDENTIALS.REGISTRAR)
+    await page.getByText('Pending registration').click()
+    await openRecordByTitle(page, formatV2DeceasedName(declaration))
+    await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
+  })
+
+  await test.step('Open the Register modal and inspect its contents', async () => {
+    await selectAction(page, 'Register')
+
+    await expect(page.getByText('Register?', { exact: true })).toBeVisible()
+    await expect(
+      page.getByText(
+        'Registering this death event will create an official civil registration record. Please ensure all details are correct before proceeding.'
+      )
+    ).toBeVisible()
+    await expect(page.getByText('Additional comments')).toBeVisible()
+
+    // Unlike birth, death's Register dialog has no required field, so it has
+    // no 'Supporting documents reviewed?'/book/page-number fields either.
+    await expect(
+      page.getByText('Supporting documents reviewed?')
+    ).not.toBeVisible()
+
+    await expect(page.getByRole('button', { name: 'Confirm' })).toBeEnabled()
+  })
+
+  await test.step('Cancel closes the modal without registering', async () => {
+    await page.getByRole('button', { name: 'Cancel' }).click()
+    await expect(page.getByText('Register?', { exact: true })).not.toBeVisible()
+    await expect(page.getByTestId('status-value')).toHaveText('Declared')
+  })
+
+  await test.step('Confirm registers the record', async () => {
+    await selectAction(page, 'Register')
+
+    const registerResponse = page.waitForResponse(
+      (res) => res.url().includes('event.actions.register') && res.ok()
+    )
+    await page.getByRole('button', { name: 'Confirm' }).click()
+    await registerResponse
+
+    // Register navigates the user out of the record view - re-find it.
+    await searchFromSearchBar(page, formatV2DeceasedName(declaration))
+    await expect(page.getByTestId('status-value')).toHaveText('Registered')
+  })
+})

--- a/packages/testland/e2e/testcases/qa-testrail-testcases/event lifecycle (core actions)/register/el-register.spec.ts
+++ b/packages/testland/e2e/testcases/qa-testrail-testcases/event lifecycle (core actions)/register/el-register.spec.ts
@@ -22,7 +22,12 @@ import {
   type Declaration as DeathDeclaration
 } from '../../../../testcases/test-data/death-declaration'
 import { formatV2ChildName } from '../../../../testcases/birth/helpers'
-import { getToken, joinValuesWith, login } from '../../../../helpers'
+import {
+  getToken,
+  joinValuesWith,
+  login,
+  triggerDeclarationAction
+} from '../../../../helpers'
 import { openRecordByTitle, searchFromSearchBar } from '../../helpers'
 
 const formatV2DeceasedName = (declaration: {
@@ -72,9 +77,7 @@ test("Validate the 'Register?' modal for birth events", async ({ page }) => {
     ).toBeVisible()
     await expect(page.getByText('WARNING!', { exact: false })).toBeVisible()
 
-    await expect(
-      page.getByText('Supporting documents reviewed?')
-    ).toBeVisible()
+    await expect(page.getByText('Supporting documents reviewed?')).toBeVisible()
     await expect(page.getByText('Register book number')).toBeVisible()
     await expect(page.getByText('Register page number')).toBeVisible()
     await expect(page.getByText('Additional comments')).toBeVisible()
@@ -99,15 +102,7 @@ test("Validate the 'Register?' modal for birth events", async ({ page }) => {
   })
 
   await test.step('Confirm registers the record', async () => {
-    await selectAction(page, 'Register')
-    await page.locator('#documents-verified').click()
-    await page.locator('.react-select__option', { hasText: /^Yes$/ }).click()
-
-    const registerResponse = page.waitForResponse(
-      (res) => res.url().includes('event.actions.register') && res.ok()
-    )
-    await page.getByRole('button', { name: 'Confirm' }).click()
-    await registerResponse
+    await triggerDeclarationAction(page, 'Register')
 
     // Register navigates the user out of the record view - re-find it.
     await searchFromSearchBar(page, formatV2ChildName(declaration))
@@ -166,13 +161,7 @@ test("Validate the 'Register?' modal for death events", async ({ page }) => {
   })
 
   await test.step('Confirm registers the record', async () => {
-    await selectAction(page, 'Register')
-
-    const registerResponse = page.waitForResponse(
-      (res) => res.url().includes('event.actions.register') && res.ok()
-    )
-    await page.getByRole('button', { name: 'Confirm' }).click()
-    await registerResponse
+    await triggerDeclarationAction(page, 'Register')
 
     // Register navigates the user out of the record view - re-find it.
     await searchFromSearchBar(page, formatV2DeceasedName(declaration))

--- a/packages/testland/e2e/testcases/qa-testrail-testcases/helpers.ts
+++ b/packages/testland/e2e/testcases/qa-testrail-testcases/helpers.ts
@@ -116,6 +116,9 @@ export type DuplicateDeathDeclaration = DeathDeclaration
  * deceased.idType/nid here (caller overrides in `dec` still win) makes every
  * call default to the same ID, so two calls sharing just a `dec` with a
  * matching `deceased.name` reliably collide on all four checks.
+ *
+ * NOTE: unused in this PR - consumed by the follow-up core actions PR's
+ * el-archive.spec.ts (delete/archive/edit/reject).
  */
 export async function createDuplicateDeathDeclaration(
   token: string,

--- a/packages/testland/e2e/testcases/qa-testrail-testcases/helpers.ts
+++ b/packages/testland/e2e/testcases/qa-testrail-testcases/helpers.ts
@@ -1,0 +1,136 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+/**
+ * Suite-specific helpers for packages/testland/e2e/testcases/qa-testrail-testcases/.
+ *
+ * This file holds ONLY functions that either behave differently from their
+ * canonical counterpart, or have no canonical counterpart at all. Everything
+ * unchanged should be imported directly by the spec file from its canonical
+ * location (e2e/helpers.ts, e2e/testcases/birth/helpers.ts,
+ * e2e/testcases/print-certificate/birth/helpers.ts,
+ * e2e/testcases/test-data/*.ts, etc.) instead of being duplicated here - see
+ * the qa-testrail-testcases skill for the full rule.
+ */
+import { Page, expect } from '@playwright/test'
+import { ActionType, ActionUpdate } from '@opencrvs/toolkit/events'
+import { getRowByTitle } from '../print-certificate/birth/helpers'
+import {
+  createDeclaration as createDeathDeclaration,
+  type Declaration as DeathDeclaration
+} from '../test-data/death-declaration'
+
+/**
+ * Opens a record from a workqueue list by its title (e.g. formatted child name) and **verifies it**
+ *
+ * Deliberate fork of e2e/testcases/print-certificate/birth/helpers.ts's
+ * openRecordByTitle: adds `.first()` on the row's button locator. Some
+ * qa-testrail-testcases workqueues can render more than one row matching the
+ * same title (e.g. right after a duplicate-detection fixture seeds a second
+ * record with the same name), which makes Playwright's strict mode throw on
+ * the canonical version's plain `.click()`.
+ *
+ * NOTE:
+ * Application polls continuously for updates. E2E tests are run in parallel.
+ * It is likely that the same workqueue will get updated, and **during** the time we select a row, and click it, it actually has diffrent user and the test fails down the line.
+ *
+ */
+export async function openRecordByTitle(page: Page, title: string) {
+  await expect(async () => {
+    await getRowByTitle(page, title)
+      .getByRole('button', { name: title })
+      .first()
+      .click()
+    try {
+      // target the event overview title to make sure this is the right one.
+      await expect(
+        page.getByRole('heading', { name: title, level: 1 })
+      ).toBeVisible({ timeout: 3_000 })
+    } catch (error) {
+      await page.goBack()
+      // This triggers toPass retry loop if the updated happened and we picked wrong one.
+      throw error
+    }
+  }).toPass({
+    timeout: 60_000,
+    intervals: [...Array(5).fill(1_000), ...Array(5).fill(2_000), 5_000]
+  })
+}
+
+/**
+ * Deliberate fork of e2e/helpers.ts's searchFromSearchBar: delegates to this
+ * file's own openRecordByTitle above (with the `.first()` fix) instead of
+ * the canonical one.
+ */
+export async function searchFromSearchBar(
+  page: Page,
+  searchText: string,
+  expectToBeFound: boolean = true,
+  /**
+   * Title the record is listed under, when it differs from what was searched
+   * for - a sealed record is found by name but listed as 'No name provided'
+   * (the event config's fallbackTitle), since its name is stripped from
+   * search results.
+   */
+  recordTitle: string = searchText
+) {
+  const searchResultRegex = /Search result for “([^”]+)”/
+  await page.locator('#searchText').fill(searchText)
+  await page.locator('#searchIconButton').click()
+  const searchResult = await page.locator('#content-name').textContent()
+  expect(searchResult).toMatch(searchResultRegex)
+
+  if (expectToBeFound) {
+    await openRecordByTitle(page, recordTitle)
+  } else {
+    await expect(
+      page.getByRole('button', { name: searchText, exact: true })
+    ).not.toBeVisible()
+  }
+}
+
+export type DuplicateDeathDeclaration = DeathDeclaration
+
+/**
+ * Creates a death declaration meant to collide with another one under the
+ * death dedup config (packages/testland/src/events/death/dedupConfig.ts),
+ * which ANDs together four checks - all four must hold for two records to
+ * be flagged as potential duplicates:
+ *  - deceased.name fuzzy-matches
+ *  - deceased.dob is within 365 days
+ *  - eventDetails.date (date of death) is within 5 days
+ *  - deceased.idType/nid match (exactly, when both records carry an ID)
+ *
+ * The canonical getDeclaration (e2e/testcases/test-data/death-declaration.ts)
+ * already fixes deceased.dob and eventDetails.date to constants (not
+ * randomised), and deceased.name comes from `dec` - but deceased.nid is
+ * `faker.string.numeric(10)`, freshly randomised on every call, so two
+ * independent calls never satisfy the ID check on their own. Fixing
+ * deceased.idType/nid here (caller overrides in `dec` still win) makes every
+ * call default to the same ID, so two calls sharing just a `dec` with a
+ * matching `deceased.name` reliably collide on all four checks.
+ */
+export async function createDuplicateDeathDeclaration(
+  token: string,
+  dec: Partial<ActionUpdate>,
+  action: ActionType = ActionType.REGISTER,
+  placeOfDeathType?: 'DECEASED_USUAL_RESIDENCE' | 'HEALTH_FACILITY'
+): Promise<{ eventId: string; declaration: DuplicateDeathDeclaration }> {
+  return createDeathDeclaration(
+    token,
+    {
+      'deceased.idType': 'NATIONAL_ID',
+      'deceased.nid': '1234567890',
+      ...dec
+    },
+    action,
+    placeOfDeathType
+  )
+}

--- a/packages/testland/e2e/testcases/qa-testrail-testcases/utils.ts
+++ b/packages/testland/e2e/testcases/qa-testrail-testcases/utils.ts
@@ -1,0 +1,123 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+/**
+ * Suite-specific override of e2e/utils.ts's ensureAssignedToUser for
+ * packages/testland/e2e/testcases/qa-testrail-testcases/. Everything else
+ * that file exports (e.g. selectAction) is unchanged here and should be
+ * imported directly from '../../utils' (from this folder) instead of being
+ * duplicated in this file - see the qa-testrail-testcases skill for the
+ * full rule.
+ */
+import { Page, expect } from '@playwright/test'
+
+const usernameToFullNameMap = {
+  'k.cwalya': 'Kalusha Cwalya',
+  'h.habazoka': 'Hakainde Habazoka',
+  'k.bwalya': 'Kalusha Bwalya',
+  'g.phiri': 'Gift Phiri',
+  'f.katongo': 'Felix Katongo',
+  'm.simbaya': 'Mapalo Simbaya',
+  'v.katongo': 'Velix Katongo',
+  'k.mweene': 'Kennedy Mweene',
+  'v.mweene': 'Venedy Mweene',
+  'm.owen': 'Mitchel Owen',
+  'c.lungu': 'Chipo Lungu',
+  'n.siame': 'Njavwa Siame',
+  'j.campbell': 'Jonathan Campbell',
+  'e.mayuka': 'Emmanuel Mayuka',
+  'm.musonda': 'Mutale Musonda',
+  't.mwila': 'Toukir Mwila',
+  'j.banda': 'Joseph Banda'
+} as const
+
+/**
+ * How long a just-completed action (Archive/Escalate/Declare with edits/etc.)
+ * can take to auto-unassign the record and have that reflected back in the
+ * client's cache. There's no DOM signal for this settling - the value simply
+ * flips once a background event.search refetch lands - so this is a
+ * deliberate, named wait rather than an incidental one.
+ */
+const ASSIGNMENT_SETTLE_WAIT_MS = 4_000
+
+/**
+ * Ensures that the record is assigned to the user and it is reflected in the event summary.
+ *
+ * Deliberate fork of e2e/utils.ts's ensureAssignedToUser: that version reads
+ * assignedTo-value exactly once before deciding whether to assign. Under this
+ * suite that single point-in-time read was flaky - the overview page can show
+ * a stale assignedTo-value for a few seconds after navigation, or after an
+ * action that auto-unassigns the record (Archive/Escalate/Declare with
+ * edits/etc.), and only catches up once a background refetch lands. This
+ * version wraps the whole check-then-assign flow in a toPass retry, with an
+ * ASSIGNMENT_SETTLE_WAIT_MS wait at the start of every lap so the settle
+ * window is respected even on the early-return path.
+ *
+ * @param username name of the user record is assigned. Used for assertion after assignment. Checking absence of something will burn the whole timeout in CI.
+ */
+export async function ensureAssignedToUser(
+  page: Page,
+  username: keyof typeof usernameToFullNameMap
+) {
+  const userFullName = usernameToFullNameMap[username]
+
+  const assignedTo = page.getByTestId('assignedTo-value')
+  const actionButton = page.getByRole('button', { name: 'Action', exact: true })
+
+  await expect(async () => {
+    await page.waitForTimeout(ASSIGNMENT_SETTLE_WAIT_MS)
+
+    await assignedTo.waitFor({ state: 'visible' })
+
+    if (await assignedTo.filter({ hasText: userFullName }).isVisible()) {
+      return
+    }
+
+    await actionButton.click()
+
+    const assignAction = page
+      .locator('#action-Dropdown-Content li')
+      .filter({ hasText: new RegExp(`^Assign$`, 'i') })
+      .first()
+
+    const hasAssignOption = await assignAction
+      .waitFor({ state: 'visible', timeout: 3_000 })
+      .then(() => true)
+      .catch(() => false)
+
+    if (!hasAssignOption) {
+      // The state must have moved on since we last read assignedTo-value
+      // (e.g. it's already assigned) - close the menu before retrying.
+      await actionButton.click()
+      throw new Error('Assign action not available - retrying')
+    }
+
+    await assignAction.click()
+
+    // Setup the listener before clicking.
+    const assignResponse = page.waitForResponse(
+      (res) =>
+        res.url().includes('event.actions.assignment.assign') &&
+        res.status() === 200
+    )
+    // Wait for the assign modal to appear
+    await page.getByRole('button', { name: 'Assign', exact: true }).click()
+
+    // Wait for the assignment API call to complete and the UI to update.
+    await assignResponse
+
+    await expect(assignedTo).toContainText(userFullName)
+  }).toPass({
+    // Each lap now starts with its own ASSIGNMENT_SETTLE_WAIT_MS wait, so the
+    // outer budget needs enough room for a few full laps, not just retries.
+    timeout: 45_000,
+    intervals: [1_000, 1_000, 2_000, 2_000, 5_000]
+  })
+}

--- a/packages/testland/package.json
+++ b/packages/testland/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "dev": "pnpm start",
     "e2e-win": "pnpm playwright test --ui",
+    "e2e-win-headed": "pnpm playwright test --headed --ui",
     "e2e": "NODE_OPTIONS=--dns-result-order=ipv4first pnpm playwright test --ui",
     "e2e-dev": "NODE_ENV=development NODE_OPTIONS=--dns-result-order=ipv4first pnpm playwright test --ui",
     "precommit": "lint-staged",

--- a/packages/testland/playwright.config.ts
+++ b/packages/testland/playwright.config.ts
@@ -36,6 +36,13 @@ const optInSuites = [
 export default defineConfig({
   timeout: TEST_TIMEOUT,
   testDir: './e2e/testcases',
+  /*
+   * Resolves DOMAIN (e2e.opencrvs.dev, falling back to qa.opencrvs.dev) when
+   * it isn't already set. Runs before workers are spawned, so this only
+   * matters for the unset-DOMAIN, non-CI/local-run case - CI always sets
+   * DOMAIN explicitly before invoking Playwright.
+   */
+  globalSetup: require.resolve('./e2e/global-setup'),
 
   /* Run tests in files in parallel */
   fullyParallel: true,


### PR DESCRIPTION
## Summary
- Config/tooling: win32 support in root package.json, `e2e-win-headed` script for testland, testland e2e `DOMAIN` pointed at qa.opencrvs.dev, `.playwright-cli`/`.playwright-mcp` added to `.gitignore`
- New `qa-testrail-testcases` skill for converting TestRail regression sheets into Playwright specs following this repo's e2e conventions
- Shared `constants.ts`/`helpers.ts`/`utils.ts` for the `qa-testrail-testcases` suite
- Core event lifecycle action specs: notify, declare, register

## Test plan
- [ ] `nx run @opencrvs/testland:typecheck` passes
- [ ] Specs run locally against qa.opencrvs.dev: notify, declare, register

🤖 Generated with [Claude Code](https://claude.com/claude-code)