### PR TITLE
fix: Left align links in record and user audit

### DIFF
--- a/packages/client/src/v2-events/features/workqueues/EventOverview/components/EventHistory/EventHistory.stories.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/components/EventHistory/EventHistory.stories.tsx
@@ -1,0 +1,149 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import React from 'react'
+import { createTRPCMsw, httpLink } from '@vafanassieff/msw-trpc'
+import superjson from 'superjson'
+import { expect, waitFor } from 'storybook/test'
+import {
+  getCurrentEventState,
+  TestUserRole,
+  tennisClubMembershipEvent
+} from '@opencrvs/commons/client'
+import {
+  AppRouter,
+  queryClient,
+  trpcOptionsProxy,
+  TRPCProvider
+} from '@client/v2-events/trpc'
+import { ROUTES, routesConfig } from '@client/v2-events/routes'
+import { tennisClubMembershipEventDocument } from '@client/v2-events/features/events/fixtures'
+import { testDataGenerator } from '@client/tests/test-data-generators'
+import { EventOverviewIndex } from '../../EventOverview'
+
+/**
+ * `EventHistory` reads the event, the user list and the location list from its
+ * host page's contexts, so it is exercised through `EventOverviewIndex` on the
+ * audit route rather than mounted on its own.
+ */
+const meta: Meta<typeof EventOverviewIndex> = {
+  title: 'EventOverview/EventHistory',
+  component: EventOverviewIndex,
+  parameters: {
+    userRole: TestUserRole.enum.LOCAL_REGISTRAR
+  },
+  decorators: [
+    (Story) => (
+      <TRPCProvider>
+        <Story />
+      </TRPCProvider>
+    )
+  ]
+}
+
+export default meta
+type Story = StoryObj<typeof EventOverviewIndex>
+
+const tRPCMsw = createTRPCMsw<AppRouter>({
+  links: [httpLink({ url: '/api/events' })],
+  transformer: { input: superjson, output: superjson }
+})
+
+const localRegistrar = testDataGenerator().user
+
+const event = tennisClubMembershipEventDocument
+
+const auditRouteParameters = {
+  offline: {
+    events: [event]
+  },
+  reactRouter: {
+    router: routesConfig,
+    initialPath: ROUTES.V2.EVENTS.EVENT.AUDIT.buildPath({
+      eventId: event.id
+    })
+  },
+  msw: {
+    handlers: {
+      events: [
+        tRPCMsw.event.search.query(() => ({
+          results: [getCurrentEventState(event, tennisClubMembershipEvent)],
+          total: 1
+        }))
+      ]
+    }
+  }
+}
+
+/**
+ * Regression test for: history links wrap onto several lines in narrow columns,
+ * so their text must stay left aligned instead of inheriting the alignment of
+ * the surrounding table cell.
+ */
+export const HistoryLinksAreLeftAligned: Story = {
+  tags: ['link-alignment-regression'],
+  parameters: {
+    ...auditRouteParameters,
+    chromatic: { disableSnapshot: true }
+  },
+  /*
+   * The history resolves action creators from the cached `user.list` response,
+   * which nothing populates in Storybook, so it is seeded here to make the
+   * action creator link render instead of "Missing user".
+   */
+  beforeEach: () => {
+    queryClient.setQueryData(
+      trpcOptionsProxy.user.list.queryKey([localRegistrar.id.localRegistrar]),
+      [localRegistrar.localRegistrar().v2]
+    )
+  },
+  play: async ({ canvasElement, step }) => {
+    await step('Wait for the event history table to load', async () => {
+      await waitFor(
+        () =>
+          expect(
+            canvasElement.querySelectorAll('#listTable-task-history button')
+              .length
+          ).toBeGreaterThan(0),
+        { timeout: 10000 }
+      )
+    })
+
+    await step('Every history link renders its text left aligned', async () => {
+      const links = Array.from(
+        canvasElement.querySelectorAll<HTMLElement>(
+          '#listTable-task-history button'
+        )
+      )
+
+      for (const link of links) {
+        expect(getComputedStyle(link).textAlign).toBe('left')
+      }
+    })
+
+    await step('The action creator link is left aligned', async () => {
+      const profileLink = await waitFor(
+        () => {
+          const element =
+            canvasElement.querySelector<HTMLElement>('#profile-link')
+          if (!element) {
+            throw new Error('Action creator link not rendered')
+          }
+          return element
+        },
+        { timeout: 5000 }
+      )
+
+      expect(getComputedStyle(profileLink).textAlign).toBe('left')
+    })
+  }
+}

--- a/packages/client/src/v2-events/features/workqueues/EventOverview/components/EventHistory/EventHistory.stories.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/components/EventHistory/EventHistory.stories.tsx
@@ -109,7 +109,7 @@ export const HistoryLinksAreLeftAligned: Story = {
   play: async ({ canvasElement, step }) => {
     await step('Wait for the event history table to load', async () => {
       await waitFor(
-        () =>
+        async () =>
           expect(
             canvasElement.querySelectorAll('#listTable-task-history button')
               .length
@@ -126,7 +126,7 @@ export const HistoryLinksAreLeftAligned: Story = {
       )
 
       for (const link of links) {
-        expect(getComputedStyle(link).textAlign).toBe('left')
+        await expect(getComputedStyle(link).textAlign).toBe('left')
       }
     })
 
@@ -143,7 +143,7 @@ export const HistoryLinksAreLeftAligned: Story = {
         { timeout: 5000 }
       )
 
-      expect(getComputedStyle(profileLink).textAlign).toBe('left')
+      await expect(getComputedStyle(profileLink).textAlign).toBe('left')
     })
   }
 }

--- a/packages/client/src/v2-events/features/workqueues/EventOverview/components/EventHistory/EventHistory.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/components/EventHistory/EventHistory.tsx
@@ -41,7 +41,7 @@ import { usePermissions } from '@client/hooks/useAuthorization'
 import { useValidatorContext } from '@client/v2-events/hooks/useValidatorContext'
 import { useEventConfiguration } from '@client/v2-events/features/events/useEventConfiguration'
 import { useUserDetails } from '@client/v2-events/hooks/useUserDetails'
-import { resolveLocationName } from '@client/v2-events/utils';
+import { resolveLocationName } from '@client/v2-events/utils'
 import { useEventOverviewInfo } from '../useEventOverviewInfo'
 import { UserAvatar } from './UserAvatar'
 import { EventHistoryDialog } from './EventHistoryDialog/EventHistoryDialog'
@@ -61,6 +61,10 @@ const LargeGreyedInfo = styled.div`
 
 const TableDiv = styled.div`
   overflow: auto;
+`
+
+const LinkLeftAligned = styled(Link)`
+  text-align: left;
 `
 
 const DEFAULT_HISTORY_RECORD_PAGE_SIZE = 10
@@ -147,7 +151,7 @@ function User({ action }: { action: ActionDocument }) {
   const canViewUser = !!user && canReadUser(user)
 
   return canViewUser ? (
-    <Link
+    <LinkLeftAligned
       font="bold14"
       id="profile-link"
       onClick={() =>
@@ -159,7 +163,7 @@ function User({ action }: { action: ActionDocument }) {
       }
     >
       <UserAvatar avatar={user.avatar} names={name} />
-    </Link>
+    </LinkLeftAligned>
   ) : (
     <UserAvatar avatar={user?.avatar} names={name} />
   )
@@ -243,7 +247,7 @@ function ActionLocation({ action }: { action: ActionDocument }) {
   }
 
   return hasAccessToOffice ? (
-    <Link
+    <LinkLeftAligned
       font="bold14"
       onClick={() => {
         navigate({
@@ -255,7 +259,7 @@ function ActionLocation({ action }: { action: ActionDocument }) {
       }}
     >
       {locationName}
-    </Link>
+    </LinkLeftAligned>
   ) : (
     locationName
   )
@@ -380,12 +384,12 @@ function EventHistory({ fullEvent }: { fullEvent: EventDocument }) {
 
       return {
         action: (
-          <Link
+          <LinkLeftAligned
             font="bold14"
             onClick={() => onHistoryRowClick(action, actionCreatorName, title)}
           >
             {title}
-          </Link>
+          </LinkLeftAligned>
         ),
         date: format(
           new Date(action.createdAt),

--- a/packages/client/src/views/UserAudit/UserAuditHistory.stories.tsx
+++ b/packages/client/src/views/UserAudit/UserAuditHistory.stories.tsx
@@ -11,6 +11,7 @@
 
 import { Meta, StoryObj } from '@storybook/react-vite'
 import React from 'react'
+import { expect, waitFor, within } from 'storybook/test'
 import { UserAuditHistory } from './UserAuditHistory'
 import { TestUserRole } from '@opencrvs/commons/client'
 
@@ -39,5 +40,34 @@ export const WithRecordReadScope: Story = {}
 export const WithoutRecordReadScope: Story = {
   parameters: {
     userRole: TestUserRole.enum.LOCAL_SYSTEM_ADMIN
+  }
+}
+
+/**
+ * Regression test for: audit action labels wrap onto several lines in the narrow
+ * action column, so their text must stay left aligned instead of inheriting the
+ * alignment of the surrounding table cell.
+ */
+export const ActionLinksAreLeftAligned: Story = {
+  tags: ['link-alignment-regression'],
+  parameters: {
+    chromatic: { disableSnapshot: true }
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+
+    await step('Wait for the audit list to load', async () => {
+      await canvas.findByText('Logged out')
+    })
+
+    await step('Audit action link renders its text left aligned', async () => {
+      const actionLink = await canvas.findByRole('button', {
+        name: 'Logged out'
+      })
+
+      await waitFor(() =>
+        expect(getComputedStyle(actionLink).textAlign).toBe('left')
+      )
+    })
   }
 }

--- a/packages/client/src/views/UserAudit/UserAuditHistory.tsx
+++ b/packages/client/src/views/UserAudit/UserAuditHistory.tsx
@@ -83,6 +83,10 @@ const AuditContent = styled.div`
   color: ${({ theme }) => theme.colors.grey600};
 `
 
+const LinkLeftAligned = styled(Link)`
+  text-align: left;
+`
+
 interface IBaseProp {
   userId: string
   userName: string | null | undefined
@@ -267,9 +271,12 @@ function UserAuditHistoryComponent(props: Props) {
     return orderBy(
       results.map((entry) => ({
         actionDescription: (
-          <Link font="bold14" onClick={() => toggleActionDetails(entry)}>
+          <LinkLeftAligned
+            font="bold14"
+            onClick={() => toggleActionDetails(entry)}
+          >
             {getActionMessage(entry)}
-          </Link>
+          </LinkLeftAligned>
         ),
         actionDescriptionString: getActionMessage(entry),
         trackingId: (() => {


### PR DESCRIPTION
## Description

User audit:
<img width="1289" height="865" alt="Screenshot from 2026-08-19 13-50-30" src="https://github.com/user-attachments/assets/529e184d-4641-478b-9ad5-40061b19e134" />

Record audit:
<img width="1290" height="676" alt="Screenshot from 2026-08-19 13-41-47" src="https://github.com/user-attachments/assets/c0529083-513f-480c-8088-51b7ae4b45ce" />


## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
