### PR TITLE
Fix create country config script

### DIFF
--- a/packages/toolkit/create-countryconfig/index.js
+++ b/packages/toolkit/create-countryconfig/index.js
@@ -38,9 +38,10 @@ function tagExists(repoUrl, tag) {
 }
 
 function resolveRef() {
-  if (version.includes('-')) {
+  console.log('version: ' + version)
+  /* if (version.includes('-')) {
     return 'develop'
-  }
+  } */
 
   const tag = 'v' + version
   if (

--- a/packages/toolkit/create-countryconfig/index.js
+++ b/packages/toolkit/create-countryconfig/index.js
@@ -37,11 +37,60 @@ function tagExists(repoUrl, tag) {
   }
 }
 
+/**
+ * Release tags (e.g. "v2.1.0"), highest first. Delegates the version-aware
+ * ordering to git itself rather than hand-parsing semver, then filters down
+ * to strict "vX.Y.Z" tags - `--sort=-version:refname` alone still leaves in
+ * non-release refs (e.g. "vtesting", "v2.0.0-beta") and peeled annotated-tag
+ * lines ("refs/tags/v2.0.0^{}").
+ */
+function listReleaseTags(repoUrl) {
+  const output = execSync(
+    'git ls-remote --tags --sort=-version:refname ' + repoUrl,
+    { encoding: 'utf-8' }
+  )
+
+  return output
+    .split('\n')
+    .map((line) => line.split('\t')[1])
+    .filter(Boolean)
+    .map((ref) => ref.replace('refs/tags/', ''))
+    .filter((tag) => /^v\d+\.\d+\.\d+$/.test(tag))
+}
+
+/**
+ * The highest release tag present in *both* repositories - used as the
+ * fallback when the version-specific tag can't be found in one or both, so
+ * scaffolding still lands on a real, matched release rather than develop.
+ */
+function getLatestCommonReleaseTag() {
+  const infrastructureTags = new Set(listReleaseTags(INFRASTRUCTURE_REPO_URL))
+  return (
+    listReleaseTags(COUNTRYCONFIG_REPO_URL).find((tag) =>
+      infrastructureTags.has(tag)
+    ) || null
+  )
+}
+
+/**
+ * A prerelease-shaped own version (e.g. "2.1.0-rc.f5ea803", what npm resolves
+ * `@next` to - a build published from every push to develop) never has a
+ * matching release tag, so scaffold straight from develop for both
+ * repositories instead of wasting a tag lookup that can only fail.
+ *
+ * Otherwise, the own "X.Y.Z" version - whether resolved via npm's `latest`
+ * dist-tag (bare invocation) or an explicit `@X.Y.Z` pin - scaffolds from the
+ * matching "vX.Y.Z" tag when it exists in both repositories. If it doesn't
+ * (e.g. `latest` lagging behind the repos, or a pin that predates one repo's
+ * tagging), fall back to the highest release tag common to both, rather than
+ * a mismatched pairing of one tagged repo at that version and another repo
+ * at a different release. Exits with an error if no matching release tag
+ * exists in both repositories.
+ */
 function resolveRef() {
-  console.log('version: ' + version)
-  /* if (version.includes('-')) {
+  if (version.includes('-')) {
     return 'develop'
-  } */
+  }
 
   const tag = 'v' + version
   if (
@@ -51,13 +100,24 @@ function resolveRef() {
     return tag
   }
 
-  console.warn(
-    '\nWarning: tag "' +
-      tag +
-      '" was not found in both the country config and infrastructure ' +
-      'repositories; falling back to develop for both.'
+  const latestCommonTag = getLatestCommonReleaseTag()
+  if (latestCommonTag) {
+    console.warn(
+      '\nWarning: tag "' +
+        tag +
+        '" was not found in both repositories; falling back to the latest ' +
+        'available release, ' +
+        latestCommonTag +
+        '.'
+    )
+    return latestCommonTag
+  }
+
+  console.error(
+    '\nError: no matching release tag was found in both the country config and ' +
+      'infrastructure repositories.'
   )
-  return 'develop'
+  process.exit(1)
 }
 
 function cloneRepository(repoUrl, ref, targetDir) {

--- a/packages/toolkit/create-countryconfig/index.js
+++ b/packages/toolkit/create-countryconfig/index.js
@@ -17,8 +17,54 @@ const fs = require('fs')
 
 const COUNTRYCONFIG_REPO_URL =
   'https://github.com/opencrvs/opencrvs-countryconfig.git'
-const INFRASTRUCTURE_REPO_URL =
-  'https://github.com/opencrvs/infrastructure.git'
+const INFRASTRUCTURE_REPO_URL = 'https://github.com/opencrvs/infrastructure.git'
+
+const { version } = JSON.parse(
+  fs.readFileSync(path.join(__dirname, 'package.json'), 'utf-8')
+)
+
+function tagExists(repoUrl, tag) {
+  try {
+    execSync(
+      'git ls-remote --exit-code --tags ' + repoUrl + ' refs/tags/' + tag,
+      {
+        stdio: 'pipe'
+      }
+    )
+    return true
+  } catch (err) {
+    return false
+  }
+}
+
+function resolveRef() {
+  if (version.includes('-')) {
+    return 'develop'
+  }
+
+  const tag = 'v' + version
+  if (
+    tagExists(COUNTRYCONFIG_REPO_URL, tag) &&
+    tagExists(INFRASTRUCTURE_REPO_URL, tag)
+  ) {
+    return tag
+  }
+
+  console.warn(
+    '\nWarning: tag "' +
+      tag +
+      '" was not found in both the country config and infrastructure ' +
+      'repositories; falling back to develop for both.'
+  )
+  return 'develop'
+}
+
+function cloneRepository(repoUrl, ref, targetDir) {
+  execSync(
+    'git clone --depth 1 --branch ' + ref + ' ' + repoUrl + ' ' + targetDir,
+    { stdio: 'inherit' }
+  )
+}
 
 const projectName = process.argv[2]
 
@@ -33,31 +79,48 @@ const countryconfigDirName = projectName + '-countryconfig'
 const infrastructureDirName = projectName + '-infrastructure'
 
 const countryconfigTargetDir = path.resolve(process.cwd(), countryconfigDirName)
-const infrastructureTargetDir = path.resolve(process.cwd(), infrastructureDirName)
+const infrastructureTargetDir = path.resolve(
+  process.cwd(),
+  infrastructureDirName
+)
 
 if (fs.existsSync(countryconfigTargetDir)) {
-  console.error('Error: Directory "' + countryconfigDirName + '" already exists.')
+  console.error(
+    'Error: Directory "' + countryconfigDirName + '" already exists.'
+  )
   process.exit(1)
 }
 
 if (fs.existsSync(infrastructureTargetDir)) {
-  console.error('Error: Directory "' + infrastructureDirName + '" already exists.')
+  console.error(
+    'Error: Directory "' + infrastructureDirName + '" already exists.'
+  )
   process.exit(1)
 }
 
-console.log('\nScaffolding OpenCRVS country config in ./' + countryconfigDirName + '...\n')
+const ref = resolveRef()
+
+console.log(
+  '\nScaffolding OpenCRVS country config in ./' + countryconfigDirName + '...\n'
+)
 
 try {
-  execSync('git clone --depth 1 ' + COUNTRYCONFIG_REPO_URL + ' ' + countryconfigDirName, { stdio: 'inherit' })
+  cloneRepository(COUNTRYCONFIG_REPO_URL, ref, countryconfigDirName)
 } catch (err) {
   console.error('Failed to clone the country config repository:', err.message)
   process.exit(1)
 }
 
 try {
-  fs.rmSync(path.join(countryconfigTargetDir, '.git'), { recursive: true, force: true })
+  fs.rmSync(path.join(countryconfigTargetDir, '.git'), {
+    recursive: true,
+    force: true
+  })
 } catch (err) {
-  console.error('Failed to remove .git directory from country config:', err.message)
+  console.error(
+    'Failed to remove .git directory from country config:',
+    err.message
+  )
   process.exit(1)
 }
 
@@ -72,22 +135,34 @@ if (fs.existsSync(pkgPath)) {
     process.exit(1)
   }
 } else {
-  console.warn('Warning: No package.json found in the cloned country config repository. Project name was not updated.')
+  console.warn(
+    'Warning: No package.json found in the cloned country config repository. Project name was not updated.'
+  )
 }
 
-console.log('\nScaffolding OpenCRVS infrastructure in ./' + infrastructureDirName + '...\n')
+console.log(
+  '\nScaffolding OpenCRVS infrastructure in ./' +
+    infrastructureDirName +
+    '...\n'
+)
 
 try {
-  execSync('git clone --depth 1 ' + INFRASTRUCTURE_REPO_URL + ' ' + infrastructureDirName, { stdio: 'inherit' })
+  cloneRepository(INFRASTRUCTURE_REPO_URL, ref, infrastructureDirName)
 } catch (err) {
   console.error('Failed to clone the infrastructure repository:', err.message)
   process.exit(1)
 }
 
 try {
-  fs.rmSync(path.join(infrastructureTargetDir, '.git'), { recursive: true, force: true })
+  fs.rmSync(path.join(infrastructureTargetDir, '.git'), {
+    recursive: true,
+    force: true
+  })
 } catch (err) {
-  console.error('Failed to remove .git directory from infrastructure:', err.message)
+  console.error(
+    'Failed to remove .git directory from infrastructure:',
+    err.message
+  )
   process.exit(1)
 }
 

--- a/packages/toolkit/create-countryconfig/index.js
+++ b/packages/toolkit/create-countryconfig/index.js
@@ -37,6 +37,20 @@ function tagExists(repoUrl, tag) {
   }
 }
 
+function branchExists(repoUrl, branch) {
+  try {
+    execSync(
+      'git ls-remote --exit-code --heads ' + repoUrl + ' refs/heads/' + branch,
+      {
+        stdio: 'pipe'
+      }
+    )
+    return true
+  } catch (err) {
+    return false
+  }
+}
+
 /**
  * Release tags (e.g. "v2.1.0"), highest first. Delegates the version-aware
  * ordering to git itself rather than hand-parsing semver, then filters down
@@ -74,9 +88,15 @@ function getLatestCommonReleaseTag() {
 
 /**
  * A prerelease-shaped own version (e.g. "2.1.0-rc.f5ea803", what npm resolves
- * `@next` to - a build published from every push to develop) never has a
- * matching release tag, so scaffold straight from develop for both
- * repositories instead of wasting a tag lookup that can only fail.
+ * `@next` to - a build published from every push to a branch) never has a
+ * matching release tag, so it's resolved as a branch instead. Its base
+ * version (stripped of the "-rc.<sha>" suffix) tells apart two different
+ * situations: an RC for a version already being stabilized on its own
+ * "release/X.Y.Z" branch (e.g. "2.0.1-rc.*" while a patch release is in
+ * progress) versus an RC for a version that hasn't been branched off yet and
+ * only exists on develop (e.g. "2.1.0-rc.*" while that release branch hasn't
+ * been cut). Scaffold from the release branch when it exists in both
+ * repositories, otherwise fall back to develop.
  *
  * Otherwise, the own "X.Y.Z" version - whether resolved via npm's `latest`
  * dist-tag (bare invocation) or an explicit `@X.Y.Z` pin - scaffolds from the
@@ -89,6 +109,13 @@ function getLatestCommonReleaseTag() {
  */
 function resolveRef() {
   if (version.includes('-')) {
+    const releaseBranch = 'release/' + version.split('-')[0]
+    if (
+      branchExists(COUNTRYCONFIG_REPO_URL, releaseBranch) &&
+      branchExists(INFRASTRUCTURE_REPO_URL, releaseBranch)
+    ) {
+      return releaseBranch
+    }
     return 'develop'
   }
 


### PR DESCRIPTION
## Description

Currently latest develop repos of cc and infra are always used for bootstrap when running 
npm create @opencrvs/countryconfig@2.0.0 my-country.
Cloned repos get code from develop branch instead of release/2.0.0 for example

npm view @opencrvs/create-countryconfig@latest version => 2.0.0
npm view @opencrvs/create-countryconfig@next version => 2.0.1-rc.6acf897


PR aims to align create country script to the following behavior:
| Command | npm resolves to | `resolveRef()` in `index.js` | Result |
|---|---|---|---|
| `npm create @opencrvs/countryconfig my-country` | `latest` dist-tag (always a clean `X.Y.Z` release) | exact `vX.Y.Z` tag match in both repos | clones `vX.Y.Z` from both repos |
| `npm create @opencrvs/countryconfig@2.0.0 my-country` | `2.0.0` (published) | exact `v2.0.0` tag match in both repos | clones `v2.0.0` from both repos |
| `npm create @opencrvs/countryconfig@2.0.1 my-country` | fails — `2.0.1` not published | n/a | npm errors before install: `No matching version found` |
| `npm create @opencrvs/countryconfig@next my-country` → resolves to `2.0.1-rc.<sha>` | prerelease build for a version currently being stabilized | `release/2.0.1` branch exists in both repos | clones `release/2.0.1` from both repos |
| `npm create @opencrvs/countryconfig@next my-country` → resolves to `2.1.0-rc.<sha>` | prerelease build for a version not yet branched off | no `release/2.1.0` branch yet in either repo | falls back to `develop` in both repos |
| Any `@X.Y.Z` whose tag is missing from one/both repos | published npm version, but no matching git tag yet | falls back to highest release tag common to both repos | clones that tag, with a warning |
| No release tag exists in either repo at all | — | — | hard error, exits with code 1 |

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
