### PR TITLE
fix(ocrvs-11994): add TTL for events config cache

### DIFF
--- a/packages/events/src/environment.ts
+++ b/packages/events/src/environment.ts
@@ -9,7 +9,7 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 
-import { cleanEnv, str, url, bool } from 'envalid'
+import { cleanEnv, str, url, bool, num } from 'envalid'
 
 /**
  * When defining variables aim to be consistent with existing values.
@@ -33,5 +33,9 @@ export const env = cleanEnv(process.env, {
     default: true,
     desc: 'Enable two-factor authentication. When disabled, verification codes are set to 000000.'
   }),
-  DEFAULT_USER_PASSWORD: str({ devDefault: 'test', default: undefined })
+  DEFAULT_USER_PASSWORD: str({ devDefault: 'test', default: undefined }),
+  EVENT_CONFIG_CACHE_TTL_MS: num({
+    default: 60_000,
+    desc: 'How long (ms) the events service caches event/workqueue configuration fetched from countryconfig before refetching. Bounds how stale served config can be after a countryconfig deploy that does not restart the events service.'
+  })
 })

--- a/packages/events/src/index.ts
+++ b/packages/events/src/index.ts
@@ -14,9 +14,12 @@ import '@opencrvs/commons/monitoring'
 import { env } from './environment'
 import { server } from './server'
 import { getAnonymousToken } from './service/auth'
-import { getInMemoryEventConfigurations } from './service/config/config'
+import {
+  getInMemoryEventConfigurations,
+  onEventConfigurationsLoaded
+} from './service/config/config'
 import { triggerSystemReady } from './service/config/systemReady'
-import { ensureIndexExists } from './service/indexing/indexing'
+import { ensureIndicesExist } from './service/indexing/indexing'
 import { ensureConnection } from './storage/postgres/events'
 import { startAnnouncementWorker } from './workers/announcementWorker'
 
@@ -34,10 +37,11 @@ export async function main() {
     const configurations = await getInMemoryEventConfigurations(
       `Bearer ${anonymousToken}`
     )
-    for (const configuration of configurations) {
-      logger.info(`Loaded event configuration: ${configuration.id}`)
-      await ensureIndexExists(configuration)
-    }
+    await ensureIndicesExist(configurations)
+
+    // Repeats the setup above on every later refetch, so an event configured
+    // after startup can be indexed without restarting the service.
+    onEventConfigurationsLoaded(ensureIndicesExist)
   } catch (error) {
     if (error instanceof Error) {
       logger.error(error.message)

--- a/packages/events/src/service/config/config.ts
+++ b/packages/events/src/service/config/config.ts
@@ -22,13 +22,66 @@ import {
 } from '@opencrvs/commons'
 import { env } from '@events/environment'
 /**
- * During 1.9.0 we support only docker swarm configuration.
- * In docker swarm deployment process updates all the containers.
- * There shouldn't be a situation where countryconfig changes and events do not restart.
+ * Configuration is served from countryconfig, which can be deployed
+ * independently of the events service (e.g. a Kubernetes rollout that updates
+ * countryconfig but not events). A time-boxed cache keeps configuration off the
+ * hot path (it is read on nearly every request, including auth middleware)
+ * while bounding how stale it can be to `EVENT_CONFIG_CACHE_TTL_MS` — no events
+ * restart is required to pick up a config change.
  */
+function createTtlConfigCache<T>(
+  label: string,
+  fetcher: (token: TokenWithBearer) => Promise<T>
+) {
+  let value: T | null = null
+  let fetchedAt = 0
+  let inFlight: Promise<T> | null = null
 
-let inMemoryEventConfigurations: EventConfig[] | null = null
-let inMemoryWorkqueueConfigurations: WorkqueueConfig[] | null = null
+  return async function getCached(token: TokenWithBearer): Promise<T> {
+    // In development always fetch, so config changes are picked up immediately.
+    if (!env.isProduction) {
+      return fetcher(token)
+    }
+
+    if (
+      value !== null &&
+      Date.now() - fetchedAt < env.EVENT_CONFIG_CACHE_TTL_MS
+    ) {
+      return value
+    }
+
+    // Coalesce concurrent refetches into a single request so an expiry doesn't
+    // stampede countryconfig from the many call sites.
+    if (!inFlight) {
+      logger.info(`Refetching ${label} from countryconfig`)
+      inFlight = fetcher(token)
+        .then((fetched) => {
+          value = fetched
+          fetchedAt = Date.now()
+          return fetched
+        })
+        .finally(() => {
+          inFlight = null
+        })
+    }
+
+    try {
+      return await inFlight
+    } catch (error) {
+      // Serve the last good value if a refetch fails, so a transient
+      // countryconfig outage doesn't break event operations.
+      if (value !== null) {
+        logger.error(
+          `Failed to refetch ${label}; serving previously cached value. ${String(
+            error
+          )}`
+        )
+        return value
+      }
+      throw error
+    }
+  }
+}
 
 export async function getEventConfigurations(token: TokenWithBearer) {
   const res = await fetch(new URL('/config/events', env.COUNTRY_CONFIG_URL), {
@@ -48,25 +101,13 @@ export async function getEventConfigurations(token: TokenWithBearer) {
 }
 
 /**
- * @returns in-memory event configurations when running in production-like environment.
+ * @returns event configurations, cached in production for up to
+ * `EVENT_CONFIG_CACHE_TTL_MS` (always fresh in development).
  */
-export async function getInMemoryEventConfigurations(token: TokenWithBearer) {
-  if (!env.isProduction) {
-    logger.info(
-      `Running in ${process.env.NODE_ENV} mode. Fetching event configurations from API`
-    )
-    // In development, we should always fetch the latest configurations
-    return getEventConfigurations(token)
-  }
-
-  if (inMemoryEventConfigurations) {
-    logger.info('Returning in-memory event configurations')
-    return inMemoryEventConfigurations
-  }
-
-  inMemoryEventConfigurations = await getEventConfigurations(token)
-  return inMemoryEventConfigurations
-}
+export const getInMemoryEventConfigurations = createTtlConfigCache(
+  'event configurations',
+  getEventConfigurations
+)
 
 async function findEventConfigurationById({
   eventType,
@@ -114,27 +155,13 @@ async function getWorkqueueConfigurations(token: TokenWithBearer) {
 }
 
 /**
- * @returns in-memory workqueue configurations when running in production-like environment.
+ * @returns workqueue configurations, cached in production for up to
+ * `EVENT_CONFIG_CACHE_TTL_MS` (always fresh in development).
  */
-export async function getInMemoryWorkqueueConfigurations(
-  token: TokenWithBearer
-) {
-  if (!env.isProduction) {
-    logger.info(
-      `Running in ${process.env.NODE_ENV} mode. Fetching workqueue configurations from API`
-    )
-    // In production, we should always fetch the latest configurations
-    return getWorkqueueConfigurations(token)
-  }
-
-  if (inMemoryWorkqueueConfigurations) {
-    logger.info('Returning in-memory workqueue configurations')
-    return inMemoryWorkqueueConfigurations
-  }
-
-  inMemoryWorkqueueConfigurations = await getWorkqueueConfigurations(token)
-  return inMemoryWorkqueueConfigurations
-}
+export const getInMemoryWorkqueueConfigurations = createTtlConfigCache(
+  'workqueue configurations',
+  getWorkqueueConfigurations
+)
 
 export async function getRoles() {
   const res = await fetch(new URL('/config/roles', env.COUNTRY_CONFIG_URL), {

--- a/packages/events/src/service/config/config.ts
+++ b/packages/events/src/service/config/config.ts
@@ -31,7 +31,8 @@ import { env } from '@events/environment'
  */
 function createTtlConfigCache<T>(
   label: string,
-  fetcher: (token: TokenWithBearer) => Promise<T>
+  fetcher: (token: TokenWithBearer) => Promise<T>,
+  afterFetch?: (value: T) => Promise<void>
 ) {
   let value: T | null = null
   let fetchedAt = 0
@@ -40,7 +41,9 @@ function createTtlConfigCache<T>(
   return async function getCached(token: TokenWithBearer): Promise<T> {
     // In development always fetch, so config changes are picked up immediately.
     if (!env.isProduction) {
-      return fetcher(token)
+      const fetched = await fetcher(token)
+      await afterFetch?.(fetched)
+      return fetched
     }
 
     if (
@@ -55,10 +58,19 @@ function createTtlConfigCache<T>(
     if (!inFlight) {
       logger.info(`Refetching ${label} from countryconfig`)
       inFlight = fetcher(token)
-        .then((fetched) => {
+        .then(async (fetched) => {
+          // Before the value is served, so search indices are in place by the
+          // time the service uses the configuration.
+          await afterFetch?.(fetched)
           value = fetched
           fetchedAt = Date.now()
           return fetched
+        })
+        .catch((error: unknown) => {
+          // Bounds retries to one per TTL. Left expired, a failed attempt would
+          // turn every subsequent request into another refetch.
+          fetchedAt = Date.now()
+          throw error
         })
         .finally(() => {
           inFlight = null
@@ -83,13 +95,30 @@ function createTtlConfigCache<T>(
   }
 }
 
+/**
+ * Countryconfig tags the configuration with an entity tag, so an unchanged
+ * configuration costs a 304 instead of retransmitting and reparsing ~150kB on
+ * every refetch. Countryconfig versions without the tag answer 200 as before.
+ */
+let lastFetchedEventConfigurations: {
+  etag: string
+  configurations: EventConfig[]
+} | null = null
+
 export async function getEventConfigurations(token: TokenWithBearer) {
   const res = await fetch(new URL('/config/events', env.COUNTRY_CONFIG_URL), {
     headers: {
       'Content-Type': 'application/json',
-      Authorization: token
+      Authorization: token,
+      ...(lastFetchedEventConfigurations && {
+        'If-None-Match': lastFetchedEventConfigurations.etag
+      })
     }
   })
+
+  if (res.status === 304 && lastFetchedEventConfigurations) {
+    return lastFetchedEventConfigurations.configurations
+  }
 
   if (!res.ok) {
     throw new Error(
@@ -97,7 +126,27 @@ export async function getEventConfigurations(token: TokenWithBearer) {
     )
   }
 
-  return array(EventConfig).parse(await res.json())
+  const configurations = array(EventConfig).parse(await res.json())
+  const etag = res.headers.get('etag')
+  lastFetchedEventConfigurations = etag ? { etag, configurations } : null
+
+  return configurations
+}
+
+let eventConfigurationsLoadedListener:
+  | ((configurations: EventConfig[]) => Promise<void>)
+  | null = null
+
+/**
+ * Registers the handler run on each fetch of event configurations, to set up
+ * search indices for events configured after startup. Registered rather than
+ * passed to `createTtlConfigCache` directly: importing indexing here would
+ * close a require cycle through the tRPC context.
+ */
+export function onEventConfigurationsLoaded(
+  listener: (configurations: EventConfig[]) => Promise<void>
+) {
+  eventConfigurationsLoadedListener = listener
 }
 
 /**
@@ -106,7 +155,8 @@ export async function getEventConfigurations(token: TokenWithBearer) {
  */
 export const getInMemoryEventConfigurations = createTtlConfigCache(
   'event configurations',
-  getEventConfigurations
+  getEventConfigurations,
+  async (configurations) => eventConfigurationsLoadedListener?.(configurations)
 )
 
 async function findEventConfigurationById({

--- a/packages/events/src/service/indexing/indexing.test.ts
+++ b/packages/events/src/service/indexing/indexing.test.ts
@@ -22,6 +22,7 @@ import {
   EventIndex,
   EventState,
   field,
+  FieldConfig,
   FieldConditional,
   FieldType,
   generateActionDeclarationInput,
@@ -30,7 +31,9 @@ import {
   QueryType,
   TENNIS_CLUB_MEMBERSHIP,
   TestUserRole,
-  UUID
+  UUID,
+  generateEventConfig,
+  generateTranslationConfig
 } from '@opencrvs/commons/events'
 import { encodeScope } from '@opencrvs/commons'
 import {
@@ -41,6 +44,7 @@ import {
   TEST_USER_DEFAULT_SCOPES
 } from '@events/tests/utils'
 import {
+  getEventAliasName,
   getEventIndexName,
   getOrCreateClient
 } from '@events/storage/elasticsearch'
@@ -50,6 +54,8 @@ import {
   buildElasticQueryFromSearchPayload,
   withJurisdictionFilters
 } from './query'
+import { ensureIndexExists, ensureIndicesExist } from './indexing'
+import { encodeFieldId } from './utils'
 
 test('records are not indexed when they are created', async () => {
   const { user, generator } = await setupTestCase()
@@ -1539,4 +1545,88 @@ describe('placeOfEvent location hierarchy handling', () => {
       expectedLocationHierarchy
     )
   })
+})
+
+const EVENT_ID = 'book-club-membership'
+const ADDED_FIELD_ID = 'applicant.nickname'
+
+const originalFields: FieldConfig[] = [
+  {
+    id: 'applicant.email',
+    type: FieldType.EMAIL,
+    label: generateTranslationConfig('Email')
+  }
+]
+
+const addedField: FieldConfig = {
+  id: ADDED_FIELD_ID,
+  type: FieldType.TEXT,
+  label: generateTranslationConfig('Nickname')
+}
+
+async function getDeclarationFieldMappings(indexName: string) {
+  const mappings = await getOrCreateClient().indices.getMapping({
+    index: indexName
+  })
+  const declaration =
+    Object.values(mappings)[0].mappings.properties?.declaration
+
+  return declaration && 'properties' in declaration
+    ? declaration.properties
+    : undefined
+}
+
+test('mappings for a field added to a deployed event are applied without a reindex', async () => {
+  const indexName = getEventIndexName(EVENT_ID)
+
+  await ensureIndexExists(
+    generateEventConfig({ id: EVENT_ID, fields: originalFields })
+  )
+
+  const beforeFieldWasAdded = await getDeclarationFieldMappings(indexName)
+  expect(beforeFieldWasAdded).toBeDefined()
+  expect(beforeFieldWasAdded).not.toHaveProperty(encodeFieldId(ADDED_FIELD_ID))
+
+  await ensureIndexExists(
+    generateEventConfig({
+      id: EVENT_ID,
+      fields: [...originalFields, addedField]
+    })
+  )
+
+  const afterFieldWasAdded = await getDeclarationFieldMappings(indexName)
+  expect(afterFieldWasAdded?.[encodeFieldId(ADDED_FIELD_ID)]).toEqual({
+    type: 'keyword'
+  })
+})
+
+test('an event configured after startup gets a searchable index', async () => {
+  const existingEvent = generateEventConfig({
+    id: 'tennis-club-membership',
+    fields: originalFields
+  })
+  const addedEvent = generateEventConfig({
+    id: EVENT_ID,
+    fields: originalFields
+  })
+  const addedEventIndexName = getEventIndexName(addedEvent.id)
+  const esClient = getOrCreateClient()
+
+  await ensureIndicesExist([existingEvent])
+
+  expect(await esClient.indices.exists({ index: addedEventIndexName })).toBe(
+    false
+  )
+
+  await ensureIndicesExist([existingEvent, addedEvent])
+
+  expect(await esClient.indices.exists({ index: addedEventIndexName })).toBe(
+    true
+  )
+  expect(
+    await esClient.indices.existsAlias({
+      name: getEventAliasName(),
+      index: addedEventIndexName
+    })
+  ).toBe(true)
 })

--- a/packages/events/src/service/indexing/indexing.ts
+++ b/packages/events/src/service/indexing/indexing.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- index lifecycle lives here alongside the mappings it writes */
 /*
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -268,6 +269,16 @@ function formFieldsToDataMapping(fields: FieldConfig[]) {
   )
 }
 
+/** Shared by index creation and updates, so the two cannot drift apart. */
+function declarationMapping(
+  formFields: FieldConfig[]
+): estypes.MappingProperty {
+  return {
+    type: 'object',
+    properties: formFieldsToDataMapping(formFields)
+  }
+}
+
 export async function createIndex(
   indexName: string,
   formFields: FieldConfig[],
@@ -293,10 +304,7 @@ export async function createIndex(
           assignedTo: { type: 'keyword' },
           updatedBy: { type: 'keyword' },
           updatedByUserRole: { type: 'keyword' },
-          declaration: {
-            type: 'object',
-            properties: formFieldsToDataMapping(formFields)
-          },
+          declaration: declarationMapping(formFields),
           trackingId: { type: 'keyword' },
           legalStatuses: {
             type: 'object',
@@ -350,28 +358,72 @@ export async function createIndex(
   }
 }
 
+/**
+ * Mappings are only written when an index is created, so a field added to an
+ * event afterwards would be mapped by whatever Elasticsearch infers on first
+ * write — searchable, but not as configured. Pushing the configured mapping
+ * fixes that without a reindex: Elasticsearch merges new fields into an
+ * existing mapping. A changed field *type* is not a legal merge, so it is
+ * logged and left for a reindex rather than failing the rest of the setup.
+ */
+async function syncIndexMappings(
+  indexName: string,
+  eventConfiguration: EventConfig
+) {
+  const esClient = getOrCreateClient()
+
+  try {
+    await esClient.indices.putMapping({
+      index: indexName,
+      properties: {
+        declaration: declarationMapping(
+          getDeclarationFields(eventConfiguration)
+        )
+      }
+    })
+  } catch (error) {
+    logger.error(
+      `Failed to update mappings for index ${indexName}. If a field type changed, a reindex is required. ${String(
+        error
+      )}`
+    )
+  }
+}
+
 export async function ensureIndexExists(eventConfiguration: EventConfig) {
   const esClient = getOrCreateClient()
   const indexName = getEventIndexName(eventConfiguration.id)
 
-  const isAlreadyWriteAlias = await esClient.indices.existsAlias({
-    name: indexName
-  })
-  if (isAlreadyWriteAlias) {
-    logger.info(
-      `Write alias ${indexName} already exists — index setup already complete`
-    )
-    return
+  // Alias membership is the common case, and covers an index reachable through
+  // its own write alias, which is how a reindexed event is set up.
+  const isSearchable =
+    (await esClient.indices.existsAlias({
+      name: getEventAliasName(),
+      index: indexName
+    })) || (await esClient.indices.existsAlias({ name: indexName }))
+
+  if (!isSearchable) {
+    if (!(await esClient.indices.exists({ index: indexName }))) {
+      logger.info(`Creating index ${indexName}`)
+      await createIndex(indexName, getDeclarationFields(eventConfiguration))
+
+      return
+    }
+
+    logger.info(`Adding existing index ${indexName} to the search alias`)
+    await ensureAlias(indexName)
   }
 
-  const hasConcreteIndex = await esClient.indices.exists({ index: indexName })
+  await syncIndexMappings(indexName, eventConfiguration)
+}
 
-  if (!hasConcreteIndex) {
-    logger.info(`Creating index ${indexName}`)
-    await createIndex(indexName, getDeclarationFields(eventConfiguration))
-  } else {
-    logger.info(`Index ${indexName} already exists as a concrete index.`)
-    await ensureAlias(indexName)
+/**
+ * Run at startup and on every configuration refetch, so an event configured
+ * after startup can be indexed without restarting the service.
+ */
+export async function ensureIndicesExist(configurations: EventConfig[]) {
+  for (const configuration of configurations) {
+    await ensureIndexExists(configuration)
   }
 }
 


### PR DESCRIPTION
- **countryconfig: https://github.com/opencrvs/opencrvs-countryconfig/pull/1504**
- **testland: https://github.com/opencrvs/opencrvs-testland/pull/2287**

**What's new:** the events service re-reads configuration from countryconfig every ~60 seconds instead of caching it for the pod's lifetime. After a countryconfig deploy, a running events
  service catches up on its own.

  ### What this fixes

  On Kubernetes, countryconfig and events roll out independently. If events started before the new countryconfig was live, it kept the old configuration forever — new records failed
  validation, sat stuck in the outbox, and logged `Field with id <field> not found in event config`. The only fix was a manual restart of the events pod. That now resolves itself within a
  minute, with no restart and no ordering requirement between the two rollouts. Docker Swarm was never affected and is unchanged.

  ### How to think about it

  > This makes the events service agree with countryconfig faster. It does nothing to make countryconfig agree with records already in your database.

  The same error message comes from two opposite situations:

  - **Configuration behind the records** — a field was added, events hadn't caught up. A newer configuration exists, so refetching resolves it. **Fixed; clears by itself.**
  - **Configuration ahead of the records** — a field was deliberately removed, made required, or given stricter validation, while older records remain. Refetching returns exactly the
  configuration that rejects them. **Not fixed**, and refreshing sooner only applies the stricter rules sooner.

  ### Still requires a restart

  Adding a **new event type** (not just a new field). Records created for a new event type before the restart go into a wrongly structured search index that a later restart won't repair —
  recovery means a reindex.

  ### Still unsafe after go-live

  Removing fields, adding required fields, tightening validation. Adding **optional** fields remains the safe change.

  Worth knowing why this bites hard: events validates a record's *entire* stored declaration on every action, so a legacy record carrying a since-removed field will fail the next time anyone
  registers, corrects, or prints it — even though nobody touched that field and it's no longer in the form. There is still no record migration in 2.0.1 (tracked in #7463 and #6691).

  ### Also worth knowing

  - A newly added field works in forms immediately, but won't search or sort reliably in workqueues until a reindex, since index structure is only written when an index is first created.
  - Browsers keep their own copy of the form, so staff should reload after a configuration change.
  - With more than one events pod, pods can disagree for up to a minute after a deploy.

  ### Action required to adopt

  None — on by default, 60-second interval, no Helm or environment changes. Tunable via `EVENT_CONFIG_CACHE_TTL_MS`.