### PR TITLE
fix: Pinned pgbackrest version to values.yaml

### DIFF
--- a/charts/dependencies/files/postgres/postgres-backup-config.sh
+++ b/charts/dependencies/files/postgres/postgres-backup-config.sh
@@ -15,7 +15,7 @@ set -e
 common_config(){
 apt update -q
 apt upgrade -y -q
-apt install -y -q pgbackrest=2.59.0-1.pgdg13+1 openssh-client
+apt install -y -q pgbackrest={{ .Values.postgres.pgbackrest_version }}* openssh-client
 # Common configuration for backup and restore
 # Temporal directory required for pushing WAL files
 echo "Create pgbackrest temp directory with correct permissions"

--- a/charts/dependencies/templates/postgres-restore-job-configmap.yaml
+++ b/charts/dependencies/templates/postgres-restore-job-configmap.yaml
@@ -25,7 +25,7 @@ data:
           - |
             apt update
             apt upgrade -y
-            apt install -y pgbackrest openssh-client
+            apt install -y pgbackrest={{ .Values.postgres.pgbackrest_version }}* openssh-client
             cat > /etc/ssh/ssh_config.d/backup.conf <<'EOF'
             StrictHostKeyChecking no
             EOF

--- a/charts/dependencies/templates/postgres-scripts-configmap.yaml
+++ b/charts/dependencies/templates/postgres-scripts-configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 data:
 {{- range $path, $file := .Files.Glob "files/postgres/*" }}
     {{ base $path }}: |
-{{ toString $file | indent 8 }}
+{{ tpl (toString $file) $ | indent 8 }}
 {{- end }}
 kind: ConfigMap
 metadata:

--- a/charts/dependencies/values.yaml
+++ b/charts/dependencies/values.yaml
@@ -87,6 +87,10 @@ postgres:
     # Requested persistent storage size
     storage_size: '10Gi'
 
+  # pgBackRest version (major.minor.hotfix). Single source of truth for both
+  # backup/restore scripts
+  pgbackrest_version: 2.59.0
+
   # Backup section
   backup:
     # Enable/Disable backup


### PR DESCRIPTION
## Description

Goal of this PR is to ship hotfix from https://github.com/opencrvs/opencrvs-core/pull/13502 into release/2.0.1 branch

Original Commit id: https://github.com/opencrvs/opencrvs-core/pull/13502/changes/e4faae0fe35a22d2a75d43d7b76a1a102ed200e9

## Testing

Helm chart built from `fix-pgbackrest` branch: https://github.com/opencrvs/opencrvs-core/actions/runs/32477595890

Changes applied to farajaland staging: https://github.com/opencrvs/opencrvs-farajaland-infrastructure/actions/runs/32477673168/job/96758764977

Restore job manually triggered:
```
k create job --from cronjob/postgres-restore pr
```

Logs:
```
vmudryi@farajaland-demo-1:~k logs -f pr-4lmpc
pod "postgres-restore-runner" deleted from opencrvs-deps-staging namespace
pod/postgres-restore-runner created
statefulset.apps/postgres scaled
pod/postgres-restore-runner condition met
Waiting for container initialization
Waiting for container initialization
Waiting for container initialization
Waiting for container initialization
Waiting for container initialization
pgBackRest 2.59.0
2026-08-21 11:41:44.498 P00   INFO: restore command begin 2.59.0: --config=/etc/pgbackrest/pgbackrest.conf --delta --exec-id=3445-b98bb747 --force --log-level-console=info --pg1-path=/var/lib/postgresql/data --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-host=10.0.1.2 --repo1-host-user=backup --repo1-path=/home/backup/production/postgres --repo1-type=posix --stanza=main
2026-08-21 11:41:46.314 P00   INFO: repo1: restore backup set 20260802-010053F_20260803-010006D, recovery will start at 2026-08-03 01:00:06
2026-08-21 11:41:46.317 P00   INFO: remove invalid files/links/paths from '/var/lib/postgresql/data'
2026-08-21 11:42:41.237 P00   INFO: write updated /var/lib/postgresql/data/postgresql.auto.conf
2026-08-21 11:42:41.247 P00   INFO: restore global/pg_control (performed last to ensure aborted restores cannot be started)
2026-08-21 11:42:41.248 P00   INFO: restore size = 50.2MB, file total = 1390
2026-08-21 11:42:41.250 P00   INFO: restore command end: completed successfully (56756ms)
statefulset.apps/postgres scaled
```

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
