### PR TITLE
fix: require auth on country config user-notification triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## 2.0.1 Release Candidate
 
+### Security fixes
+
+- Every `/triggers/user/*` user-notification request sent to the country config now carries an `Authorization` header, so country configurations can require authentication on those routes. Previously the `all-user-notification` route was called without a token and country configurations shipped all of these routes with `auth: false`, letting anyone who could reach the service trigger 2FA codes, password-reset credentials and notification emails or SMS to arbitrary recipients. The background announcement worker now authenticates with an anonymous token, and the username-retrieval flow mints a system token instead of forwarding an `Authorization` header it never receives. [#13501](https://github.com/opencrvs/opencrvs-core/pull/13501)
+
+  **Deployment notes:**
+
+  - Country configurations must remove `auth: false` from every route in `src/config/routes/userNotificationRoutes.ts`. Until they do, the endpoints stay open — the core change alone does not close them. The routes then inherit the default `jwt` strategy, which accepts tokens with the `opencrvs:countryconfig-user` audience; every core caller now sends one.
+  - Run `npx @opencrvs/toolkit verify-endpoints` against a locally-running country config to confirm the required public endpoints still respond and the secured ones reject unauthenticated requests. It exits non-zero if any check fails.
+
 ### Improvements
 
 - Added `createdBy` as a config paramater to filter records created by the user [#13287](https://github.com/opencrvs/opencrvs-core/issues/13287)

--- a/packages/auth/src/features/retrievalSteps/sendUserName/handler.test.ts
+++ b/packages/auth/src/features/retrievalSteps/sendUserName/handler.test.ts
@@ -71,8 +71,19 @@ describe('username reminder', () => {
           nonce: '12345'
         }
       })
+      /*
+       * The Authorization header is asserted explicitly: `/sendUserName` is
+       * itself unauthenticated, so there is no incoming token to forward. If
+       * this handler stops minting one, country config rejects the trigger
+       * with a 401 and the user silently never receives their username.
+       */
       expect(triggerUserEventNotification).toHaveBeenCalledWith(
-        expect.objectContaining({ event: 'username-reminder' })
+        expect.objectContaining({
+          event: 'username-reminder',
+          authHeader: {
+            Authorization: expect.stringMatching(/^Bearer \S+$/)
+          }
+        })
       )
     })
   })

--- a/packages/auth/src/features/retrievalSteps/sendUserName/handler.ts
+++ b/packages/auth/src/features/retrievalSteps/sendUserName/handler.ts
@@ -18,9 +18,13 @@ import {
   RetrievalSteps,
   deleteRetrievalStepInformation
 } from '@auth/features/retrievalSteps/verifyUser/service'
-import { triggerUserEventNotification } from '@opencrvs/commons'
+import { triggerUserEventNotification, TokenUserType } from '@opencrvs/commons'
 import { env } from '@auth/environment'
-import { recordAnonymousUserAuditEvent } from '@auth/features/authenticate/service'
+import { JWT_ISSUER } from '@auth/constants'
+import {
+  createToken,
+  recordAnonymousUserAuditEvent
+} from '@auth/features/authenticate/service'
 
 interface IPayload {
   nonce: string
@@ -52,7 +56,23 @@ export default async function sendUserNameHandler(
       username: retrievalStepInformation.username
     },
     countryConfigUrl: env.COUNTRY_CONFIG_URL_INTERNAL,
-    authHeader: { Authorization: request.headers.authorization as string }
+    /*
+     * Username retrieval is a pre-authentication flow: the caller proves
+     * itself with the nonce, not a token, so there is no incoming
+     * Authorization header to forward. Mint a short-lived system token
+     * instead — the same way the 2FA and password-reset code notifications do
+     * — so country config can require auth on `/triggers/user/*`.
+     */
+    authHeader: {
+      Authorization: `Bearer ${await createToken(
+        'auth',
+        [],
+        ['opencrvs:countryconfig-user'],
+        JWT_ISSUER,
+        undefined,
+        TokenUserType.enum.system
+      )}`
+    }
   })
 
   await recordAnonymousUserAuditEvent({

--- a/packages/commons/src/notification/UserNotifications.ts
+++ b/packages/commons/src/notification/UserNotifications.ts
@@ -89,22 +89,12 @@ export type TriggerPayload = {
   [K in TriggerEvent]: z.infer<(typeof TriggerPayload)[K]>
 }
 
-// authHeader is not required for all-user-notification endpoint.
-export async function triggerUserEventNotification(args: {
-  event: typeof TriggerEvent.ALL_USER_NOTIFICATION
-  payload: TriggerPayload[typeof TriggerEvent.ALL_USER_NOTIFICATION]
-  countryConfigUrl: string
-}): Promise<Response>
-
-export async function triggerUserEventNotification<
-  T extends Exclude<TriggerEvent, typeof TriggerEvent.ALL_USER_NOTIFICATION>
->(args: {
-  event: T
-  payload: TriggerPayload[T]
-  countryConfigUrl: string
-  authHeader: { Authorization: string }
-}): Promise<Response>
-
+/*
+ * Every event carries an Authorization header. Interactive flows forward the
+ * acting user's token; the background announcement worker fetches an anonymous
+ * token first (see getAnonymousToken in the events service). This lets country
+ * configs require authentication on all `/triggers/user/*` routes.
+ */
 export async function triggerUserEventNotification<T extends TriggerEvent>({
   event,
   payload,
@@ -114,7 +104,7 @@ export async function triggerUserEventNotification<T extends TriggerEvent>({
   event: T
   payload: TriggerPayload[T]
   countryConfigUrl: string
-  authHeader?: { Authorization: string }
+  authHeader: { Authorization: string }
 }): Promise<Response> {
   return await fetch(joinUrl(countryConfigUrl, `triggers/user/${event}`), {
     method: 'POST',

--- a/packages/events/src/router/announcement/announcement.test.ts
+++ b/packages/events/src/router/announcement/announcement.test.ts
@@ -24,7 +24,7 @@ import {
   processNextAnnouncement
 } from '@events/workers/announcementWorker'
 import { env } from '@events/environment'
-import { mswServer } from '@events/tests/msw'
+import { ANONYMOUS_TOKEN, mswServer } from '@events/tests/msw'
 
 const scope = encodeScope({ type: 'config.update-all' })
 
@@ -75,7 +75,14 @@ async function insertAdminWithEmail(
   const email = 'admin@test.com'
   const result = await eventsDb
     .insertInto('users')
-    .values({ role: 'ADMIN', status: 'active', email, officeId, firstname: '', surname: '' })
+    .values({
+      role: 'ADMIN',
+      status: 'active',
+      email,
+      officeId,
+      firstname: '',
+      surname: ''
+    })
     .returning('id')
     .executeTakeFirstOrThrow()
   return { id: result.id as UUID, email }
@@ -464,10 +471,12 @@ describe('processNextAnnouncement', () => {
       .execute()
 
     const capturedBcc: string[] = []
+    const capturedAuth: (string | null)[] = []
     mswServer.use(
       http.post(ALL_USER_NOTIFICATION_URL, async ({ request }) => {
         const body = (await request.json()) as { recipient: { bcc: string[] } }
         capturedBcc.push(...body.recipient.bcc)
+        capturedAuth.push(request.headers.get('authorization'))
         return HttpResponse.json({ ok: true })
       })
     )
@@ -481,6 +490,12 @@ describe('processNextAnnouncement', () => {
 
     expect(announcement.status).toBe('SENT')
     expect(capturedBcc).toEqual(expect.arrayContaining(recipients))
+    /*
+     * A broadcast has no acting user, so the worker fetches an anonymous token
+     * of its own. Asserted explicitly: if it stops doing so, country config
+     * rejects the dispatch with a 401 and no announcement is ever delivered.
+     */
+    expect(capturedAuth).toEqual([`Bearer ${ANONYMOUS_TOKEN}`])
   })
 
   test('sends recipients in chunks of BCC_CHUNK_SIZE and updates progress after each', async () => {

--- a/packages/events/src/tests/msw.ts
+++ b/packages/events/src/tests/msw.ts
@@ -65,6 +65,9 @@ const tennisClubMembershipEventWithCustomAction = {
   ])
 }
 
+/** Token the mocked auth service hands out for anonymous (userless) callers. */
+export const ANONYMOUS_TOKEN = 'anonymous-token'
+
 const handlers = [
   http.post<PathParams<never>, { filenames: string[] }>(
     `${env.DOCUMENTS_URL}/presigned-urls`,
@@ -134,6 +137,13 @@ const handlers = [
     HttpResponse.json({
       access_token: 'some-token'
     })
+  ),
+  // The announcement worker fetches this before dispatching a broadcast, since
+  // no user is involved. Without a handler the call escapes to a real auth
+  // service, so the test only passes on machines where one happens to be
+  // running.
+  http.get(`${env.AUTH_URL}/internal/anonymous-token`, () =>
+    HttpResponse.json({ token: ANONYMOUS_TOKEN })
   )
 ]
 

--- a/packages/events/src/workers/announcementWorker.ts
+++ b/packages/events/src/workers/announcementWorker.ts
@@ -15,6 +15,7 @@ import {
   triggerUserEventNotification
 } from '@opencrvs/commons'
 import { env } from '@events/environment'
+import { getAnonymousToken } from '@events/service/auth'
 import { getClient } from '@events/storage/postgres/events'
 import {
   getNextProcessableAnnouncement,
@@ -69,6 +70,11 @@ export async function processNextAnnouncement() {
   )
 
   try {
+    // No user is involved in a background broadcast, so authenticate with an
+    // anonymous token (audience includes opencrvs:countryconfig-user) rather
+    // than a user token. This lets country config require auth on the route.
+    const token = await getAnonymousToken()
+
     const res = await triggerUserEventNotification({
       event: TriggerEvent.ALL_USER_NOTIFICATION,
       payload: {
@@ -80,7 +86,8 @@ export async function processNextAnnouncement() {
           bcc: chunk.filter((e) => e !== admin.email)
         }
       },
-      countryConfigUrl: env.COUNTRY_CONFIG_URL
+      countryConfigUrl: env.COUNTRY_CONFIG_URL,
+      authHeader: { Authorization: `Bearer ${token}` }
     })
 
     if (res.ok) {

--- a/packages/toolkit/src/cli.ts
+++ b/packages/toolkit/src/cli.ts
@@ -9,6 +9,7 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 import { runUpgrade } from './migrations/v2.0'
+import { runVerifyEndpoints } from './verify/endpoints'
 
 const args = process.argv.slice(2)
 
@@ -19,8 +20,31 @@ Commands:
   environment init       Initialise a new environment
   upgrade                Upgrade an existing environment
   check-translations     Check translation files for completeness
+  verify-endpoints       Verify the locally-running country config exposes the
+                         expected endpoints and keeps secured ones locked down
 
 Run 'opencrvs <command> --help' for more information on a command.
+`.trim()
+
+const VERIFY_ENDPOINTS_USAGE = `
+Usage: opencrvs verify-endpoints [country-config-url]
+
+Run this after 'opencrvs upgrade', with the upgraded country config running
+locally, to confirm it still behaves correctly. It checks over HTTP that:
+  - required public endpoints exist (respond 2xx), and
+  - user-notification trigger endpoints are either absent or reject
+    unauthenticated requests (never processed without a token).
+
+Arguments:
+  [country-config-url]   Optional. Domain or URL of the country config
+                         service. Defaults to 'http://localhost:3040', the
+                         port country config listens on locally. A bare
+                         domain is assumed to use https.
+
+Options:
+  -h, --help             Show this message.
+
+Exits with a non-zero status if any check fails.
 `.trim()
 
 const UPGRADE_USAGE = `
@@ -52,6 +76,8 @@ function main() {
       return handleUpgrade()
     case 'check-translations':
       return handleCheckTranslations()
+    case 'verify-endpoints':
+      return handleVerifyEndpoints()
     default:
       console.error(`Unknown command: ${command}\n`)
       console.log(USAGE)
@@ -120,6 +146,36 @@ function handleCheckTranslations() {
   console.log('Checking translations...')
   console.warn('This command is not implemented yet!')
   process.exit(1)
+}
+
+async function handleVerifyEndpoints() {
+  const verifyArgs = args.slice(1)
+
+  if (verifyArgs.includes('--help') || verifyArgs.includes('-h')) {
+    console.log(VERIFY_ENDPOINTS_USAGE)
+    process.exit(0)
+  }
+
+  const positional = verifyArgs.filter((arg) => !arg.startsWith('-'))
+
+  if (positional.length > 1) {
+    console.error(
+      `Unexpected extra argument(s): ${positional.slice(1).join(', ')}\n`
+    )
+    console.log(VERIFY_ENDPOINTS_USAGE)
+    process.exit(1)
+  }
+
+  try {
+    // Defaults to http://localhost:3040 when no target is given.
+    await runVerifyEndpoints(positional[0])
+  } catch (error) {
+    console.error(
+      'Endpoint verification failed:',
+      error instanceof Error ? error.message : error
+    )
+    process.exit(1)
+  }
 }
 
 main()

--- a/packages/toolkit/src/verify/endpoints.ts
+++ b/packages/toolkit/src/verify/endpoints.ts
@@ -1,0 +1,416 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+/* eslint-disable no-console */
+// Type-only import: erased at build time, so it adds no runtime dependency on
+// @opencrvs/commons (which is a devDependency of the toolkit).
+import type { TriggerEvent } from '@opencrvs/commons/notification'
+
+/*
+ * Minimal ANSI helpers, inlined rather than pulled from a colour library: the
+ * toolkit is published to npm and the CLI is bundled with `--packages=external`,
+ * so anything imported here becomes a runtime dependency country configs have
+ * to install. Colours are suppressed when stdout is not a TTY or NO_COLOR is
+ * set, so piped and CI output stays free of escape codes.
+ */
+const useColor = Boolean(process.stdout.isTTY) && !process.env.NO_COLOR
+const wrap =
+  (code: number) =>
+  (text: string): string =>
+    useColor ? `\u001b[${code}m${text}\u001b[0m` : text
+
+const bold = wrap(1)
+const dim = wrap(2)
+const red = wrap(31)
+const green = wrap(32)
+const yellow = wrap(33)
+
+const REQUEST_TIMEOUT_MS = 15000
+
+/**
+ * The country config service listens on port 3040 locally. This command is
+ * meant to be run against that instance right after `opencrvs upgrade`, to
+ * confirm the upgraded config still exposes the expected endpoints and keeps
+ * the secured ones locked down.
+ */
+const DEFAULT_TARGET_URL = 'http://localhost:3040'
+
+interface EndpointCheck {
+  method: 'GET' | 'POST'
+  /** Concrete path that is actually requested. */
+  path: string
+  /**
+   * Route pattern to show in the output when `path` substitutes a concrete
+   * value for a `{param}`. Defaults to `path` when omitted.
+   */
+  label?: string
+}
+
+/**
+ * Publicly-served endpoints every country config must expose. The client and
+ * login apps, and core services, fetch these before or without user
+ * authentication, so they must respond with a 2xx status.
+ *
+ * `/fonts/{filename}` is handled separately: it is public but parameterised
+ * with a country-specific filename we cannot know, so we probe a made-up name.
+ */
+const REQUIRED_PUBLIC_ENDPOINTS: readonly EndpointCheck[] = [
+  { method: 'GET', path: '/client-config.js' },
+  { method: 'GET', path: '/login-config.js' },
+  { method: 'GET', path: '/handlebars.js' },
+  { method: 'GET', path: '/content/client' },
+  { method: 'GET', path: '/content/login' },
+  { method: 'GET', path: '/content/map.geojson' },
+  { method: 'GET', path: '/content/country-logo' },
+  { method: 'GET', path: '/config/application' },
+  { method: 'GET', path: '/config/workqueues' },
+  { method: 'GET', path: '/config/locations' },
+  { method: 'GET', path: '/config/roles' },
+  { method: 'GET', path: '/config/events' }
+]
+
+/** Made-up path segment used to probe parameterised routes we can't enumerate. */
+const PROBE_SEGMENT = 'verify-endpoints-probe'
+
+/**
+ * User-notification trigger events. Core forwards an authenticated token to
+ * each of these, so a country config must never process them unauthenticated.
+ *
+ * Kept in sync with `TriggerEvent` in `@opencrvs/commons/notification` by the
+ * compile-time guard below.
+ */
+const SECURED_TRIGGER_USER_EVENTS = [
+  'user-created',
+  'user-updated',
+  'username-reminder',
+  'reset-password',
+  'reset-password-by-admin',
+  'resend-invite',
+  '2fa',
+  'all-user-notification',
+  'change-phone-number',
+  'change-email-address'
+] as const satisfies readonly TriggerEvent[]
+
+/**
+ * Endpoints that must require authentication. Each must either be absent (404)
+ * or reject an unauthenticated request (401/403) — never process it. Paths
+ * with `{param}` segments use a throwaway concrete value; authentication is
+ * enforced before the handler ever inspects the parameters (so `/certificates`
+ * ids and the like do not need to be real).
+ */
+const SECURED_ENDPOINTS: readonly EndpointCheck[] = [
+  ...SECURED_TRIGGER_USER_EVENTS.map(
+    (event): EndpointCheck => ({
+      method: 'POST',
+      path: `/triggers/user/${event}`
+    })
+  ),
+  { method: 'POST', path: '/trigger/telemetry' },
+  { method: 'GET', path: '/triggers/system/ready' },
+  {
+    method: 'GET',
+    path: `/certificates/${PROBE_SEGMENT}`,
+    label: '/certificates/{id}'
+  },
+  { method: 'GET', path: '/certificates' },
+  { method: 'GET', path: '/config/users' }
+]
+
+/**
+ * Used only when `/config/events` cannot be fetched, so the event action
+ * triggers are still checked against their route patterns.
+ */
+const FALLBACK_EVENT_TRIGGERS: readonly EndpointCheck[] = [
+  {
+    method: 'POST',
+    path: `/trigger/events/${PROBE_SEGMENT}/actions/${PROBE_SEGMENT}`,
+    label: '/trigger/events/{event}/actions/{action}'
+  },
+  {
+    method: 'POST',
+    path: `/trigger/events/birth/actions/${PROBE_SEGMENT}`,
+    label: '/trigger/events/birth/actions/{action}'
+  },
+  {
+    method: 'POST',
+    path: `/trigger/events/death/actions/${PROBE_SEGMENT}`,
+    label: '/trigger/events/death/actions/{action}'
+  }
+]
+
+type CheckStatus = number | 'error'
+
+const isSuccess = (status: CheckStatus): boolean =>
+  status !== 'error' && status >= 200 && status < 300
+
+const requiresAuthOrAbsent = (status: CheckStatus): boolean =>
+  status === 401 || status === 403 || status === 404
+
+/**
+ * Issues a single request and returns its HTTP status, or `'error'` when the
+ * request could not be completed (DNS failure, connection refused, timeout).
+ */
+async function requestStatus(
+  url: string,
+  method: 'GET' | 'POST'
+): Promise<CheckStatus> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+  try {
+    const response = await fetch(url, {
+      method,
+      signal: controller.signal,
+      // Sent without an Authorization header on purpose. A secured route
+      // rejects with 401/403 before ever reading the body.
+      headers:
+        method === 'POST' ? { 'Content-Type': 'application/json' } : undefined,
+      body: method === 'POST' ? '{}' : undefined
+    })
+    return response.status
+  } catch {
+    return 'error'
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+interface EventTriggerConfig {
+  id: string
+  actions: string[]
+}
+
+function toEventTriggerConfig(value: unknown): EventTriggerConfig | null {
+  if (typeof value !== 'object' || value === null) {
+    return null
+  }
+  const record = value as Record<string, unknown>
+  if (typeof record.id !== 'string') {
+    return null
+  }
+  const actions = Array.isArray(record.actions)
+    ? Array.from(
+        new Set(
+          record.actions
+            .map((action) => {
+              if (typeof action !== 'object' || action === null) {
+                return null
+              }
+              const type = (action as Record<string, unknown>).type
+              return typeof type === 'string' ? type : null
+            })
+            .filter((type): type is string => type !== null)
+        )
+      )
+    : []
+  return { id: record.id, actions }
+}
+
+/**
+ * Fetches the event configuration so the event action triggers can be checked
+ * against the real event ids and action types. Returns `null` if the endpoint
+ * is unreachable or does not return the expected shape.
+ */
+async function fetchEventConfigs(
+  baseUrl: string
+): Promise<EventTriggerConfig[] | null> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+  try {
+    const response = await fetch(`${baseUrl}/config/events`, {
+      signal: controller.signal
+    })
+    if (!response.ok) {
+      return null
+    }
+    const body: unknown = await response.json()
+    if (!Array.isArray(body)) {
+      return null
+    }
+    return body
+      .map(toEventTriggerConfig)
+      .filter((config): config is EventTriggerConfig => config !== null)
+  } catch {
+    return null
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/**
+ * Normalises the CLI argument into a base URL. Accepts either a bare domain
+ * (`example.org`, assumed https) or a full URL, and strips any trailing slash.
+ */
+function resolveBaseUrl(input: string): string {
+  const withProtocol = /^https?:\/\//i.test(input) ? input : `https://${input}`
+  return withProtocol.replace(/\/+$/, '')
+}
+
+function describeStatus(status: CheckStatus): string {
+  return status === 'error' ? 'no response' : `HTTP ${status}`
+}
+
+function endpointLabel(check: EndpointCheck): string {
+  const shown = check.label ?? check.path
+  const suffix = check.label ? dim(` → ${check.path}`) : ''
+  return `${check.method} ${shown}${suffix}`
+}
+
+function line(ok: boolean, label: string, detail: string): string {
+  const mark = ok ? green('✓') : red('✗')
+  return `  ${mark} ${label} ${dim(`(${detail})`)}`
+}
+
+function securedDetail(status: CheckStatus): string {
+  if (status === 401 || status === 403) {
+    return `${describeStatus(status)} — auth required`
+  }
+  if (status === 404) {
+    return `${describeStatus(status)} — not implemented`
+  }
+  if (status === 'error') {
+    return `${describeStatus(status)} — request failed`
+  }
+  return `${describeStatus(status)} — INSECURE: processed without a token`
+}
+
+export async function runVerifyEndpoints(
+  target: string = DEFAULT_TARGET_URL
+): Promise<void> {
+  const baseUrl = resolveBaseUrl(target)
+  console.log(bold(`Verifying country config endpoints at ${baseUrl}\n`))
+
+  let failures = 0
+
+  console.log(bold('Required public endpoints (must respond 2xx):'))
+  for (const check of REQUIRED_PUBLIC_ENDPOINTS) {
+    const status = await requestStatus(`${baseUrl}${check.path}`, check.method)
+    const ok = isSuccess(status)
+    if (!ok) {
+      failures++
+    }
+    const detail =
+      status === 404
+        ? `${describeStatus(status)} — missing`
+        : ok
+          ? describeStatus(status)
+          : `${describeStatus(status)} — unexpected`
+    console.log(line(ok, endpointLabel(check), detail))
+  }
+
+  // `/fonts/{filename}` is public but the filename is country-specific and
+  // cannot be automated, so we probe a made-up name. A registered public route
+  // returns 404 (file not found) or 200 (if the name happens to exist); either
+  // is acceptable. 401/403 would mean the route was wrongly put behind auth.
+  {
+    const path = `/fonts/${PROBE_SEGMENT}.ttf`
+    const status = await requestStatus(`${baseUrl}${path}`, 'GET')
+    const ok = status === 200 || status === 404
+    if (!ok) {
+      failures++
+    }
+    let detail: string
+    if (status === 404) {
+      detail = `${describeStatus(status)} — reachable (made-up filename)`
+    } else if (status === 200) {
+      detail = describeStatus(status)
+    } else if (status === 401 || status === 403) {
+      detail = `${describeStatus(status)} — must be public`
+    } else {
+      detail = `${describeStatus(status)} — unexpected`
+    }
+    console.log(line(ok, `GET /fonts/{filename}${dim(` → ${path}`)}`, detail))
+  }
+
+  console.log()
+  console.log(bold('Secured endpoints (must be absent or require auth):'))
+  for (const check of SECURED_ENDPOINTS) {
+    const status = await requestStatus(`${baseUrl}${check.path}`, check.method)
+    const ok = requiresAuthOrAbsent(status)
+    if (!ok) {
+      failures++
+    }
+    console.log(line(ok, endpointLabel(check), securedDetail(status)))
+  }
+
+  console.log()
+  console.log(bold('Event action triggers (must be absent or require auth):'))
+  const events = await fetchEventConfigs(baseUrl)
+  if (!events) {
+    console.log(
+      '  ' +
+        yellow(
+          'Could not read /config/events; falling back to route-pattern checks.'
+        )
+    )
+    for (const check of FALLBACK_EVENT_TRIGGERS) {
+      const status = await requestStatus(
+        `${baseUrl}${check.path}`,
+        check.method
+      )
+      const ok = requiresAuthOrAbsent(status)
+      if (!ok) {
+        failures++
+      }
+      console.log(line(ok, endpointLabel(check), securedDetail(status)))
+    }
+  } else if (events.length === 0) {
+    console.log('  ' + yellow('No events configured.'))
+  } else {
+    for (const event of events) {
+      // Fall back to a made-up action when an event declares none, so the
+      // route is still exercised.
+      const actions = event.actions.length ? event.actions : [PROBE_SEGMENT]
+      const failed: Array<{ action: string; status: CheckStatus }> = []
+      for (const action of actions) {
+        const status = await requestStatus(
+          `${baseUrl}/trigger/events/${event.id}/actions/${action}`,
+          'POST'
+        )
+        if (!requiresAuthOrAbsent(status)) {
+          failed.push({ action, status })
+        }
+      }
+      const pattern = `POST /trigger/events/${event.id}/actions/{action}`
+      if (failed.length === 0) {
+        console.log(
+          line(true, pattern, `${actions.length} action(s) — all require auth`)
+        )
+      } else {
+        for (const failure of failed) {
+          failures++
+          console.log(
+            line(
+              false,
+              `POST /trigger/events/${event.id}/actions/${failure.action}`,
+              securedDetail(failure.status)
+            )
+          )
+        }
+        const okCount = actions.length - failed.length
+        if (okCount > 0) {
+          console.log(
+            line(true, pattern, `${okCount} other action(s) require auth`)
+          )
+        }
+      }
+    }
+  }
+
+  console.log()
+  if (failures > 0) {
+    console.log(
+      red(bold(`✗ ${failures} check(s) failed.`)) +
+        yellow(' See the lines marked ✗ above.')
+    )
+    process.exit(1)
+  }
+  console.log(green(bold('✓ All endpoint checks passed.')))
+}


### PR DESCRIPTION
Backport of #13501 to release/2.0.1.

Every `/triggers/user/*` request now carries an Authorization header, so country configurations can require authentication on those routes. The `all-user-notification` route was previously called with no token at all, and country configurations ship every one of these routes with `auth: false` — letting anyone who can reach the service trigger 2FA codes, password-reset credentials and notification email/SMS to arbitrary recipients.

`authHeader` becomes a required parameter of
`triggerUserEventNotification`, replacing the overload pair that made it optional for `all-user-notification`. The background announcement worker now authenticates with an anonymous token, since no user is involved in a broadcast.

Also adds `opencrvs verify-endpoints`, which checks over HTTP that a locally-running country config still exposes the required public endpoints and that the secured ones reject unauthenticated requests.

Two fixes beyond the original PR, both of which affect develop equally:

- `/sendUserName` is itself unauthenticated, so the username-retrieval handler had no incoming Authorization header to forward. It forwarded `undefined`, which would have 401'd at the country config and silently dropped every username reminder. It now mints a system token the same way the 2FA and password-reset notifications do.
- The announcement worker's anonymous-token fetch had no msw handler, so it escaped to a real auth service and the test only passed on machines running one.

Both new behaviours are asserted in tests rather than left implicit, since a regression in either fails closed and silently.

Divergences from the upstream PR, which targets a different tree:

- The dispatch helper lives in `commons/src/notification/UserNotifications.ts` here, not in a separate `dispatch.ts`.
- The `auth: false` removals belong to the `opencrvs-countryconfig` repo; `packages/countryconfig-template` and `packages/testland` do not exist on this branch. The core change alone does not close the endpoints.
- `password-reset-link` and `username-reminder-link` are not trigger events on this release, so the verify tool omits them.
- The verify tool's colour helpers are inlined instead of importing `kleur/colors`. The toolkit is published to npm and bundled with `--packages=external`, so importing it would add a runtime dependency country configs must install; the hoisted kleur here is 3.0.3, which has no `colors` submodule.

## Description

Clearly describe what has been changed. Include relevant context or background.
Explain how the issue was fixed (if applicable) and the root cause.

Link this pull request to the GitHub issue (and optionally name the branch `ocrvs-<issue #>`)

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
