### PR TITLE
Make the Deployment rollout strategy configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Added `createdBy` as a config paramater to filter records created by the user [#13287](https://github.com/opencrvs/opencrvs-core/issues/13287)
 - Added `createdIn` as a config parameter to filter records by the office or administrative area they were created in. Unlike `declaredIn` it is populated before the record is declared, and it is never reassigned by a later declaration [#13287](https://github.com/opencrvs/opencrvs-core/issues/13287)
 - Expose `POST /locations` and `POST /administrative-areas` REST endpoints to create or update a single location or administrative area, for correcting individual data-seeding errors. Bulk seeding is unaffected and still uses the existing `locations.set`/`administrativeAreas.set` tRPC mutations. [#13336](https://github.com/opencrvs/opencrvs-core/pull/13336)
+- Make the Deployment rollout strategy configurable, and default it to `Recreate`, for OpenCRVS services [#11994](https://github.com/opencrvs/opencrvs-core/issues/11994)
 
 ### Bug fixes
 

--- a/charts/opencrvs-application/templates/deployment.yaml
+++ b/charts/opencrvs-application/templates/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ .Values.app_name }}
 spec:
   replicas: 1
+  strategy:
+    type: {{ .Values.strategy.type | default "Recreate" }}
   selector:
     matchLabels:
       app: {{ .Values.app_name }}

--- a/charts/opencrvs-application/values.yaml
+++ b/charts/opencrvs-application/values.yaml
@@ -20,3 +20,11 @@ imagePullSecrets: []
 image:
   name: ghcr.io/opencrvs/opencrvs-farajaland-demo-portals
   tag: latest
+
+# Deployment rollout strategy.
+# - Recreate: terminate the existing pod before creating its replacement.
+#   Guarantees the old pod is gone before the new one starts; causes a
+#   brief outage since this chart runs a single replica.
+# - RollingUpdate: Kubernetes' default gradual pod swap.
+strategy:
+  type: Recreate

--- a/charts/opencrvs-mosip/templates/_helpers.tpl
+++ b/charts/opencrvs-mosip/templates/_helpers.tpl
@@ -12,3 +12,26 @@
 {{- $http_scheme := include "http-scheme" . }}
 {{- printf "%s://%s.%s" $http_scheme $service_name .Values.hostname }}
 {{- end }}
+
+{{/*
+strategy-helper
+---
+Renders the Deployment's `.spec.strategy` block for one of the MOSIP
+services. Global default lives under `strategy:`, overridable per-service
+under <service>.strategy (e.g. mosip_api.strategy.type).
+
+Parameters:
+- .service_name: The name of the microservice (e.g. "mosip-api"), used to
+  key into per-service overrides.
+- .Values: The top-level Values object for the Helm chart.
+*/}}
+{{- define "strategy-helper" -}}
+{{- $service_name := .service_name }}
+{{- $service_key_name := ( $service_name | replace "-" "_" ) }}
+{{- $global := .Values.strategy | default dict }}
+{{- $service_values := index .Values $service_key_name | default dict }}
+{{- $service_strategy := $service_values.strategy | default dict }}
+{{- $type := $service_strategy.type | default $global.type | default "RollingUpdate" }}
+strategy:
+  type: {{ $type }}
+{{- end }}

--- a/charts/opencrvs-mosip/templates/esignet-mock.yaml
+++ b/charts/opencrvs-mosip/templates/esignet-mock.yaml
@@ -44,6 +44,7 @@ metadata:
   name: esignet-mock
 spec:
   replicas: 1
+  {{- include "strategy-helper" (dict "service_name" "esignet_mock" "Values" .Values) | indent 2 }}
   selector:
     matchLabels:
       app: esignet-mock

--- a/charts/opencrvs-mosip/templates/mosip-api.yaml
+++ b/charts/opencrvs-mosip/templates/mosip-api.yaml
@@ -44,6 +44,7 @@ metadata:
   name: mosip-api
 spec:
   replicas: 1
+  {{- include "strategy-helper" (dict "service_name" "mosip_api" "Values" .Values) | indent 2 }}
   selector:
     matchLabels:
       app: mosip-api

--- a/charts/opencrvs-mosip/templates/mosip-mock.yaml
+++ b/charts/opencrvs-mosip/templates/mosip-mock.yaml
@@ -18,6 +18,7 @@ metadata:
   name: mosip-mock
 spec:
   replicas: 1
+  {{- include "strategy-helper" (dict "service_name" "mosip_mock" "Values" .Values) | indent 2 }}
   selector:
     matchLabels:
       app: mosip-mock

--- a/charts/opencrvs-mosip/values.yaml
+++ b/charts/opencrvs-mosip/values.yaml
@@ -1,6 +1,17 @@
 hostname: opencrvs.localhost
 ingress:
   ssl_enabled: false
+
+# Deployment rollout strategy, applied to all three MOSIP mock/test services
+# below unless overridden per-service under <service>.strategy (e.g.
+# mosip_api.strategy.type).
+# - Recreate: terminate the existing pod before creating its replacement.
+#   Guarantees the old pod is gone before the new one starts; causes a
+#   brief outage since these run a single replica.
+# - RollingUpdate: Kubernetes' default gradual pod swap.
+strategy:
+  type: Recreate
+
 mosip_mock:
   enabled: true
   image:

--- a/charts/opencrvs-services/README.md
+++ b/charts/opencrvs-services/README.md
@@ -393,6 +393,21 @@ helm upgrade --install opencrvs oci://ghcr.io/opencrvs/opencrvs-services \
             <td>Number of PODs not available while deployment within ReplicaSet</td>
         </tr>
         <tr>
+            <td>strategy.type</td>
+            <td>Recreate</td>
+            <td>Deployment rollout strategy. <code>Recreate</code> terminates all existing PODs before creating replacement ones, guaranteeing old PODs are gone before new ones start (at the cost of a brief outage). <code>RollingUpdate</code> swaps PODs gradually instead. Configuration is available per service as well, add <code>&ltservice_name&gt.strategy.&ltkey&gt</code></td>
+        </tr>
+        <tr>
+            <td>strategy.maxSurge</td>
+            <td>{}</td>
+            <td>Only used when <code>strategy.type</code> is <code>RollingUpdate</code>. Maximum number/percentage of PODs that can be created above the desired replica count during the rollout.</td>
+        </tr>
+        <tr>
+            <td>strategy.maxUnavailable</td>
+            <td>{}</td>
+            <td>Only used when <code>strategy.type</code> is <code>RollingUpdate</code>. Maximum number/percentage of PODs that can be unavailable during the rollout.</td>
+        </tr>
+        <tr>
             <td>resources</td>
             <td>{}</td>
             <td>Resources allocated to OpenCRVS microservices (Kubernetes PODs). Properties in this section could be defined per microservice as well.</td>

--- a/charts/opencrvs-services/templates/_helpers.tpl
+++ b/charts/opencrvs-services/templates/_helpers.tpl
@@ -82,6 +82,52 @@ resources:
     cpu: {{ $service.cpuLimit | default $global.cpuLimit | quote }}
 {{- end }}
 
+{{/*
+
+strategy-helper
+---
+Renders the Deployment's `.spec.strategy` block.
+
+type: Recreate       -> all existing pods are terminated before any
+                         replacement pods are created. Guarantees old pods
+                         are gone before new ones start, at the cost of a
+                         brief outage for that service during rollout.
+type: RollingUpdate   -> pods are swapped gradually according to maxSurge /
+                         maxUnavailable (set either to tune it; omit both to
+                         fall back to Kubernetes' own defaults).
+
+Global default lives under `strategy:`, overridable per-service under
+<service>.strategy (same lookup pattern as resources-helper/pdb-helper).
+
+Parameters:
+- .service_name: The name of the microservice, used to key into per-service
+  overrides.
+- .Values: The top-level Values object for the Helm chart.
+*/}}
+{{- define "strategy-helper" -}}
+{{- $service_name := .service_name }}
+{{- $service_key_name := ( $service_name | replace "-" "_" ) }}
+{{- $global := .Values.strategy | default dict }}
+{{- $service_values := index .Values $service_key_name | default dict }}
+{{- $service_strategy := $service_values.strategy | default dict }}
+{{- $type := $service_strategy.type | default $global.type | default "RollingUpdate" }}
+strategy:
+  type: {{ $type }}
+{{- if eq $type "RollingUpdate" }}
+{{- $maxSurge := $service_strategy.maxSurge | default $global.maxSurge }}
+{{- $maxUnavailable := $service_strategy.maxUnavailable | default $global.maxUnavailable }}
+{{- if or $maxSurge $maxUnavailable }}
+  rollingUpdate:
+    {{- if $maxSurge }}
+    maxSurge: {{ $maxSurge }}
+    {{- end }}
+    {{- if $maxUnavailable }}
+    maxUnavailable: {{ $maxUnavailable }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
 {{- define "pdb-helper" -}}
 {{- if .Values.pdb.enabled }}
 {{- $service_name := .service_name }}

--- a/charts/opencrvs-services/templates/auth-deployment.yaml
+++ b/charts/opencrvs-services/templates/auth-deployment.yaml
@@ -7,6 +7,7 @@ metadata:
   name: auth
 spec:
   replicas: {{ .Values.auth.replicas | default 1 }}
+  {{- include "strategy-helper" (dict "service_name" "auth" "Values" .Values) | indent 2 }}
   selector:
     matchLabels:
       app: auth

--- a/charts/opencrvs-services/templates/client-deployment.yaml
+++ b/charts/opencrvs-services/templates/client-deployment.yaml
@@ -38,6 +38,7 @@ metadata:
   name: client
 spec:
   replicas: {{ .Values.client.replicas | default 1 }}
+  {{- include "strategy-helper" (dict "service_name" "client" "Values" .Values) | indent 2 }}
   selector:
     matchLabels:
       app: client

--- a/charts/opencrvs-services/templates/countryconfig-deployment.yaml
+++ b/charts/opencrvs-services/templates/countryconfig-deployment.yaml
@@ -62,6 +62,7 @@ metadata:
   name: countryconfig
 spec:
   replicas: {{ .Values.countryconfig.replicas | default 1 }}
+  {{- include "strategy-helper" (dict "service_name" "countryconfig" "Values" .Values) | indent 2 }}
   selector:
     matchLabels:
       app: countryconfig

--- a/charts/opencrvs-services/templates/dashboards-deployment.yaml
+++ b/charts/opencrvs-services/templates/dashboards-deployment.yaml
@@ -37,6 +37,7 @@ metadata:
   name: dashboards
 spec:
   replicas: {{ .Values.dashboards.replicas | default 1 }}
+  {{- include "strategy-helper" (dict "service_name" "dashboards" "Values" .Values) | indent 2 }}
   selector:
     matchLabels:
       app: dashboards

--- a/charts/opencrvs-services/templates/documents-deployment.yaml
+++ b/charts/opencrvs-services/templates/documents-deployment.yaml
@@ -8,6 +8,7 @@ metadata:
   name: documents
 spec:
   replicas: {{ .Values.documents.replicas | default 1 }}
+  {{- include "strategy-helper" (dict "service_name" "documents" "Values" .Values) | indent 2 }}
   selector:
     matchLabels:
       app: documents

--- a/charts/opencrvs-services/templates/events-deployment.yaml
+++ b/charts/opencrvs-services/templates/events-deployment.yaml
@@ -37,6 +37,7 @@ metadata:
   name: events
 spec:
   replicas: {{ .Values.events.replicas | default 1 }}
+  {{- include "strategy-helper" (dict "service_name" "events" "Values" .Values) | indent 2 }}
   selector:
     matchLabels:
       app: events

--- a/charts/opencrvs-services/templates/gateway-deployment.yaml
+++ b/charts/opencrvs-services/templates/gateway-deployment.yaml
@@ -38,6 +38,7 @@ metadata:
   name: gateway
 spec:
   replicas: {{ .Values.gateway.replicas | default 1 }}
+  {{- include "strategy-helper" (dict "service_name" "gateway" "Values" .Values) | indent 2 }}
   selector:
     matchLabels:
       app: gateway

--- a/charts/opencrvs-services/templates/login-deployment.yaml
+++ b/charts/opencrvs-services/templates/login-deployment.yaml
@@ -37,6 +37,7 @@ metadata:
   name: login
 spec:
   replicas: {{ .Values.login.replicas | default 1 }}
+  {{- include "strategy-helper" (dict "service_name" "login" "Values" .Values) | indent 2 }}
   selector:
     matchLabels:
       app: login

--- a/charts/opencrvs-services/values.yaml
+++ b/charts/opencrvs-services/values.yaml
@@ -230,6 +230,17 @@ pdb:
   enabled: true
   minAvailable: 50%
 
+# Deployment rollout strategy, applied to all services below unless
+# overridden per-service under <service>.strategy (e.g. auth.strategy).
+# - Recreate: terminate all existing pods before creating replacements.
+#   Guarantees old pods are gone before new ones start; causes a brief
+#   outage for that service during rollout.
+# - RollingUpdate: swap pods gradually. Optionally set maxSurge and/or
+#   maxUnavailable (globally here, or per-service) to tune it; Kubernetes'
+#   own defaults (25%/25%) apply if neither is set.
+strategy:
+  type: Recreate
+
 # Resources allocated to OpenCRVS microservices (Kubernetes PODs):
 resources:
   memoryRequest: '128Mi'


### PR DESCRIPTION
## Description

Adds a configurable .spec.strategy to the Kubernetes Deployments in charts/opencrvs-services, charts/opencrvs-mosip, and charts/opencrvs-application, and changes the default from Kubernetes' implicit RollingUpdate (25% max surge / 25% max unavailable) to Recreate.

## Testing

Rendered the affected templates with the real Helm/Sprig template semantics (Go's text/template, matching Helm's engine) across Recreate, RollingUpdate with no params, RollingUpdate with maxSurge/maxUnavailable, and a per-service override — all produce valid, correctly-structured Deployment YAML.

See e2e execution results as well

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
