### PR TITLE
fix(toolkit): create countryconfig.csv on check-translations --write

### DIFF
--- a/.github/workflows/publish-toolkit-to-npm.yml
+++ b/.github/workflows/publish-toolkit-to-npm.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.branch_name }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/packages/toolkit/src/translations/check.ts
+++ b/packages/toolkit/src/translations/check.ts
@@ -144,12 +144,15 @@ export function check(cwd: string): CheckResult {
 /**
  * Adds a row per missing message, filling in only English — the rest is copy
  * somebody has to write. Returns the ids added.
+ *
+ * Creates countryconfig.csv if it doesn't exist yet.
  */
 export function writeMissing(cwd: string, missing: Message[]) {
-  const file = readCsvFile(path.join(cwd, OWN_FILE))
-
-  if (!file) {
-    throw new Error(`${OWN_FILE} not found in ${cwd}`)
+  const file = readCsvFile(path.join(cwd, OWN_FILE)) ?? {
+    header: 'id,description,en',
+    body: [],
+    newline: '\n',
+    trailingNewline: true
   }
 
   const columns = file.header.split(',')


### PR DESCRIPTION
## Description

- [x] Create countryconfig.csv file if not exists
- [x] Use branch name from input in publish-toolkit workflow

https://github.com/user-attachments/assets/74398933-cb7e-4692-bca4-b0301bcaa181

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
