### PR TITLE
fix: clean up status indices as part of cleanup step

### DIFF
--- a/charts/opencrvs-services/templates/data-cleanup-job.yaml
+++ b/charts/opencrvs-services/templates/data-cleanup-job.yaml
@@ -100,7 +100,7 @@ spec:
           command: ["/bin/sh", "-c"]
           args:
             - |
-              approved_words="${ES_INDEX_PREFIX:-events}_ ${ELASTICSEARCH_INDEX_NAME:-ocrvs}"
+              approved_words="${ES_INDEX_PREFIX:-events}_ ${ELASTICSEARCH_INDEX_NAME:-ocrvs} ${ES_REINDEXING_STATUS_INDEX:-reindexing_status}"
               indices=$(curl -sS -XGET http://$ELASTICSEARCH_HOST/_cat/indices?h=index)
               echo "Running elasticsearch cleanup script..."
               echo "--------------------------"


### PR DESCRIPTION
## Description
Remove all deployment specific indices as part of `data-cleanup`
We have a limit of 1000 shards. If we leave anything dangling, it will inevitably fill up.

- We clean up other indices but new `reindexing_status` index is left hanging.
- Used by: https://github.com/search?q=repo%3Aopencrvs%2Fe2e+data-cleanup&type=code

Successful run: https://github.com/opencrvs/e2e/actions/runs/32835074384/job/97767388740


Clearly describe what has been changed. Include relevant context or background.
Explain how the issue was fixed (if applicable) and the root cause.

Link this pull request to the GitHub issue (and optionally name the branch `ocrvs-<issue #>`)

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
