### PR TITLE
fix(events): limit user.list input to 100 ids

### DIFF
--- a/packages/events/src/router/user/index.ts
+++ b/packages/events/src/router/user/index.ts
@@ -380,7 +380,8 @@ export const userRouter = router({
       return user
     }),
   list: userOnlyProcedure
-    .input(z.array(z.string()))
+    // Limit to prevent user enumeration with arbitrarily large IN (...) queries
+    .input(z.array(z.string()).max(100))
     .output(z.array(UserOrSystemSummary))
     .query(async ({ input }) => getUsersById(input)),
   search: searchUsersRoute(userAndSystemProcedure.use(canSearchUsers)),


### PR DESCRIPTION
Prevents user enumeration with large IN (...) queries. Is not too realistic with UUIDs but with legacy Mongo id's it's somewhat doable. 