### PR TITLE
fix(client): truncate long location names in LocationPicker with ellipsis

### DIFF
--- a/packages/client/src/components/LocationPicker.interaction.stories.tsx
+++ b/packages/client/src/components/LocationPicker.interaction.stories.tsx
@@ -1,0 +1,72 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import React from 'react'
+import { expect, waitFor, within } from 'storybook/test'
+import { noop } from 'lodash'
+import { LocationPicker } from './LocationPicker'
+import { TRPCProvider } from '../v2-events/trpc'
+
+const LONG_LOCATION_ID = 'long-location-id'
+const LONG_LOCATION_LABEL =
+  'HQ Office of PSA, PSA HQ, Quezon City, Metro Manila (Second District), National Capital Region (NCR)'
+
+const meta: Meta<typeof LocationPicker> = {
+  title: 'LocationPicker/Interaction',
+  component: LocationPicker,
+  args: {
+    onChangeLocation: noop,
+    selectedLocationId: LONG_LOCATION_ID,
+    additionalLocations: [
+      {
+        id: LONG_LOCATION_ID,
+        searchableText: LONG_LOCATION_LABEL,
+        displayLabel: LONG_LOCATION_LABEL
+      }
+    ]
+  },
+  decorators: [
+    (Story) => (
+      <TRPCProvider>
+        <Story />
+      </TRPCProvider>
+    )
+  ],
+  parameters: {
+    chromatic: { disableSnapshot: true }
+  }
+}
+
+export default meta
+
+type Story = StoryObj<typeof LocationPicker>
+
+// Regression test for a long location name overlapping neighbouring UI.
+export const LongLocationNameTruncatesWithEllipsis: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    // Wait for the picker to resolve its suspended location queries.
+    const label = await canvas.findByText(LONG_LOCATION_LABEL)
+
+    // title attr is what drives the native hover tooltip; can't assert the tooltip itself.
+    await expect(label).toHaveAttribute('title', LONG_LOCATION_LABEL)
+
+    // Must actually be clipped, not just styled to allow it.
+    await waitFor(() => {
+      expect(label.scrollWidth).toBeGreaterThan(label.clientWidth)
+    })
+
+    const style = getComputedStyle(label)
+    await expect(style.textOverflow).toBe('ellipsis')
+    await expect(style.whiteSpace).toBe('nowrap')
+  }
+}

--- a/packages/client/src/components/LocationPicker.tsx
+++ b/packages/client/src/components/LocationPicker.tsx
@@ -66,6 +66,13 @@ const ModalBody = styled.div`
   background: ${({ theme }) => theme.colors.white};
   padding: 8px 0;
 `
+const LocationLabel = styled.span`
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  max-width: 220px;
+`
+
 const StyledLocationSearch = styled(LocationSearch)`
   flex-direction: column;
   width: 100%;
@@ -155,11 +162,17 @@ export function LocationPicker({
         disabled={disabled}
         type="secondary"
       >
-        <span>
+        <LocationLabel
+          title={
+            (selectedSearchedLocation &&
+              selectedSearchedLocation.displayLabel) ||
+            ''
+          }
+        >
           {(selectedSearchedLocation &&
             selectedSearchedLocation.displayLabel) ||
             ''}
-        </span>
+        </LocationLabel>
         <MapPin color={disabled ? colors.grey200 : undefined} />
       </PickerButton>
       {modalVisible && (


### PR DESCRIPTION
## Description

https://github.com/user-attachments/assets/7216eae2-7c54-4676-885d-275c4ebd9be8

- **Root cause**: `LocationPicker`'s label span had no width constraint, so a long location name (with several admin levels) rendered at full width and overlapped neighbouring UI, e.g. the office-name heading on the Team page.
- Truncate the label with ellipsis (`max-width: 220px`) and add a `title` attribute so the full name is reachable on hover.
- Added a Storybook interaction test (`LocationPicker.interaction.stories.tsx`) covering a long location name; verified it fails without the fix and passes with it.

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly