### PR TITLE
feat(auth): deprecate OAuth token parameters passed in the query string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,26 @@ For the integration's own release history prior to this move, see [`packages/mos
 
 [#13502](https://github.com/opencrvs/opencrvs-core/pull/13502)
 
+### Deprecations
+
+#### `POST /auth/token` parameters in the query string
+
+The token endpoint reads its parameters from the request body _or_ the URL. Sending them in the URL puts the client secret into gateway and proxy access logs, Sentry breadcrumbs, and every intermediary on the way (CWE-598). RFC 6749 §2.3.1 requires them in the body, and **a future release will read them only from there** — so integrations still authenticating via the URL should move now. This affects both grants: `client_credentials` (`client_id`, `client_secret`) and `urn:opencrvs:oauth:grant-type:token-exchange` (`subject_token`, `subject_token_type`, `requested_token_type`, `event_id`, `action_id`).
+
+```diff
+-curl -X POST '<gateway>/auth/token?client_id=...&client_secret=...&grant_type=client_credentials'
++curl -X POST '<gateway>/auth/token' \
++  -H 'Content-Type: application/x-www-form-urlencoded' \
++  -d 'client_id=...&client_secret=...&grant_type=client_credentials'
+```
+
+Client IDs and secrets themselves keep working — only how they are transmitted changes.
+
+Until the removal, behaviour depends on the environment, so the change surfaces in development rather than in production:
+
+- **Production (`NODE_ENV=production`) keeps working**, but each such request logs an error naming the parameters, so operators can find the callers left to migrate. **Rotate any secret sent this way** — it may still be in retained logs.
+- **Every other deployment rejects the request** with `400 invalid_request` naming the parameters to move, so integrations testing against dev or staging fail immediately.
+
 ### Improvements
 
 - User avatars are now drawn by OpenCRVS itself rather than fetched from the third-party service `ui-avatars.com`. Previously each avatar sent the user's full name to that service and showed nothing at all offline; initials are now rendered locally, so avatars work offline and no user's name leaves the country's deployment [#3769](https://github.com/opencrvs/opencrvs-core/issues/3769)

--- a/packages/auth/src/features/oauthToken/handler.test.ts
+++ b/packages/auth/src/features/oauthToken/handler.test.ts
@@ -10,6 +10,17 @@
  */
 import { AuthServer, createServer } from '@auth/server'
 import * as authService from '@auth/features/authenticate/service'
+import { logger } from '@opencrvs/commons'
+
+const CREDENTIALS =
+  'client_id=123&client_secret=456&grant_type=client_credentials'
+
+const formEncodedRequest = (payload: string) => ({
+  method: 'POST' as const,
+  url: '/token',
+  payload,
+  headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
+})
 
 describe('authenticate handler receives a request', () => {
   let server: AuthServer
@@ -33,32 +44,89 @@ describe('authenticate handler receives a request', () => {
       jest
         .spyOn(authService, 'authenticateSystem')
         .mockRejectedValue(new Error('Invalid credentials'))
-      const res = await server.server.inject({
-        method: 'POST',
-        url: '/token?client_id=123&client_secret=456&grant_type=client_credentials'
-      })
+      const res = await server.server.inject(formEncodedRequest(CREDENTIALS))
 
       expect(res.statusCode).toBe(401)
     })
   })
   describe('events service says credentials are valid', () => {
     it('returns a token to the client', async () => {
+      const res = await server.server.inject(formEncodedRequest(CREDENTIALS))
+
+      expect(JSON.parse(res.payload).access_token).toBe('789')
+    })
+    it('returns a token when using a JSON payload', async () => {
       const res = await server.server.inject({
         method: 'POST',
-        url: '/token?client_id=123&client_secret=456&grant_type=client_credentials'
+        url: '/token',
+        payload: {
+          client_id: '123',
+          client_secret: '456',
+          grant_type: 'client_credentials'
+        }
       })
 
       expect(JSON.parse(res.payload).access_token).toBe('789')
     })
   })
-  describe('form-encoded payload support', () => {
-    it('returns a token when using form-encoded payload', async () => {
+
+  describe('parameters are passed in the deprecated query string', () => {
+    const nodeEnv = process.env.NODE_ENV
+
+    afterEach(() => {
+      process.env.NODE_ENV = nodeEnv
+      jest.restoreAllMocks()
+    })
+
+    it('rejects the request outside production', async () => {
+      process.env.NODE_ENV = 'development'
       const res = await server.server.inject({
         method: 'POST',
-        url: '/token',
-        payload:
-          'client_id=123&client_secret=456&grant_type=client_credentials',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
+        url: `/token?${CREDENTIALS}`
+      })
+
+      expect(res.statusCode).toBe(400)
+      expect(JSON.parse(res.payload).error).toBe('invalid_request')
+      expect(JSON.parse(res.payload).error_description).toContain(
+        'client_secret'
+      )
+    })
+
+    it('issues a token in production, logging the parameters', async () => {
+      process.env.NODE_ENV = 'production'
+      const logError = jest.spyOn(logger, 'error').mockImplementation()
+
+      const res = await server.server.inject({
+        method: 'POST',
+        url: `/token?${CREDENTIALS}`
+      })
+
+      expect(JSON.parse(res.payload).access_token).toBe('789')
+      expect(logError).toHaveBeenCalledWith(
+        expect.stringContaining('grant_type, client_id, client_secret')
+      )
+    })
+
+    it('reports parameters the payload also carries', async () => {
+      process.env.NODE_ENV = 'production'
+      const logError = jest.spyOn(logger, 'error').mockImplementation()
+
+      const res = await server.server.inject({
+        ...formEncodedRequest(CREDENTIALS),
+        url: '/token?client_secret=456'
+      })
+
+      expect(JSON.parse(res.payload).access_token).toBe('789')
+      expect(logError).toHaveBeenCalledWith(
+        expect.stringContaining('client_secret')
+      )
+    })
+
+    it('ignores non-OAuth query parameters', async () => {
+      process.env.NODE_ENV = 'development'
+      const res = await server.server.inject({
+        ...formEncodedRequest(CREDENTIALS),
+        url: '/token?utm_source=docs'
       })
 
       expect(JSON.parse(res.payload).access_token).toBe('789')

--- a/packages/auth/src/features/oauthToken/handler.ts
+++ b/packages/auth/src/features/oauthToken/handler.ts
@@ -9,15 +9,32 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 import * as Hapi from '@hapi/hapi'
+import { logger } from '@opencrvs/commons'
 import { clientCredentialsHandler } from './client-credentials'
 import * as oauthResponse from './responses'
 import { tokenExchangeHandler } from './token-exchange'
-import { getParam } from './utils'
+import { deprecatedQueryParams, getParam } from './utils'
 
 export async function tokenHandler(
   request: Hapi.Request,
   h: Hapi.ResponseToolkit
 ) {
+  const queryParams = deprecatedQueryParams(request)
+
+  if (queryParams.length > 0) {
+    // Reject outside production, so integrations hit this while developing
+    // rather than when the fallback goes; production keeps working, but loudly.
+    if (process.env.NODE_ENV !== 'production') {
+      return oauthResponse.queryParametersDeprecated(h, queryParams)
+    }
+
+    logger.error(
+      `Deprecated: POST /token got OAuth parameters in the query string ` +
+        `(${queryParams.join(', ')}). Send them in the request body instead. ` +
+        `Secrets sent this way are in the access logs and should be rotated.`
+    )
+  }
+
   const grantType = getParam(request, 'grant_type')
 
   if (grantType === 'client_credentials') {

--- a/packages/auth/src/features/oauthToken/responses.ts
+++ b/packages/auth/src/features/oauthToken/responses.ts
@@ -22,6 +22,24 @@ export const invalidRequest = (h: Hapi.ResponseToolkit) =>
     .header('Cache-Control', 'no-store')
     .code(400)
 
+export const queryParametersDeprecated = (
+  h: Hapi.ResponseToolkit,
+  params: string[]
+) =>
+  h
+    .response({
+      error: 'invalid_request',
+      error_description:
+        `Send OAuth parameters in a form-encoded request body, not in the query ` +
+        `string (got ${params.join(', ')} in the URL). The query string leaks ` +
+        `secrets into access logs and will stop being read; production still ` +
+        `accepts it, non-production no longer does.`,
+      error_uri:
+        'Refer to https://documentation.opencrvs.org/technology/interoperability/authenticate-a-client'
+    })
+    .header('Cache-Control', 'no-store')
+    .code(400)
+
 export const invalidGrantType = (h: Hapi.ResponseToolkit) =>
   h
     .response({

--- a/packages/auth/src/features/oauthToken/utils.ts
+++ b/packages/auth/src/features/oauthToken/utils.ts
@@ -26,17 +26,10 @@ const OAUTH_TOKEN_PARAMS = [
  * Retrieves a parameter from either the request payload or query string.
  * Prioritizes payload over query for POST requests with form data.
  *
- * @deprecated the query string fallback is going away, see
- * {@link deprecatedQueryParams}
+ * @deprecated the query string fallback is going away
  */
 export const getParam = (req: Hapi.Request, key: string) =>
   (req.payload as any)?.[key] || req.query[key]
 
-/**
- * OAuth parameters this request passed in the query string, where they leak
- * into access logs and Sentry breadcrumbs (CWE-598). RFC 6749 §2.3.1 requires
- * them in the body. Counted even when the payload also carries them — the URL
- * has already been logged by the time we get here.
- */
 export const deprecatedQueryParams = (req: Hapi.Request) =>
   OAUTH_TOKEN_PARAMS.filter((key) => key in req.query)

--- a/packages/auth/src/features/oauthToken/utils.ts
+++ b/packages/auth/src/features/oauthToken/utils.ts
@@ -10,9 +10,33 @@
  */
 import * as Hapi from '@hapi/hapi'
 
+/** Every parameter the token endpoint reads, across both grants. */
+const OAUTH_TOKEN_PARAMS = [
+  'grant_type',
+  'client_id',
+  'client_secret',
+  'subject_token',
+  'subject_token_type',
+  'requested_token_type',
+  'event_id',
+  'action_id'
+]
+
 /**
  * Retrieves a parameter from either the request payload or query string.
  * Prioritizes payload over query for POST requests with form data.
+ *
+ * @deprecated the query string fallback is going away, see
+ * {@link deprecatedQueryParams}
  */
 export const getParam = (req: Hapi.Request, key: string) =>
   (req.payload as any)?.[key] || req.query[key]
+
+/**
+ * OAuth parameters this request passed in the query string, where they leak
+ * into access logs and Sentry breadcrumbs (CWE-598). RFC 6749 §2.3.1 requires
+ * them in the body. Counted even when the payload also carries them — the URL
+ * has already been logged by the time we get here.
+ */
+export const deprecatedQueryParams = (req: Hapi.Request) =>
+  OAUTH_TOKEN_PARAMS.filter((key) => key in req.query)

--- a/packages/events/src/service/auth/index.ts
+++ b/packages/events/src/service/auth/index.ts
@@ -44,12 +44,13 @@ export async function getActionConfirmationToken(
     action_id: actionId
   })
 
-  const res = await fetch(new URL(`token?${params}`, env.AUTH_URL), {
+  const res = await fetch(new URL('token', env.AUTH_URL), {
     method: 'POST',
     headers: {
-      'Content-Type': 'application/json',
+      'Content-Type': 'application/x-www-form-urlencoded',
       Authorization: token
-    }
+    },
+    body: params
   })
 
   if (!res.ok) {

--- a/packages/events/src/tests/msw.ts
+++ b/packages/events/src/tests/msw.ts
@@ -132,7 +132,7 @@ const handlers = [
     HttpResponse.json({ status: 'forwarded' }, { status: 202 })
   ),
   // token exchange for `event.actions.register.confirm` and `event.actions.register.reject`
-  // query params such as `subject_token`, `subject_token_type` omitted for simplicity
+  // body params such as `subject_token`, `subject_token_type` omitted for simplicity
   http.post(`${env.AUTH_URL}/token`, () =>
     HttpResponse.json({
       access_token: 'some-token'

--- a/packages/mosip-api/src/opencrvs-api.test.ts
+++ b/packages/mosip-api/src/opencrvs-api.test.ts
@@ -33,34 +33,30 @@ test('direct authentication with OpenCRVS', async (t) => {
   await t.test(
     'obtains a confirmation token via client_credentials and token exchange',
     async () => {
-      const requests: URL[] = []
+      const requests: URLSearchParams[] = []
       const mswServer = setupServer(
-        http.post(`${AUTH_URL}/token`, ({ request }) => {
-          const url = new URL(request.url)
-          requests.push(url)
+        http.post(`${AUTH_URL}/token`, async ({ request }) => {
+          // Parameters belong in the body — the query string leaks the secret.
+          assert.strictEqual(new URL(request.url).search, '')
+          const params = new URLSearchParams(await request.text())
+          requests.push(params)
 
-          if (url.searchParams.get('grant_type') === 'client_credentials') {
+          if (params.get('grant_type') === 'client_credentials') {
+            assert.strictEqual(params.get('client_id'), 'test-client-id')
             assert.strictEqual(
-              url.searchParams.get('client_id'),
-              'test-client-id'
-            )
-            assert.strictEqual(
-              url.searchParams.get('client_secret'),
+              params.get('client_secret'),
               'test-client-secret'
             )
             return HttpResponse.json({ access_token: 'system-token' })
           }
 
           assert.strictEqual(
-            url.searchParams.get('grant_type'),
+            params.get('grant_type'),
             'urn:opencrvs:oauth:grant-type:token-exchange'
           )
-          assert.strictEqual(
-            url.searchParams.get('subject_token'),
-            'system-token'
-          )
-          assert.strictEqual(url.searchParams.get('event_id'), EVENT_ID)
-          assert.strictEqual(url.searchParams.get('action_id'), ACTION_ID)
+          assert.strictEqual(params.get('subject_token'), 'system-token')
+          assert.strictEqual(params.get('event_id'), EVENT_ID)
+          assert.strictEqual(params.get('action_id'), ACTION_ID)
           return HttpResponse.json({ access_token: 'confirmation-token' })
         })
       )

--- a/packages/mosip-api/src/opencrvs-api.ts
+++ b/packages/mosip-api/src/opencrvs-api.ts
@@ -69,8 +69,12 @@ export const getConfirmationToken = async (
     grant_type: 'client_credentials'
   })
   const clientCredentialsResponse = await fetch(
-    `${env.OPENCRVS_AUTH_URL}/token?${clientCredentialsParams}`,
-    { method: 'POST' }
+    `${env.OPENCRVS_AUTH_URL}/token`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: clientCredentialsParams
+    }
   )
   if (!clientCredentialsResponse.ok) {
     throw new OpenCRVSError(
@@ -88,10 +92,11 @@ export const getConfirmationToken = async (
     event_id: eventId,
     action_id: actionId
   })
-  const tokenExchangeResponse = await fetch(
-    `${env.OPENCRVS_AUTH_URL}/token?${tokenExchangeParams}`,
-    { method: 'POST' }
-  )
+  const tokenExchangeResponse = await fetch(`${env.OPENCRVS_AUTH_URL}/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: tokenExchangeParams
+  })
   if (!tokenExchangeResponse.ok) {
     throw new OpenCRVSError(
       `Token exchange failed: ${tokenExchangeResponse.status} ${await tokenExchangeResponse.text()}`

--- a/packages/testland/e2e/support/helpers.ts
+++ b/packages/testland/e2e/support/helpers.ts
@@ -167,13 +167,16 @@ export async function getToken(
 }
 
 export async function getClientToken(client_id: string, client_secret: string) {
-  const authUrl = `${GATEWAY_HOST}/auth/token?client_id=${client_id}&client_secret=${client_secret}&grant_type=client_credentials`
-
-  const authResponse = await fetch(authUrl, {
+  const authResponse = await fetch(`${GATEWAY_HOST}/auth/token`, {
     method: 'POST',
     headers: {
-      'Content-Type': 'application/json'
-    }
+      'Content-Type': 'application/x-www-form-urlencoded'
+    },
+    body: new URLSearchParams({
+      client_id,
+      client_secret,
+      grant_type: 'client_credentials'
+    })
   })
 
   const authBody = await authResponse.json()

--- a/packages/testland/postman/Authenticate.postman_collection.json
+++ b/packages/testland/postman/Authenticate.postman_collection.json
@@ -32,26 +32,32 @@
         "header": [
           {
             "key": "Content-Type",
-            "value": "application/json",
+            "value": "application/x-www-form-urlencoded",
             "type": "text"
           }
         ],
         "url": {
-          "raw": "{{auth}}/token?client_id={{client_id}}&client_secret={{client_secret}}&grant_type=client_credentials",
+          "raw": "{{auth}}/token",
           "host": ["{{auth}}"],
-          "path": ["token"],
-          "query": [
+          "path": ["token"]
+        },
+        "body": {
+          "mode": "urlencoded",
+          "urlencoded": [
             {
               "key": "client_id",
-              "value": "{{client_id}}"
+              "value": "{{client_id}}",
+              "type": "text"
             },
             {
               "key": "client_secret",
-              "value": "{{client_secret}}"
+              "value": "{{client_secret}}",
+              "type": "text"
             },
             {
               "key": "grant_type",
-              "value": "client_credentials"
+              "value": "client_credentials",
+              "type": "text"
             }
           ]
         }

--- a/packages/testland/src/events/adoption/sealing-service.ts
+++ b/packages/testland/src/events/adoption/sealing-service.ts
@@ -130,10 +130,11 @@ export async function getAdoptionSealingToken(): Promise<string | undefined> {
     grant_type: 'client_credentials'
   })
 
-  const response = await fetch(
-    new URL(`auth/token?${params}`, GATEWAY_URL).toString(),
-    { method: 'POST' }
-  )
+  const response = await fetch(new URL('auth/token', GATEWAY_URL).toString(), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: params
+  })
 
   if (!response.ok) {
     throw new Error(

--- a/packages/testland/src/government-portal-api/system-client.ts
+++ b/packages/testland/src/government-portal-api/system-client.ts
@@ -131,16 +131,18 @@ const fetchToken = async (
   clientSecret: string,
   apiBaseUrl: string
 ): Promise<TokenResponse> => {
-  const authenticateResponse = await fetch(
-    `${apiBaseUrl}/auth/token?client_id=${clientId}&client_secret=${clientSecret}&grant_type=client_credentials`,
-    {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'x-correlation-id': `${clientId}-${Date.now()}`
-      }
-    }
-  )
+  const authenticateResponse = await fetch(`${apiBaseUrl}/auth/token`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'x-correlation-id': `${clientId}-${Date.now()}`
+    },
+    body: new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      grant_type: 'client_credentials'
+    })
+  })
 
   const res: TokenResponse = await authenticateResponse.json()
 


### PR DESCRIPTION
Deprecation step for #13599, which removes the query-string fallback outright. Merge this first; #13599 then only has to delete the fallback and stop the gateway forwarding `req.url.search`.

## Why

`POST /auth/token` reads its parameters from the request body _or_ the URL, so a client can send `?client_id=...&client_secret=...` and put its secret into access logs - [code scanning alert #89](https://github.com/opencrvs/opencrvs-core/security/code-scanning/89) (CWE-598). RFC 6749 §2.3.1 requires them in the body.

## Behaviour

The query string is still read, but no longer silently:

| | `NODE_ENV=production` | anything else |
| --- | --- | --- |
| Request | succeeds | `400 invalid_request` |
| Offending parameters named | in a `logger.error` line | in `error_description` |

## Migration

```diff
-curl -X POST '<gateway>/auth/token?client_id=...&client_secret=...&grant_type=client_credentials'
+curl -X POST '<gateway>/auth/token' \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -d 'client_id=...&client_secret=...&grant_type=client_credentials'
```
