### PR TITLE
fix: prevent SSRF attacks by ensuring origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,7 @@ Re-running after a partial failure requires clearing the data first. [#11207](ht
 - Stop offering custom actions (e.g. `ESCALATE`) on a draft. Executing one deleted the draft while leaving the event undeclared, making the record impossible to find again [#13245](https://github.com/opencrvs/opencrvs-core/issues/13245)
 - Stop reporting an email or mobile number as already in use when it is merely contained in an existing one. Duplicate and existence checks on users matched substrings, so creating a user with the email `a@x.com` was rejected as a duplicate of an existing `ba@x.com`. Email, mobile and username now match whole values; email and username stay case-insensitive in effect. [#11207](https://github.com/opencrvs/opencrvs-core/issues/11207)
 - Return a conflict naming the offending field, instead of an internal server error, when a write trips a unique constraint on a user's email, mobile or username. The application-level duplicate checks are broader than the constraints, so this is reachable only when two requests race — but the cause was masked in production and reached the caller as `Internal server error`. Covers creating a user as well as changing an existing user's email, phone number or name. [#11207](https://github.com/opencrvs/opencrvs-core/issues/11207)
+- Stop the gateway's `/events/{path*}` proxy from forwarding requests outside the events service. [#13587](https://github.com/opencrvs/opencrvs-core/issues/13587)
 
 ## 2.0.0
 

--- a/packages/gateway/src/v2-events/event-config/routes.test.ts
+++ b/packages/gateway/src/v2-events/event-config/routes.test.ts
@@ -1,0 +1,40 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+import { env } from '@gateway/environment'
+import { trpcProxy } from '@gateway/v2-events/event-config/routes'
+
+const [{ handler }] = trpcProxy
+
+const proxy = (path: string, search = '') => {
+  const h = { proxy: jest.fn() }
+  handler.call(null, { params: { path }, url: { search } } as never, h as never)
+  return new URL(h.proxy.mock.calls[0][0].uri)
+}
+
+describe('events proxy', () => {
+  it('forwards the path to the events service', () => {
+    expect(proxy('event.get', '?batch=1').toString()).toBe(
+      `${env.EVENTS_URL}event.get?batch=1`
+    )
+  })
+
+  // https://github.com/opencrvs/opencrvs-core/issues/13587
+  it.each([
+    'http:/\\/httpbin.org/headers',
+    'http://evil.example/x',
+    '//evil.example/x',
+    '\\\\evil.example/x',
+    'https://user:pass@evil.example/x',
+    '../../../x'
+  ])('never leaves the events service host: %s', (path) => {
+    expect(proxy(path).host).toBe(new URL(env.EVENTS_URL).host)
+  })
+})

--- a/packages/gateway/src/v2-events/event-config/routes.ts
+++ b/packages/gateway/src/v2-events/event-config/routes.ts
@@ -9,6 +9,7 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 import { env } from '@gateway/environment'
+import { badRequest } from '@hapi/boom'
 import { ServerRoute } from '@hapi/hapi'
 import { logger } from '@opencrvs/commons'
 
@@ -19,9 +20,15 @@ export const trpcProxy = [
     handler: (req, h) => {
       logger.info(`Proxying request to ${req.params.path}`)
 
+      const uri = new URL(req.params.path, env.EVENTS_URL)
+
+      if (uri.origin !== new URL(env.EVENTS_URL).origin) {
+        // Prevent open redirect / SSRF attacks by ensuring the proxied URL is within the expected origin
+        throw badRequest('Invalid path')
+      }
+
       return h.proxy({
-        uri:
-          new URL(req.params.path, env.EVENTS_URL).toString() + req.url.search,
+        uri: uri.toString() + req.url.search,
         passThrough: true
       })
     },

--- a/packages/gateway/src/v2-events/event-config/routes.ts
+++ b/packages/gateway/src/v2-events/event-config/routes.ts
@@ -9,7 +9,6 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 import { env } from '@gateway/environment'
-import { badRequest } from '@hapi/boom'
 import { ServerRoute } from '@hapi/hapi'
 import { logger } from '@opencrvs/commons'
 
@@ -20,12 +19,9 @@ export const trpcProxy = [
     handler: (req, h) => {
       logger.info(`Proxying request to ${req.params.path}`)
 
-      const uri = new URL(req.params.path, env.EVENTS_URL)
-
-      if (uri.origin !== new URL(env.EVENTS_URL).origin) {
-        // Prevent open redirect / SSRF attacks by ensuring the proxied URL is within the expected origin
-        throw badRequest('Invalid path')
-      }
+      // Prevent open redirect / SSRF attacks by ensuring the proxied URL is within env.EVENTS_URL
+      const uri = new URL(env.EVENTS_URL)
+      uri.pathname = req.params.path
 
       return h.proxy({
         uri: uri.toString() + req.url.search,


### PR DESCRIPTION
Fixes https://github.com/opencrvs/opencrvs-core/issues/13587 by ensuring the proxied requests don't go outside events-service.

