### PR TITLE
docs: fix typo succesfully -> successfully

### DIFF
--- a/packages/client/src/src-sw.ts
+++ b/packages/client/src/src-sw.ts
@@ -49,7 +49,7 @@ cleanupOutdatedCaches()
  * As the config file can change after the app is built, we cannot precache it
  * as we do with other assets. Instead, we use the NetworkFirst strategy that
  * tries to load the file, but falls back to the cached version. This version is updated
- * when a new version is succesfully loaded.
+ * when a new version is successfully loaded.
  * https://developers.google.com/web/tools/workbox/modules/workbox-strategies#network_first_network_falling_back_to_cache
  */
 


### PR DESCRIPTION
Corrects the misspelling `succesfully` -> `successfully` in `packages/client/src/src-sw.ts`.

Documentation only, no behaviour change.