### PR TITLE
docs: correct yarn references in testland and countryconfig-template

### DIFF
--- a/packages/countryconfig-template/README.md
+++ b/packages/countryconfig-template/README.md
@@ -172,7 +172,7 @@ Changes to dependency or image build files trigger a full rebuild instead, for e
 
 ```
 package.json
-yarn.lock
+pnpm-lock.yaml
 Dockerfile
 ```
 

--- a/packages/testland/README.md
+++ b/packages/testland/README.md
@@ -173,7 +173,7 @@ Changes to dependency or image build files trigger a full rebuild instead, for e
 
 ```
 package.json
-yarn.lock
+pnpm-lock.yaml
 Dockerfile
 ```
 

--- a/packages/testland/e2e/README.md
+++ b/packages/testland/e2e/README.md
@@ -2,11 +2,11 @@
 
 ### Run against localhost
 
-`yarn e2e-dev`
+`pnpm e2e-dev`
 
 ### Run against a deployed environment
 
-`NODE_TLS_REJECT_UNAUTHORIZED=0 DOMAIN=<your-env>.opencrvs.dev yarn e2e`
+`NODE_TLS_REJECT_UNAUTHORIZED=0 DOMAIN=<your-env>.opencrvs.dev pnpm e2e`
 
 ## How to write a test
 


### PR DESCRIPTION
Ref #13528

Small documentation corrections found while rewriting the Contributing pages ([opencrvs/documentation#61](https://github.com/opencrvs/documentation/pull/61)), which now point contributors at `packages/testland/e2e` as the home of the e2e suite.

| File | Was | Now |
| --- | --- | --- |
| `packages/testland/e2e/README.md` | `yarn e2e-dev`, `yarn e2e` | `pnpm e2e-dev`, `pnpm e2e` |
| `packages/testland/README.md` | `yarn.lock` | `pnpm-lock.yaml` |
| `packages/countryconfig-template/README.md` | `yarn.lock` | `pnpm-lock.yaml` |