### PR TITLE
fix(toolkit): print secrets in stdout instead of env file

### DIFF
--- a/packages/toolkit/src/environment/manage-users.ts
+++ b/packages/toolkit/src/environment/manage-users.ts
@@ -30,7 +30,7 @@ const checkbox = (options: any) => inquirerPrompt('checkbox', options)
 
 import { info, warn } from './logger'
 import { readYamlFile, writeYamlFile } from './utils'
-import { getUsers } from './templates'
+import { extractAndModifyUsers } from './templates'
 
 export interface User {
   name: string
@@ -62,7 +62,7 @@ function updateInventoryFile(filePath: string, users: User[]) {
 function parseInventoryFile(filePath: string): User[] {
   try {
     const data = readYamlFile(filePath)
-    return getUsers(data)
+    return extractAndModifyUsers(data)
   } catch {
     return []
   }

--- a/packages/toolkit/src/environment/setup-environment.ts
+++ b/packages/toolkit/src/environment/setup-environment.ts
@@ -10,7 +10,6 @@
  */
 
 import { Octokit } from '@octokit/core'
-import dotenv from 'dotenv'
 import kleur from 'kleur'
 import prompts, { PromptObject } from 'prompts'
 
@@ -48,7 +47,7 @@ import {
 } from './github'
 
 import { derivedVariables } from './derived-variables'
-import { generateLongPassword, findExistingValue, storeSecrets } from './utils'
+import { generateLongPassword, findExistingValue } from './utils'
 
 import { error, info, log, success, warn } from './logger'
 import { generateInventory, copyChartsValues } from './templates'
@@ -165,7 +164,6 @@ function getAnswers(existingValues: (Secret | Variable)[]): Answers {
 }
 
 async function promptAndStoreAnswer(
-  environment: string,
   questions: Array<QuestionDescriptor<any>>,
   existingValues: Array<Secret | Variable>
 ) {
@@ -265,8 +263,6 @@ async function promptAndStoreAnswer(
 
   ALL_ANSWERS.push(result)
 
-  storeSecrets(environment, getAnswers(existingValues))
-
   const existingValuesForQuestions = questions
     // Only variables can have previous values we can use
     .filter((question) => question.valueType === 'VARIABLE')
@@ -308,11 +304,7 @@ ALL_QUESTIONS.push(
     }
   )
 
-  const { githubToken } = await promptAndStoreAnswer(
-    '',
-    githubTokenQuestion,
-    []
-  )
+  const { githubToken } = await promptAndStoreAnswer(githubTokenQuestion, [])
 
   const octokit = new Octokit({
     auth: githubToken
@@ -376,10 +368,6 @@ ALL_QUESTIONS.push(
   if (!environment) {
     process.exit(1)
   }
-  // Read users .env file based on the environment name they gave above, e.g. .env.production
-  dotenv.config({
-    path: `${process.cwd()}/.env.${environment}`
-  })
 
   await createEnvironment(
     octokit,
@@ -448,20 +436,15 @@ ALL_QUESTIONS.push(
           'WARNING! You are setting up a production environment.\n Make sure you have read the deployment guide carefully before proceeding.\n'
         )
     )
-    await promptAndStoreAnswer(
-      environment,
-      githubOtherQuestions,
-      existingValues
-    )
+    await promptAndStoreAnswer(githubOtherQuestions, existingValues)
   }
 
   log('\n', kleur.bold().underline('Docker Hub'))
-  await promptAndStoreAnswer(environment, dockerhubQuestions, existingValues)
+  await promptAndStoreAnswer(dockerhubQuestions, existingValues)
 
   log('\n', kleur.bold().underline('Kubernetes & Runtime'))
 
   const infrastructure = await promptAndStoreAnswer(
-    environment,
     infrastructureQuestions,
     existingValues
   )
@@ -531,7 +514,7 @@ ALL_QUESTIONS.push(
       kleur.bold().green('✔'),
       kleur.bold().yellow(' Disk encryption is enabled')
     )
-    await promptAndStoreAnswer(environment, diskQuestions, existingValues)
+    await promptAndStoreAnswer(diskQuestions, existingValues)
   } else {
     if (!enableEncryption && !encryption_key_defined && environment_exists) {
       log(
@@ -604,7 +587,6 @@ ALL_QUESTIONS.push(
   let backupHostPublicKey = ''
   if (configureBackup) {
     const backupAnswers = await promptAndStoreAnswer(
-      environment,
       backupQuestions,
       existingValues
     )
@@ -673,11 +655,7 @@ ALL_QUESTIONS.push(
   }
 
   log('\n', kleur.bold().underline('Monitoring'))
-  await promptAndStoreAnswer(
-    environment,
-    databaseAndMonitoringQuestions,
-    existingValues
-  )
+  await promptAndStoreAnswer(databaseAndMonitoringQuestions, existingValues)
   const sentryDSNExists = findExistingValue(
     'SENTRY_DSN',
     'SECRET',
@@ -687,7 +665,7 @@ ALL_QUESTIONS.push(
 
   log('\n', kleur.bold().underline('Sentry'))
   if (sentryDSNExists) {
-    await promptAndStoreAnswer(environment, sentryQuestions, existingValues)
+    await promptAndStoreAnswer(sentryQuestions, existingValues)
   } else {
     const { useSentry } = await prompts([
       {
@@ -699,19 +677,15 @@ ALL_QUESTIONS.push(
     ])
 
     if (useSentry) {
-      await promptAndStoreAnswer(environment, sentryQuestions, existingValues)
+      await promptAndStoreAnswer(sentryQuestions, existingValues)
     }
   }
 
   log('\n', kleur.bold().underline('METABASE ADMIN'))
-  await promptAndStoreAnswer(
-    environment,
-    metabaseAdminQuestions,
-    existingValues
-  )
+  await promptAndStoreAnswer(metabaseAdminQuestions, existingValues)
 
   log('\n', kleur.bold().underline('SMTP'))
-  await promptAndStoreAnswer(environment, emailQuestions, existingValues)
+  await promptAndStoreAnswer(emailQuestions, existingValues)
 
   const allAnswers = ALL_ANSWERS.reduce((acc, answer) => {
     return { ...acc, ...answer }
@@ -1033,7 +1007,12 @@ ALL_QUESTIONS.push(
       name: 'RESTORE_HOST',
       value: answerOrExisting(
         restoreHost,
-        findExistingValue('RESTORE_HOST', 'VARIABLE', 'ENVIRONMENT', existingValues),
+        findExistingValue(
+          'RESTORE_HOST',
+          'VARIABLE',
+          'ENVIRONMENT',
+          existingValues
+        ),
         (val) => val || ''
       ),
       didExist: findExistingValue(
@@ -1098,8 +1077,6 @@ ALL_QUESTIONS.push(
         (variable.type !== 'VARIABLE' ||
           variable.value !== variable.didExist?.value)
     )
-
-  storeSecrets(environment, updates)
 
   /*
    * List out all updates to the variables and confirm with the user
@@ -1405,6 +1382,10 @@ ${addon_message}
 ${kleur.yellow('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━')}
 ${kleur.yellow('Please KINDLY read hints above')}
     `)
-  log('\nAll variables stored in', kleur.cyan(`.env.${environment}`))
-  log(kleur.bold().yellow('DO NOT COMMIT THIS FILE TO GIT!'))
+  log(
+    '\nAll secrets and variables were printed above.',
+    kleur
+      .bold()
+      .yellow('Store them in a password manager — they are not saved to disk.')
+  )
 })()

--- a/packages/toolkit/src/environment/setup-environment.ts
+++ b/packages/toolkit/src/environment/setup-environment.ts
@@ -1215,6 +1215,15 @@ ALL_QUESTIONS.push(
     process.exit(0)
   }
 
+  log(
+    kleur
+      .bold()
+      .red(
+        "⚠️  COPY THESE NOW INTO A PASSWORD MANAGER — YOU WON'T SEE THEM AGAIN"
+      )
+  )
+  log('')
+
   const saveChanges = await confirm({
     message: 'Do you want to continue?',
     default: true

--- a/packages/toolkit/src/environment/templates.ts
+++ b/packages/toolkit/src/environment/templates.ts
@@ -21,12 +21,6 @@ Handlebars.registerHelper('data_label_idx', function (value) {
   return parseInt(value) + 2
 })
 
-export function getUsers(data: any): any {
-  if (!data?.all?.vars?.users) {
-    return { users: [] }
-  }
-  return data.all.vars.users
-}
 // START: TEMPORAL SECTION FOR TRANSITION FROM DOCKER SWARM TO K8s
 // Extract users from the old inventory
 // Docker swarm format to new
@@ -35,6 +29,9 @@ export function extractAndModifyUsers(data: any): any {
     return { users: [] }
   }
   const users = data.all.vars.users.map((user: any) => {
+    if (user.role) {
+      return user
+    }
     const { sudoer, ...rest } = user
     return {
       ...rest,

--- a/packages/toolkit/src/environment/update-workflows.ts
+++ b/packages/toolkit/src/environment/update-workflows.ts
@@ -99,6 +99,10 @@ async function updateWorkflows(
   const { workflows } = config
 
   for (const workflowPath of workflows) {
+    if (!existsSync(workflowPath)) {
+      log(`  ↷ Skipped ${workflowPath} (not found in this repository)`)
+      continue
+    }
     try {
       const fileContents = readFileSync(workflowPath, 'utf8')
 

--- a/packages/toolkit/src/environment/utils.ts
+++ b/packages/toolkit/src/environment/utils.ts
@@ -9,12 +9,10 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 
-import fs, { readFileSync, writeFileSync } from 'fs'
+import fs from 'fs'
 import * as yaml from 'js-yaml'
 
-import dotenv from 'dotenv'
 import { Secret, Variable } from './github'
-import { Answers } from './custom-types'
 
 export function generateLongPassword() {
   const chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
@@ -36,38 +34,6 @@ export function findExistingValue<T extends string>(
   ) as
     | (T extends 'SECRET' ? Secret : T extends 'VARIABLE' ? Variable : never)
     | undefined
-}
-
-/**
- * Merges and stores secrets in `.env.{environment}` file.
- * Updates existing variables, preserves unchanged ones, adds new ones.
- *
- * @param environment - Environment name (e.g., 'production')
- * @param answers - Variables to update: `[{ name: 'KEY', value: 'val' }]`
- *
- * @example
- * storeSecrets('prod', [{ name: 'API_KEY', value: 'abc123' }]);
- */
-export function storeSecrets(environment: string, answers: Answers) {
-  let envConfig: Record<string, string> = {}
-  try {
-    envConfig = dotenv.parse(
-      readFileSync(`${process.cwd()}/.env.${environment}`)
-    )
-  } catch (error) {
-    envConfig = {}
-  }
-
-  const linesFromAnswers = answers.map(
-    (update) => `${update.name}="${update.value}"`
-  )
-  const linesFromEnvConfig = Object.entries(envConfig)
-    .filter(([name]) => !answers.find((update) => update.name === name))
-    .map(([name, value]) => `${name}="${value}"`)
-
-  const allLines = [...linesFromEnvConfig, ...linesFromAnswers].sort()
-
-  writeFileSync(`.env.${environment}`, allLines.join('\n'))
 }
 
 export function readYamlFile(filePath: any): any {


### PR DESCRIPTION
## Description

**Change:**
- `countryconfig init` now prints generated secrets/variables to stdout instead of writing them to `.env.<environment>`, removing the on-disk leak vector and making it easy to pipe values into a password manager.
- Also fixes two bugs hit while testing this locally: `environment init`'s SSH Users step crashing on inventories still using the legacy `sudoer` field, and `environment upgrade` crashing entirely on a hardcoded workflow filename missing from the target repo.

**Design decisions:**
- Dropped the `.env` file's role as a crash-resume/pre-fill mechanism (`dotenv.config` read) since nothing writes it anymore — re-running after an interruption no longer pre-fills previous answers.

**Tests:**
- Ran `environment upgrade` then `environment init` end-to-end against `opencrvs-countryconfig` (still pinned to `@opencrvs/toolkit@2.0.0`), reproducing and confirming the fix for both crashes, then verified secrets print to stdout instead of being written to `.env.{env_name}`.

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly