### PR TITLE
fix: allow users to receive `sendUserName` notification

### DIFF
--- a/packages/auth/src/features/retrievalSteps/sendUserName/handler.ts
+++ b/packages/auth/src/features/retrievalSteps/sendUserName/handler.ts
@@ -19,9 +19,13 @@ import {
   deleteRetrievalStepInformation,
   RETRIEVAL_FLOW_USER_NAME
 } from '@auth/features/retrievalSteps/verifyUser/service'
-import { triggerUserEventNotification } from '@opencrvs/commons'
+import { triggerUserEventNotification, TokenUserType } from '@opencrvs/commons'
 import { env } from '@auth/environment'
-import { recordAnonymousUserAuditEvent } from '@auth/features/authenticate/service'
+import {
+  createToken,
+  recordAnonymousUserAuditEvent
+} from '@auth/features/authenticate/service'
+import { JWT_ISSUER } from '@auth/constants'
 
 interface IPayload {
   nonce: string
@@ -62,7 +66,16 @@ export default async function sendUserNameHandler(
       username: retrievalStepInformation.username
     },
     countryConfigUrl: env.COUNTRY_CONFIG_URL_INTERNAL,
-    authHeader: { Authorization: request.headers.authorization as string }
+    authHeader: {
+      Authorization: `Bearer ${await createToken(
+        'auth',
+        [],
+        ['opencrvs:countryconfig-user'],
+        JWT_ISSUER,
+        undefined,
+        TokenUserType.enum.system
+      )}`
+    }
   })
 
   await recordAnonymousUserAuditEvent({


### PR DESCRIPTION
Fixes #13575

**Testing was manual**: I added SMTP values to E2E environment and tested this is working 👍 

...because, we don't have a mechanism for validating SMS/email flows in E2E. Noticed it's not resolved with other tests too https://github.com/opencrvs/opencrvs-core/blob/ea5e6cf8905e2d9d8452ac3d1894c8df20f02916/packages/testland/e2e/testcases/login/1-login-with-valid-information.spec.ts#L39-L42 