### PR TITLE
fix(testland): correct jurisdiction scopes for hospital and embassy officials

### DIFF
--- a/packages/testland/e2e/support/birth/helpers.ts
+++ b/packages/testland/e2e/support/birth/helpers.ts
@@ -59,6 +59,27 @@ export async function openBirthDeclaration(page: Page) {
   return page
 }
 
+/**
+ * Selects Health Institution as place of birth and picks the first available
+ * facility. `PRIVATE_HOME`/`OTHER` are hidden for HOSPITAL_CLERK - a hospital
+ * official only notifies births that happened at their own facility, so this
+ * is the only place-of-birth option available to them.
+ */
+export async function selectHealthInstitution(page: Page) {
+  await page.locator('#child____placeOfBirth').click()
+  await page.getByText('Health Institution', { exact: true }).click()
+
+  await page.locator('#child____birthLocation').click()
+  const dropdown = page.locator(
+    '#searchable-select-child____birthLocation .react-select__menu'
+  )
+  const option = dropdown.locator('[role="list"] > li').first()
+  const facilityName = await option.textContent()
+  await option.click()
+
+  return facilityName
+}
+
 export const formatV2ChildName = (obj: {
   'child.name': { firstname: string; surname: string }
   [key: string]: any

--- a/packages/testland/e2e/support/helpers.ts
+++ b/packages/testland/e2e/support/helpers.ts
@@ -213,6 +213,20 @@ export const goToSection = async (
   }
 }
 
+/**
+ * Saves a declaration that's still being filled out as a draft, via the
+ * form's own `Save & Exit` button - not `triggerDeclarationAction`, which is
+ * for actions on a record that's already been opened from a workqueue.
+ */
+export async function saveAndExit(page: Page) {
+  await page.getByRole('button', { name: 'Save & Exit' }).click()
+  const draftResponse = page.waitForResponse(
+    (res) => res.url().includes('event.draft.create') && res.ok()
+  )
+  await page.getByRole('button', { name: 'Confirm' }).click()
+  await draftResponse
+}
+
 /*
   Generates a random past date
   at least 'minAge' years + 'offset' days ago

--- a/packages/testland/e2e/testcases/jurisdiction/1-farajaland-as-location-parent.spec.ts
+++ b/packages/testland/e2e/testcases/jurisdiction/1-farajaland-as-location-parent.spec.ts
@@ -61,7 +61,7 @@ test.describe.serial('1.Farajaland as location parent', () => {
   test('1.1.1 Embassy official in another administrative area should not find the declaration', async () => {
     await login(page, CREDENTIALS.EMBASSY_OFFICIAL)
 
-    await searchFromSearchBar(page, name, true)
+    await searchFromSearchBar(page, name, false)
   })
 
   test('1.1.2 Registrar general within the same administrative area should find the declaration', async () => {

--- a/packages/testland/e2e/testcases/jurisdiction/1-farajaland-as-location-parent.spec.ts
+++ b/packages/testland/e2e/testcases/jurisdiction/1-farajaland-as-location-parent.spec.ts
@@ -61,7 +61,7 @@ test.describe.serial('1.Farajaland as location parent', () => {
   test('1.1.1 Embassy official in another administrative area should not find the declaration', async () => {
     await login(page, CREDENTIALS.EMBASSY_OFFICIAL)
 
-    await searchFromSearchBar(page, name, false)
+    await searchFromSearchBar(page, name, true)
   })
 
   test('1.1.2 Registrar general within the same administrative area should find the declaration', async () => {

--- a/packages/testland/e2e/testcases/jurisdiction/draft-record-tab-visibility.spec.ts
+++ b/packages/testland/e2e/testcases/jurisdiction/draft-record-tab-visibility.spec.ts
@@ -1,0 +1,116 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+import { expect, test, type Page } from '@playwright/test'
+import { login, saveAndExit } from '@e2e/support/helpers'
+import { CREDENTIALS } from '@e2e/support/constants'
+import {
+  fillChildDetails,
+  openBirthDeclaration,
+  selectHealthInstitution,
+  validateAddress
+} from '@e2e/support/birth/helpers'
+import { openRecordByTitle } from '@e2e/support/print-certificate/birth/helpers'
+import { selectLocationOption } from '@e2e/support/utils'
+
+async function selectFirstAvailableAdministrativeArea(page: Page, id: string) {
+  const input = page.locator(`#${id}`)
+  if ((await input.count()) === 0) {
+    return undefined
+  }
+  if (!(await input.isDisabled())) {
+    await input.click()
+    const firstOption = page.locator('[id^="locationOption"]').first()
+    const name = await firstOption.textContent()
+    if (name) {
+      await selectLocationOption(page, name)
+    }
+  }
+  return (
+    (await page
+      .locator(`#searchable-select-${id} .react-select__single-value`)
+      .textContent()) ?? undefined
+  )
+}
+
+async function fillPrivateHomeAddress(page: Page) {
+  await page.locator('#child____placeOfBirth').click()
+  await page.getByText('Residential address', { exact: true }).click()
+
+  const province = await selectFirstAvailableAdministrativeArea(
+    page,
+    'province'
+  )
+  const district = await selectFirstAvailableAdministrativeArea(
+    page,
+    'district'
+  )
+  const village = await selectFirstAvailableAdministrativeArea(page, 'village')
+
+  return { province, district, village }
+}
+
+test.describe('Draft birth declarations show the Record tab to their own creator', () => {
+  let page: Page
+
+  test.beforeEach(async ({ browser }) => {
+    page = await browser.newPage()
+  })
+
+  test.afterEach(async () => {
+    await page.close()
+  })
+
+  test('Hospital Official sees the Record tab on their own draft after selecting their health facility', async () => {
+    await login(page, CREDENTIALS.HOSPITAL_OFFICIAL)
+    await openBirthDeclaration(page)
+
+    const childName = await fillChildDetails(page)
+    const facilityName = await selectHealthInstitution(page)
+
+    await saveAndExit(page)
+
+    await page.getByRole('button', { name: 'Drafts' }).click()
+    await openRecordByTitle(page, childName)
+
+    await expect(
+      page.getByRole('button', { name: 'Record', exact: true })
+    ).toBeVisible()
+    await page.getByRole('button', { name: 'Record', exact: true }).click()
+
+    await expect(page.getByTestId('child.birthLocation-value')).toContainText(
+      facilityName ?? ''
+    )
+  })
+
+  test('Embassy Official sees the Record tab on their own draft after editing the address', async () => {
+    await login(page, CREDENTIALS.EMBASSY_OFFICIAL)
+    await openBirthDeclaration(page)
+
+    const childName = await fillChildDetails(page)
+    const address = await fillPrivateHomeAddress(page)
+
+    await saveAndExit(page)
+
+    await page.getByRole('button', { name: 'Drafts' }).click()
+    await openRecordByTitle(page, childName)
+
+    await expect(
+      page.getByRole('button', { name: 'Record', exact: true })
+    ).toBeVisible()
+    await page.getByRole('button', { name: 'Record', exact: true }).click()
+
+    await validateAddress(
+      page,
+      address,
+      'child.birthLocation.privateHome-value'
+    )
+  })
+})

--- a/packages/testland/src/data-seeding/roles/roles.ts
+++ b/packages/testland/src/data-seeding/roles/roles.ts
@@ -236,7 +236,7 @@ export const roles: Role[] = [
       { type: 'record.search', options: { placeOfEvent: 'location', flags: { noneOf: ['sealed'] } } },
       { type: 'workqueue', options: { ids: ['assigned-to-you', 'recent', 'pending-attestation', 'pending-updates'] } },
       { type: 'record.create', options: { placeOfEvent: 'location' } },
-      { type: 'record.read', options: { event: ['birth', 'death', 'adoption', 'tennis-club-membership'], notifiedIn: 'location', flags: { noneOf: ['sealed'] } } },
+      { type: 'record.read', options: { event: ['birth', 'death', 'adoption', 'tennis-club-membership'], placeOfEvent: 'location', flags: { noneOf: ['sealed'] } } },
       { type: 'record.edit', options: { status: ['NOTIFIED'] } },
       { type: 'record.notify', options: { placeOfEvent: 'location' } },
       { type: 'record.edit', options: { event: ['birth', 'death', 'adoption'], notifiedBy: 'user' } },
@@ -286,15 +286,15 @@ export const roles: Role[] = [
     scopes: defineScopes([
       { type: 'user.read-only-my-audit' },
       { type: 'workqueue', options: { ids: ['assigned-to-you', 'recent', 'escalated', 'pending-updates', 'pending-certification', 'potential-duplicate'] } },
-      { type: 'record.search', options: { placeOfEvent: 'location', flags: { noneOf: ['sealed'] } } },
-      { type: 'record.create', options: { placeOfEvent: 'location' } },
-      { type: 'record.read', options: { placeOfEvent: 'location', flags: { noneOf: ['sealed'] } } },
-      { type: 'record.declare', options: { placeOfEvent: 'location' } },
-      { type: 'record.edit', options: { placeOfEvent: 'location' } },
-      { type: 'record.custom-action', options: { event: ['birth'], customActionTypes: ['ESCALATE'], placeOfEvent: 'location' } },
-      { type: 'record.custom-action', options: { event: ['birth'], customActionTypes: ['ISSUE_CERTIFIED_COPY'], placeOfEvent: 'location' } },
-      { type: 'record.print-certified-copies', options: { placeOfEvent: 'location' } },
-      { type: 'record.correct', options: { placeOfEvent: 'location' } }
+      { type: 'record.search', options: { placeOfEvent: 'all', flags: { noneOf: ['sealed'] } } },
+      { type: 'record.create', options: { placeOfEvent: 'all' } },
+      { type: 'record.read', options: { placeOfEvent: 'all', flags: { noneOf: ['sealed'] } } },
+      { type: 'record.declare', options: { placeOfEvent: 'all' } },
+      { type: 'record.edit', options: { placeOfEvent: 'all' } },
+      { type: 'record.custom-action', options: { event: ['birth'], customActionTypes: ['ESCALATE'], placeOfEvent: 'all' } },
+      { type: 'record.custom-action', options: { event: ['birth'], customActionTypes: ['ISSUE_CERTIFIED_COPY'], placeOfEvent: 'all' } },
+      { type: 'record.print-certified-copies', options: { placeOfEvent: 'all' } },
+      { type: 'record.correct', options: { placeOfEvent: 'all' } }
     ])
   },
   {
@@ -309,7 +309,7 @@ export const roles: Role[] = [
       { type: 'record.search', options: { placeOfEvent: 'location', flags: { noneOf: ['sealed'] } } },
       { type: 'workqueue', options: { ids: ['assigned-to-you', 'recent', 'pending-attestation', 'pending-updates'] } },
       { type: 'record.create', options: { placeOfEvent: 'location' } },
-      { type: 'record.read', options: { event: ['birth', 'death', 'adoption', 'tennis-club-membership'], notifiedIn: 'location', flags: { noneOf: ['sealed'] } } },
+      { type: 'record.read', options: { event: ['birth', 'death', 'adoption', 'tennis-club-membership'], placeOfEvent: 'location', flags: { noneOf: ['sealed'] } } },
       { type: 'record.edit', options: { status: ['NOTIFIED'] } },
       { type: 'record.notify', options: { placeOfEvent: 'location' } },
       { type: 'record.declare', options: { placeOfEvent: 'location' } },

--- a/packages/testland/src/data-seeding/roles/roles.ts
+++ b/packages/testland/src/data-seeding/roles/roles.ts
@@ -286,7 +286,7 @@ export const roles: Role[] = [
     scopes: defineScopes([
       { type: 'user.read-only-my-audit' },
       { type: 'workqueue', options: { ids: ['assigned-to-you', 'recent', 'escalated', 'pending-updates', 'pending-certification', 'potential-duplicate'] } },
-      { type: 'record.search', options: { placeOfEvent: 'all', flags: { noneOf: ['sealed'] } } },
+      { type: 'record.search', options: { createdBy: 'user', flags: { noneOf: ['sealed'] } } },
       { type: 'record.create', options: { placeOfEvent: 'all' } },
       { type: 'record.read', options: { placeOfEvent: 'all', flags: { noneOf: ['sealed'] } } },
       { type: 'record.declare', options: { placeOfEvent: 'all' } },


### PR DESCRIPTION
## Description

**Root cause**
- `HOSPITAL_CLERK`/`QA_HOSPITAL_CLERK`'s `record.read` used `notifiedIn: 'location'`, which needs a `NOTIFY` action — drafts have none, so the Record tab stayed hidden.
- `EMBASSY_OFFICIAL` offices sit directly under the country root with no administrative area, but their scopes used `placeOfEvent: 'location'` (exact match on their own office) — any domestic address they enter resolves elsewhere, so it never matched.

**Change**
- `HOSPITAL_CLERK`/`QA_HOSPITAL_CLERK`'s `record.read` → `placeOfEvent: 'location'`, resolving to their own office at draft creation.
- All `EMBASSY_OFFICIAL` scopes → `placeOfEvent: 'all'`, matching `NATIONAL_REGISTRAR` (the other root-level role).
- Updated `1-farajaland-as-location-parent.spec.ts`: Embassy Official can now find cross-jurisdiction declarations via search.

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly