### PR TITLE
fix: Postgres stanza creation under regular user

### DIFF
--- a/.github/workflows/deploy-to-feature-environment.yml
+++ b/.github/workflows/deploy-to-feature-environment.yml
@@ -284,6 +284,7 @@ jobs:
                 stack: '${{ steps.generate_stack.outputs.stack }}',
                 'keep-e2e': '${{ needs.generate_stack_name_and_branch.outputs.keep_e2e }}',
                 branch: e2eBranch,
+                'actor': '${{ github.actor }}',
                 reset: 'true',
               },
             });

--- a/charts/dependencies/templates/postgres-on-deploy-job.yaml
+++ b/charts/dependencies/templates/postgres-on-deploy-job.yaml
@@ -23,11 +23,11 @@ spec:
             - -c
             - |
               kubectl exec -n {{ .Release.Namespace }} postgres-0 -- \
-                  pgbackrest --stanza="$PGBACKREST_STANZA" info > /tmp/pgbackrest_info 2>&1
+                  su postgres -c "pgbackrest --stanza=$PGBACKREST_STANZA info" > /tmp/pgbackrest_info 2>&1
               if grep -q "missing stanza path" /tmp/pgbackrest_info; then
                 echo "Stanza '$PGBACKREST_STANZA' does not exist. Initializing..."
                 kubectl exec -n {{ .Release.Namespace }} postgres-0 -- \
-                  pgbackrest --stanza="$PGBACKREST_STANZA" stanza-create
+                  su postgres -c "pgbackrest --stanza=$PGBACKREST_STANZA stanza-create"
                 echo "Stanza '$PGBACKREST_STANZA' created."
               else
                 echo "Stanza '$PGBACKREST_STANZA' already exists."


### PR DESCRIPTION
## Description

This PR aims to fix stanza creation and is continuation to: https://github.com/opencrvs/opencrvs-core/pull/13370

Reference release notes: https://pgbackrest.org/release.html#2.59.0

> IMPORTANT NOTE: Starting with this release, only the restore command may be run as root by default. Use allow-root to run other commands as root (though this is not recommended).

Postgres container didn't had fixed pgbackrest client version, as a result after upstream repository upgrade, backup server and database server become incompatible: https://github.com/opencrvs/opencrvs-testland-infrastructure/actions/runs/31007653528/job/92311571523

```
2026-08-05 12:55:35.749 P00   INFO: backup command begin 2.58.0: --config=/etc/pgbackrest/pgbackrest.conf --exec-id=69817-7bed5302 --log-level-console=info --pg1-path=/var/lib/postgresql/data --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-host=10.0.1.2 --repo1-host-user=backup --repo1-path=/home/backup/migration-production/postgres --repo1-retention-diff=7 --repo1-retention-full=1 --repo1-type=posix --stanza=main --type=full
2026-08-05 12:55:36.244 P00  ERROR: [039]: expected value '2.58.0' for greeting key 'version' but got '2.59.0'
                                    HINT: is the same version of pgBackRest installed on the local and remote host?
2026-08-05 12:55:36.244 P00   INFO: backup command end: aborted with exception [039]
```

Manual upgrade lead to issue with root user, see release notes:
```
2026-08-05 13:01:23.306 P00  ERROR: [031]: the 'backup' command must not be run as the root user
                                    HINT: running as root can create files that the regular user cannot access, causing later commands to fail.
                                    HINT: set the 'allow-root' option to allow running this command as root.
2026-08-05 13:01:23.306 P00   INFO: backup command end: aborted with exception [031]
```

## Testing

<img width="1882" height="136" alt="image" src="https://github.com/user-attachments/assets/133ec2e0-344e-43dc-a3a9-8da2e9a509e9" />


Fix for e2e job workflow included:
<img width="894" height="304" alt="image" src="https://github.com/user-attachments/assets/bfa60a83-f0d8-45a2-b73b-c43be84a8859" />


## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
