### PR TITLE
fix: Allow to define service type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Expose `POST /locations` and `POST /administrative-areas` REST endpoints to create or update a single location or administrative area, for correcting individual data-seeding errors. Bulk seeding is unaffected and still uses the existing `locations.set`/`administrativeAreas.set` tRPC mutations. [#13336](https://github.com/opencrvs/opencrvs-core/pull/13336)
 - The MOSIP charts now pass `OPENCRVS_AUTH_URL` to mosip-api and pin the mosip-api, mosip-mock and esignet-mock images to `2.0.1`. Implementations running the MOSIP integration should redeploy the `opencrvs-mosip` chart. [#13362](https://github.com/opencrvs/opencrvs-core/pull/13362)
 - Make the Deployment rollout strategy configurable, and default it to `Recreate`, for OpenCRVS services [#11994](https://github.com/opencrvs/opencrvs-core/issues/11994)
+- The dependencies Helm chart's datastore Services now support a configurable `service_type` [#13690](https://github.com/opencrvs/opencrvs-core/pull/13690)
 
 ### Bug fixes
 

--- a/charts/dependencies/README.md
+++ b/charts/dependencies/README.md
@@ -42,6 +42,8 @@ Any particular service within this helm chart can be disabled by setting `<servi
 | priority_class.enabled  | bool   | `false`        | Enable or disable priority class for datastores. Enabling this option will avoid unnecessary pod eviction.                                                                                     |
 | backup.enabled          | bool   | `true`         | Enable or disable data backup. Please check [Backup configuration](#backup-configuration) for more options. Usually this option is enabled on Production environment                           |
 | restore.enabled         | bool   | `true`         | Enable or disable data restore. Please check [Restore configuration](#restore-configuration) for more options. Usually this option is enabled on Staging environment                           |
+| service_type            | string | `ClusterIP`    | Kubernetes Service type for datastore Services (MongoDB, Postgres, Elasticsearch, Kibana, Redis, MinIO), e.g. `ClusterIP` or `NodePort`. Applies to all of them; there is no per-service override. |
+
 
 ## MongoDB
 
@@ -59,6 +61,7 @@ This section allows you to configure the deployment of MongoDB within your infra
 | node_selector | dict | `{}` | Label selector for datastore nodes, usually used to keep data persistent |
 | backup_schedule | string | `n/a` | Backup cronjob schedule, if not defined then values from `backup.schedule` is used |
 | backup_server_dir | string | `n/a` | Directory to store encrypted backup on backup server, if not defined `backup.backup_server_dir` is used |
+| node_port | int | `n/a` | Fixed NodePort to expose port `27017` on. Only used when the global `service_type` is `NodePort`, otherwise a random port is assigned |
 
 ## Postgres
 
@@ -91,6 +94,7 @@ This section allows you to configure the postgres deployment within your infrast
 | restore.server_secret | string | `backup-server-ssh-credentials` | Name of the Kubernetes secret with backup server credentials, usually backup server is used for restore, thats why credentials are shared |
 | restore.encryption_secret | string | `restore-encryption-secret` | Name of the Kubernetes secret containing the backup encryption key |
 | restore.schedule | string | `0 3 * * *` | Restore cronjob schedule, if not defined then value from `restore.schedule` is used |
+| node_port | int | `n/a` | Fixed NodePort to expose port `5432` on. Only used when the global `service_type` is `NodePort`, otherwise a random port is assigned |
 
 ## Elasticsearch
 
@@ -106,6 +110,8 @@ This section allows you to configure the deployment and authentication settings 
 | pvc.access_mode         | string  | ReadWriteOnce         | Kubernetes PVC access mode                                                                                                                   |
 | host_data_path          | string  | `/data/elasticsearch` | Path to persistent data on VM (host)                                                                                                         |
 | node_selector           | dict    | `{}`                  | Label selector for datastore nodes, usually used to keep data persistent                                                                     |
+| node_port               | int     | `n/a`                 | Fixed NodePort to expose port `9200` on. Only used when the global `service_type` is `NodePort`, otherwise a random port is assigned          |
+| node_port_transport     | int     | `n/a`                 | Fixed NodePort to expose port `9300` on. Only used when the global `service_type` is `NodePort`, otherwise a random port is assigned          |
 
 ## MinIO
 
@@ -132,6 +138,8 @@ This section allows you to configure the deployment and authentication settings 
 | restore.type            | string | `dump`                          | Restore method: `dump` (from encrypted archive) or `differential` (same as for backup)                                                       |
 | restore.server_secret   | string | `backup-server-ssh-credentials` | Name of the Kubernetes secret with backup server credentials, usually backup server is used for restore, thats why credentials are shared    |
 | restore.schedule        | string | `0 3 * * *`                     | Restore cronjob schedule, if not defined then value from `restore.schedule` is used                                                          |
+| node_port               | int    | `n/a`                            | Fixed NodePort to expose port `3535` on. Only used when the global `service_type` is `NodePort`, otherwise a random port is assigned          |
+| node_port_console       | int    | `n/a`                            | Fixed NodePort to expose port `3536` (console) on. Only used when the global `service_type` is `NodePort`, otherwise a random port is assigned |
 
 ### MinIO Credentials
 
@@ -188,6 +196,7 @@ OpenCRVS is using Bitnami package for Redis https://hub.docker.com/r/bitnami/red
 | enabled   | true          | Enable or disable redis service                                                 |
 | env       | {}            | Flat dictionary (key/value) of environment variables passed to docker container |
 | auth_mode | disabled      | Authentication mode, possible values `disabled`, `acl` or `password`            |
+| node_port | `n/a`         | Fixed NodePort to expose port `6379` on. Only used when the global `service_type` is `NodePort`, otherwise a random port is assigned |
 
 ### Redis authentication
 
@@ -387,6 +396,10 @@ Elastalert rules can be extended by modifying or defining new rules. Rules can b
 4. Re-deploy dependencies helm chart
 
 ### Kibana
+
+| Key       | Type   | Default | Description                                                                                                                          |
+| --------- | ------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| node_port | int    | `n/a`   | Fixed NodePort to expose port `5601` on. Only used when the global `service_type` is `NodePort`, otherwise a random port is assigned |
 
 Kibana has support for custom configuration shipped by default as config.ndjson file in helm chart: [charts/dependencies/files/kibana/config.ndjson](https://github.com/opencrvs/infrastructure/blob/develop/charts/dependencies/files/kibana/config.ndjson)
 

--- a/charts/dependencies/templates/elasticsearch.yaml
+++ b/charts/dependencies/templates/elasticsearch.yaml
@@ -25,11 +25,14 @@ metadata:
     app: elasticsearch
   name: elasticsearch
 spec:
-  clusterIP: None
+  type: {{ .Values.service_type | default "ClusterIP" }}
   ports:
     - name: '9200'
       port: 9200
       targetPort: 9200
+      {{- if .Values.elasticsearch.node_port }}
+      nodePort: {{ .Values.elasticsearch.node_port }}
+      {{- end }}
     - name: '9300'
       port: 9300
       targetPort: 9300

--- a/charts/dependencies/templates/kibana.yaml
+++ b/charts/dependencies/templates/kibana.yaml
@@ -32,12 +32,15 @@ kind: Service
 metadata:
   name: kibana
 spec:
-  type: ClusterIP
+  type: {{ .Values.service_type | default "ClusterIP" }}
   ports:
     - port: 5601
       targetPort: 5601
       protocol: TCP
       name: http
+      {{- if .Values.kibana.node_port }}
+      nodePort: {{ .Values.kibana.node_port }}
+      {{- end }}
   selector:
     app: kibana
 ---

--- a/charts/dependencies/templates/minio.yaml
+++ b/charts/dependencies/templates/minio.yaml
@@ -58,14 +58,23 @@ metadata:
     app: minio
   name: minio
 spec:
-  clusterIP: None
+  type: {{ .Values.service_type | default "ClusterIP" }}
+  {{- if eq .Values.service_type "NodePort" }}
+  nodePort: {{ .Values.minio.node_port | default 30535 }}
+  {{- end }}
   ports:
     - name: '3535'
       port: 3535
       targetPort: 3535
+      {{- if .Values.minio.node_port }}
+      nodePort: {{ .Values.minio.node_port }}
+      {{- end }}
     - name: '3536'
       port: 3536
       targetPort: 3536
+      {{- if .Values.minio.node_port_console }}
+      nodePort: {{ .Values.minio.node_port_console }}
+      {{- end }}
   selector:
     app: minio
 ---

--- a/charts/dependencies/templates/mongodb.yaml
+++ b/charts/dependencies/templates/mongodb.yaml
@@ -23,10 +23,13 @@ metadata:
     app: mongodb
   name: mongodb
 spec:
-  clusterIP: None
+  type: {{ .Values.service_type | default "ClusterIP" }}
   ports:
     - port: 27017
       targetPort: 27017
+      {{- if .Values.mongodb.node_port }}
+      nodePort: {{ .Values.mongodb.node_port }}
+      {{- end }}
   selector:
     app: mongodb
 ---

--- a/charts/dependencies/templates/postgres.yaml
+++ b/charts/dependencies/templates/postgres.yaml
@@ -27,10 +27,16 @@ metadata:
     app: postgres
   name: postgres
 spec:
-  clusterIP: None
+  type: {{ .Values.service_type | default "ClusterIP" }}
+  {{- if eq .Values.service_type "NodePort" }}
+  nodePort: {{ .Values.postgres.node_port | default 30432 }}
+  {{- end }}
   ports:
     - port: 5432
       targetPort: 5432
+      {{- if .Values.postgres.node_port }}
+      nodePort: {{ .Values.postgres.node_port }}
+      {{- end }}
   selector:
     app: postgres
 ---

--- a/charts/dependencies/templates/redis.yaml
+++ b/charts/dependencies/templates/redis.yaml
@@ -6,10 +6,13 @@ metadata:
     app: redis
   name: redis
 spec:
-  clusterIP: None
+  type: {{ .Values.service_type | default "ClusterIP" }}
   ports:
     - port: 6379
       targetPort: 6379
+      {{- if .Values.redis.node_port }}
+      nodePort: {{ .Values.redis.node_port }}
+      {{- end }}
   selector:
     app: redis
 ---

--- a/charts/dependencies/values.yaml
+++ b/charts/dependencies/values.yaml
@@ -54,6 +54,8 @@ mongodb:
   # Pass mongodb credentials over variables:
   # admin_user_name: admin
   # admin_user_password: password
+  # Fixed NodePort to expose port 27017 on, only used when `service_type` is `NodePort`.
+  # node_port: 30017
 
 postgres:
   # Enable postgres deployment.
@@ -65,6 +67,8 @@ postgres:
   admin_user_secret_name: postgres-admin-user
   # admin user name is postgres, define password here:
   # admin_user_password:
+  # Fixed NodePort to expose port 5432 on, only used when `service_type` is `NodePort`.
+  # node_port: 30432
 
   # Persistent Volume Claim (PVC) configuration
   # NOTE: This configuration is used only when `storage_type` is set to `pvc`.
@@ -183,6 +187,9 @@ elasticsearch:
     memoryLimit: '8Gi'
     cpuLimit: '8'
 
+  # Fixed NodePorts, only used when `service_type` is `NodePort`.
+  # node_port: 30920            # exposes port 9200
+
 # monitoring aggregates following components:
 # - kibana
 # - metricbeat
@@ -201,6 +208,8 @@ kibana:
   users_secret: kibana-users-secret
   # Configmap for custom configuration file
   # custom_config_configmap: kibana-custom-config
+  # Fixed NodePort to expose port 5601 on, only used when `service_type` is `NodePort`.
+  # node_port: 30601
 
 metricbeat:
   image: docker.elastic.co/beats/metricbeat:8.19.15
@@ -273,6 +282,10 @@ minio:
   # Node selector for MinIO pods, usually used to keep data persistent on specified nodes.
   node_selector: {}
 
+  # Fixed NodePorts, only used when `service_type` is `NodePort`.
+  # node_port: 30535         # exposes port 3535
+  # node_port_console: 30536 # exposes port 3536
+
   backup:
     # Enable or disable backup functionality for MinIO.
     enabled: false
@@ -326,6 +339,8 @@ redis:
   auth_users:
     - GATEWAY
     - AUTH
+  # Fixed NodePort to expose port 6379 on, only used when `service_type` is `NodePort`.
+  # node_port: 30379
 
 influxdb:
   enabled: true


### PR DESCRIPTION
## Description

Related PR: https://github.com/opencrvs/opencrvs-countryconfig/pull/1515

Allow exposing dependencies services under node port on Tilt based environments.
Random strategy was chosen to avoid conflict with other services that may potentially run on developers machine.

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
