### PR TITLE
refactor!: align the trigger endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,11 +80,18 @@ For the integration's own release history prior to this move, see [`packages/mos
 
 [#13502](https://github.com/opencrvs/opencrvs-core/pull/13502)
 
-#### The system-ready trigger moved to `/trigger/system/ready`
+#### Country config triggers are all served under `/trigger`
 
-Events calls the country config on startup so it can register its integrations. That endpoint was `GET /triggers/system/ready`; it is now `GET /trigger/system/ready`, matching the singular `/trigger/...` prefix of the other country config triggers.
+The user-notification and system-ready triggers were served under `/triggers/`, while the event action and telemetry triggers used `/trigger/`. All of them now use the singular prefix:
 
-**Country configs that implement the trigger must rename their route.** A country config still serving the old path answers 404, which events treats as "not implemented" — it logs and moves on, so integrations declared by the country config silently never get registered.
+| Before | After |
+| --- | --- |
+| `POST /triggers/user/{event}` | `POST /trigger/user/{event}` |
+| `GET /triggers/system/ready` | `GET /trigger/system/ready` |
+
+`POST /trigger/events/{event}/actions/{action}` and `POST /trigger/telemetry` are unchanged.
+
+**Country configs must rename these routes.** `opencrvs upgrade` does it for you: the `rename-trigger-paths` codemod rewrites the `path` of every matching Hapi route under `src/`, then lists every `/triggers/` reference it could not rewrite — a path built at runtime, a route config it did not recognise — for you to rename by hand.
 
 [#13562](https://github.com/opencrvs/opencrvs-core/issues/13562)
 
@@ -231,7 +238,7 @@ Re-running after a partial failure requires clearing the data first. [#11207](ht
 
 ### Security fixes
 
-- Every `/triggers/user/*` user-notification request sent to the country config now carries an `Authorization` header, so country configurations can require authentication on those routes. Previously the `all-user-notification` route was called without a token and country configurations shipped all of these routes with `auth: false`, letting anyone who could reach the service trigger 2FA codes, password-reset credentials and notification emails or SMS to arbitrary recipients. The background announcement worker now authenticates with an anonymous token, and the username-retrieval flow mints a system token instead of forwarding an `Authorization` header it never receives. [#13501](https://github.com/opencrvs/opencrvs-core/pull/13501)
+- Every `/trigger/user/*` user-notification request sent to the country config now carries an `Authorization` header, so country configurations can require authentication on those routes. Previously the `all-user-notification` route was called without a token and country configurations shipped all of these routes with `auth: false`, letting anyone who could reach the service trigger 2FA codes, password-reset credentials and notification emails or SMS to arbitrary recipients. The background announcement worker now authenticates with an anonymous token, and the username-retrieval flow mints a system token instead of forwarding an `Authorization` header it never receives. [#13501](https://github.com/opencrvs/opencrvs-core/pull/13501)
 
   **Deployment notes:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,14 @@ For the integration's own release history prior to this move, see [`packages/mos
 
 [#13502](https://github.com/opencrvs/opencrvs-core/pull/13502)
 
+#### The system-ready trigger moved to `/trigger/system/ready`
+
+Events calls the country config on startup so it can register its integrations. That endpoint was `GET /triggers/system/ready`; it is now `GET /trigger/system/ready`, matching the singular `/trigger/...` prefix of the other country config triggers.
+
+**Country configs that implement the trigger must rename their route.** A country config still serving the old path answers 404, which events treats as "not implemented" — it logs and moves on, so integrations declared by the country config silently never get registered.
+
+[#13562](https://github.com/opencrvs/opencrvs-core/issues/13562)
+
 ### Deprecations
 
 #### `POST /auth/token` parameters in the query string

--- a/packages/auth/src/features/retrievalSteps/sendUserName/handler.ts
+++ b/packages/auth/src/features/retrievalSteps/sendUserName/handler.ts
@@ -71,7 +71,7 @@ export default async function sendUserNameHandler(
      * itself with the nonce, not a token, so there is no incoming
      * Authorization header to forward. Mint a short-lived system token
      * instead — the same way the 2FA and password-reset code notifications do
-     * — so country config can require auth on `/triggers/user/*`.
+     * — so country config can require auth on `/trigger/user/*`.
      */
     authHeader: {
       Authorization: `Bearer ${await createToken(

--- a/packages/commons/src/notification/dispatch.ts
+++ b/packages/commons/src/notification/dispatch.ts
@@ -17,7 +17,7 @@ import { TriggerEvent, TriggerPayload } from './UserNotifications'
  * Every event carries an Authorization header. Interactive flows forward the
  * acting user's token; the background announcement worker fetches a service
  * token first (see getServiceToken in the events service). This lets country
- * configs require authentication on all `/triggers/user/*` routes.
+ * configs require authentication on all `/trigger/user/*` routes.
  */
 export async function triggerUserEventNotification<T extends TriggerEvent>({
   event,
@@ -31,7 +31,7 @@ export async function triggerUserEventNotification<T extends TriggerEvent>({
   authHeader: { Authorization: string }
 }): Promise<Response> {
   const response = await fetch(
-    joinUrl(countryConfigUrl, `triggers/user/${event}`),
+    joinUrl(countryConfigUrl, `trigger/user/${event}`),
     {
       method: 'POST',
       body: JSON.stringify(payload),

--- a/packages/countryconfig-template/src/api/notification/notification.user.email.test.ts
+++ b/packages/countryconfig-template/src/api/notification/notification.user.email.test.ts
@@ -47,7 +47,7 @@ describe('User notification - Email', () => {
     it(event, async () => {
       await server.server.inject({
         method: 'POST',
-        url: `/triggers/user/${event}`,
+        url: `/trigger/user/${event}`,
         payload,
         auth: { strategy: 'jwt', credentials: {} }
       })

--- a/packages/countryconfig-template/src/api/notification/notification.user.sms.test.ts
+++ b/packages/countryconfig-template/src/api/notification/notification.user.sms.test.ts
@@ -59,7 +59,7 @@ describe('User notification - sms', () => {
       await server.server
         .inject({
           method: 'POST',
-          url: `/triggers/user/${event}`,
+          url: `/trigger/user/${event}`,
           payload,
           auth: { strategy: 'jwt', credentials: {} }
         })

--- a/packages/countryconfig-template/src/config/routes/userNotificationRoutes.ts
+++ b/packages/countryconfig-template/src/config/routes/userNotificationRoutes.ts
@@ -13,7 +13,7 @@ import { makeNotificationHandler } from '@countryconfig/api/notification/handler
 import { ReqRefDefaults, ServerRoute } from '@hapi/hapi'
 
 /*
- * All `/triggers/user/*` routes below inherit the default JWT auth strategy
+ * All `/trigger/user/*` routes below inherit the default JWT auth strategy
  * (see `server.auth.default('jwt')` in index.ts). Every core caller forwards a
  * token whose audience includes `opencrvs:countryconfig-user`:
  *   - the events service forwards the acting user's token (user tokens carry
@@ -33,7 +33,7 @@ export default function getUserNotificationRoutes(): ServerRoute<ReqRefDefaults>
   return [
     {
       method: 'POST',
-      path: '/triggers/user/user-created',
+      path: '/trigger/user/user-created',
       handler: makeNotificationHandler('user-created'),
       options: {
         tags: ['api'],
@@ -42,7 +42,7 @@ export default function getUserNotificationRoutes(): ServerRoute<ReqRefDefaults>
     },
     {
       method: 'POST',
-      path: '/triggers/user/user-updated',
+      path: '/trigger/user/user-updated',
       handler: makeNotificationHandler('user-updated'),
       options: {
         tags: ['api'],
@@ -51,7 +51,7 @@ export default function getUserNotificationRoutes(): ServerRoute<ReqRefDefaults>
     },
     {
       method: 'POST',
-      path: '/triggers/user/username-reminder',
+      path: '/trigger/user/username-reminder',
       handler: makeNotificationHandler('username-reminder'),
       options: {
         tags: ['api'],
@@ -60,7 +60,7 @@ export default function getUserNotificationRoutes(): ServerRoute<ReqRefDefaults>
     },
     {
       method: 'POST',
-      path: '/triggers/user/reset-password',
+      path: '/trigger/user/reset-password',
       handler: makeNotificationHandler('reset-password'),
       options: {
         tags: ['api'],
@@ -69,7 +69,7 @@ export default function getUserNotificationRoutes(): ServerRoute<ReqRefDefaults>
     },
     {
       method: 'POST',
-      path: '/triggers/user/reset-password-by-admin',
+      path: '/trigger/user/reset-password-by-admin',
       handler: makeNotificationHandler('reset-password-by-admin'),
       options: {
         tags: ['api'],
@@ -78,7 +78,7 @@ export default function getUserNotificationRoutes(): ServerRoute<ReqRefDefaults>
     },
     {
       method: 'POST',
-      path: '/triggers/user/password-reset-link',
+      path: '/trigger/user/password-reset-link',
       handler: makeNotificationHandler('password-reset-link'),
       options: {
         tags: ['api'],
@@ -87,7 +87,7 @@ export default function getUserNotificationRoutes(): ServerRoute<ReqRefDefaults>
     },
     {
       method: 'POST',
-      path: '/triggers/user/username-reminder-link',
+      path: '/trigger/user/username-reminder-link',
       handler: makeNotificationHandler('username-reminder-link'),
       options: {
         tags: ['api'],
@@ -96,7 +96,7 @@ export default function getUserNotificationRoutes(): ServerRoute<ReqRefDefaults>
     },
     {
       method: 'POST',
-      path: '/triggers/user/resend-invite',
+      path: '/trigger/user/resend-invite',
       handler: makeNotificationHandler('resend-invite'),
       options: {
         tags: ['api'],
@@ -105,7 +105,7 @@ export default function getUserNotificationRoutes(): ServerRoute<ReqRefDefaults>
     },
     {
       method: 'POST',
-      path: '/triggers/user/2fa',
+      path: '/trigger/user/2fa',
       handler: makeNotificationHandler('2fa'),
       options: {
         tags: ['api'],
@@ -114,7 +114,7 @@ export default function getUserNotificationRoutes(): ServerRoute<ReqRefDefaults>
     },
     {
       method: 'POST',
-      path: '/triggers/user/all-user-notification',
+      path: '/trigger/user/all-user-notification',
       handler: makeNotificationHandler('all-user-notification'),
       options: {
         tags: ['api'],
@@ -123,7 +123,7 @@ export default function getUserNotificationRoutes(): ServerRoute<ReqRefDefaults>
     },
     {
       method: 'POST',
-      path: '/triggers/user/change-phone-number',
+      path: '/trigger/user/change-phone-number',
       handler: makeNotificationHandler('change-phone-number'),
       options: {
         tags: ['api'],
@@ -132,7 +132,7 @@ export default function getUserNotificationRoutes(): ServerRoute<ReqRefDefaults>
     },
     {
       method: 'POST',
-      path: '/triggers/user/change-email-address',
+      path: '/trigger/user/change-email-address',
       handler: makeNotificationHandler('change-email-address'),
       options: {
         tags: ['api'],

--- a/packages/countryconfig-template/src/index.ts
+++ b/packages/countryconfig-template/src/index.ts
@@ -591,7 +591,7 @@ export async function createServer() {
 
   server.route({
     method: 'GET',
-    path: '/triggers/system/ready',
+    path: '/trigger/system/ready',
     handler: systemReadyHandler,
     options: {
       tags: ['api', 'integration'],

--- a/packages/events/src/router/announcement/announcement.test.ts
+++ b/packages/events/src/router/announcement/announcement.test.ts
@@ -88,7 +88,7 @@ async function insertAdminWithEmail(
   return { id: result.id as UUID, email }
 }
 
-const ALL_USER_NOTIFICATION_URL = `${env.COUNTRY_CONFIG_URL}/triggers/user/all-user-notification`
+const ALL_USER_NOTIFICATION_URL = `${env.COUNTRY_CONFIG_URL}/trigger/user/all-user-notification`
 
 describe('announcement.broadcast', () => {
   describe('authorization', () => {

--- a/packages/events/src/router/user/user.sendResetPasswordInvite.test.ts
+++ b/packages/events/src/router/user/user.sendResetPasswordInvite.test.ts
@@ -64,7 +64,7 @@ test('sendResetPasswordInvite calls triggerUserEventNotification with reset-pass
 
   mswServer.use(
     http.post(
-      `${env.COUNTRY_CONFIG_URL}/triggers/user/:event`,
+      `${env.COUNTRY_CONFIG_URL}/trigger/user/:event`,
       async ({ request, params }) => {
         capturedEvent = params.event as string
         capturedBody = await request.json()

--- a/packages/events/src/router/user/user.sendUsernameReminder.test.ts
+++ b/packages/events/src/router/user/user.sendUsernameReminder.test.ts
@@ -58,7 +58,7 @@ test('sendUsernameReminder calls triggerUserEventNotification with username-remi
 
   mswServer.use(
     http.post(
-      `${env.COUNTRY_CONFIG_URL}/triggers/user/:event`,
+      `${env.COUNTRY_CONFIG_URL}/trigger/user/:event`,
       async ({ request, params }) => {
         capturedEvent = params.event as string
         capturedBody = await request.json()

--- a/packages/events/src/router/user/user.update.test.ts
+++ b/packages/events/src/router/user/user.update.test.ts
@@ -303,7 +303,7 @@ test('Does not trigger username change when name is not provided', async () => {
   const mock = vi.fn()
   mswServer.use(
     http.post(
-      `${env.COUNTRY_CONFIG_URL}/triggers/user/user-updated`,
+      `${env.COUNTRY_CONFIG_URL}/trigger/user/user-updated`,
       async ({ request }) => {
         const req = await request.json()
         mock(req)
@@ -367,7 +367,7 @@ test('Changes username when the name changes and notifies about it', async () =>
   const mock = vi.fn()
   mswServer.use(
     http.post(
-      `${env.COUNTRY_CONFIG_URL}/triggers/user/user-updated`,
+      `${env.COUNTRY_CONFIG_URL}/trigger/user/user-updated`,
       async ({ request }) => {
         const req = await request.json()
         mock(req)

--- a/packages/events/src/service/config/systemReady.test.ts
+++ b/packages/events/src/service/config/systemReady.test.ts
@@ -53,7 +53,7 @@ describe('triggerSystemReady', () => {
 
     expect(mockFetch).toHaveBeenCalledTimes(1)
     const [url, options] = mockFetch.mock.calls[0]
-    expect(String(url)).toContain('/triggers/system/ready')
+    expect(String(url)).toContain('/trigger/system/ready')
     expect(options?.headers).toMatchObject({
       Authorization: 'Bearer bootstrap-token'
     })

--- a/packages/events/src/service/config/systemReady.ts
+++ b/packages/events/src/service/config/systemReady.ts
@@ -34,7 +34,7 @@ async function attemptSystemReady() {
   // window, so it is minted per attempt rather than once up front
   const bootstrapToken = await getIntegrationCreatorToken(REQUEST_TIMEOUT_MS)
   const res = await fetch(
-    new URL('/triggers/system/ready', env.COUNTRY_CONFIG_URL).toString(),
+    new URL('/trigger/system/ready', env.COUNTRY_CONFIG_URL).toString(),
     {
       method: 'GET',
       headers: { Authorization: `Bearer ${bootstrapToken}` },

--- a/packages/events/src/tests/msw.ts
+++ b/packages/events/src/tests/msw.ts
@@ -125,7 +125,7 @@ const handlers = [
       return HttpResponse.json(payload)
     }
   ),
-  http.post(`${env.COUNTRY_CONFIG_URL}/triggers/user/:event`, () =>
+  http.post(`${env.COUNTRY_CONFIG_URL}/trigger/user/:event`, () =>
     HttpResponse.json({})
   ),
   http.post(`${env.COUNTRY_CONFIG_URL}/trigger/telemetry`, () =>

--- a/packages/testland/src/api/notification/notification.user.email.test.ts
+++ b/packages/testland/src/api/notification/notification.user.email.test.ts
@@ -47,7 +47,7 @@ describe('User notification - Email', () => {
     it(event, async () => {
       await server.server.inject({
         method: 'POST',
-        url: `/triggers/user/${event}`,
+        url: `/trigger/user/${event}`,
         payload,
         auth: { strategy: 'jwt', credentials: {} }
       })
@@ -87,7 +87,7 @@ describe('User notification - Email - recovery link URL escaping', () => {
     async (event) => {
       await server.server.inject({
         method: 'POST',
-        url: `/triggers/user/${event}`,
+        url: `/trigger/user/${event}`,
         payload: {
           recipient,
           token: hostileToken

--- a/packages/testland/src/api/notification/notification.user.sms.test.ts
+++ b/packages/testland/src/api/notification/notification.user.sms.test.ts
@@ -59,7 +59,7 @@ describe('User notification - sms', () => {
       await server.server
         .inject({
           method: 'POST',
-          url: `/triggers/user/${event}`,
+          url: `/trigger/user/${event}`,
           payload,
           auth: { strategy: 'jwt', credentials: {} }
         })
@@ -101,7 +101,7 @@ describe('User notification - sms - recovery link URL escaping', () => {
       await server.server
         .inject({
           method: 'POST',
-          url: `/triggers/user/${event}`,
+          url: `/trigger/user/${event}`,
           payload: {
             recipient,
             token: hostileToken

--- a/packages/testland/src/config/routes/userNotificationRoutes.ts
+++ b/packages/testland/src/config/routes/userNotificationRoutes.ts
@@ -13,7 +13,7 @@ import { makeNotificationHandler } from '@countryconfig/api/notification/handler
 import { ReqRefDefaults, ServerRoute } from '@hapi/hapi'
 
 /*
- * All `/triggers/user/*` routes below inherit the default JWT auth strategy
+ * All `/trigger/user/*` routes below inherit the default JWT auth strategy
  * (see `server.auth.default('jwt')` in index.ts). Every core caller forwards a
  * token whose audience includes `opencrvs:countryconfig-user`:
  *   - the events service forwards the acting user's token (user tokens carry
@@ -33,7 +33,7 @@ export default function getUserNotificationRoutes(): ServerRoute<ReqRefDefaults>
   return [
     {
       method: 'POST',
-      path: '/triggers/user/user-created',
+      path: '/trigger/user/user-created',
       handler: makeNotificationHandler('user-created'),
       options: {
         tags: ['api'],
@@ -42,7 +42,7 @@ export default function getUserNotificationRoutes(): ServerRoute<ReqRefDefaults>
     },
     {
       method: 'POST',
-      path: '/triggers/user/user-updated',
+      path: '/trigger/user/user-updated',
       handler: makeNotificationHandler('user-updated'),
       options: {
         tags: ['api'],
@@ -51,7 +51,7 @@ export default function getUserNotificationRoutes(): ServerRoute<ReqRefDefaults>
     },
     {
       method: 'POST',
-      path: '/triggers/user/username-reminder',
+      path: '/trigger/user/username-reminder',
       handler: makeNotificationHandler('username-reminder'),
       options: {
         tags: ['api'],
@@ -60,7 +60,7 @@ export default function getUserNotificationRoutes(): ServerRoute<ReqRefDefaults>
     },
     {
       method: 'POST',
-      path: '/triggers/user/reset-password',
+      path: '/trigger/user/reset-password',
       handler: makeNotificationHandler('reset-password'),
       options: {
         tags: ['api'],
@@ -69,7 +69,7 @@ export default function getUserNotificationRoutes(): ServerRoute<ReqRefDefaults>
     },
     {
       method: 'POST',
-      path: '/triggers/user/reset-password-by-admin',
+      path: '/trigger/user/reset-password-by-admin',
       handler: makeNotificationHandler('reset-password-by-admin'),
       options: {
         tags: ['api'],
@@ -78,7 +78,7 @@ export default function getUserNotificationRoutes(): ServerRoute<ReqRefDefaults>
     },
     {
       method: 'POST',
-      path: '/triggers/user/password-reset-link',
+      path: '/trigger/user/password-reset-link',
       handler: makeNotificationHandler('password-reset-link'),
       options: {
         tags: ['api'],
@@ -87,7 +87,7 @@ export default function getUserNotificationRoutes(): ServerRoute<ReqRefDefaults>
     },
     {
       method: 'POST',
-      path: '/triggers/user/username-reminder-link',
+      path: '/trigger/user/username-reminder-link',
       handler: makeNotificationHandler('username-reminder-link'),
       options: {
         tags: ['api'],
@@ -96,7 +96,7 @@ export default function getUserNotificationRoutes(): ServerRoute<ReqRefDefaults>
     },
     {
       method: 'POST',
-      path: '/triggers/user/resend-invite',
+      path: '/trigger/user/resend-invite',
       handler: makeNotificationHandler('resend-invite'),
       options: {
         tags: ['api'],
@@ -105,7 +105,7 @@ export default function getUserNotificationRoutes(): ServerRoute<ReqRefDefaults>
     },
     {
       method: 'POST',
-      path: '/triggers/user/2fa',
+      path: '/trigger/user/2fa',
       handler: makeNotificationHandler('2fa'),
       options: {
         tags: ['api'],
@@ -114,7 +114,7 @@ export default function getUserNotificationRoutes(): ServerRoute<ReqRefDefaults>
     },
     {
       method: 'POST',
-      path: '/triggers/user/all-user-notification',
+      path: '/trigger/user/all-user-notification',
       handler: makeNotificationHandler('all-user-notification'),
       options: {
         tags: ['api'],
@@ -123,7 +123,7 @@ export default function getUserNotificationRoutes(): ServerRoute<ReqRefDefaults>
     },
     {
       method: 'POST',
-      path: '/triggers/user/change-phone-number',
+      path: '/trigger/user/change-phone-number',
       handler: makeNotificationHandler('change-phone-number'),
       options: {
         tags: ['api'],
@@ -132,7 +132,7 @@ export default function getUserNotificationRoutes(): ServerRoute<ReqRefDefaults>
     },
     {
       method: 'POST',
-      path: '/triggers/user/change-email-address',
+      path: '/trigger/user/change-email-address',
       handler: makeNotificationHandler('change-email-address'),
       options: {
         tags: ['api'],

--- a/packages/testland/src/index.ts
+++ b/packages/testland/src/index.ts
@@ -720,7 +720,7 @@ export async function createServer() {
 
   server.route({
     method: 'GET',
-    path: '/triggers/system/ready',
+    path: '/trigger/system/ready',
     handler: systemReadyHandler,
     options: {
       tags: ['api', 'integration'],

--- a/packages/toolkit/src/migrations/v2.1/add-recovery-link-notifications.ts
+++ b/packages/toolkit/src/migrations/v2.1/add-recovery-link-notifications.ts
@@ -34,7 +34,7 @@
  *     `convertPayloadToVariable` switch, building the recovery URL from the
  *     token in the payload
  *   - `src/config/routes/userNotificationRoutes.ts`: adds the two
- *     `POST /triggers/user/*` routes core posts to
+ *     `POST /trigger/user/*` routes core posts to
  *   - `src/api/notification/email-templates/other/*.html`: writes the two
  *     email bodies
  *   - `src/translations/notification.csv`: adds the two SMS messages
@@ -516,11 +516,11 @@ function updateRoutes(project: Project, cwd: string) {
   }
 
   for (const event of RECOVERY_EVENTS) {
-    if (routesArray.getText().includes(`/triggers/user/${event.id}`)) continue
+    if (routesArray.getText().includes(`/trigger/user/${event.id}`)) continue
 
     routesArray.addElement(`{
   method: 'POST',
-  path: '/triggers/user/${event.id}',
+  path: '/trigger/user/${event.id}',
   handler: makeNotificationHandler('${event.id}'),
   options: {
     auth: false,
@@ -528,7 +528,7 @@ function updateRoutes(project: Project, cwd: string) {
     description: '${event.routeDescription}'
   }
 }`)
-    console.log(`  ✓ ${ROUTES_FILE}: POST /triggers/user/${event.id}`)
+    console.log(`  ✓ ${ROUTES_FILE}: POST /trigger/user/${event.id}`)
   }
 }
 

--- a/packages/toolkit/src/migrations/v2.1/index.ts
+++ b/packages/toolkit/src/migrations/v2.1/index.ts
@@ -12,6 +12,7 @@ import { main as addExplicitCorrectionFlags } from './add-explicit-correction-fl
 import { main as addRecoveryLinkNotifications } from './add-recovery-link-notifications'
 import { main as addTranslations } from './add-translations'
 import { main as enableTelemetry } from './enable-telemetry'
+import { main as renameTriggerPaths } from './rename-trigger-paths'
 
 /**
  * Run the upgrade process for the country config in the current working
@@ -19,6 +20,7 @@ import { main as enableTelemetry } from './enable-telemetry'
  */
 export async function runUpgrade(dockerSwarm: boolean) {
   await addExplicitCorrectionFlags()
+  await renameTriggerPaths()
   await addRecoveryLinkNotifications()
   await addTranslations()
   await enableTelemetry()

--- a/packages/toolkit/src/migrations/v2.1/rename-trigger-paths.ts
+++ b/packages/toolkit/src/migrations/v2.1/rename-trigger-paths.ts
@@ -1,0 +1,245 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+
+/**
+ * Codemod: Rename the `/triggers/...` country config routes to `/trigger/...`.
+ *
+ * Usage:
+ *   ts-node -r tsconfig-paths/register src/migrations/v2.1/rename-trigger-paths.ts
+ *
+ * Why:
+ *   The user-notification and system-ready triggers were served under
+ *   `/triggers/`, while the event action and telemetry triggers use
+ *   `/trigger/`. v2.1 settles on the singular prefix for all of them, so core
+ *   now posts to `/trigger/user/*` and gets `/trigger/system/ready`. A route
+ *   left on the old path answers 404, which core logs and moves on from — the
+ *   notification is simply never sent and the country config's integrations
+ *   are never registered. See CHANGELOG.md ("Country config triggers are all
+ *   served under /trigger").
+ *
+ * What it does:
+ *   - Scans all TypeScript files under `src/`
+ *   - Finds every object literal that looks like a Hapi route config (a
+ *     `method` property holding an HTTP verb, or an array of them, plus a
+ *     string-literal `path`)
+ *   - Rewrites a `path` starting with any prefix in PATH_PREFIX_RENAMES
+ *   - Saves the modified files in-place
+ *   - Warns about every remaining `/triggers/` occurrence under `src/`, which
+ *     is anything this codemod cannot rewrite safely: a path built from a
+ *     template literal or variable, a route config it did not recognise, or a
+ *     test that requests the old path
+ */
+
+import {
+  Node,
+  ObjectLiteralExpression,
+  Project,
+  SourceFile,
+  SyntaxKind
+} from 'ts-morph'
+import path from 'path'
+
+// ─── Path rename table ────────────────────────────────────────────────────────
+// Prefixes rather than whole paths: `/triggers/user/` covers one route per
+// `TriggerEvent`, and a country config may have added its own.
+
+const PATH_PREFIX_RENAMES: Record<string, string> = {
+  '/triggers/user/': '/trigger/user/',
+  '/triggers/system/': '/trigger/system/'
+}
+
+/** Matched against the remaining source text once the renames are applied. */
+const STALE_PREFIX = '/triggers/'
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const METHOD_PROPERTY_NAME = 'method'
+const PATH_PROPERTY_NAME = 'path'
+
+const HTTP_VERBS = new Set([
+  'GET',
+  'POST',
+  'PUT',
+  'PATCH',
+  'DELETE',
+  'OPTIONS',
+  'HEAD',
+  '*'
+])
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Returns true when the given object literal looks like a Hapi route config,
+ * i.e. it has a `method` property holding a recognised HTTP verb string (or an
+ * array of them) and a string-literal `path` property.
+ */
+function isRouteConfig(obj: ObjectLiteralExpression): boolean {
+  const methodProp = obj.getProperty(METHOD_PROPERTY_NAME)
+  if (!methodProp || !Node.isPropertyAssignment(methodProp)) return false
+
+  const methodInit = methodProp.getInitializer()
+  if (!methodInit) return false
+
+  if (Node.isStringLiteral(methodInit)) {
+    if (!HTTP_VERBS.has(methodInit.getLiteralValue().toUpperCase()))
+      return false
+  } else if (Node.isArrayLiteralExpression(methodInit)) {
+    const allVerbs = methodInit
+      .getElements()
+      .every(
+        (el) =>
+          Node.isStringLiteral(el) &&
+          HTTP_VERBS.has(el.getLiteralValue().toUpperCase())
+      )
+    if (!allVerbs) return false
+  } else {
+    return false
+  }
+
+  const pathProp = obj.getProperty(PATH_PROPERTY_NAME)
+  if (!pathProp || !Node.isPropertyAssignment(pathProp)) return false
+
+  const pathInit = pathProp.getInitializer()
+  return !!pathInit && Node.isStringLiteral(pathInit)
+}
+
+/**
+ * Applies PATH_PREFIX_RENAMES to the `path` of a confirmed route config.
+ * Returns the new path, or null when no prefix matched.
+ */
+function renameRoutePath(obj: ObjectLiteralExpression): string | null {
+  const pathProp = obj.getProperty(PATH_PROPERTY_NAME)
+  if (!pathProp || !Node.isPropertyAssignment(pathProp)) return null
+
+  const pathInit = pathProp.getInitializer()
+  if (!pathInit || !Node.isStringLiteral(pathInit)) return null
+
+  const oldPath = pathInit.getLiteralValue()
+  const match = Object.entries(PATH_PREFIX_RENAMES).find(([from]) =>
+    oldPath.startsWith(from)
+  )
+  if (!match) return null
+
+  const [from, to] = match
+  const newPath = to + oldPath.slice(from.length)
+  pathInit.replaceWithText(`'${newPath}'`)
+  return newPath
+}
+
+// ─── File processor ──────────────────────────────────────────────────────────
+
+function processFile(filePath: string, project: Project): number {
+  const sourceFile = project.getSourceFile(filePath)
+  if (!sourceFile) return 0
+
+  let renamedCount = 0
+  const relPath = path.relative(process.cwd(), filePath)
+
+  // Collect candidates first to avoid iterating a mutating tree
+  const candidates = sourceFile.getDescendantsOfKind(
+    SyntaxKind.ObjectLiteralExpression
+  )
+
+  for (const obj of candidates) {
+    if (!isRouteConfig(obj)) continue
+
+    const newPath = renameRoutePath(obj)
+    if (newPath) {
+      renamedCount++
+      console.log(`  [${relPath}] Renamed route path → '${newPath}'`)
+    }
+  }
+
+  return renamedCount
+}
+
+/**
+ * Reports leftover `/triggers/` occurrences. Rewriting these is guesswork —
+ * the path may be assembled at runtime — but leaving them unmentioned would
+ * hide a route that still answers on the old path.
+ */
+function warnAboutStalePaths(sourceFiles: readonly SourceFile[]) {
+  const stale: string[] = []
+
+  for (const sourceFile of sourceFiles) {
+    const relPath = path.relative(process.cwd(), sourceFile.getFilePath())
+    const lines = sourceFile.getFullText().split('\n')
+
+    lines.forEach((line, index) => {
+      if (line.includes(STALE_PREFIX)) {
+        stale.push(`  ${relPath}:${index + 1}: ${line.trim()}`)
+      }
+    })
+  }
+
+  if (stale.length === 0) return
+
+  console.log(
+    `\nWARNING: ${stale.length} remaining '${STALE_PREFIX}' reference(s) need to be renamed by hand:`
+  )
+  console.log(stale.join('\n'))
+}
+
+// ─── Entry point ─────────────────────────────────────────────────────────────
+
+async function main() {
+  const srcDir = path.join(process.cwd(), 'src')
+  console.log(`Scanning for Hapi route configs in: ${srcDir}\n`)
+  console.log('Active path renames:')
+  for (const [from, to] of Object.entries(PATH_PREFIX_RENAMES)) {
+    console.log(`  '${from}*' → '${to}*'`)
+  }
+  console.log()
+
+  const project = new Project({
+    tsConfigFilePath: path.resolve(srcDir, '../tsconfig.json'),
+    skipAddingFilesFromTsConfig: false
+  })
+
+  const sourceFiles = project.getSourceFiles().filter((sf) => {
+    const fp = sf.getFilePath()
+    return fp.includes('/src/') && !fp.includes('/node_modules/')
+  })
+
+  console.log(`Found ${sourceFiles.length} source file(s) to analyse.\n`)
+
+  let totalRenamed = 0
+  const modifiedFiles: string[] = []
+
+  for (const sourceFile of sourceFiles) {
+    const filePath = sourceFile.getFilePath()
+    const renamed = processFile(filePath, project)
+
+    if (renamed > 0) {
+      totalRenamed += renamed
+      modifiedFiles.push(filePath)
+    }
+  }
+
+  if (modifiedFiles.length === 0) {
+    console.log('No trigger route paths to rename.')
+  } else {
+    console.log(`\nSaving ${modifiedFiles.length} modified file(s)...`)
+
+    for (const filePath of modifiedFiles) {
+      const sourceFile = project.getSourceFileOrThrow(filePath)
+      await sourceFile.save()
+      console.log(`  Saved: ${path.relative(process.cwd(), filePath)}`)
+    }
+
+    console.log(`\nDone. Renamed ${totalRenamed} route path(s).`)
+  }
+
+  warnAboutStalePaths(sourceFiles)
+}
+
+export { main }

--- a/packages/toolkit/src/verify/endpoints.ts
+++ b/packages/toolkit/src/verify/endpoints.ts
@@ -98,7 +98,7 @@ const SECURED_ENDPOINTS: readonly EndpointCheck[] = [
     })
   ),
   { method: 'POST', path: '/trigger/telemetry' },
-  { method: 'GET', path: '/triggers/system/ready' },
+  { method: 'GET', path: '/trigger/system/ready' },
   {
     method: 'GET',
     path: `/certificates/${PROBE_SEGMENT}`,

--- a/packages/toolkit/src/verify/endpoints.ts
+++ b/packages/toolkit/src/verify/endpoints.ts
@@ -94,7 +94,7 @@ const SECURED_ENDPOINTS: readonly EndpointCheck[] = [
   ...SECURED_TRIGGER_USER_EVENTS.map(
     (event): EndpointCheck => ({
       method: 'POST',
-      path: `/triggers/user/${event}`
+      path: `/trigger/user/${event}`
     })
   ),
   { method: 'POST', path: '/trigger/telemetry' },


### PR DESCRIPTION
- All the trigger endpoints now start with `/trigger/`. 
- Codemod to apply the changes to a countryconfig