### PR TITLE
fix: restrict DECEASED_USUAL_RESIDENCE option of place of death

### DIFF
--- a/packages/countryconfig-template/src/events/death/forms/pages/eventDetails.ts
+++ b/packages/countryconfig-template/src/events/death/forms/pages/eventDetails.ts
@@ -109,7 +109,6 @@ const sourceCauseDeathOptions = createSelectOptions(
 
 export const PlaceOfDeath = {
   HEALTH_FACILITY: 'HEALTH_FACILITY',
-  DECEASED_USUAL_RESIDENCE: 'DECEASED_USUAL_RESIDENCE',
   OTHER: 'OTHER'
 } as const
 
@@ -118,12 +117,6 @@ const placeOfDeathMessageDescriptors = {
     defaultMessage: 'Health Institution',
     description: 'Select item for Health Institution',
     id: 'form.field.label.healthInstitution'
-  },
-  DECEASED_USUAL_RESIDENCE: {
-    defaultMessage: "Deceased's usual place of residence",
-    description:
-      'Option for place of occurrence of death same as deceased primary address',
-    id: 'form.field.label.placeOfDeathSameAsPrimary'
   },
   OTHER: {
     defaultMessage: 'Other',
@@ -385,22 +378,6 @@ export const eventDetails = defineFormPage({
       }
     },
     {
-      id: 'eventDetails.deathLocationResidence',
-      type: FieldType.ALPHA_HIDDEN,
-      required: false,
-      label: placeOfDeathMessageDescriptors.DECEASED_USUAL_RESIDENCE,
-      conditionals: [
-        {
-          type: ConditionalType.SHOW,
-          conditional: field('eventDetails.placeOfDeath').isEqualTo(
-            PlaceOfDeath.DECEASED_USUAL_RESIDENCE
-          )
-        }
-      ],
-      parent: [field('eventDetails.placeOfDeath'), field('deceased.address')],
-      value: field('deceased.address').get('administrativeArea')
-    },
-    {
       id: 'eventDetails.deathLocationId',
       type: FieldType.ALPHA_HIDDEN,
       required: false,
@@ -417,8 +394,7 @@ export const eventDetails = defineFormPage({
       ],
       value: [
         field('eventDetails.deathLocation'),
-        field('eventDetails.deathLocationOther').get('administrativeArea'),
-        field('eventDetails.deathLocationResidence')
+        field('eventDetails.deathLocationOther').get('administrativeArea')
       ]
     }
   ]

--- a/packages/testland/e2e/support/advanced-search/location-versioning-declarations.ts
+++ b/packages/testland/e2e/support/advanced-search/location-versioning-declarations.ts
@@ -199,11 +199,11 @@ export async function createDeathRegisteredWithInactiveFacility() {
   const result = await createDeathDeclaration(
     token,
     {
-      'eventDetails.placeOfDeath': 'HEALTH_FACILITY',
       'eventDetails.deathLocation': facility.id,
       'eventDetails.deathLocationId': facility.id
     },
-    ActionType.REGISTER
+    ActionType.REGISTER,
+    'HEALTH_FACILITY'
   )
 
   const [initialVersion] = facility.versions
@@ -299,7 +299,6 @@ export async function createDeathArchivedControlRecord() {
   const { eventId } = await createDeathDeclaration(
     token,
     {
-      'eventDetails.placeOfDeath': 'HEALTH_FACILITY',
       'eventDetails.deathLocation': facilityId,
       'eventDetails.deathLocationId': facilityId,
       'deceased.address': {
@@ -308,7 +307,8 @@ export async function createDeathArchivedControlRecord() {
         administrativeArea: mbulaId
       }
     },
-    ActionType.DECLARE
+    ActionType.DECLARE,
+    'HEALTH_FACILITY'
   )
 
   const client = createClient(GATEWAY_HOST + '/events', `Bearer ${token}`)

--- a/packages/testland/e2e/support/test-data/death-declaration.ts
+++ b/packages/testland/e2e/support/test-data/death-declaration.ts
@@ -26,9 +26,12 @@ import {
 import { getSignatureFile, uploadFile } from './utils'
 import { omitBy } from 'lodash'
 
+type PlaceOfDeathType = 'DECEASED_USUAL_RESIDENCE' | 'OTHER' | 'HEALTH_FACILITY'
+
 async function getPlaceOfDeath(
-  type: 'DECEASED_USUAL_RESIDENCE' | 'HEALTH_FACILITY',
-  token: string
+  type: PlaceOfDeathType,
+  token: string,
+  village: string
 ) {
   if (type === 'HEALTH_FACILITY') {
     const locations = await getLocations('HEALTH_FACILITY', token)
@@ -41,12 +44,14 @@ async function getPlaceOfDeath(
   }
 
   if (type === 'DECEASED_USUAL_RESIDENCE') {
-    const administrativeAreas = await getAdministrativeAreas(token)
-
-    const village = getIdByName(administrativeAreas, 'Klow')
-
     return {
-      'deceased.address': {
+      'eventDetails.deathLocationId': village
+    }
+  }
+
+  if (type === 'OTHER') {
+    return {
+      'eventDetails.deathLocationOther': {
         country: 'FAR',
         addressType: AddressType.DOMESTIC,
         administrativeArea: village
@@ -55,20 +60,23 @@ async function getPlaceOfDeath(
     }
   }
 
-  throw new Error('Invalid place of birth type')
+  throw new Error('Invalid place of death type')
 }
 
 async function getDeclaration({
   partialDeclaration = {},
-  placeOfDeathType: placeOfDeathType = 'DECEASED_USUAL_RESIDENCE',
+  placeOfDeathType: placeOfDeathType = 'OTHER',
   token
 }: {
   partialDeclaration?:
     | ((_: Record<string, any>) => Record<string, any>)
     | Record<string, any>
-  placeOfDeathType?: 'DECEASED_USUAL_RESIDENCE' | 'HEALTH_FACILITY'
+  placeOfDeathType?: PlaceOfDeathType
   token: string
 }) {
+  const administrativeAreas = await getAdministrativeAreas(token)
+  const village = getIdByName(administrativeAreas, 'Klow')
+
   const mockDeclaration = {
     'spouse.dob': '1975-02-18',
     'spouse.age': undefined,
@@ -95,12 +103,17 @@ async function getDeclaration({
     'deceased.nationality': 'FAR',
     'spouse.addressSameAs': 'YES',
     'deceased.maritalStatus': 'MARRIED',
+    'deceased.address': {
+      country: 'FAR',
+      addressType: AddressType.DOMESTIC,
+      administrativeArea: village
+    },
     'eventDetails.placeOfDeath': placeOfDeathType,
     'eventDetails.mannerOfDeath': 'MANNER_NATURAL',
     'deceased.numberOfDependants': 3,
     'eventDetails.sourceCauseDeath': 'PHYSICIAN',
     'eventDetails.causeOfDeathEstablished': true,
-    ...(await getPlaceOfDeath(placeOfDeathType, token))
+    ...(await getPlaceOfDeath(placeOfDeathType, token, village))
   }
 
   const overrides =
@@ -129,7 +142,7 @@ export async function createDeclaration(
   token: string,
   dec?: ((_: ActionUpdate) => Partial<ActionUpdate>) | Partial<ActionUpdate>,
   action: ActionType = ActionType.REGISTER,
-  placeOfDeathType?: 'DECEASED_USUAL_RESIDENCE' | 'HEALTH_FACILITY',
+  placeOfDeathType?: PlaceOfDeathType,
   /**
    * Only honored for a system/integration token — the server resolves it
    * from the user's own `primaryOfficeId` for a normal user token, ignoring

--- a/packages/testland/e2e/testcases/death/declaration/death-declaration-1.spec.ts
+++ b/packages/testland/e2e/testcases/death/declaration/death-declaration-1.spec.ts
@@ -58,7 +58,7 @@ test.describe.serial('1. Death declaration case - 1', () => {
       date: getRandomDate(0, 20),
       causeOfDeathEstablished: true,
       sourceCauseDeath: 'Physician',
-      placeOfDeath: "Deceased's usual place of residence"
+      placeOfDeath: 'Other'
     },
     causeOfDeathDetails: {
       causeOfDeathA: {

--- a/packages/testland/e2e/testcases/jurisdiction/death-at-residence-in-another-district.spec.ts
+++ b/packages/testland/e2e/testcases/jurisdiction/death-at-residence-in-another-district.spec.ts
@@ -23,8 +23,10 @@ import { CREDENTIALS } from '@e2e/support/constants'
 
 /**
  * Picks an option out of an administrative area dropdown. The options are
- * matched inside the open dropdown: a registrar's own province and district are
- * pre-filled, so their names also appear in the closed select.
+ * matched inside the open dropdown: a local registrar's own province
+ * and district are pre-filled, so their names also appear in the closed select.
+ * Nothing is pre-filled for the Registrar General, who has no administrative
+ * area of their own.
  */
 async function selectAdministrativeArea(page: Page, id: string, name: string) {
   await page.locator(`#${id}`).click()
@@ -36,9 +38,13 @@ async function selectAdministrativeArea(page: Page, id: string, name: string) {
 
 /**
  * A death at the deceased's usual place of residence belongs to the district
- * that residence is in, whoever declares it. Declaring it from a district it
- * did not happen in is what tells the two apart: the record has to land where
- * the deceased lived, not at the office that filed it.
+ * that residence is in, whoever declares it. Filing it from an office that is
+ * not in that district is what tells the two apart: the record has to land
+ * where the deceased lived, not at the office that filed it.
+ *
+ * The Registrar General declares it because the option is only offered to roles
+ * whose `record.create` placeOfEvent is unrestricted — an administrative area
+ * bound registrar cannot pick a usual residence at all.
  */
 test.describe.serial('Death at a usual residence in another district', () => {
   let page: Page
@@ -53,7 +59,6 @@ test.describe.serial('Death at a usual residence in another district', () => {
       dob: getRandomDate(75, 200),
       idType: 'None',
       maritalStatus: 'Single',
-      // Isamba, not the Ibombo district the declaring registrar works in
       address: {
         province: 'Central',
         district: 'Isamba',
@@ -77,7 +82,7 @@ test.describe.serial('Death at a usual residence in another district', () => {
       idType: 'None'
     },
     review: {
-      comment: 'Died at home, reported to the Ibombo office'
+      comment: 'Died at home, reported to the HQ office'
     }
   }
 
@@ -94,8 +99,8 @@ test.describe.serial('Death at a usual residence in another district', () => {
     await page.close()
   })
 
-  test('Ibombo registrar starts a death declaration', async () => {
-    await login(page, CREDENTIALS.REGISTRAR)
+  test('Registrar General starts a death declaration', async () => {
+    await login(page, CREDENTIALS.REGISTRAR_GENERAL)
 
     await page.click('#header-new-event')
     await page.getByLabel('Death').click()

--- a/packages/testland/e2e/testcases/jurisdiction/death-form-jurisdiction-restrictions.spec.ts
+++ b/packages/testland/e2e/testcases/jurisdiction/death-form-jurisdiction-restrictions.spec.ts
@@ -87,7 +87,7 @@ test.describe('Death form - place of death jurisdiction restrictions', () => {
     await expect(page.getByText('Other', { exact: true })).toBeVisible()
   })
 
-  test('Community Leader should not be able to choose Health Institution as place of death', async () => {
+  test('Community Leader should only be able to choose Other as place of death', async () => {
     await login(page, CREDENTIALS.COMMUNITY_LEADER)
     await openDeathDeclaration(page)
 
@@ -98,12 +98,27 @@ test.describe('Death form - place of death jurisdiction restrictions', () => {
     ).toBeHidden()
     await expect(
       page.getByText("Deceased's usual place of residence", { exact: true })
-    ).toBeVisible()
+    ).toBeHidden()
     await expect(page.getByText('Other', { exact: true })).toBeVisible()
   })
 
-  test('Registrar should be able to choose all place of death options', async () => {
+  test('Registrar should not be able to choose the deceased usual place of residence', async () => {
     await login(page, CREDENTIALS.REGISTRAR)
+    await openDeathDeclaration(page)
+
+    await page.locator('#eventDetails____placeOfDeath').click()
+
+    await expect(
+      page.getByText('Health Institution', { exact: true })
+    ).toBeVisible()
+    await expect(
+      page.getByText("Deceased's usual place of residence", { exact: true })
+    ).toBeHidden()
+    await expect(page.getByText('Other', { exact: true })).toBeVisible()
+  })
+
+  test('Registrar General should be able to choose all place of death options', async () => {
+    await login(page, CREDENTIALS.REGISTRAR_GENERAL)
     await openDeathDeclaration(page)
 
     await page.locator('#eventDetails____placeOfDeath').click()

--- a/packages/testland/src/events/death/forms/pages/deceased.ts
+++ b/packages/testland/src/events/death/forms/pages/deceased.ts
@@ -509,8 +509,6 @@ export const deceased = defineFormPage({
       },
       configuration: {
         streetAddressForm: defaultStreetAddressConfiguration,
-        // Deceased's residence at time of death is a demographic fact about the event, not a current address.
-        anchorToDateOfEvent: true,
         activeOnly: true
       }
     }

--- a/packages/testland/src/events/death/forms/pages/eventDetails.ts
+++ b/packages/testland/src/events/death/forms/pages/eventDetails.ts
@@ -152,7 +152,10 @@ const placeOfDeathOptions = [
     conditionals: [
       {
         type: ConditionalType.SHOW,
-        conditional: not(user.hasRole('HOSPITAL_CLERK'))
+        conditional: or(
+          user.hasRole('EMBASSY_OFFICIAL'),
+          user.hasRole('NATIONAL_REGISTRAR')
+        )
       }
     ]
   },


### PR DESCRIPTION
## Description

### Problem:
In testland:
Death form has:
 - `Usual place of residence` field. 
 - `Place of death` field.
 - `Place of death` is restricted by user's `record.create` scope whereas `Usual place of residence` has no such restrictions.
 - `Place of Death` is a dropdown which has an option to select the `Usual place of residence` as the `Place of Death`
 
Thus, if a user inputs the `Usual place of residence` to be outside of their jurisdiction and then goes on to  select the `Usual place of residence` as the `Place of Death`, they therefore inputs a placeOfEvent outside their jurisdiction.

### Solution:
To mitigate this, in this PR, we are removing the `Usual place of residence` option of `Place of Death` field for the users who have some restrictions on their record.create scope based on placeOfEvent. So, only users with `placeOfEvent: 'all'` or no `placeOfEvent` at all in their `record.create` scope will see the `Usual place of residence` option.

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
