### PR TITLE
Keep rerunning mosip-api confirmation until dependencies are available

### DIFF
--- a/packages/mosip-api/package.json
+++ b/packages/mosip-api/package.json
@@ -6,7 +6,7 @@
     "node": "22.x.x"
   },
   "scripts": {
-    "start": "NODE_ENV=development tsx watch --env-file-if-exists=../../.env src/index.ts",
+    "start": "NODE_ENV=development tsx watch --include './src/**/*' --env-file-if-exists=../../.env src/index.ts",
     "start:prod": "NODE_ENV=production tsx src/index.ts",
     "copy-example-certs": "mkdir -p certs && cp -n docs/example-certs/* certs/ || true",
     "prestart": "pnpm copy-example-certs",

--- a/packages/mosip-api/src/opencrvs-api.ts
+++ b/packages/mosip-api/src/opencrvs-api.ts
@@ -93,6 +93,13 @@ export const assertCanConfirmRegistrations = async (
     const payload = decode(token) as { scope?: string[] } | null
     scope = payload?.scope ?? []
   } catch (error) {
+    if (!env.isProd) {
+      logger.warn(
+        'Could not authenticate the OpenCRVS system client yet — waiting for OpenCRVS to be ready and the MOSIP integration to be seeded. Retrying in 3s...'
+      )
+      await new Promise((resolve) => setTimeout(resolve, 3000))
+      return assertCanConfirmRegistrations(logger)
+    }
     logger.error(
       { event: 'opencrvs.system-client.auth.failed', err: error },
       'Could not authenticate the OpenCRVS system client. Set OPENCRVS_CLIENT_ID and OPENCRVS_CLIENT_SECRET to valid credentials.'


### PR DESCRIPTION
## Description

This fixes issue on local dev env startup, where mosip-api was not available on initial startup. Now it refreshes every 3 sec, until it works. This can depend on either data seeding or countryconfig API.

Additionally fix the mosip-api restart, now it restarts if any files under mosip-api/src are changed.

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
