### PR TITLE
fix: Remove origin repository URL after clonning

### DIFF
--- a/packages/toolkit/create-countryconfig/index.js
+++ b/packages/toolkit/create-countryconfig/index.js
@@ -151,7 +151,7 @@ function cloneRepository(
   repoUrl,
   ref,
   targetDir,
-  { keepHistory = false } = {}
+  { keepHistory = false, replaceOriginWithUpstream = false } = {}
 ) {
   const depthFlag = keepHistory ? '' : '--depth 1 '
   execSync(
@@ -179,6 +179,17 @@ function cloneRepository(
       )
       process.exit(1)
     }
+  }
+  if (replaceOriginWithUpstream) {
+    console.log("Replacing 'origin' remote with 'upstream' in " + targetDir + "...")
+    execSync('git remote remove origin', {
+      cwd: targetDir,
+      stdio: 'inherit'
+    })
+    execSync('git remote add upstream ' + repoUrl, {
+      cwd: targetDir,
+      stdio: 'inherit'
+    })
   }
 }
 
@@ -251,7 +262,8 @@ console.log(
 
 try {
   cloneRepository(INFRASTRUCTURE_REPO_URL, ref, infrastructureDirName, {
-    keepHistory: true
+    keepHistory: true,
+    replaceOriginWithUpstream: true
   })
 } catch (err) {
   console.error('Failed to clone the infrastructure repository:', err.message)
@@ -267,4 +279,3 @@ console.log('  git init')
 console.log('  npm install\n')
 console.log('To get started with the infrastructure:\n')
 console.log('  cd ' + infrastructureDirName)
-console.log('  git init\n')

--- a/packages/toolkit/create-countryconfig/index.js
+++ b/packages/toolkit/create-countryconfig/index.js
@@ -151,7 +151,7 @@ function cloneRepository(
   repoUrl,
   ref,
   targetDir,
-  { keepHistory = false, replaceOriginWithUpstream = false } = {}
+  { keepHistory = false } = {}
 ) {
   const depthFlag = keepHistory ? '' : '--depth 1 '
   execSync(
@@ -179,18 +179,20 @@ function cloneRepository(
       )
       process.exit(1)
     }
+    return
   }
-  if (replaceOriginWithUpstream) {
-    console.log("Replacing 'origin' remote with 'upstream' in " + targetDir + "...")
-    execSync('git remote remove origin', {
-      cwd: targetDir,
-      stdio: 'inherit'
-    })
-    execSync('git remote add upstream ' + repoUrl, {
-      cwd: targetDir,
-      stdio: 'inherit'
-    })
-  }
+
+  console.log(
+    "Replacing 'origin' remote with 'upstream' in " + targetDir + '...'
+  )
+  execSync('git remote remove origin', {
+    cwd: targetDir,
+    stdio: 'inherit'
+  })
+  execSync('git remote add upstream ' + repoUrl, {
+    cwd: targetDir,
+    stdio: 'inherit'
+  })
 }
 
 const projectName = process.argv[2]
@@ -262,8 +264,7 @@ console.log(
 
 try {
   cloneRepository(INFRASTRUCTURE_REPO_URL, ref, infrastructureDirName, {
-    keepHistory: true,
-    replaceOriginWithUpstream: true
+    keepHistory: true
   })
 } catch (err) {
   console.error('Failed to clone the infrastructure repository:', err.message)
@@ -279,3 +280,9 @@ console.log('  git init')
 console.log('  npm install\n')
 console.log('To get started with the infrastructure:\n')
 console.log('  cd ' + infrastructureDirName)
+console.log('  git remote add origin <your-infrastructure-repo-url>')
+console.log('  git push -u origin ' + ref + '\n')
+console.log(
+  'The "upstream" remote points at the official infrastructure repository, ' +
+    'so you can pull future releases with `git fetch upstream`.\n'
+)


### PR DESCRIPTION
## Description

Goal of this PR is to properly init both repositories:
- countryconfig
- infrastructure

## Testing

<img width="730" height="654" alt="image" src="https://github.com/user-attachments/assets/e3b96454-b027-4029-94e0-ab81a1c68d5b" />

Remote upstream in infrastructure repository:

<img width="540" height="83" alt="image" src="https://github.com/user-attachments/assets/92be4291-12ee-405e-93e9-73157734fb99" />


Countryconfig repository status:

<img width="520" height="48" alt="image" src="https://github.com/user-attachments/assets/3b2ca6c6-abfe-4f0f-b4f4-8dce15ec1748" />


## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
