### PR TITLE
fix: don't restart data-seed job on failure

### DIFF
--- a/charts/opencrvs-services/templates/data-seed-job.yaml
+++ b/charts/opencrvs-services/templates/data-seed-job.yaml
@@ -47,7 +47,8 @@ spec:
                   name: {{ .Values.minio.users_secret }}
           {{- end }}
           {{- include "render-env-vars" (dict "service_name" "data_seed" "Values" .Values) }}
-      restartPolicy: "OnFailure"
+      restartPolicy: "Never"
+  backoffLimit: 0
 
 {{ include "network-policy-rules" (dict "service_name" "deployment-jobs" "Values" .Values) }}
 


### PR DESCRIPTION
## Description

Set restartPolicy to Never and backoffLimit to 0 so the data-seed post-install hook job fails fast instead of retrying, per Kubernetes docs recommendation for run-once Jobs.

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
