### PR TITLE
fix(client): show assignee avatar immediately after assigning

### DIFF
--- a/packages/client/src/v2-events/features/events/useEvents/api.ts
+++ b/packages/client/src/v2-events/features/events/useEvents/api.ts
@@ -20,6 +20,7 @@ import {
   EventDocument,
   EventDocumentOnlyLastAction,
   EventIndex,
+  ActionType,
   findLastAssignmentAction,
   getCurrentEventState,
   User
@@ -309,12 +310,29 @@ export async function onMarkNotDuplicate(data: EventDocument) {
   await refetchSearchQuery(data.id)
 }
 
-export async function onAssign(updatedEvent: EventDocumentOnlyLastAction) {
-  await Promise.all([
-    invalidateWorkqueues(),
-    refetchSearchQuery(updatedEvent.id)
-  ])
+/**
+ * Write a new assignee onto every cached search result for an event.
+ *
+ * Only the assignment is patched, never the whole row: the server redacts a
+ * sealed record's index while leaving the document readable, so rebuilding the
+ * row from the local document would put the real title back on screen.
+ */
+function setLocalEventIndexAssignment(id: string, assignedTo: string | null) {
+  getQueriesData(trpcOptionsProxy.event.search).forEach(([queryKey]) => {
+    queryClient.setQueryData<inferOutput<typeof trpcOptionsProxy.event.search>>(
+      queryKey,
+      (oldData) =>
+        oldData && {
+          ...oldData,
+          results: oldData.results.map((eventIndex) =>
+            eventIndex.id === id ? { ...eventIndex, assignedTo } : eventIndex
+          )
+        }
+    )
+  })
+}
 
+export async function onAssign(updatedEvent: EventDocumentOnlyLastAction) {
   const lastAssignment = findLastAssignmentAction(updatedEvent.actions)
   const localEvent = findLocalEventDocument(updatedEvent.id)
 
@@ -328,6 +346,22 @@ export async function onAssign(updatedEvent: EventDocumentOnlyLastAction) {
     ...updatedEvent,
     actions: localActions.concat(updatedEvent.actions)
   })
+
+  /*
+   * Nothing below refreshes the workqueue rows: `invalidateWorkqueues` only
+   * invalidates `workqueue.count` and `refetchSearchQuery` only the by-id
+   * entry, while the count-diff (procedures/count.ts) never fires for an
+   * assignment, which moves no record between workqueues.
+   */
+  setLocalEventIndexAssignment(
+    updatedEvent.id,
+    lastAssignment.type === ActionType.ASSIGN ? lastAssignment.assignedTo : null
+  )
+
+  await Promise.all([
+    invalidateWorkqueues(),
+    refetchSearchQuery(updatedEvent.id)
+  ])
 }
 
 export async function refetchDraftsList() {


### PR DESCRIPTION
Closes #13648

### Before
https://github.com/user-attachments/assets/93b594c5-3e0b-492e-a688-7c9fff042b10

### After
https://github.com/user-attachments/assets/e26df4dc-772f-44c1-a32e-f52cc7164d5b

