### PR TITLE
Hide action specific content from 'Waiting for external validation' -dialog

### DIFF
--- a/packages/client/src/v2-events/features/workqueues/EventOverview/components/EventHistory/EventHistoryDialog/EventHistoryDialog.stories.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/components/EventHistory/EventHistoryDialog/EventHistoryDialog.stories.tsx
@@ -100,7 +100,7 @@ const fullEvent = {
 }
 
 const argbase = {
-  userName: 'Jhon Doe',
+  userName: 'Jane Doe',
   fullEvent,
   validatorContext: getTestValidatorContext(),
   action: {
@@ -112,7 +112,7 @@ const meta: Meta<typeof EventHistoryDialog> = {
   title: 'Components/EventHistoryDialog',
   component: EventHistoryDialog,
   args: {
-    userName: 'Jhon Doe',
+    userName: 'Jane Doe',
     fullEvent,
     validatorContext: getTestValidatorContext()
   }
@@ -299,7 +299,53 @@ export const RegisteredWithDialogFormValues: Story = {
   }
 }
 
-const generator = testDataGenerator()
+const waitingForExternalValidationRegisterAction = {
+  ...actionBase,
+  status: 'Requested' as const,
+  id: generateUuid(prng),
+  type: ActionType.REGISTER,
+  declaration,
+  annotation: {
+    'register.dialog.comments': 'Reviewed all supporting documents'
+  }
+}
+
+const eventWaitingForExternalValidation = {
+  id: getUUID(),
+  type: 'tennis-club-membership',
+  actions: [
+    {
+      ...actionBase,
+      id: generateUuid(prng),
+      type: ActionType.CREATE
+    },
+    {
+      ...actionBase,
+      id: generateUuid(prng),
+      type: ActionType.DECLARE,
+      declaration
+    },
+    waitingForExternalValidationRegisterAction
+  ],
+  trackingId: 'ABCD123',
+  updatedAt: '2021-01-01',
+  createdAt: '2021-01-01'
+}
+
+export const WaitingForExternalValidation: Story = {
+  name: 'Waiting for external validation — no Register details (regression: #13735)',
+  args: {
+    ...argbase,
+    title: 'Waiting for external validation',
+    fullEvent: eventWaitingForExternalValidation,
+    action: waitingForExternalValidationRegisterAction
+  },
+  parameters: {
+    offline: {
+      configs: [eventConfigurationWithRegisterForm]
+    }
+  }
+}
 
 export const Rejected: Story = {
   args: {
@@ -334,7 +380,7 @@ export const Archived: Story = {
     const canvas = within(canvasElement)
     // Wait for the dialog to render before asserting on absence.
     await expect(
-      canvas.findByText('Jhon Doe', { exact: false })
+      canvas.findByText('Jane Doe', { exact: false })
     ).resolves.toBeInTheDocument()
     await expect(canvas.queryByText('Comment')).not.toBeInTheDocument()
   }

--- a/packages/client/src/v2-events/features/workqueues/EventOverview/components/EventHistory/EventHistoryDialog/components/ActionTypeSpecificContent.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/components/EventHistory/EventHistoryDialog/components/ActionTypeSpecificContent.tsx
@@ -11,6 +11,7 @@
 import React from 'react'
 import {
   ActionDocument,
+  ActionStatus,
   ActionType,
   EventDocument,
   ValidatorContext
@@ -86,6 +87,11 @@ export function ActionTypeSpecificContent({
   ]
 
   if (coreDialogFormActions.includes(type)) {
+    // For the "Waiting for external validation" action, dont render any form content.
+    if (action.status === ActionStatus.Requested) {
+      return null
+    }
+
     return (
       <ActionFormContent
         action={action}


### PR DESCRIPTION
## Description

Resolves https://github.com/opencrvs/opencrvs-core/issues/13735

Before:
<img width="800"  alt="Screenshot 2026-09-08 at 12 44 53" src="https://github.com/user-attachments/assets/10747a10-a821-4d1a-a81c-f7944ace287d" />

After:
<img width="800" alt="Screenshot 2026-09-08 at 12 44 18" src="https://github.com/user-attachments/assets/ed80f0c9-b5eb-4119-97f4-ae6c03a1e845" />


## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
