### PR TITLE
Fix issues on certificate templates

### DIFF
--- a/packages/testland/e2e/testcases/application/side-menu-navigation.spec.ts
+++ b/packages/testland/e2e/testcases/application/side-menu-navigation.spec.ts
@@ -134,7 +134,7 @@ test.describe('Side menu navigation', () => {
 
     await expect(
       page.getByRole('button', { name: 'Assigned to you' })
-    ).toBeVisible()
+    ).toBeVisible({ timeout: 30_000 })
     await expect(page.getByRole('button', { name: 'Recent' })).toBeVisible()
   })
 

--- a/packages/testland/e2e/testcases/print-certificate/birth/validate-pdf-details.spec.ts
+++ b/packages/testland/e2e/testcases/print-certificate/birth/validate-pdf-details.spec.ts
@@ -91,6 +91,16 @@ test.describe
       'Ibombo, Central, Farajaland'
     )
   })
+
+  test('Place of registration includes the office name', async () => {
+    await expect(page.locator('#print')).toContainText('Ibombo District Office')
+  })
+
+  test('Certificate count area has no missing-translation text', async () => {
+    await expect(page.locator('#print')).not.toContainText(
+      'Missing translation for certificates.birth.printedCertificateCount'
+    )
+  })
 })
 
 test.describe.serial("Validate 'Birth Certificate' PDF details", () => {
@@ -138,6 +148,16 @@ test.describe.serial("Validate 'Birth Certificate' PDF details", () => {
     await expect(page.locator('#print')).toContainText('Klow Village Hospital')
     await expect(page.locator('#print')).toContainText(
       'Ibombo, Central, Farajaland'
+    )
+  })
+
+  test('Place of registration includes the office name', async () => {
+    await expect(page.locator('#print')).toContainText('Ibombo District Office')
+  })
+
+  test('Certificate count area has no missing-translation text', async () => {
+    await expect(page.locator('#print')).not.toContainText(
+      'Missing translation for certificates.birth.printedCertificateCount'
     )
   })
 })

--- a/packages/testland/src/api/certificates/source/v2.birth-certificate-certified-copy.svg
+++ b/packages/testland/src/api/certificates/source/v2.birth-certificate-certified-copy.svg
@@ -15,8 +15,8 @@ Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencr
     font-size="8" letter-spacing="0px">
     <tspan x="220.625" y="678.552">&#x2028;</tspan>
     <tspan x="61" y="691.352">{{ $lookup $metadata "modifiedAt"}}</tspan>
-    <tspan x="61" y="701.352">{{$intlWithParams 'certificates.birth.printedCertificateCount'
-      'copiesPrintedForTemplate' ($lookup $metadata "copiesPrintedForTemplate")}}</tspan>
+    {{#ifCond ($lookup $metadata "legalStatuses.REGISTERED.createdAtLocation.name") '!==' undefined }}<tspan x="61" y="701.352">{{$intlWithParams 'certificates.birth.printedCertificateCount'
+      'copiesPrintedForTemplate' ($lookup $metadata "copiesPrintedForTemplate")}}</tspan>{{/ifCond}}
   </text>
   <text fill="#222222" xml:space="preserve" style="white-space: pre" font-family="Noto Sans"
     font-size="8" font-weight="600" letter-spacing="0px">
@@ -345,7 +345,7 @@ Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencr
         {{#ifCond (lookup $declaration 'father.addressSameAs') '===' 'YES'}}
           <tspan x="307" y="432.104">{{$lookup $declaration 'mother.address.administrativeHierarchy'}}</tspan>
         {{else}}
-          <tspan x="307" y="432.104">{{$join ", " ($or ($lookup $declaration 'father.address.district') ($lookup $declaration 'father.address.streetLevelDetails.district2')) ($or ($lookup $declaration 'father.address.province') ($lookup $declaration 'father.address.streetLevelDetails.state')) ($lookup $declaration 'father.address.country')}}</tspan>
+          <tspan x="307" y="432.104">{{$lookup $declaration 'father.address.administrativeHierarchy'}}</tspan>
         {{/ifCond}}
       {{/ifCond}}
     </text>
@@ -422,7 +422,7 @@ Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencr
   <g clip-path="url(#clip17_946_2501)">
     <text fill="#222222" xml:space="preserve" style="white-space: pre" font-family="Noto Sans"
       font-size="8" letter-spacing="0px">
-      <tspan x="307" y="550.104">{{$join ", " ($lookup $metadata "legalStatuses.REGISTERED.createdAtLocation.district") ($lookup $metadata "legalStatuses.REGISTERED.createdAtLocation.province") ($lookup $metadata "legalStatuses.REGISTERED.createdAtLocation.country")}}</tspan>
+      <tspan x="307" y="550.104">{{$join ", " ($lookup $metadata "legalStatuses.REGISTERED.createdAtLocation.name") ($lookup $metadata "legalStatuses.REGISTERED.createdAtLocation.district") ($lookup $metadata "legalStatuses.REGISTERED.createdAtLocation.province") ($lookup $metadata "legalStatuses.REGISTERED.createdAtLocation.country")}}</tspan>
     </text>
   </g>
   <line x1="65" y1="556.5" x2="533" y2="556.5" stroke="#ECECEC" />

--- a/packages/testland/src/api/certificates/source/v2.birth-certificate.svg
+++ b/packages/testland/src/api/certificates/source/v2.birth-certificate.svg
@@ -75,8 +75,8 @@ Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencr
     font-size="8" letter-spacing="0px">
     <tspan x="234.289" y="654.552">&#x2028;</tspan>
     <tspan x="80.9999" y="667.352">{{$lookup $metadata "updatedAt"}}</tspan>
-    <tspan x="80.9999" y="643.352">{{$intlWithParams 'certificates.birth.printedCertificateCount'
-      'copiesPrintedForTemplate' ($lookup $metadata "copiesPrintedForTemplate")}}</tspan>
+    {{#ifCond ($lookup $metadata "legalStatuses.REGISTERED.createdAtLocation.name") '!==' undefined }}<tspan x="80.9999" y="643.352">{{$intlWithParams 'certificates.birth.printedCertificateCount'
+      'copiesPrintedForTemplate' ($lookup $metadata "copiesPrintedForTemplate")}}</tspan>{{/ifCond}}
   </text>
   <text fill="#222222" xml:space="preserve" style="white-space: pre" font-family="Noto Sans"
     font-size="8" font-weight="bold" letter-spacing="0px">

--- a/packages/testland/src/translations/countryconfig.csv
+++ b/packages/testland/src/translations/countryconfig.csv
@@ -7,6 +7,7 @@ birth.search.criteria.label.prefix.mother,Mother prefix,Mother's,De la mère
 certificates.birth.certificate,Birth Certificate,Birth Certificate,Acte de naissance
 certificates.birth.certificate.copy,Birth Certificate Certified Copy,Birth Certificate Certified Copy,Copie certifiée conforme de l'acte de naissance
 certificates.birth.registration.receipt,Birth Registration Receipt,Birth Registration Receipt,Reçu d'enregistrement de naissance
+certificates.birth.printedCertificateCount,Number of copies printed of this birth certificate,Printed copies: {copiesPrintedForTemplate},Exemplaires imprimés : {copiesPrintedForTemplate}
 certificates.death.certificate,Death Certificate,Death Certificate,Certificat de décès
 certificates.death.certificate.copy,Death Certificate Certified Copy,Death Certificate Certified Copy,Copie certifiée conforme du certificat de décès
 certificates.marriage.certificate,Marriage Certificate,Marriage Certificate,Acte de mariage


### PR DESCRIPTION
## Description

Resolves https://github.com/opencrvs/opencrvs-core/issues/13731
Resolves https://github.com/opencrvs/opencrvs-core/issues/13652

* Certified copy: place of registration now includes the office name, and fathers address shows all 4 levels like mothers
* Printed count: added the missing translation, and hid the count on advance-of-registration prints


## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
