### PR TITLE
fix: Manage utilities images as part of init-release

### DIFF
--- a/.github/workflows/build-images-from-branch.yml
+++ b/.github/workflows/build-images-from-branch.yml
@@ -465,7 +465,7 @@ jobs:
     if: success() && github.event_name == 'push' && github.ref_name == 'develop'
     runs-on: ubuntu-26.04
     steps:
-      - uses: actions/github-script@v8
+      - uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.TESTLAND_WORKFLOW_TOKEN }}
           script: |

--- a/.github/workflows/check-missing-translation.yml
+++ b/.github/workflows/check-missing-translation.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js from core nvmrc
         uses: actions/setup-node@v6

--- a/.github/workflows/clean-up-pr-environment.yml
+++ b/.github/workflows/clean-up-pr-environment.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Slugify the branch name for k8s
         id: slugify-branch-name
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             function slugify(str) {
@@ -57,7 +57,7 @@ jobs:
 
       - name: Remove keep e2e label
         if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, '🔒 Keep e2e') }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.issues.removeLabel({
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-26.04
     steps:
       - name: Trigger namespace cleanup workflow in e2e
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.E2E_WORKFLOWS_TOKEN }}
           script: |

--- a/.github/workflows/countryconfig-to-openapi.yml
+++ b/.github/workflows/countryconfig-to-openapi.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/deploy-to-feature-environment.yml
+++ b/.github/workflows/deploy-to-feature-environment.yml
@@ -165,7 +165,7 @@ jobs:
 
       - name: Slugify the branch name
         id: slugify_bname
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             function slugify(str) {
@@ -241,7 +241,7 @@ jobs:
 
       - name: Trigger E2E Workflow
         id: dispatch_e2e
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           # TODO: Replace with fine-grained e2e token
           github-token: ${{ secrets.E2E_WORKFLOWS_TOKEN }}
@@ -311,7 +311,7 @@ jobs:
     runs-on: ubuntu-26.04
     steps:
       - name: Wait for Environment Deployment (Deploy Job)
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.E2E_WORKFLOWS_TOKEN }}
           script: |
@@ -363,7 +363,7 @@ jobs:
               }
             }
       - name: Update github comment on PR
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.CORE_ISSUES_PR_TOKEN }}
           script: |
@@ -391,7 +391,7 @@ jobs:
             }
 
       - name: Wait for E2E Workflow Completion
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.E2E_WORKFLOWS_TOKEN }}
           script: |

--- a/.github/workflows/fix-renovate-lockfile.yml
+++ b/.github/workflows/fix-renovate-lockfile.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Setup pnpm
         # No `version:` — action-setup reads `packageManager` from package.json
         # (pnpm@10.34.5), matching what the lockfile was authored with.
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Use Node.js from .nvmrc
         uses: actions/setup-node@v6

--- a/.github/workflows/init-release.yml
+++ b/.github/workflows/init-release.yml
@@ -74,7 +74,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Use Node.js from .nvmrc
         uses: actions/setup-node@v6
@@ -240,7 +240,7 @@ jobs:
       # ("refs/heads/master") that context.ref carries. The workflow dispatch
       # API requires a plain branch name, so ref_name is the correct value.
       - name: Trigger workflow in infrastructure
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.INFRASTRUCTURE_WORKFLOW_TOKEN }}
           script: |
@@ -254,7 +254,7 @@ jobs:
               }
             })
       - name: Create release branch in e2e repo
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.E2E_WORKFLOWS_TOKEN }}
           script: |

--- a/.github/workflows/init-release.yml
+++ b/.github/workflows/init-release.yml
@@ -133,6 +133,10 @@ jobs:
           ' charts/opencrvs-services/values.yaml
           rm charts/opencrvs-services/values.yaml.bak
 
+          # Bump the shared utilities image tag (used by helper jobs and init
+          # containers) to track the same release version.
+          yq -i ".utilities.image.tag = \"v$VERSION\"" charts/dependencies/values.yaml
+
           # Point the countryconfig-template Tiltfile's local-dev defaults at
           # this release, so `tilt up` picks up the right core images and
           # Helm charts out of the box without anyone needing to export

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -48,7 +48,7 @@ jobs:
               - If it's a breaking change, include a migration guide answering "What do I need to do to upgrade?".
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Use Node.js from .nvmrc
         uses: actions/setup-node@v6
@@ -130,7 +130,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Use Node.js from .nvmrc
         uses: actions/setup-node@v6
@@ -210,7 +210,7 @@ jobs:
 
       - name: Setup pnpm
         if: steps.check-scripts.outputs.skip != 'true'
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Use Node.js from .nvmrc
         if: steps.check-scripts.outputs.skip != 'true'
@@ -309,7 +309,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Use Node.js from .nvmrc
         uses: actions/setup-node@v6
@@ -346,7 +346,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Use Node.js from .nvmrc
         uses: actions/setup-node@v6
@@ -406,7 +406,7 @@ jobs:
           path: .
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Use Node.js from .nvmrc
         uses: actions/setup-node@v6
@@ -461,7 +461,7 @@ jobs:
           path: .
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Use Node.js from .nvmrc
         uses: actions/setup-node@v6
@@ -512,7 +512,7 @@ jobs:
           path: .
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Use Node.js from .nvmrc
         uses: actions/setup-node@v6
@@ -556,7 +556,7 @@ jobs:
           path: .
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Use Node.js from .nvmrc
         uses: actions/setup-node@v6
@@ -591,7 +591,7 @@ jobs:
           path: pr
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           package_json_file: pr/package.json
 
@@ -652,7 +652,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Use Node.js from .nvmrc
         uses: actions/setup-node@v6

--- a/.github/workflows/publish-toolkit-to-npm.yml
+++ b/.github/workflows/publish-toolkit-to-npm.yml
@@ -234,7 +234,7 @@ jobs:
           ref: ${{ needs.plan.outputs.sha }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/test-upgrade-script.yml
+++ b/.github/workflows/test-upgrade-script.yml
@@ -35,7 +35,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || github.ref }}
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
       - name: Use Node.js from .nvmrc
         uses: actions/setup-node@v6
         with:

--- a/charts/dependencies/values.yaml
+++ b/charts/dependencies/values.yaml
@@ -507,4 +507,4 @@ priority_class:
 utilities:
   image:
     repository: ghcr.io/opencrvs/ocrvs-utilities
-    tag: v2.1.0
+    tag: v2.1.0-beta


### PR DESCRIPTION
## FIXME

After merging this PR close following PRs:
- https://github.com/opencrvs/opencrvs-core/pull/13747
- https://github.com/opencrvs/opencrvs-core/pull/13746

Remove branches:
- release/1.2.3
- release/1.2.4

## Description

- `init-release.yml` bumped image tags in `charts/opencrvs-services/values.yaml` but never touched `charts/dependencies/values.yaml`, so the shared `utilities` image tag (used by backup/restore helper jobs and init containers) stayed pinned at an old version instead of tracking the release.
- Added a `yq` step that sets `utilities.image.tag` in `charts/dependencies/values.yaml` to `v<VERSION>` alongside the existing `opencrvs-services` bump.
- Upgraded GitHub few actions steps

## Testing

Run test:
1. Create release branch release/1.2.3 at opencrvs-core and infrastructure
2. Run "Release - Start a new release" action: https://github.com/opencrvs/opencrvs-core/actions/runs/34240187413

Produced artifacts:

PRs at core:
- https://github.com/opencrvs/opencrvs-core/pull/13747
- https://github.com/opencrvs/opencrvs-core/pull/13746

Changes are present:
<img width="1179" height="291" alt="image" src="https://github.com/user-attachments/assets/fa33949c-bb6f-4f89-a0b5-d2ea404271e5" />


## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
