### PR TITLE
Mobile fix: back-button loops between search results and a record

### DIFF
--- a/packages/client/src/v2-events/features/events/ReadOnlyView.tsx
+++ b/packages/client/src/v2-events/features/events/ReadOnlyView.tsx
@@ -173,7 +173,9 @@ function ReadonlyView() {
   const trpc = useTRPC()
 
   if (!canAccessEventWithScopes()) {
-    navigate(ROUTES.V2.EVENTS.EVENT.buildPath({ eventId }, { backTo }))
+    navigate(ROUTES.V2.EVENTS.EVENT.buildPath({ eventId }, { backTo }), {
+      replace: true
+    })
     return null
   }
 

--- a/packages/client/src/v2-events/features/events/Search/SearchResult/SearchResultItemTitle.tsx
+++ b/packages/client/src/v2-events/features/events/Search/SearchResult/SearchResultItemTitle.tsx
@@ -55,8 +55,7 @@ export function SearchResultItemTitle({
       color={useFallbackTitle ? 'red' : 'primary'}
       onClick={() => {
         navigate(
-          ROUTES.V2.EVENTS.EVENT.buildPath({ eventId: event.id }, { backTo }),
-          { state: { fromList: true } }
+          ROUTES.V2.EVENTS.EVENT.buildPath({ eventId: event.id }, { backTo })
         )
       }}
     >

--- a/packages/client/src/v2-events/features/events/Search/SearchResult/SearchResultItemTitle.tsx
+++ b/packages/client/src/v2-events/features/events/Search/SearchResult/SearchResultItemTitle.tsx
@@ -55,7 +55,8 @@ export function SearchResultItemTitle({
       color={useFallbackTitle ? 'red' : 'primary'}
       onClick={() => {
         navigate(
-          ROUTES.V2.EVENTS.EVENT.buildPath({ eventId: event.id }, { backTo })
+          ROUTES.V2.EVENTS.EVENT.buildPath({ eventId: event.id }, { backTo }),
+          { state: { fromList: true } }
         )
       }}
     >

--- a/packages/client/src/v2-events/layouts/EventOverview/index.tsx
+++ b/packages/client/src/v2-events/layouts/EventOverview/index.tsx
@@ -184,7 +184,7 @@ export function EventOverviewLayout({
 
   const exit = () => {
     if (backTo) {
-      navigate(backTo)
+      navigate(backTo, { replace: true })
       return
     }
 

--- a/packages/client/src/v2-events/layouts/EventOverview/index.tsx
+++ b/packages/client/src/v2-events/layouts/EventOverview/index.tsx
@@ -11,7 +11,13 @@
 
 import React from 'react'
 import { defineMessages, useIntl } from 'react-intl'
-import { useLocation, useNavigate, matchPath } from 'react-router-dom'
+import {
+  useLocation,
+  useNavigate,
+  useNavigationType,
+  matchPath,
+  NavigationType
+} from 'react-router-dom'
 import {
   useTypedParams,
   useTypedSearchParams
@@ -108,7 +114,9 @@ function EventOverviewTabs() {
       <Tab
         className={isActive(ROUTES.V2.EVENTS.EVENT.path) ? 'active' : ''}
         onClick={() => {
-          navigate(ROUTES.V2.EVENTS.EVENT.buildPath({ eventId }, { backTo }))
+          navigate(ROUTES.V2.EVENTS.EVENT.buildPath({ eventId }, { backTo }), {
+            replace: true
+          })
         }}
       >
         {intl.formatMessage(messages.summary)}
@@ -120,7 +128,8 @@ function EventOverviewTabs() {
           }
           onClick={() => {
             navigate(
-              ROUTES.V2.EVENTS.EVENT.RECORD.buildPath({ eventId }, { backTo })
+              ROUTES.V2.EVENTS.EVENT.RECORD.buildPath({ eventId }, { backTo }),
+              { replace: true }
             )
           }}
         >
@@ -131,7 +140,8 @@ function EventOverviewTabs() {
         className={isActive(ROUTES.V2.EVENTS.EVENT.AUDIT.path) ? 'active' : ''}
         onClick={() => {
           navigate(
-            ROUTES.V2.EVENTS.EVENT.AUDIT.buildPath({ eventId }, { backTo })
+            ROUTES.V2.EVENTS.EVENT.AUDIT.buildPath({ eventId }, { backTo }),
+            { replace: true }
           )
         }}
       >
@@ -165,6 +175,7 @@ export function EventOverviewLayout({
   const eventResults = searchEventById.useSuspenseQuery(eventId)
 
   const navigate = useNavigate()
+  const navigationType = useNavigationType()
   const intl = useIntl()
   const flattenedIntl = useIntlFormatMessageWithFlattenedParams()
   if (eventResults.total === 0) {
@@ -181,15 +192,17 @@ export function EventOverviewLayout({
     : event
 
   const isDraft = event.status === EventStatus.enum.CREATED
-  const location = useLocation()
 
   const exit = () => {
+    // If backTo is set and we navigated via push (from a list), pop history to go back to the list.
+    // Otherwise, replace or go home as appropriate.
+    if (backTo && navigationType === NavigationType.Push) {
+      navigate(-1)
+      return
+    }
+
     if (backTo) {
-      if (location.state?.fromList) {
-        navigate(-1)
-      } else {
-        navigate(backTo, { replace: true })
-      }
+      navigate(backTo, { replace: true })
       return
     }
 

--- a/packages/client/src/v2-events/layouts/EventOverview/index.tsx
+++ b/packages/client/src/v2-events/layouts/EventOverview/index.tsx
@@ -181,10 +181,15 @@ export function EventOverviewLayout({
     : event
 
   const isDraft = event.status === EventStatus.enum.CREATED
+  const location = useLocation()
 
   const exit = () => {
     if (backTo) {
-      navigate(backTo, { replace: true })
+      if (location.state?.fromList) {
+        navigate(-1)
+      } else {
+        navigate(backTo, { replace: true })
+      }
       return
     }
 

--- a/packages/testland/e2e/testcases/correction-birth/correct-birth-verified-parent-creates-child-uin.spec.ts
+++ b/packages/testland/e2e/testcases/correction-birth/correct-birth-verified-parent-creates-child-uin.spec.ts
@@ -10,12 +10,7 @@
  */
 import path from 'path'
 import { test, expect } from '@playwright/test'
-import {
-  getToken,
-  login,
-  searchFromSearchBar,
-  switchEventTab
-} from '@e2e/support/helpers'
+import { getToken, login, switchEventTab } from '@e2e/support/helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS, GATEWAY_HOST } from '@e2e/support/constants'
 import {
@@ -43,8 +38,10 @@ async function getEventById(eventId: string, token: string) {
 }
 
 test('Correcting a birth with a verified parent ID creates the child UIN (#13734)', async ({
-  page
+  page,
+  context
 }) => {
+  test.setTimeout(180_000)
   let token: string
   let declaration: Declaration
   let eventId: string

--- a/packages/testland/e2e/testcases/correction-birth/correct-birth-verified-parent-creates-child-uin.spec.ts
+++ b/packages/testland/e2e/testcases/correction-birth/correct-birth-verified-parent-creates-child-uin.spec.ts
@@ -38,8 +38,7 @@ async function getEventById(eventId: string, token: string) {
 }
 
 test('Correcting a birth with a verified parent ID creates the child UIN (#13734)', async ({
-  page,
-  context
+  page
 }) => {
   test.setTimeout(180_000)
   let token: string

--- a/packages/testland/e2e/testcases/navigation/navigating-out-of-record-from-advanced-search.mobile.spec.ts
+++ b/packages/testland/e2e/testcases/navigation/navigating-out-of-record-from-advanced-search.mobile.spec.ts
@@ -67,9 +67,8 @@ test('Mobile: in-app Back on advanced-search results does not loop back into the
     await expect(page.getByTestId('search-result')).toBeVisible()
   })
 
-  await test.step('In-app Back must not re-open the closed record', async () => {
+  await test.step('In-app Back returns to the page before the search results', async () => {
     await page.locator('#header-go-back-button').click()
-    await expect(page.getByTestId('exit-event')).toBeHidden()
-    await expect(page).toHaveURL(/.*\/(advanced-search|search-result)/)
+    await expectInUrl(page, '/advanced-search')
   })
 })

--- a/packages/testland/e2e/testcases/navigation/navigating-out-of-record-from-advanced-search.mobile.spec.ts
+++ b/packages/testland/e2e/testcases/navigation/navigating-out-of-record-from-advanced-search.mobile.spec.ts
@@ -1,0 +1,75 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+import { expect, test } from '@playwright/test'
+import { getToken, login } from '@e2e/support/helpers'
+import { createDeclaration } from '@e2e/support/test-data/birth-declaration-with-father-brother'
+import { CREDENTIALS } from '@e2e/support/constants'
+import { expectInUrl, type } from '@e2e/support/utils'
+import { setMobileViewport } from '@e2e/support/mobile-helpers'
+
+test('Mobile: in-app Back on advanced-search results does not loop back into the closed record (#13677)', async ({
+  page
+}) => {
+  await setMobileViewport(page)
+
+  const token = await getToken(CREDENTIALS.REGISTRAR)
+  const record = await createDeclaration(token, {
+    'child.gender': 'female'
+  })
+  const { eventId } = record
+  const childFirstName = record.declaration['child.name'].firstname
+  const childSurname = record.declaration['child.name'].surname
+
+  await test.step('Login', async () => {
+    await login(page, CREDENTIALS.REGISTRAR)
+  })
+
+  await test.step('Run an advanced search that returns the record', async () => {
+    await page
+      .getByRole('button', { name: 'Go to search', exact: true })
+      .click()
+    await expectInUrl(page, '/search')
+
+    await page.click('#searchType')
+    await expectInUrl(page, '/advanced-search')
+
+    await page.getByText('Birth').click()
+    await page.getByText('Child details').click()
+    await type(page, '#firstname', childFirstName)
+    await type(page, '#surname', childSurname)
+
+    await page.click('#search')
+    await expect(page).toHaveURL(/.*\/search-result/)
+    await expect(page.getByTestId('search-result')).toBeVisible()
+  })
+
+  await test.step('Open the record from the search results', async () => {
+    await page
+      .getByTestId('search-result')
+      .getByRole('button', { name: new RegExp(childFirstName) })
+      .click()
+
+    await expectInUrl(page, `/events/${eventId}`)
+    await expect(page.getByTestId('exit-event')).toBeVisible()
+  })
+
+  await test.step('Close the record with the X button', async () => {
+    await page.getByTestId('exit-event').click()
+    await expect(page).toHaveURL(/.*\/search-result/)
+    await expect(page.getByTestId('search-result')).toBeVisible()
+  })
+
+  await test.step('In-app Back must not re-open the closed record', async () => {
+    await page.locator('#header-go-back-button').click()
+    await expect(page.getByTestId('exit-event')).toBeHidden()
+    await expect(page).toHaveURL(/.*\/(advanced-search|search-result)/)
+  })
+})


### PR DESCRIPTION
## Description

Resolves: https://github.com/opencrvs/opencrvs-core/issues/13677

Opening a record from search results and closing it left the closed record one entry "back", so the Back button re-opened it instead of returning to the search form. Closing now mirrors the browser Back button.

Add e2e test

Fixed: 

https://github.com/user-attachments/assets/d57ff2ef-8ff1-46cc-8112-ed790754a63b



## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
