### PR TITLE
fix: Ensure JWT token key rotation is working correctly on each deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2.0.2 Release Candidate
 
+### Bug fixes
+
+- Ensure JWT token key rotation is working correctly on each deployment [#13036](https://github.com/opencrvs/opencrvs-core/issues/13036)
+
 ## 2.0.1 Release
 
 ### Security fixes

--- a/charts/opencrvs-services/templates/opencrvs-token-ssl.yaml
+++ b/charts/opencrvs-services/templates/opencrvs-token-ssl.yaml
@@ -2,15 +2,12 @@
 {{- $cn := printf "auth.%s.svc.cluster.local" .Release.Namespace }}
 {{- $cert := genSignedCert $cn nil (list $cn) 4096 $ca }}
 {{- $secret_name := printf "%s-key-tls" .Release.Name }}
-{{- $secret := lookup "v1" "Secret" .Release.Namespace $secret_name }}
-{{- if not $secret }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $secret_name }}
   annotations:
-    "helm.sh/resource-policy": keep
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "0"
 type: Opaque
@@ -37,4 +34,3 @@ data:
   {{- else }}
   "public-key.pem": {{ $cert.Cert | toYaml | indent 4}}
   {{- end }}
-{{- end }}


### PR DESCRIPTION
## Description

Related issue: https://github.com/opencrvs/opencrvs-core/issues/13036

Generate new TLS certificate on every deployment to force-logout users by the same way as docker swarm does now.


## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
  - [x] Tested with `strategy.type: RollingUpdate` to make sure users are not blocked
- [x] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
