### PR TITLE
fix(charts): remove nodePort from under the Service spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2.0.2 Release Candidate
 
+### Improvements
+
+- The dependencies Helm chart's datastore Services now support a configurable `service_type` [#13690](https://github.com/opencrvs/opencrvs-core/pull/13690)
+
 ### Bug fixes
 
 - Ensure JWT token key rotation is working correctly on each deployment [#13036](https://github.com/opencrvs/opencrvs-core/issues/13036)
@@ -24,7 +28,6 @@
 - Expose `POST /locations` and `POST /administrative-areas` REST endpoints to create or update a single location or administrative area, for correcting individual data-seeding errors. Bulk seeding is unaffected and still uses the existing `locations.set`/`administrativeAreas.set` tRPC mutations. [#13336](https://github.com/opencrvs/opencrvs-core/pull/13336)
 - The MOSIP charts now pass `OPENCRVS_AUTH_URL` to mosip-api and pin the mosip-api, mosip-mock and esignet-mock images to `2.0.1`. Implementations running the MOSIP integration should redeploy the `opencrvs-mosip` chart. [#13362](https://github.com/opencrvs/opencrvs-core/pull/13362)
 - Make the Deployment rollout strategy configurable, and default it to `Recreate`, for OpenCRVS services [#11994](https://github.com/opencrvs/opencrvs-core/issues/11994)
-- The dependencies Helm chart's datastore Services now support a configurable `service_type` [#13690](https://github.com/opencrvs/opencrvs-core/pull/13690)
 
 ### Bug fixes
 

--- a/charts/dependencies/templates/minio.yaml
+++ b/charts/dependencies/templates/minio.yaml
@@ -59,9 +59,6 @@ metadata:
   name: minio
 spec:
   type: {{ .Values.service_type | default "ClusterIP" }}
-  {{- if eq .Values.service_type "NodePort" }}
-  nodePort: {{ .Values.minio.node_port | default 30535 }}
-  {{- end }}
   ports:
     - name: '3535'
       port: 3535

--- a/charts/dependencies/templates/postgres.yaml
+++ b/charts/dependencies/templates/postgres.yaml
@@ -28,9 +28,6 @@ metadata:
   name: postgres
 spec:
   type: {{ .Values.service_type | default "ClusterIP" }}
-  {{- if eq .Values.service_type "NodePort" }}
-  nodePort: {{ .Values.postgres.node_port | default 30432 }}
-  {{- end }}
   ports:
     - port: 5432
       targetPort: 5432


### PR DESCRIPTION
The port does not belong under spec, it's already present under spec -> ports so these values were redundant