### PR TITLE
fix: regression bug for clusterIP immutable field

### DIFF
--- a/charts/dependencies/Chart.yaml
+++ b/charts/dependencies/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opencrvs-dependencies-chart
 description: Dependencies required by OpenCRVS
 type: application
-version: v2.0.1
-appVersion: v2.0.1
+version: v2.0.2
+appVersion: v2.0.2

--- a/charts/dependencies/templates/elasticsearch.yaml
+++ b/charts/dependencies/templates/elasticsearch.yaml
@@ -25,7 +25,11 @@ metadata:
     app: elasticsearch
   name: elasticsearch
 spec:
-  type: {{ .Values.service_type | default "ClusterIP" }}
+  {{- $service_type := default .Values.service_type .Values.elasticsearch.service_type }}
+  type: {{ $service_type }}
+  {{- if eq $service_type "ClusterIP" }}
+  clusterIP: None
+  {{- end }}
   ports:
     - name: '9200'
       port: 9200

--- a/charts/dependencies/templates/minio.yaml
+++ b/charts/dependencies/templates/minio.yaml
@@ -58,7 +58,11 @@ metadata:
     app: minio
   name: minio
 spec:
-  type: {{ .Values.service_type | default "ClusterIP" }}
+  {{- $service_type := default .Values.service_type .Values.minio.service_type }}
+  type: {{ $service_type }}
+  {{- if eq $service_type "ClusterIP" }}
+  clusterIP: None
+  {{- end }}
   ports:
     - name: '3535'
       port: 3535

--- a/charts/dependencies/templates/mongodb.yaml
+++ b/charts/dependencies/templates/mongodb.yaml
@@ -23,7 +23,11 @@ metadata:
     app: mongodb
   name: mongodb
 spec:
-  type: {{ .Values.service_type | default "ClusterIP" }}
+  {{- $service_type := default .Values.service_type .Values.mongodb.service_type }}
+  type: {{ $service_type }}
+  {{- if eq $service_type "ClusterIP" }}
+  clusterIP: None
+  {{- end }}
   ports:
     - port: 27017
       targetPort: 27017

--- a/charts/dependencies/templates/postgres.yaml
+++ b/charts/dependencies/templates/postgres.yaml
@@ -27,7 +27,11 @@ metadata:
     app: postgres
   name: postgres
 spec:
-  type: {{ .Values.service_type | default "ClusterIP" }}
+  {{- $service_type := default .Values.service_type .Values.postgres.service_type }}
+  type: {{ $service_type }}
+  {{- if eq $service_type "ClusterIP" }}
+  clusterIP: None
+  {{- end }}
   ports:
     - port: 5432
       targetPort: 5432

--- a/charts/dependencies/templates/redis.yaml
+++ b/charts/dependencies/templates/redis.yaml
@@ -6,7 +6,11 @@ metadata:
     app: redis
   name: redis
 spec:
-  type: {{ .Values.service_type | default "ClusterIP" }}
+  {{- $service_type := default .Values.service_type .Values.redis.service_type }}
+  type: {{ $service_type }}
+  {{- if eq $service_type "ClusterIP" }}
+  clusterIP: None
+  {{- end }}
   ports:
     - port: 6379
       targetPort: 6379

--- a/charts/dependencies/values.yaml
+++ b/charts/dependencies/values.yaml
@@ -20,6 +20,8 @@ ingress:
   # Resolver will be attached to Traefik CRD IngressRoute
   tls_resolver: ''
 
+service_type: ClusterIP
+
 # Kubernetes storage type, available options are `pvc` or `host_path`
 storage_type: pvc
 

--- a/charts/opencrvs-application/Chart.yaml
+++ b/charts/opencrvs-application/Chart.yaml
@@ -5,5 +5,5 @@ description: |
   This chart can be used as a starting point for creating new application
   charts by providing common configurations and templates.
 type: application
-version: v2.0.1
-appVersion: 'v2.0.1'
+version: v2.0.2
+appVersion: 'v2.0.2'

--- a/charts/opencrvs-mosip/Chart.yaml
+++ b/charts/opencrvs-mosip/Chart.yaml
@@ -3,5 +3,5 @@ name: opencrvs-mosip
 description: |
   OpenCRVS API for MOSIP https://github.com/opencrvs/mosip/tree/main
 type: application
-version: v2.0.1
-appVersion: 'v2.0.1'
+version: v2.0.2
+appVersion: 'v2.0.2'

--- a/charts/opencrvs-services/Chart.yaml
+++ b/charts/opencrvs-services/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opencrvs-services
 description: OpenCRVS Services
 type: application
-version: v2.0.1
-appVersion: v2.0.1
+version: v2.0.2
+appVersion: v2.0.2


### PR DESCRIPTION
## Description

Related PR: https://github.com/opencrvs/opencrvs-core/pull/13690

Goal of this PR is to fix regression bug introduced by allowing cluster level services to have IP address:
<img width="748" height="200" alt="image" src="https://github.com/user-attachments/assets/82580e79-a539-4daa-9ff5-8c5e2fd43fdd" />

As a result services deployed on previous releases are not able to deploy with newer: https://github.com/opencrvs/opencrvs-countryconfig-perf-test-infra/actions/runs/34350587913/job/102463490074#step:5:174

<img width="1628" height="203" alt="image" src="https://github.com/user-attachments/assets/c3e865ae-3d29-4e74-8ffa-6a41a2755837" />

This PR changes behaviour to create service with same definition as it was in v2.0.1


## Testing deployment

https://github.com/opencrvs/opencrvs-countryconfig-perf-test-infra/actions/runs/34350587913/job/102482680751

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
