### PR TITLE
Support .jfif images in Minio

### DIFF
--- a/packages/commons/src/documents.test.ts
+++ b/packages/commons/src/documents.test.ts
@@ -9,7 +9,32 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 
-import { FullDocumentPath } from './documents'
+import { FullDocumentPath, isMinioUrl } from './documents'
+
+describe('isMinioUrl', () => {
+  const host = 'https://minio.opencrvs.dev'
+
+  it.each(['jpg', 'jpeg', 'jfif', 'png', 'pdf', 'svg'])(
+    'matches a document url with a .%s extension',
+    (extension) => {
+      expect(isMinioUrl(`${host}/ocrvs/event-1/document-1.${extension}`)).toBe(
+        true
+      )
+    }
+  )
+
+  it('matches a .jfif document url with a query string', () => {
+    expect(isMinioUrl(`${host}/ocrvs/event-1/document-1.jfif?token=abc`)).toBe(
+      true
+    )
+  })
+
+  it('does not match non-document urls', () => {
+    expect(isMinioUrl(`${host}/index.html`)).toBe(false)
+    expect(isMinioUrl(`${host}/ocrvs/event-1/document-1.exe`)).toBe(false)
+  })
+})
+
 describe('FullDocumentPath', () => {
   it('should transform a path without slash prefix to have slash prefix', () => {
     const result = FullDocumentPath.parse(

--- a/packages/commons/src/documents.ts
+++ b/packages/commons/src/documents.ts
@@ -12,7 +12,7 @@
 import * as z from 'zod/v4'
 
 export const MINIO_REGEX =
-  /^https?:\/\/[^\/]+(.*)?\/[^\/?]+\.(jpg|png|jpeg|pdf|svg)(\?.*)?$/i
+  /^https?:\/\/[^\/]+(.*)?\/[^\/?]+\.(jpg|jpeg|jfif|png|pdf|svg)(\?.*)?$/i
 
 export function isBase64FileString(str: string) {
   if (str === '' || str.trim() === '') {
@@ -56,4 +56,3 @@ export type DocumentPath = z.infer<typeof DocumentPath>
 export const toDocumentPath = (path: FullDocumentPath): DocumentPath => {
   return path.split('/').slice(2).join('/') as DocumentPath
 }
-

--- a/packages/documents/src/features/uploadDocument/handler.test.ts
+++ b/packages/documents/src/features/uploadDocument/handler.test.ts
@@ -294,6 +294,34 @@ describe('fileUploadHandler', () => {
     expect(res.statusCode).toBe(200)
     expect(minioPutMock).toHaveBeenCalled()
   })
+
+  it('persists the client-reported content type so extensions Minio cannot infer (e.g. .jfif) stay renderable', async () => {
+    const transactionId = 'transaction-jfif'
+    const body =
+      `--${boundary}${CRLF}` +
+      createFormProperty('transactionId', transactionId) +
+      `--${boundary}${CRLF}` +
+      `Content-Disposition: form-data; name="file"; filename="photo.jfif"${CRLF}` +
+      `Content-Type: image/jpeg${CRLF}${CRLF}` +
+      `jpeg-bytes${CRLF}` +
+      `--${boundary}--${CRLF}`
+
+    const res = await server.server.inject({
+      method: 'POST',
+      url: '/files',
+      payload: Buffer.from(body, 'utf8'),
+      headers: {
+        'Content-Type': `multipart/form-data; boundary=${boundary}`,
+        authorization: `Bearer ${token}`
+      }
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.payload).toEqual(`${transactionId}.jfif`)
+
+    const metaData = minioPutMock.mock.calls[0][3]
+    expect(metaData['content-type']).toBe('image/jpeg')
+  })
 })
 
 describe('verify document uploader handler', () => {

--- a/packages/documents/src/features/uploadDocument/handler.ts
+++ b/packages/documents/src/features/uploadDocument/handler.ts
@@ -108,9 +108,12 @@ export async function fileUploadHandler(
     )
   }
 
+  // Persist the content type the client reported for the file
+  const contentType = file.hapi.headers['content-type']
+
   await minioClient.putObject(MINIO_BUCKET, filePath, file, {
     'created-by': userId,
-    ...(filename.endsWith('.pdf') && { 'content-type': 'application/pdf' })
+    ...(contentType && { 'content-type': contentType })
   })
 
   return filePath

--- a/packages/testland/e2e/testcases/birth/declarations/birth-declaration-3.spec.ts
+++ b/packages/testland/e2e/testcases/birth/declarations/birth-declaration-3.spec.ts
@@ -19,7 +19,6 @@ import {
   login,
   logout,
   switchEventTab,
-  uploadImage,
   uploadImageToSection,
   triggerDeclarationAction
 } from '@e2e/support/helpers'
@@ -27,6 +26,10 @@ import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '@e2e/support/constants'
 import { fillDate, validateAddress } from '@e2e/support/birth/helpers'
 import { openRecordByTitle } from '@e2e/support/print-certificate/birth/helpers'
+
+// A minimal but valid 1x1 JPEG
+const JFIF_JPEG_BASE64 =
+  '/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAABAAEBAREA/8QAFAABAAAAAAAAAAAAAAAAAAAAA//EABQQAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQEAAD8AfwD/2Q=='
 
 test.describe.serial('3. Birth declaration case - 3', () => {
   let page: Page
@@ -392,11 +395,19 @@ test.describe.serial('3. Birth declaration case - 3', () => {
         await goToSection(page, 'documents')
       })
 
-      test('3.1.5.1 Upload proof of birth', async () => {
-        await uploadImage(
-          page,
-          page.locator('button[name="documents____proofOfBirth"]')
-        )
+      test('3.1.5.1 Upload proof of birth as a .jfif image', async () => {
+        const fileChooserPromise = page.waitForEvent('filechooser')
+        await page.locator('button[name="documents____proofOfBirth"]').click()
+        const fileChooser = await fileChooserPromise
+        await fileChooser.setFiles({
+          name: 'proof-of-birth.jfif',
+          mimeType: 'image/jpeg',
+          buffer: Buffer.from(JFIF_JPEG_BASE64, 'base64')
+        })
+
+        await expect(
+          page.getByRole('button', { name: 'Delete attachment' })
+        ).toBeVisible()
       })
 
       test("3.1.5.2 Upload proof of mother's id", async () => {
@@ -767,6 +778,26 @@ test.describe.serial('3. Birth declaration case - 3', () => {
         (resp) =>
           resp.url().includes('/api/events/event.get') && resp.status() === 200
       )
+    })
+
+    test('3.2.1a The .jfif proof of birth is served as an image and previews correctly', async () => {
+      // The document viewer defaults to the first uploaded file: the proof of birth we uploaded as a `.jfif`.
+      await expect(page.locator('#select_document')).toContainText(
+        'Proof of birth'
+      )
+
+      const previewImage = page.getByAltText('Supporting Document')
+      await expect(previewImage).toBeVisible()
+
+      await expect
+        .poll(
+          () =>
+            previewImage.evaluate(
+              (img) => (img as HTMLImageElement).naturalWidth
+            ),
+          { timeout: 15_000 }
+        )
+        .toBeGreaterThan(0)
     })
 
     test('3.2.2 Verify information on "Record" -tab', async () => {


### PR DESCRIPTION
## Description

Resolves: https://github.com/opencrvs/opencrvs-core/issues/13727

I first considered disallowing `.jfif` files, but they are a valid file extension for the `image/jpeg` MIME type. So decided to add support for them instead.

Changes:
* Add `jfif` to `MINIO_REGEX` allowed file extensions.
* In the documents-package, persist the content type sent by the browser for the file.
* Add unit tests and e2e test.

Before:

https://github.com/user-attachments/assets/d58b3b56-89d9-4f35-9417-38d7039d2beb



After:

https://github.com/user-attachments/assets/0e6c804a-b91a-409a-8e26-66dde04f9d31



## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
