### PR TITLE
fix: Enable networking policy for OpenTelemetry collector

### DIFF
--- a/packages/toolkit/src/environment/templates/charts-values/opentelemetry/values.yaml
+++ b/packages/toolkit/src/environment/templates/charts-values/opentelemetry/values.yaml
@@ -3,6 +3,13 @@ mode: deployment
 image:
   repository: otel/opentelemetry-collector-k8s
 
+networkPolicy:
+  enabled: true
+presets:
+  kubernetesObjects:
+    networking:
+      enabled: true
+
 resources:
   requests:
     cpu: 100m


### PR DESCRIPTION
## Description

Related issue: https://github.com/opencrvs/opencrvs-core/issues/13284

Related PR: https://github.com/opencrvs/opencrvs-core/pull/13497

**Root cause:** the OpenTelemetry collector Helm values didn't enable a network policy, so it was missing the ingress/egress rules needed to communicate under the cluster's default-deny networking setup.

**Change:** enable `networkPolicy` and the `kubernetesObjects.networking` preset in `packages/toolkit/src/environment/templates/charts-values/opentelemetry/values.yaml` for the collector chart.

## Testing

Target environment: https://perf-test.opencrvs.dev

Dependencies deployment: https://github.com/opencrvs/opencrvs-countryconfig-perf-test-infra/actions/runs/34452184929


Networking policies after deployment:
<img width="1396" height="244" alt="image" src="https://github.com/user-attachments/assets/104506fd-ef39-4e4c-9e9c-9d1dabeb294b" />

<img width="1218" height="739" alt="image" src="https://github.com/user-attachments/assets/3d8ada31-24ec-452f-ba8e-f6cbe5e1bb9a" />

<img width="1221" height="762" alt="image" src="https://github.com/user-attachments/assets/920c2b24-8a77-45b1-9696-7ead0e16559e" />

<img width="1216" height="677" alt="image" src="https://github.com/user-attachments/assets/ff946ba5-2a76-4bba-a052-1cd3030915e9" />
