### PR TITLE
fix: Add annotations and labels support to NetworkPolicy

### DIFF
--- a/charts/opencrvs-services/README.md
+++ b/charts/opencrvs-services/README.md
@@ -342,6 +342,11 @@ helm upgrade --install opencrvs oci://ghcr.io/opencrvs/opencrvs-services \
             <td>List of namespaces OpenCRVS pods are allowed to reach. Only takes effect when <code>egress_mode</code> is not <code>full</code>. Grants egress on any port to every pod in each listed namespace (e.g. the dependencies chart's namespace) — see "Hardening" in this README.</td>
         </tr>
         <tr>
+            <td>network_policy.annotations / labels</td>
+            <td>{}</td>
+            <td>Extra annotations/labels applied to the <code>metadata</code> of every generated NetworkPolicy (not the <code>podSelector</code>). Overridable per service via <code>&lt;service&gt;.network_policy.annotations</code>/<code>.labels</code>, which in turn can be overridden per rule via <code>annotations</code>/<code>labels</code> on an entry in <code>rules</code>/<code>custom_rules</code>.</td>
+        </tr>
+        <tr>
             <td>&lt;service&gt;.network_policy.rules</td>
             <td>[]</td>
             <td>Chart-provided service-specific NetworkPolicy rules. Rules use Kubernetes NetworkPolicy spec syntax, except <code>podSelector</code> is generated from <code>app_label</code>.</td>

--- a/charts/opencrvs-services/templates/_network-policy-helper.tpl
+++ b/charts/opencrvs-services/templates/_network-policy-helper.tpl
@@ -14,12 +14,21 @@
 {{- $egress_mode := $network_policy.egress_mode | default "deny" -}}
 {{- $private_cidrs := list "10.0.0.0/8" "172.16.0.0/12" "192.168.0.0/16" -}}
 
+{{- $annotations := merge ($network_policy.annotations | default dict) ($root.network_policy.annotations | default dict) -}}
+{{- $labels := merge (dict "app" $appLabel) ($network_policy.labels | default dict) ($root.network_policy.labels | default dict) -}}
+
 {{- if and (ne $ingress_mode "deny") $service_values.port }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ printf "%s-allow-ingress" $service_name | trunc 63 | trimSuffix "-" }}
+{{- if $annotations }}
+  annotations:
+{{ toYaml $annotations | indent 4 }}
+{{- end }}
+  labels:
+{{ toYaml $labels | indent 4 }}
 spec:
   podSelector:
     matchLabels:
@@ -49,6 +58,12 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ printf "%s-allow-egress" $service_name | trunc 63 | trimSuffix "-" }}
+{{- if $annotations }}
+  annotations:
+{{ toYaml $annotations | indent 4 }}
+{{- end }}
+  labels:
+{{ toYaml $labels | indent 4 }}
 spec:
   podSelector:
     matchLabels:
@@ -71,11 +86,19 @@ spec:
 {{- if not $rule.name }}
 {{- fail (printf "network_policy rule for service %s must define name" $service_name) }}
 {{- end }}
+{{- $rule_annotations := merge ($rule.annotations | default dict) $annotations -}}
+{{- $rule_labels := merge ($rule.labels | default dict) $labels -}}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ printf "%s-%s" $service_name $rule.name | trunc 63 | trimSuffix "-" }}
+{{- if $rule_annotations }}
+  annotations:
+{{ toYaml $rule_annotations | indent 4 }}
+{{- end }}
+  labels:
+{{ toYaml $rule_labels | indent 4 }}
 spec:
   podSelector:
     matchLabels:

--- a/charts/opencrvs-services/templates/network-policy.yaml
+++ b/charts/opencrvs-services/templates/network-policy.yaml
@@ -1,4 +1,8 @@
 {{- if .Values.network_policy.enabled }}
+
+{{/* Include network policy rules for deployment-jobs */}}
+{{- include "network-policy-rules" (dict "service_name" "deployment-jobs" "Values" .Values) }}
+
 {{- $ingress_mode := .Values.network_policy.ingress_mode | default "deny" -}}
 {{- $egress_mode := .Values.network_policy.egress_mode | default "deny" -}}
 {{- $deny_ingress := ne $ingress_mode "full" -}}

--- a/charts/opencrvs-services/values.yaml
+++ b/charts/opencrvs-services/values.yaml
@@ -181,6 +181,13 @@ network_policy:
   # chart is typically deployed to a separate namespace. See "Hardening"
   # in README.md.
   allowed_namespaces: []
+  # Extra annotations/labels applied to every generated NetworkPolicy's
+  # metadata (not the podSelector). Override per service under
+  # <service>.network_policy.annotations / .labels, which take precedence
+  # over these; a rule under network_policy.rules/custom_rules can further
+  # override via its own annotations/labels.
+  annotations: {}
+  labels: {}
 
 # See kubernetes documentation for more information on service types:
 # https://kubernetes.io/docs/concepts/services-networking/service/
@@ -464,13 +471,16 @@ events:
 deployment_jobs:
   service_account:
     name: deployment-jobs
-    network_policy:
-      ingress_mode: deny
-      egress_mode: full
     annotations:
       'helm.sh/hook': pre-install,pre-upgrade
       'helm.sh/hook-weight': '-10'
       'helm.sh/hook-delete-policy': before-hook-creation
+  network_policy:
+    annotations:
+      'helm.sh/hook': pre-install,pre-upgrade
+      'helm.sh/hook-weight': '-10'
+    ingress_mode: deny
+    egress_mode: full
 
 # data_migration: Job to migrate datastores while deployment
 data_migration:


### PR DESCRIPTION
## Description

- **Root cause:** the postdeploy validation job — like every other one-time deployment job sharing the `deployment-jobs` service account — had no network policy egress rules. This was found while running post-deploy validation: with the default-deny egress mode, SMTP validation to public IPs was failing.
- **Change:** enable `network-policy-rules` for the shared `deployment-jobs` service group in `network-policy.yaml`, covering all pre/post-deploy jobs (`data-seed-job`, `postgres-on-deploy-job`, `postgres-on-restore-cronjob`, `elasticsearch-on-deploy`, `data-migration-job`, `elasticsearch-reindex-job`, `validate-postdeploy-job`), not just the failing validation job.
- **Change:** add `annotations`/`labels` support to the NetworkPolicy helper (rule > service > global precedence) so the generated policies can be tagged/labelled and managed by adding helm hooks as annotations.
- **Fix:** `deployment_jobs.network_policy` in `values.yaml` was nested under `service_account` and silently ignored — moved to the correct level so `egress_mode: full` actually takes effect.

Example: https://github.com/opencrvs/opencrvs-countryconfig-perf-test-infra/actions/runs/34455386528

<img width="845" height="164" alt="image" src="https://github.com/user-attachments/assets/2a0d7cfb-46d6-4882-98c5-94b8760ea668" />

## Testing

https://github.com/opencrvs/opencrvs-countryconfig-perf-test-infra/actions/runs/34461239445

New policy was created as predeploy helm hook:
<img width="886" height="227" alt="image" src="https://github.com/user-attachments/assets/76c8e252-1ae6-4f85-bacf-b6a607c04820" />

Validation passes:
<img width="834" height="165" alt="image" src="https://github.com/user-attachments/assets/ff48471a-3825-434b-89bf-23804708298b" />
