### PR TITLE
fix: clear drafts when the user role is changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,10 +84,10 @@ For the integration's own release history prior to this move, see [`packages/mos
 
 The user-notification and system-ready triggers were served under `/triggers/`, while the event action and telemetry triggers used `/trigger/`. All of them now use the singular prefix:
 
-| Before | After |
-| --- | --- |
+| Before                        | After                        |
+| ----------------------------- | ---------------------------- |
 | `POST /triggers/user/{event}` | `POST /trigger/user/{event}` |
-| `GET /triggers/system/ready` | `GET /trigger/system/ready` |
+| `GET /triggers/system/ready`  | `GET /trigger/system/ready`  |
 
 `POST /trigger/events/{event}/actions/{action}` and `POST /trigger/telemetry` are unchanged.
 
@@ -235,6 +235,7 @@ Re-running after a partial failure requires clearing the data first. [#11207](ht
 - Return a conflict naming the offending field, instead of an internal server error, when a write trips a unique constraint on a user's email, mobile or username. The application-level duplicate checks are broader than the constraints, so this is reachable only when two requests race — but the cause was masked in production and reached the caller as `Internal server error`. Covers creating a user as well as changing an existing user's email, phone number or name. [#11207](https://github.com/opencrvs/opencrvs-core/issues/11207)
 - Stop the gateway's `/events/{path*}` proxy from forwarding requests outside the events service. [#13587](https://github.com/opencrvs/opencrvs-core/issues/13587)
 - Stop the "Send username reminder?" and "Reset password?" confirmation modals from rendering a blank gap where the recipient's email or phone number used to be. The user search endpoint returns a user summary that no longer carries `email`/`mobile`, so the `{recipient}` placeholder never resolved. Both messages now name only the delivery method. **Country configurations must update `sysAdHome.sendUsernameReminderInviteModalMessage` and `sysAdHome.user.resetPasswordModal.message` in `client.csv` to drop `{recipient}`** — a translation that still references it will fail to format. [#13578](https://github.com/opencrvs/opencrvs-core/issues/13578)
+- Remove a user's in-progress drafts when their **role** changes, not only when their office changes. A draft is written against the role that authored it — form fields, available actions and flags can all be conditional on the role — so after a role change the old drafts stayed in the Drafts workqueue with no action the new role could take. The confirmation dialog shown before saving the user now covers a role change as well as an office move. **Country configurations must replace `form.field.label.changeOfficeWarningTitle` and `form.field.label.changeOfficeWarningBody` in `client.csv` with `form.field.label.removeDraftsWarningTitle` and `form.field.label.removeDraftsWarningBody`.** [#13763](https://github.com/opencrvs/opencrvs-core/issues/13763)
 
 ## 2.0.1 Release
 

--- a/packages/client/src/i18n/messages/views/userForm.ts
+++ b/packages/client/src/i18n/messages/views/userForm.ts
@@ -104,17 +104,18 @@ export const messages = {
     description: 'label for updating user',
     id: 'form.field.label.updatingUser'
   },
-  changeOfficeWarningTitle: {
-    defaultMessage: 'Change office?',
+  removeDraftsWarningTitle: {
+    defaultMessage: 'Change role or office?',
     description:
-      'Title for the confirmation dialog when changing a user office',
-    id: 'form.field.label.changeOfficeWarningTitle'
+      'Title for the confirmation dialog when a change removes a user in-progress drafts',
+    id: 'form.field.label.removeDraftsWarningTitle'
   },
-  changeOfficeWarningBody: {
+  removeDraftsWarningBody: {
     defaultMessage:
-      "Changing this user's office will remove their in-progress drafts. Do you want to continue?",
-    description: 'Body for the confirmation dialog when changing a user office',
-    id: 'form.field.label.changeOfficeWarningBody'
+      "Changing this user's role or office will remove their in-progress drafts. Do you want to continue?",
+    description:
+      'Body for the confirmation dialog when a change removes a user in-progress drafts',
+    id: 'form.field.label.removeDraftsWarningBody'
   },
   phoneNumberFormat: {
     id: 'validations.phoneNumberFormat',

--- a/packages/client/src/views/SysAdmin/Team/user/userEditor/UserEditor.tsx
+++ b/packages/client/src/views/SysAdmin/Team/user/userEditor/UserEditor.tsx
@@ -622,10 +622,16 @@ const ReviewUserComponent = () => {
                 },
                 data
               }
-              const officeChanged =
+              /*
+               * Both a new office and a new role clear the user's in-progress
+               * drafts server-side, so either change needs confirming first.
+               */
+              const clearsDrafts =
                 targetUser?.type === TokenUserType.enum.user &&
-                payload.primaryOfficeId !== targetUser.primaryOfficeId
-              if (officeChanged) {
+                (payload.primaryOfficeId !== targetUser.primaryOfficeId ||
+                  payload.role !== targetUser.role)
+
+              if (clearsDrafts) {
                 setPendingPayload(payload)
               } else {
                 submitUpdate(payload)
@@ -664,13 +670,13 @@ const ReviewUserComponent = () => {
             </Button>
           ]}
           isOpen={true}
-          title={intl.formatMessage(messages.changeOfficeWarningTitle)}
+          title={intl.formatMessage(messages.removeDraftsWarningTitle)}
           onClose={() => {
             setPendingPayload(null)
           }}
         >
           <Text color="grey500" element="p" variant="reg16">
-            {intl.formatMessage(messages.changeOfficeWarningBody)}
+            {intl.formatMessage(messages.removeDraftsWarningBody)}
           </Text>
         </Dialog>
       )}

--- a/packages/countryconfig-template/src/translations/client.csv
+++ b/packages/countryconfig-template/src/translations/client.csv
@@ -663,8 +663,6 @@ form.field.label.app.whoContDet.father,,Father,Père
 form.field.label.app.whoContDet.mother,,Mother,Mère
 form.field.label.birthLocation,,Hospital / Clinic,Hôpital / Clinique
 form.field.label.certificatePrintInAdvance,,Print in advance,Imprimer à l'avance pour les signatures et la collecte
-form.field.label.changeOfficeWarningBody,,Changing this user's office will remove their in-progress drafts. Do you want to continue?,Changer le bureau de cet utilisateur supprimera ses brouillons en cours. Voulez-vous continuer ?
-form.field.label.changeOfficeWarningTitle,,Change office?,Changer de bureau ?
 form.field.label.cityUrbanOption,Label for City,Town,Ville
 form.field.label.confirm,,Yes,Oui
 form.field.label.country,,Country,Pays
@@ -728,6 +726,8 @@ form.field.label.registrationOffice,,Registration Office,Bureau d'enregistrement
 form.field.label.relationOtherFamilyMember,Label for other family member relation,Other family member,Autre membre de la famille
 form.field.label.relationSomeoneElse,,Someone else,Quelqu'un d'autre
 form.field.label.relationshipToSpouses,,Relationship to spouses,Relation avec les époux
+form.field.label.removeDraftsWarningBody,Body for the confirmation dialog when a change removes a user in-progress drafts,Changing this user's role or office will remove their in-progress drafts. Do you want to continue?,Changer le rôle ou le bureau de cet utilisateur supprimera ses brouillons en cours. Voulez-vous continuer ?
+form.field.label.removeDraftsWarningTitle,Title for the confirmation dialog when a change removes a user in-progress drafts,Change role or office?,Changer de rôle ou de bureau ?
 form.field.label.self,The title that appears when selecting self as informant,Self,Soi-même
 form.field.label.sex,,Sex,Sexe
 form.field.label.sexFemale,Label for option female,Female,Femme

--- a/packages/events/src/router/user/user.update.test.ts
+++ b/packages/events/src/router/user/user.update.test.ts
@@ -812,7 +812,30 @@ test('clears all drafts when primaryOfficeId changes via user.update', async () 
   expect(await draftClient.event.draft.list()).toHaveLength(0)
 })
 
-test('preserves drafts when primaryOfficeId stays the same via user.update', async () => {
+test('clears all drafts when role changes via user.update', async () => {
+  const { user, generator } = await setupTestCase()
+  const adminClient = createTestClient(user, [USER_EDIT_SCOPE])
+  const draftClient = createTestClient(user)
+
+  const event = await draftClient.event.create(generator.event.create())
+  await draftClient.event.draft.create({
+    eventId: event.id,
+    type: 'DECLARE',
+    status: 'Accepted',
+    transactionId: 'test-transaction-id'
+  })
+
+  expect(await draftClient.event.draft.list()).toHaveLength(1)
+
+  await adminClient.user.update({
+    ...generateUpdateInput(user),
+    role: 'some-other-role'
+  })
+
+  expect(await draftClient.event.draft.list()).toHaveLength(0)
+})
+
+test('preserves drafts when neither primaryOfficeId nor role changes via user.update', async () => {
   const { user, generator } = await setupTestCase()
   const adminClient = createTestClient(user, [USER_EDIT_SCOPE])
   const draftClient = createTestClient(user)

--- a/packages/events/src/service/users/api.ts
+++ b/packages/events/src/service/users/api.ts
@@ -239,7 +239,12 @@ export async function updateUser(
       officeId: incomingOfficeId
     })
 
-    if (incomingOfficeId && incomingOfficeId !== existingUser.officeId) {
+    const officeChanged =
+      incomingOfficeId && incomingOfficeId !== existingUser.officeId
+    const roleChanged =
+      otherFields.role && otherFields.role !== existingUser.role
+
+    if (officeChanged || roleChanged) {
       await draftsRepo.deleteDraftsByUserIdInTrx(trx, userId)
     }
 

--- a/packages/testland/e2e/testcases/team/create-user-administrator.spec.ts
+++ b/packages/testland/e2e/testcases/team/create-user-administrator.spec.ts
@@ -136,6 +136,11 @@ test.describe.serial('1. Create and update user -1', () => {
       await continueForm(page)
 
       await page.getByRole('button', { name: 'Confirm' }).click()
+      await page
+        .getByRole('dialog')
+        .getByRole('button', { name: 'Confirm' })
+        .click()
+
       await expect(page.getByText('Farajaland CRS')).toBeVisible()
     })
 

--- a/packages/testland/e2e/testcases/team/edit-user.spec.ts
+++ b/packages/testland/e2e/testcases/team/edit-user.spec.ts
@@ -99,7 +99,10 @@ test("Can update newly created user's location and role", async ({
 
   await test.step('Confirm user update', async () => {
     await page.getByRole('button', { name: 'Confirm' }).click()
-    await page.locator('#confirm_office_change').click()
+    await page
+      .getByRole('dialog')
+      .getByRole('button', { name: 'Confirm' })
+      .click()
     await expect(page.locator('#content-name')).toHaveText(fullName)
     await expect(page.getByTestId('office-link-value')).toHaveText(
       'Ezhi District Hospital'

--- a/packages/testland/e2e/testcases/team/user-office-change.spec.ts
+++ b/packages/testland/e2e/testcases/team/user-office-change.spec.ts
@@ -81,20 +81,25 @@ const expectVersionCard = async (
   await expect(page.getByText('OpenCRVS v2.1.0', { exact: true })).toBeVisible()
 }
 
-test('Scope changes after office change - user loses access when the office changes', async ({
-  browser
-}) => {
-  test.setTimeout(180_000)
+type RegistrarWithDrafts = {
+  username: string
+  fullName: string
+  childName: string
+  trackingId: string
+  eventId: string
+  draftNames: string[]
+  draftCountBeforeChange: number
+}
 
-  const page = await browser.newPage()
-  let username = ''
-  let fullName = ''
-  let childName = ''
-  let trackingId = ''
-  let eventId = ''
-  let draftCountBeforeChange = 0
-
-  await test.step('Create a new registrar user and set up initial record and drafts', async () => {
+/**
+ * Creates a Registrar in Ibombo District Office, logs them in, declares one
+ * record and leaves `draftCount` in-progress drafts behind.
+ *
+ * Every test below starts from this state and then has an administrator change
+ * something about the user, so what survives the change is all that differs.
+ */
+const setupRegistrarWithDrafts = async (page: Page, draftCount: number) =>
+  test.step('Create a new registrar user and set up initial record and drafts', async (): Promise<RegistrarWithDrafts> => {
     const adminToken = await getToken(CREDENTIALS.NATIONAL_SYSTEM_ADMIN)
     const client = createClient(
       GATEWAY_HOST + '/events',
@@ -107,8 +112,8 @@ test('Scope changes after office change - user loses access when the office chan
       surname: `${faker.person.lastName()}${faker.string.alphanumeric(6)}`
     }
 
-    fullName = `${name.firstname} ${name.surname}`
-    username = `${name.firstname[0]}.${name.surname}`
+    const fullName = `${name.firstname} ${name.surname}`
+    const username = `${name.firstname[0]}.${name.surname}`
       .toLowerCase()
       .replace(/[^a-z0-9.]/g, '')
 
@@ -146,9 +151,8 @@ test('Scope changes after office change - user loses access when the office chan
       ActionType.DECLARE
     )
 
-    trackingId = declaration.trackingId!
-    eventId = declaration.eventId
-    childName = formatV2ChildName(declaration.declaration)
+    const trackingId = declaration.trackingId!
+    const childName = formatV2ChildName(declaration.declaration)
 
     await searchFromSearchBar(page, childName, true)
     await expect(page.getByTestId('tracking-id-value')).toContainText(
@@ -156,11 +160,11 @@ test('Scope changes after office change - user loses access when the office chan
     )
 
     const draftNames: string[] = []
-    for (let i = 0; i < 3; i++) {
+    for (let i = 0; i < draftCount; i++) {
       draftNames.push(await createDraft(page))
     }
 
-    draftCountBeforeChange = await countDraftRows(page, draftNames.length)
+    const draftCountBeforeChange = await countDraftRows(page, draftNames.length)
     expect(draftCountBeforeChange).toBe(draftNames.length)
 
     for (const draftName of draftNames) {
@@ -168,7 +172,26 @@ test('Scope changes after office change - user loses access when the office chan
         page.getByRole('button', { name: draftName, exact: true })
       ).toBeVisible()
     }
+
+    return {
+      username,
+      fullName,
+      childName,
+      trackingId,
+      eventId: declaration.eventId,
+      draftNames,
+      draftCountBeforeChange
+    }
   })
+
+test('Scope changes after office change - user loses access when the office changes', async ({
+  browser
+}) => {
+  test.setTimeout(180_000)
+
+  const page = await browser.newPage()
+  const { username, fullName, trackingId, eventId, draftCountBeforeChange } =
+    await setupRegistrarWithDrafts(page, 3)
 
   await test.step('Local administrator moves the user to Isamba District Office', async () => {
     await logout(page)
@@ -244,95 +267,16 @@ test('Scope changes after office and role changes', async ({ browser }) => {
   test.setTimeout(180_000)
 
   const page = await browser.newPage()
-  let username = ''
-  let fullName = ''
-  let childName = ''
-  let trackingId = ''
-  let eventId = ''
-  let draftCountBeforeChange = 0
+  const { username, fullName, trackingId, eventId, draftCountBeforeChange } =
+    await setupRegistrarWithDrafts(page, 3)
 
-  await test.step('Create a new registrar user and set up initial record and drafts', async () => {
-    const adminToken = await getToken(CREDENTIALS.NATIONAL_SYSTEM_ADMIN)
-    const client = createClient(
-      GATEWAY_HOST + '/events',
-      `Bearer ${adminToken}`
-    )
-
-    const name = {
-      firstname: faker.person.firstName(),
-      // Append random chars to ensure username is unique
-      surname: `${faker.person.lastName()}${faker.string.alphanumeric(6)}`
-    }
-
-    fullName = `${name.firstname} ${name.surname}`
-    username = `${name.firstname[0]}.${name.surname}`
-      .toLowerCase()
-      .replace(/[^a-z0-9.]/g, '')
-
-    const offices = await getLocations('CRVS_OFFICE', adminToken)
-    const ibomboDistrictOfficeId = getIdByName(
-      offices,
-      'Ibombo District Office'
-    )
-
-    await client.user.create.mutate({
-      name,
-      role: 'LOCAL_REGISTRAR',
-      primaryOfficeId: ibomboDistrictOfficeId,
-      mobile: `07${faker.string.numeric(8)}`,
-      email: faker.internet.email(),
-      fullHonorificName: fullName,
-      device: 'web',
-      data: {}
-    })
-
-    await loginWithNewUser(page, username)
-
-    const { token, refreshToken } = await getAuthTokens(
-      username,
-      NEW_USER_PASSWORD
-    )
-
-    await waitForAuthenticatedLanding(page, refreshToken)
-
-    await createPIN(page)
-    await page.goto(CLIENT_URL)
-
-    const declaration = await createDeclaration(
-      token,
-      undefined,
-      ActionType.DECLARE
-    )
-
-    trackingId = declaration.trackingId!
-    eventId = declaration.eventId
-    childName = formatV2ChildName(declaration.declaration)
-
-    await searchFromSearchBar(page, childName, true)
-    await expect(page.getByTestId('tracking-id-value')).toContainText(
-      trackingId
-    )
-
-    const draftNames: string[] = []
-    for (let i = 0; i < 3; i++) {
-      draftNames.push(await createDraft(page))
-    }
-
+  await test.step('The new user starts out as a Registrar in Ibombo District Office', async () => {
     await expectVersionCard(
       page,
       fullName,
       'Registrar',
       'Ibombo District Office'
     )
-
-    draftCountBeforeChange = await countDraftRows(page, draftNames.length)
-    await expect(draftCountBeforeChange).toBe(draftNames.length)
-
-    for (const draftName of draftNames) {
-      await expect(
-        page.getByRole('button', { name: draftName, exact: true })
-      ).toBeVisible()
-    }
 
     await logout(page)
   })
@@ -411,5 +355,112 @@ test('Scope changes after office and role changes', async ({ browser }) => {
     await expect(
       page.getByText(`No event or draft found with id: ${eventId}`)
     ).toBeVisible()
+  })
+})
+
+test('Drafts are removed when only the role changes', async ({ browser }) => {
+  test.setTimeout(180_000)
+
+  const page = await browser.newPage()
+  const { username, fullName, childName, trackingId, draftCountBeforeChange } =
+    await setupRegistrarWithDrafts(page, 3)
+
+  await test.step('Local administrator changes the role to Registration Officer, keeping the office', async () => {
+    await logout(page)
+    await login(page, CREDENTIALS.LOCAL_SYSTEM_ADMIN)
+
+    await page.getByRole('button', { name: 'Organisation' }).click()
+    await page.getByRole('button', { name: 'Central' }).click()
+    await page.getByRole('button', { name: 'Ibombo', exact: true }).click()
+    await page.getByRole('button', { name: 'Ibombo District Office' }).click()
+    await expect(page.locator('#content-name')).toHaveText(
+      'Ibombo District Office'
+    )
+
+    await page.getByRole('button', { name: fullName }).click()
+    await expect(page.locator('#content-name')).toHaveText(fullName)
+
+    await page.locator('#sub-page-header-munu-button-dropdownMenu').click()
+    await page.getByText('Edit details').click()
+    await expect(page.getByText('Confirm details')).toBeVisible()
+
+    await page.getByTestId('change-button-role').click()
+    await page.locator('#role').click()
+    await page.getByText('Registration Officer', { exact: true }).click()
+    await page.getByRole('button', { name: 'Continue' }).click()
+
+    /*
+     * Registration Officer holds `profile.electronic-signature`, so the
+     * signature page stays in the flow between the role page and the review.
+     */
+    const signButton = page.getByRole('button', { name: 'Sign', exact: true })
+    if (await signButton.isVisible()) {
+      await signButton.click()
+      await drawSignature(page, 'signature_canvas_element', false)
+      await page.getByRole('button', { name: 'Apply' }).click()
+    }
+
+    const continueButton = page.getByRole('button', { name: 'Continue' })
+    if (await continueButton.isVisible()) {
+      await continueButton.click()
+    }
+
+    await expect(page.getByText('Confirm details')).toBeVisible()
+    await expect(page.getByTestId('role-value')).toHaveText(
+      'Registration Officer'
+    )
+    // The office is deliberately left alone: the role alone must clear drafts.
+    await expect(page.getByTestId('primaryOfficeId-value')).toHaveText(
+      'Ibombo District Office, Ibombo, Central, Farajaland'
+    )
+
+    await page.getByRole('button', { name: 'Confirm' }).click()
+
+    await expect(page.getByText('Change role or office?')).toBeVisible()
+    await expect(
+      page.getByText(
+        "Changing this user's role or office will remove their in-progress drafts. Do you want to continue?"
+      )
+    ).toBeVisible()
+
+    await page.getByTestId('confirm_office_change').click()
+
+    await expect(
+      page.getByText('Registration Officer', { exact: true })
+    ).toBeVisible()
+    await expect(page.getByTestId('office-link-value')).toHaveText(
+      'Ibombo District Office'
+    )
+
+    await logout(page)
+  })
+
+  await test.step('The drafts are gone, while the records of the office remain accessible', async () => {
+    const { refreshToken } = await getAuthTokens(username, NEW_USER_PASSWORD)
+    expect(refreshToken).toBeDefined()
+
+    await waitForAuthenticatedLanding(page, refreshToken)
+    await page.goto(CLIENT_URL)
+
+    await expectVersionCard(
+      page,
+      fullName,
+      'Registration Officer',
+      'Ibombo District Office'
+    )
+
+    const draftCountAfterChange = await countDraftRows(page, 0)
+    expect(draftCountAfterChange).toBe(0)
+    expect(draftCountBeforeChange).toBeGreaterThan(0)
+
+    /*
+     * The office did not change, so everything but the drafts is still there.
+     * Without this the test would also pass if the role change had locked the
+     * user out of the office's records altogether.
+     */
+    await searchFromSearchBar(page, childName, true)
+    await expect(page.getByTestId('tracking-id-value')).toContainText(
+      trackingId
+    )
   })
 })

--- a/packages/testland/e2e/testcases/team/user-office-change.spec.ts
+++ b/packages/testland/e2e/testcases/team/user-office-change.spec.ts
@@ -231,7 +231,10 @@ test('Scope changes after office change - user loses access when the office chan
 
     await page.getByRole('button', { name: 'Continue' }).click()
     await page.getByRole('button', { name: 'Confirm' }).click()
-    await page.getByTestId('confirm_office_change').click()
+    await page
+      .getByRole('dialog')
+      .getByRole('button', { name: 'Confirm' })
+      .click()
 
     await expect(page.getByTestId('office-link-value')).toHaveText(
       'Isamba District Office'
@@ -315,7 +318,10 @@ test('Scope changes after office and role changes', async ({ browser }) => {
     await expect(page.getByTestId('role-value')).toHaveText('Hospital Official')
 
     await page.getByRole('button', { name: 'Confirm' }).click()
-    await page.getByTestId('confirm_office_change').click()
+    await page
+      .getByRole('dialog')
+      .getByRole('button', { name: 'Confirm' })
+      .click()
 
     await expect(page.getByTestId('office-link-value')).toHaveText(
       'Isamba District Office'
@@ -423,7 +429,10 @@ test('Drafts are removed when only the role changes', async ({ browser }) => {
       )
     ).toBeVisible()
 
-    await page.getByTestId('confirm_office_change').click()
+    await page
+      .getByRole('dialog')
+      .getByRole('button', { name: 'Confirm' })
+      .click()
 
     await expect(
       page.getByText('Registration Officer', { exact: true })

--- a/packages/testland/src/translations/client.csv
+++ b/packages/testland/src/translations/client.csv
@@ -663,8 +663,6 @@ form.field.label.app.whoContDet.father,,Father,Père
 form.field.label.app.whoContDet.mother,,Mother,Mère
 form.field.label.birthLocation,,Hospital / Clinic,Hôpital / Clinique
 form.field.label.certificatePrintInAdvance,,Print in advance,Imprimer à l'avance pour les signatures et la collecte
-form.field.label.changeOfficeWarningBody,,Changing this user's office will remove their in-progress drafts. Do you want to continue?,Changer le bureau de cet utilisateur supprimera ses brouillons en cours. Voulez-vous continuer ?
-form.field.label.changeOfficeWarningTitle,,Change office?,Changer de bureau ?
 form.field.label.cityUrbanOption,Label for City,Town,Ville
 form.field.label.confirm,,Yes,Oui
 form.field.label.country,,Country,Pays
@@ -728,6 +726,8 @@ form.field.label.registrationOffice,,Registration Office,Bureau d'enregistrement
 form.field.label.relationOtherFamilyMember,Label for other family member relation,Other family member,Autre membre de la famille
 form.field.label.relationSomeoneElse,,Someone else,Quelqu'un d'autre
 form.field.label.relationshipToSpouses,,Relationship to spouses,Relation avec les époux
+form.field.label.removeDraftsWarningBody,Body for the confirmation dialog when a change removes a user in-progress drafts,Changing this user's role or office will remove their in-progress drafts. Do you want to continue?,Changer le rôle ou le bureau de cet utilisateur supprimera ses brouillons en cours. Voulez-vous continuer ?
+form.field.label.removeDraftsWarningTitle,Title for the confirmation dialog when a change removes a user in-progress drafts,Change role or office?,Changer de rôle ou de bureau ?
 form.field.label.self,The title that appears when selecting self as informant,Self,Soi-même
 form.field.label.sex,,Sex,Sexe
 form.field.label.sexFemale,Label for option female,Female,Femme


### PR DESCRIPTION
https://github.com/opencrvs/opencrvs-core/issues/13763

Earlier, the drafts were only cleared when the admin changed users office. Now it also clears when the roles is changed.