### PR TITLE
fix: stop metabase startup from installing packages over the internet

### DIFF
--- a/packages/countryconfig-template/assets/metabase/run.sh
+++ b/packages/countryconfig-template/assets/metabase/run.sh
@@ -97,14 +97,10 @@ if [ -z "${OPENCRVS_METABASE_ADMIN_PASSWORD}" ]; then
   exit 1
 fi
 
-apk update
-apk upgrade
-apk add --no-cache gettext
-apk add --no-cache util-linux
-
 export MB_JETTY_PORT=${MB_JETTY_PORT:-4444}
 export MB_DB_FILE=${MB_DB_FILE:-'/data/metabase/metabase.mv.db'}
-export OPENCRVS_METABASE_ADMIN_PASSWORD_SALT=$(uuidgen)
+export OPENCRVS_METABASE_ADMIN_PASSWORD_SALT=$(cat /proc/sys/kernel/random/uuid 2>/dev/null || uuidgen)
+
 SALT_AND_PASSWORD=$OPENCRVS_METABASE_ADMIN_PASSWORD_SALT$OPENCRVS_METABASE_ADMIN_PASSWORD
 export OPENCRVS_METABASE_ADMIN_PASSWORD_HASH=$(java -cp $METABASE_JAR clojure.main -e "(require 'metabase.util.password) (println (metabase.util.password/hash-bcrypt \"$SALT_AND_PASSWORD\"))" 2>/dev/null | tail -n 1)
 

--- a/packages/countryconfig-template/assets/metabase/update-database.sh
+++ b/packages/countryconfig-template/assets/metabase/update-database.sh
@@ -28,13 +28,13 @@ environment_configuration_sql_file=${OPENCRVS_ENVIRONMENT_CONFIGURATION_SQL_FILE
 # as environment variables
 #########
 
-if ! which envsubst >/dev/null; then
-  echo "envsubst could not be found. Please install envsubst before continuing."
-  echo "MacOS: brew install gettext && brew link --force gettext"
-  exit 1
-fi
 echo "Applying environment configuration from $environment_configuration_sql_file"
-envsubst < $environment_configuration_sql_file > $environment_configuration_sql_file.tmp
+
+# Expand $VAR / ${VAR} using bash's own heredoc expansion instead of envsubst,
+# because envsubst is not installed in the Metabase image
+eval "cat <<OPENCRVS_ENV_EOF
+$(cat "$environment_configuration_sql_file")
+OPENCRVS_ENV_EOF" > "$environment_configuration_sql_file.tmp"
 
 java -cp "$metabase_jar" org.h2.tools.RunScript -url jdbc:h2:"$metabase_db_path_for_metabase" -script "$environment_configuration_sql_file.tmp"
 rm $environment_configuration_sql_file.tmp

--- a/packages/testland/assets/metabase/run.sh
+++ b/packages/testland/assets/metabase/run.sh
@@ -97,14 +97,10 @@ if [ -z "${OPENCRVS_METABASE_ADMIN_PASSWORD}" ]; then
   exit 1
 fi
 
-apk update
-apk upgrade
-apk add --no-cache gettext
-apk add --no-cache util-linux
-
 export MB_JETTY_PORT=${MB_JETTY_PORT:-4444}
 export MB_DB_FILE=${MB_DB_FILE:-'/data/metabase/metabase.mv.db'}
-export OPENCRVS_METABASE_ADMIN_PASSWORD_SALT=$(uuidgen)
+export OPENCRVS_METABASE_ADMIN_PASSWORD_SALT=$(cat /proc/sys/kernel/random/uuid 2>/dev/null || uuidgen)
+
 SALT_AND_PASSWORD=$OPENCRVS_METABASE_ADMIN_PASSWORD_SALT$OPENCRVS_METABASE_ADMIN_PASSWORD
 export OPENCRVS_METABASE_ADMIN_PASSWORD_HASH=$(java -cp $METABASE_JAR clojure.main -e "(require 'metabase.util.password) (println (metabase.util.password/hash-bcrypt \"$SALT_AND_PASSWORD\"))" 2>/dev/null | tail -n 1)
 

--- a/packages/testland/assets/metabase/update-database.sh
+++ b/packages/testland/assets/metabase/update-database.sh
@@ -28,13 +28,13 @@ environment_configuration_sql_file=${OPENCRVS_ENVIRONMENT_CONFIGURATION_SQL_FILE
 # as environment variables
 #########
 
-if ! which envsubst >/dev/null; then
-  echo "envsubst could not be found. Please install envsubst before continuing."
-  echo "MacOS: brew install gettext && brew link --force gettext"
-  exit 1
-fi
 echo "Applying environment configuration from $environment_configuration_sql_file"
-envsubst < $environment_configuration_sql_file > $environment_configuration_sql_file.tmp
+
+# Expand $VAR / ${VAR} using bash's own heredoc expansion instead of envsubst,
+# because envsubst is not installed in the Metabase image
+eval "cat <<OPENCRVS_ENV_EOF
+$(cat "$environment_configuration_sql_file")
+OPENCRVS_ENV_EOF" > "$environment_configuration_sql_file.tmp"
 
 java -cp "$metabase_jar" org.h2.tools.RunScript -url jdbc:h2:"$metabase_db_path_for_metabase" -script "$environment_configuration_sql_file.tmp"
 rm $environment_configuration_sql_file.tmp


### PR DESCRIPTION
The dashboards pod never gets as far as starting Metabase. run.sh runs `apk add gettext util-linux` at startup, but since chart v2.1.0 the dashboards Deployment renders NetworkPolicies, and the chart default is network_policy.egress_mode: private - RFC1918 only. The fetches to dl-cdn.alpinelinux.org are dropped, the CNI surfaces the denial as EACCES, and apk reports "Permission denied" and gives up. The container serves nothing, so the Registrations, Completeness and Registry dashboards all return Bad Gateway.

Both tools have in-image equivalents, so drop the installs rather than widen the pod's egress:

- uuidgen (util-linux) -> /proc/sys/kernel/random/uuid, keeping uuidgen as the fallback for local macOS runs. An empty salt now fails loudly instead of silently producing a bcrypt hash nobody can log in with.
- envsubst (gettext) -> pure bash script

countryconfig-template holds a byte-identical copy of both scripts and is patched the same way, so new country configs don't scaffold from the broken version.

Note this only takes effect once the countryconfig assets image is rebuilt and redeployed.

Fixes #13775

## Testing


Dashboard container started without issues:
<img width="1907" height="350" alt="image" src="https://github.com/user-attachments/assets/79941644-19de-4db2-85ec-084e8f390dc4" />

Manually run script inside container to generate environment-configuration.sql.tmp:
<img width="825" height="363" alt="image" src="https://github.com/user-attachments/assets/02622a91-99bc-40cb-aac9-7b9ac4826911" />

Generated file has all environment variables substituted:
<img width="1883" height="649" alt="image" src="https://github.com/user-attachments/assets/2b71129a-3afb-4fad-9da0-87d9a6e575a2" />



## ToDo
-  [ ] Once the fix is confirmed, write codemod changes
-  [x] Make sure when any pr gets merged in develop, the e2e includes dashboard  
