### PR TITLE
fix: align avatars with names on the Team and Audit pages

### DIFF
--- a/packages/client/src/v2-events/features/workqueues/EventOverview/components/EventHistory/UserAvatar.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/components/EventHistory/UserAvatar.tsx
@@ -14,11 +14,6 @@ import { User } from '@opencrvs/commons/client'
 import { Avatar } from '@client/components/Avatar'
 import { getUsersFullName } from '@client/v2-events/utils'
 
-/*
- * The gap belongs to the row, not to the avatar's markup: an avatar renders as
- * an `<img>` only when the user has uploaded a photo, and as initials or a
- * placeholder otherwise.
- */
 const NameAvatar = styled.div`
   display: flex;
   align-items: center;

--- a/packages/client/src/v2-events/features/workqueues/EventOverview/components/EventHistory/UserAvatar.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/components/EventHistory/UserAvatar.tsx
@@ -14,12 +14,15 @@ import { User } from '@opencrvs/commons/client'
 import { Avatar } from '@client/components/Avatar'
 import { getUsersFullName } from '@client/v2-events/utils'
 
+/*
+ * The gap belongs to the row, not to the avatar's markup: an avatar renders as
+ * an `<img>` only when the user has uploaded a photo, and as initials or a
+ * placeholder otherwise.
+ */
 const NameAvatar = styled.div`
   display: flex;
   align-items: center;
-  img {
-    margin-right: 10px;
-  }
+  gap: 10px;
 `
 
 /**

--- a/packages/components/src/List/List.styles.ts
+++ b/packages/components/src/List/List.styles.ts
@@ -8,12 +8,9 @@
  *
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
-import { css } from 'styled-components'
+import { css, FlattenSimpleInterpolation } from 'styled-components'
 
-/** Colours and fonts here approximate the v4 tokens; they are realigned to Figma separately. */
-
-/** The leading slot holds a 40px avatar or icon, plus its gap to the label. */
-export const START_COLUMN_WIDTH = '52px'
+export const START_COLUMN_WIDTH = '44px'
 
 /**
  * The trailing gutter is reserved for the whole table, so the value columns sit
@@ -21,7 +18,7 @@ export const START_COLUMN_WIDTH = '52px'
  */
 export const ACTIONS_COLUMN_WIDTH = '96px'
 
-const stackedBelow = (styles: ReturnType<typeof css>) => css`
+const stackedBelow = (styles: FlattenSimpleInterpolation) => css`
   @media (max-width: ${({ theme }) => theme.grid.breakpoints.md}px) {
     ${styles}
   }
@@ -63,6 +60,8 @@ export const row = css`
     display: grid;
     grid-template-columns: auto 1fr auto;
     align-items: start;
+    padding: 16px 0;
+    row-gap: 4px;
   `)}
 `
 
@@ -87,6 +86,11 @@ const cell = css`
   vertical-align: top;
   text-align: left;
   word-wrap: anywhere;
+
+  ${stackedBelow(css`
+    padding-top: 0;
+    padding-bottom: 0;
+  `)}
 `
 
 export const startCell = css`
@@ -109,7 +113,6 @@ export const labelCell = css`
   ${stackedBelow(css`
     display: block;
     width: 100%;
-    padding-bottom: 0;
     grid-column: 2;
     grid-row: 1;
   `)}
@@ -132,7 +135,6 @@ export const valueCell = css`
     justify-content: space-between;
     gap: 16px;
     width: 100%;
-    padding-top: 8px;
     grid-column: 2;
   `)}
 `

--- a/packages/components/src/Table/Table.tsx
+++ b/packages/components/src/Table/Table.tsx
@@ -41,14 +41,6 @@ const TableHeader = styled.div<{
   align-items: top;
   border-bottom: 1px solid ${({ theme }) => theme.colors.grey300};
   border-radius: 2px 2px 0 0;
-
-  & span:first-child {
-    padding-left: 8px;
-  }
-
-  & span:last-child {
-    padding-right: 8px;
-  }
 `
 
 const TableHeaderText = styled.div`
@@ -68,13 +60,6 @@ const TableBody = styled.div<{
 
   & div:last-of-type {
     ${({ footerColumns }) => (footerColumns ? 'border-bottom: none;' : '')};
-  }
-  & span:first-child {
-    padding-left: 8px;
-  }
-
-  & span:last-child {
-    padding-right: 8px;
   }
 `
 const RowWrapper = styled.div<{
@@ -118,12 +103,6 @@ const TableFooter = styled(RowWrapper)<{
     color: ${({ theme }) => theme.colors.copy};
     ${({ theme }) => theme.fonts.bold14};
   }
-  & span:first-child {
-    padding-left: 8px;
-  }
-  & span:last-child {
-    padding-right: 8px;
-  }
 `
 
 const ContentWrapper = styled.span<{
@@ -139,6 +118,12 @@ const ContentWrapper = styled.span<{
   cursor: ${({ sortable }) => (sortable ? 'pointer' : 'default')};
   color: ${({ theme }) => theme.colors.grey400};
   padding: 0 4px;
+  &:first-child {
+    padding-left: 8px;
+  }
+  &:last-child {
+    padding-right: 8px;
+  }
 `
 const ValueWrapper = styled.span<{
   width: number
@@ -161,6 +146,12 @@ const ValueWrapper = styled.span<{
   text-overflow: ellipsis;
   overflow: hidden;
   ${({ color }) => color && `color: ${color};`}
+  &:first-child {
+    padding-left: 8px;
+  }
+  &:last-child {
+    padding-right: 8px;
+  }
 `
 const Error = styled.span`
   color: ${({ theme }) => theme.colors.negative};


### PR DESCRIPTION
## Description

Closes [#13640](https://github.com/opencrvs/opencrvs-core/issues/13640) — No gap between avatar and name in the 'By' column on the Record Audit page
Closes [#13670](https://github.com/opencrvs/opencrvs-core/issues/13670) — Mobile: Name not vertically centered with avatar/badge on Team page

- **Root cause:** two CSS rules reached past what they were meant to style — one indented the avatar inside a table cell, the other centred list rows by their padding instead of their content.
- Audit tab, "By" column: the name no longer sits against the avatar, and the avatar lines up with the column heading.
- Team page on mobile: the name now sits level with the avatar and the status badge.
- Team list: tightened the gap between avatar and name.

<img width="202" height="611" alt="image" src="https://github.com/user-attachments/assets/afaddf75-0193-4b3d-acae-0dc00ea9d49c" />
<img width="496" height="277" alt="image" src="https://github.com/user-attachments/assets/b28274b5-abd6-4041-90c3-84f7d883ea84" />



## Checklist

- [x] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests — verified by measurement in Storybook; these components have no unit test suite
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths) — both breakpoints, header/body/footer rows, and cells with nested content
- [x] I have updated the changelog with this change (if applicable) — n/a, both are regressions in unreleased 2.1 work already covered by the #4024 entry
- [ ] I have updated the GitHub issue status accordingly