### PR TITLE
fix: show a corrected value below the original on correction review

### DIFF
--- a/packages/client/src/v2-events/features/events/components/Output.tsx
+++ b/packages/client/src/v2-events/features/events/components/Output.tsx
@@ -101,6 +101,19 @@ const DeletedEmpty = styled(Deleted)`
   text-decoration: none;
 `
 
+/*
+ * What the field held sits above what it is becoming. They were bare siblings
+ * parted by a `<br>`, which stacks them only while the parent lays its children
+ * out as text; a flex parent instead takes each as an item of its own and sets
+ * them along its main axis. Stacking them here is the row's business no longer.
+ */
+const Changed = styled.span`
+  display: flex;
+  flex-direction: column;
+  /* The strike belongs to the value, so the box may not outgrow its text. */
+  align-items: flex-start;
+`
+
 /**
  *  Used for setting output/read (REVIEW) values for FORM input/write fields (string defaults based on FieldType).
  * For setting default fields for intl object @see setEmptyValuesForFields
@@ -471,22 +484,19 @@ export function Output({
     }
 
     return (
-      <>
+      <Changed>
         {!isEmptyValue(field, previousValue) && (
-          <>
-            <Deleted>
-              <ValueOutput
-                anchor={anchor}
-                config={previousValueField ?? field}
-                eventConfig={eventConfig}
-                value={previousValue}
-              />
-            </Deleted>
-            <br />
-          </>
+          <Deleted>
+            <ValueOutput
+              anchor={anchor}
+              config={previousValueField ?? field}
+              eventConfig={eventConfig}
+              value={previousValue}
+            />
+          </Deleted>
         )}
         {valueOutput}
-      </>
+      </Changed>
     )
   }
 
@@ -500,21 +510,20 @@ export function Output({
       />
     )
     return (
-      <>
+      <Changed>
         {isEmptyValue(field, previousValue) ? (
           // For a deleted 'dash', we dont want to overline the dash
           <DeletedEmpty>{'-'}</DeletedEmpty>
         ) : (
           <Deleted>{deleted}</Deleted>
         )}
-        <br />
         <ValueOutput
           anchor={anchor}
           config={field}
           eventConfig={eventConfig}
           value={value}
         />
-      </>
+      </Changed>
     )
   }
 


### PR DESCRIPTION
## Description

Closes [#13692](https://github.com/opencrvs/opencrvs-core/issues/13692) — Mobile: Original and corrected values not on the same line on correction review pages

- **Root cause:** the original and corrected values were stacked by a line break, which stopped working when review rows moved onto the shared list component in 2.1 — on mobile that cell sets its contents out in a row, so the corrected value was thrown to the opposite edge instead of sitting under the original.
- Correction review, both flows: the corrected value sits on the line below the original again, starting at the same place.
- The pair now stacks itself rather than relying on the row to do it, so it looks the same at every width. Desktop is unchanged.

**Note:** the issue's "expected behaviour" says the two values should be on the *same* line. That is not the design — the change always goes on the next line — so this PR stacks them at every width.

<img width="786" height="452" alt="image" src="https://github.com/user-attachments/assets/986c9dc9-82e0-40f9-88ef-f21e59ab9775" />

<img width="468" height="652" alt="image" src="https://github.com/user-attachments/assets/47572ef9-d70e-49ab-a6a2-6b6012a88c76" />


## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests — verified by measurement against the existing correction review stories; no test asserted the old layout
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths) — both correction flows, phone and desktop widths, and values too long to fit on one line
- [x] I have updated the changelog with this change (if applicable) — n/a, a regression in unreleased 2.1 work already covered by the #4024 entry
- [ ] I have updated the GitHub issue status accordingly
