### PR TITLE
fix: stop jurisdiction banner appearing after download

### DIFF
--- a/packages/client/src/v2-events/features/events/actions/dedup/getDuplicates.ts
+++ b/packages/client/src/v2-events/features/events/actions/dedup/getDuplicates.ts
@@ -22,7 +22,7 @@ export function potentialDuplicatesQueryKey(eventId: string) {
   return ['event', 'potentialDuplicates', eventId] as const
 }
 
-async function fetchPotentialDuplicates(eventId: string) {
+function fetchPotentialDuplicates(eventId: string) {
   return trpcClient.event.getDuplicates.query({ eventId })
 }
 
@@ -55,7 +55,7 @@ export async function prefetchPotentialDuplicates(eventId: string) {
   try {
     await queryClient.fetchQuery({
       queryKey: potentialDuplicatesQueryKey(eventId),
-      queryFn: () => fetchAndCachePotentialDuplicates(eventId)
+      queryFn: async () => fetchAndCachePotentialDuplicates(eventId)
     })
   } catch (error) {
     // The user is not authorized to see duplicates — otherwise, rethrow.

--- a/packages/client/src/v2-events/features/events/actions/dedup/getDuplicates.ts
+++ b/packages/client/src/v2-events/features/events/actions/dedup/getDuplicates.ts
@@ -9,23 +9,54 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 
-import { isExpectedAccessError, trpcClient } from '@client/v2-events/trpc'
+import {
+  isExpectedAccessError,
+  queryClient,
+  trpcClient
+} from '@client/v2-events/trpc'
 import { cacheFiles } from '@client/v2-events/features/files/cache'
 import { cacheUsersFromEventDocument } from '@client/v2-events/features/users/cache'
 import { setEventData } from '../../useEvents/api'
 
+export function potentialDuplicatesQueryKey(eventId: string) {
+  return ['event', 'potentialDuplicates', eventId] as const
+}
+
+async function fetchPotentialDuplicates(eventId: string) {
+  return trpcClient.event.getDuplicates.query({ eventId })
+}
+
+type PotentialDuplicates = Awaited<ReturnType<typeof fetchPotentialDuplicates>>
+
+async function cachePotentialDuplicates(
+  potentialDuplicates: PotentialDuplicates
+) {
+  for (const eventDocument of potentialDuplicates) {
+    await Promise.all([
+      cacheFiles(eventDocument),
+      cacheUsersFromEventDocument(eventDocument)
+    ])
+    setEventData(eventDocument.id, eventDocument)
+  }
+}
+
+/**
+ * Fetches the potential duplicate records for `eventId` and populates the
+ * cache for each one (files, users, event document), so downstream code
+ * (e.g. duplicate review) can read them from cache.
+ */
+export async function fetchAndCachePotentialDuplicates(eventId: string) {
+  const potentialDuplicates = await fetchPotentialDuplicates(eventId)
+  await cachePotentialDuplicates(potentialDuplicates)
+  return potentialDuplicates
+}
+
 export async function prefetchPotentialDuplicates(eventId: string) {
   try {
-    const potentialDuplicates = await trpcClient.event.getDuplicates.query({
-      eventId
+    await queryClient.fetchQuery({
+      queryKey: potentialDuplicatesQueryKey(eventId),
+      queryFn: () => fetchAndCachePotentialDuplicates(eventId)
     })
-    for (const eventDocument of potentialDuplicates) {
-      await Promise.all([
-        cacheFiles(eventDocument),
-        cacheUsersFromEventDocument(eventDocument)
-      ])
-      setEventData(eventDocument.id, eventDocument)
-    }
   } catch (error) {
     // The user is not authorized to see duplicates — otherwise, rethrow.
     if (!isExpectedAccessError(error)) {

--- a/packages/client/src/v2-events/features/events/actions/dedup/useDuplicatesAvailable.ts
+++ b/packages/client/src/v2-events/features/events/actions/dedup/useDuplicatesAvailable.ts
@@ -29,7 +29,7 @@ export function useDuplicatesAvailable(
 ) {
   const duplicatesQuery = useQuery({
     queryKey: potentialDuplicatesQueryKey(event.id),
-    queryFn: () => fetchAndCachePotentialDuplicates(event.id),
+    queryFn: async () => fetchAndCachePotentialDuplicates(event.id),
     enabled: canReviewDuplicates && event.potentialDuplicates.length > 0
   })
 

--- a/packages/client/src/v2-events/features/events/actions/dedup/useDuplicatesAvailable.ts
+++ b/packages/client/src/v2-events/features/events/actions/dedup/useDuplicatesAvailable.ts
@@ -9,24 +9,33 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 
-import { useQueries } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { EventIndex } from '@opencrvs/commons/client'
-import { useTRPC } from '@client/v2-events/trpc'
+import {
+  fetchAndCachePotentialDuplicates,
+  potentialDuplicatesQueryKey
+} from './getDuplicates'
 
 /**
- * Whether every record matched as a potential duplicate of `event` is present in
- * the local cache.
+ * Whether every potential duplicate of `event` is available to the current
+ * user. Resolves to `true` while still loading, to avoid a false "not
+ * available" before the fetch has settled.
  */
 export function useDuplicatesAvailable(event: EventIndex) {
-  const trpc = useTRPC()
-
-  const duplicates = useQueries({
-    queries: event.potentialDuplicates.map(({ id }) => ({
-      ...trpc.event.get.queryOptions({ eventId: id, waitFor: false }),
-      enabled: false,
-      staleTime: Infinity
-    }))
+  const duplicatesQuery = useQuery({
+    queryKey: potentialDuplicatesQueryKey(event.id),
+    queryFn: () => fetchAndCachePotentialDuplicates(event.id),
+    enabled: event.potentialDuplicates.length > 0
   })
 
-  return duplicates.every(({ data }) => Boolean(data))
+  if (duplicatesQuery.isLoading) {
+    return true
+  }
+
+  if (!duplicatesQuery.data) {
+    return false
+  }
+
+  const availableIds = new Set(duplicatesQuery.data.map(({ id }) => id))
+  return event.potentialDuplicates.every(({ id }) => availableIds.has(id))
 }

--- a/packages/client/src/v2-events/features/events/actions/dedup/useDuplicatesAvailable.ts
+++ b/packages/client/src/v2-events/features/events/actions/dedup/useDuplicatesAvailable.ts
@@ -19,13 +19,18 @@ import {
 /**
  * Whether every potential duplicate of `event` is available to the current
  * user. Resolves to `true` while still loading, to avoid a false "not
- * available" before the fetch has settled.
+ * available" before the fetch has settled. Fetches nothing when
+ * `canReviewDuplicates` is `false` — the server rejects the call outright in
+ * that case, so there's nothing to ask for.
  */
-export function useDuplicatesAvailable(event: EventIndex) {
+export function useDuplicatesAvailable(
+  event: EventIndex,
+  canReviewDuplicates: boolean
+) {
   const duplicatesQuery = useQuery({
     queryKey: potentialDuplicatesQueryKey(event.id),
     queryFn: () => fetchAndCachePotentialDuplicates(event.id),
-    enabled: event.potentialDuplicates.length > 0
+    enabled: canReviewDuplicates && event.potentialDuplicates.length > 0
   })
 
   if (duplicatesQuery.isLoading) {

--- a/packages/client/src/v2-events/features/workqueues/Actions/useActionConfigurationResolver.tsx
+++ b/packages/client/src/v2-events/features/workqueues/Actions/useActionConfigurationResolver.tsx
@@ -58,7 +58,10 @@ export function useEventActionConfigurationResolver(event: EventIndex) {
   const isDownloaded = Boolean(cachedEvent.data)
   const validatorContext = useValidatorContext(cachedEvent.data)
   const isAssigning = events.actions.assignment.assign.isAssigning(event.id)
-  const areDuplicatesAvailable = useDuplicatesAvailable(event)
+  const areDuplicatesAvailable = useDuplicatesAvailable(
+    event,
+    isActionAllowedForUser(ActionType.MARK_AS_DUPLICATE)
+  )
 
   const resolveAction = useCallback(
     <T extends WorkqueueActionType | ClientSpecificAction>(

--- a/packages/client/src/v2-events/features/workqueues/EventOverview/EventOverview.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/EventOverview.tsx
@@ -11,6 +11,7 @@
 import React from 'react'
 import { useTypedParams } from 'react-router-typesafe-routes/dom'
 import {
+  ActionType,
   EventDocument,
   getCurrentEventState,
   dangerouslyGetCurrentEventStateWithDrafts,
@@ -32,6 +33,7 @@ import { useDrafts } from '../../drafts/useDrafts'
 import { DuplicateWarning } from '../../events/actions/dedup/DuplicateWarning'
 import { DuplicateReviewUnavailable } from '../../events/actions/dedup/DuplicateReviewUnavailable'
 import { useDuplicatesAvailable } from '../../events/actions/dedup/useDuplicatesAvailable'
+import { useUserAllowedActions } from '../Actions/useUserAllowedActions'
 import { EventSummary } from './components/EventSummary'
 import { useEventOverviewInfo } from './components/useEventOverviewInfo'
 
@@ -178,18 +180,29 @@ function EventOverviewContainer() {
   const params = useTypedParams(ROUTES.V2.EVENTS.EVENT)
   const { eventIndex, fullEvent, shouldShowFullOverview } =
     useEventOverviewInfo(params.eventId)
-  const areDuplicatesAvailable = useDuplicatesAvailable(eventIndex)
+  const { isActionAllowed } = useUserAllowedActions(eventIndex)
+  const hasDuplicateReviewScope = isActionAllowed(ActionType.MARK_AS_DUPLICATE)
+  const areDuplicatesAvailable = useDuplicatesAvailable(
+    eventIndex,
+    hasDuplicateReviewScope
+  )
   const isDownloaded = fullEvent !== undefined
   /*
    * Until the record is downloaded the matches have not been fetched either, so
    * their absence says nothing about whether the user may review them.
    */
-  const canNotReviewDuplicate = isDownloaded && !areDuplicatesAvailable
+  /*
+   * Without the scope to review duplicates at all, the server refuses every
+   * match lookup regardless of jurisdiction, so there's nothing meaningful to
+   * report — show the ordinary warning, not the "cannot review" banner.
+   */
+  const isMatchUnavailable =
+    hasDuplicateReviewScope && isDownloaded && !areDuplicatesAvailable
 
   return (
     <>
       {eventIndex.potentialDuplicates.length > 0 &&
-        (canNotReviewDuplicate ? (
+        (isMatchUnavailable ? (
           <DuplicateReviewUnavailable />
         ) : (
           <DuplicateWarning

--- a/packages/client/src/v2-events/features/workqueues/EventOverview/components/ActionMenuStories/LocalRegistrarInteraction/DuplicateReviewScope.interaction.stories.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/components/ActionMenuStories/LocalRegistrarInteraction/DuplicateReviewScope.interaction.stories.tsx
@@ -1,0 +1,152 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, within } from 'storybook/test'
+import superjson from 'superjson'
+import { createTRPCMsw, httpLink } from '@vafanassieff/msw-trpc'
+import {
+  ActionType,
+  createPrng,
+  EventDocument,
+  generateActionDocument,
+  generateTrackingId,
+  getCurrentEventState,
+  getUUID,
+  TENNIS_CLUB_MEMBERSHIP,
+  tennisClubMembershipEvent,
+  TestUserRole
+} from '@opencrvs/commons/client'
+import { AppRouter } from '@client/v2-events/trpc'
+import { ROUTES, routesConfig } from '@client/v2-events/routes'
+import { testDataGenerator } from '@client/tests/test-data-generators'
+
+export default {
+  title: 'ActionMenu/LocalRegistrar/DuplicateReviewScope'
+} as Meta
+
+const generator = testDataGenerator()
+const registrationAgent = generator.user.registrationAgent()
+
+const prng = createPrng(42)
+const trackingId = generateTrackingId(prng)
+const duplicateTrackingId = generateTrackingId(prng)
+
+const eventId = getUUID()
+const duplicateId = getUUID()
+
+const createAction = generateActionDocument({
+  configuration: tennisClubMembershipEvent,
+  action: ActionType.CREATE,
+  defaults: { createdBy: registrationAgent.v2.id }
+})
+
+const declareAction = generateActionDocument({
+  configuration: tennisClubMembershipEvent,
+  action: ActionType.DECLARE,
+  defaults: { createdBy: registrationAgent.v2.id }
+})
+
+const duplicateDetectedAction = generateActionDocument({
+  configuration: tennisClubMembershipEvent,
+  action: ActionType.DUPLICATE_DETECTED,
+  defaults: {
+    createdBy: registrationAgent.v2.id,
+    content: {
+      duplicates: [{ id: duplicateId, trackingId: duplicateTrackingId }]
+    }
+  }
+})
+
+const assignAction = generateActionDocument({
+  configuration: tennisClubMembershipEvent,
+  action: ActionType.ASSIGN,
+  defaults: {
+    createdBy: registrationAgent.v2.id,
+    assignedTo: registrationAgent.v2.id
+  }
+})
+
+/** Downloaded, flagged as a potential duplicate, assigned to a user without `record.review-duplicates`. */
+const eventUnderReview: EventDocument = {
+  type: TENNIS_CLUB_MEMBERSHIP,
+  id: eventId,
+  trackingId,
+  createdAt: new Date(Date.now() - 1000).toISOString(),
+  updatedAt: new Date(Date.now() - 1000).toISOString(),
+  actions: [createAction, declareAction, duplicateDetectedAction, assignAction]
+}
+
+const tRPCMsw = createTRPCMsw<AppRouter>({
+  links: [httpLink({ url: '/api/events' })],
+  transformer: { input: superjson, output: superjson }
+})
+
+let getDuplicatesCallCount = 0
+
+/*
+ * `REGISTRATION_AGENT` lacks `record.review-duplicates` (see
+ * MarkAsDuplicate.interaction.stories.tsx). Such a user should see the
+ * ordinary duplicate warning, not the jurisdiction "cannot review" banner —
+ * and the client shouldn't call `getDuplicates` at all for them.
+ */
+export const NoBannerAndNoFetchWithoutReviewScope: StoryObj = {
+  parameters: {
+    chromatic: { disableSnapshot: true },
+    userRole: TestUserRole.enum.REGISTRATION_AGENT,
+    reactRouter: {
+      router: routesConfig,
+      initialPath: ROUTES.V2.EVENTS.EVENT.buildPath({ eventId })
+    },
+    offline: { events: [eventUnderReview] },
+    msw: {
+      handlers: {
+        event: [
+          tRPCMsw.event.search.query(() => ({
+            total: 1,
+            results: [
+              getCurrentEventState(eventUnderReview, tennisClubMembershipEvent)
+            ]
+          })),
+          tRPCMsw.event.get.query(() => eventUnderReview),
+          tRPCMsw.event.getDuplicates.query(() => {
+            getDuplicatesCallCount++
+            return []
+          })
+        ]
+      }
+    }
+  },
+  beforeEach: () => {
+    getDuplicatesCallCount = 0
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+
+    await step(
+      'The ordinary duplicate warning is shown, not the "cannot review" banner',
+      async () => {
+        await expect(
+          await canvas.findByText(
+            `Potential duplicate of record ${duplicateTrackingId}`
+          )
+        ).toBeVisible()
+        await expect(
+          canvas.queryByText('You cannot review this record for duplicates')
+        ).toBeNull()
+      }
+    )
+
+    await step('getDuplicates is never called for this user', async () => {
+      await new Promise((resolve) => setTimeout(resolve, 1000))
+      await expect(getDuplicatesCallCount).toBe(0)
+    })
+  }
+}

--- a/packages/client/src/v2-events/features/workqueues/EventOverview/components/ActionMenuStories/LocalRegistrarInteraction/DuplicateReviewUnavailable.interaction.stories.tsx
+++ b/packages/client/src/v2-events/features/workqueues/EventOverview/components/ActionMenuStories/LocalRegistrarInteraction/DuplicateReviewUnavailable.interaction.stories.tsx
@@ -1,0 +1,176 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, within } from 'storybook/test'
+import superjson from 'superjson'
+import { createTRPCMsw, httpLink } from '@vafanassieff/msw-trpc'
+import {
+  ActionType,
+  createPrng,
+  EventDocument,
+  generateActionDocument,
+  generateTrackingId,
+  getCurrentEventState,
+  getUUID,
+  TENNIS_CLUB_MEMBERSHIP,
+  tennisClubMembershipEvent,
+  TestUserRole
+} from '@opencrvs/commons/client'
+import { AppRouter } from '@client/v2-events/trpc'
+import { ROUTES, routesConfig } from '@client/v2-events/routes'
+import { testDataGenerator } from '@client/tests/test-data-generators'
+
+export default {
+  title: 'ActionMenu/LocalRegistrar/DuplicateReviewUnavailable'
+} as Meta
+
+const generator = testDataGenerator()
+const localRegistrar = generator.user.localRegistrar()
+
+const prng = createPrng(42)
+const trackingId = generateTrackingId(prng)
+const duplicateTrackingId = generateTrackingId(prng)
+
+const eventId = getUUID()
+const duplicateId = getUUID()
+
+const createAction = generateActionDocument({
+  configuration: tennisClubMembershipEvent,
+  action: ActionType.CREATE,
+  defaults: { createdBy: localRegistrar.v2.id }
+})
+
+const declareAction = generateActionDocument({
+  configuration: tennisClubMembershipEvent,
+  action: ActionType.DECLARE,
+  defaults: { createdBy: localRegistrar.v2.id }
+})
+
+const duplicateDetectedAction = generateActionDocument({
+  configuration: tennisClubMembershipEvent,
+  action: ActionType.DUPLICATE_DETECTED,
+  defaults: {
+    createdBy: localRegistrar.v2.id,
+    content: {
+      duplicates: [{ id: duplicateId, trackingId: duplicateTrackingId }]
+    }
+  }
+})
+
+const assignAction = generateActionDocument({
+  configuration: tennisClubMembershipEvent,
+  action: ActionType.ASSIGN,
+  defaults: {
+    createdBy: localRegistrar.v2.id,
+    assignedTo: localRegistrar.v2.id
+  }
+})
+
+/** Already downloaded and flagged as a potential duplicate, within jurisdiction. */
+const eventUnderReview: EventDocument = {
+  type: TENNIS_CLUB_MEMBERSHIP,
+  id: eventId,
+  trackingId,
+  createdAt: new Date(Date.now() - 1000).toISOString(),
+  updatedAt: new Date(Date.now() - 1000).toISOString(),
+  actions: [createAction, declareAction, duplicateDetectedAction, assignAction]
+}
+
+/** The matched record — within jurisdiction, but slow to resolve via `getDuplicates`. */
+const matchedEvent: EventDocument = {
+  type: TENNIS_CLUB_MEMBERSHIP,
+  id: duplicateId,
+  trackingId: duplicateTrackingId,
+  createdAt: new Date(Date.now() - 2000).toISOString(),
+  updatedAt: new Date(Date.now() - 2000).toISOString(),
+  actions: [
+    generateActionDocument({
+      configuration: tennisClubMembershipEvent,
+      action: ActionType.CREATE
+    }),
+    generateActionDocument({
+      configuration: tennisClubMembershipEvent,
+      action: ActionType.DECLARE
+    })
+  ]
+}
+
+const tRPCMsw = createTRPCMsw<AppRouter>({
+  links: [httpLink({ url: '/api/events' })],
+  transformer: { input: superjson, output: superjson }
+})
+
+/*
+ * Regression test: the main record is already downloaded (cached), but the
+ * server takes a while to answer `getDuplicates` for the matched record — the
+ * user has access to it, it's just slow. The "you cannot review" jurisdiction
+ * banner must never render during that wait; only the ordinary duplicate
+ * warning should ever be shown, once the match resolves.
+ */
+export const NotShownWhileDuplicateStillLoading: StoryObj = {
+  parameters: {
+    chromatic: { disableSnapshot: true },
+    userRole: TestUserRole.enum.LOCAL_REGISTRAR,
+    reactRouter: {
+      router: routesConfig,
+      initialPath: ROUTES.V2.EVENTS.EVENT.buildPath({ eventId })
+    },
+    // Only the main record is already in cache — the matched record is not,
+    // it only becomes available once the slow `getDuplicates` call resolves.
+    offline: { events: [eventUnderReview] },
+    msw: {
+      handlers: {
+        event: [
+          tRPCMsw.event.search.query(() => ({
+            total: 1,
+            results: [
+              getCurrentEventState(eventUnderReview, tennisClubMembershipEvent)
+            ]
+          })),
+          tRPCMsw.event.get.query(() => eventUnderReview),
+          tRPCMsw.event.getDuplicates.query(async () => {
+            await new Promise((resolve) => setTimeout(resolve, 1500))
+            return [matchedEvent]
+          })
+        ]
+      }
+    }
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+
+    await step(
+      'While duplicates are still loading, the jurisdiction banner never appears',
+      async () => {
+        for (let i = 0; i < 10; i++) {
+          await expect(
+            canvas.queryByText('You cannot review this record for duplicates')
+          ).toBeNull()
+          await new Promise((resolve) => setTimeout(resolve, 100))
+        }
+      }
+    )
+
+    await step(
+      'Once duplicates resolve, the ordinary duplicate warning is shown',
+      async () => {
+        await expect(
+          await canvas.findByText(
+            `Potential duplicate of record ${duplicateTrackingId}`
+          )
+        ).toBeVisible()
+        await expect(
+          canvas.queryByText('You cannot review this record for duplicates')
+        ).toBeNull()
+      }
+    )
+  }
+}

--- a/packages/countryconfig-template/assets/metabase/run.sh
+++ b/packages/countryconfig-template/assets/metabase/run.sh
@@ -97,14 +97,10 @@ if [ -z "${OPENCRVS_METABASE_ADMIN_PASSWORD}" ]; then
   exit 1
 fi
 
-apk update
-apk upgrade
-apk add --no-cache gettext
-apk add --no-cache util-linux
-
 export MB_JETTY_PORT=${MB_JETTY_PORT:-4444}
 export MB_DB_FILE=${MB_DB_FILE:-'/data/metabase/metabase.mv.db'}
-export OPENCRVS_METABASE_ADMIN_PASSWORD_SALT=$(uuidgen)
+export OPENCRVS_METABASE_ADMIN_PASSWORD_SALT=$(cat /proc/sys/kernel/random/uuid 2>/dev/null || uuidgen)
+
 SALT_AND_PASSWORD=$OPENCRVS_METABASE_ADMIN_PASSWORD_SALT$OPENCRVS_METABASE_ADMIN_PASSWORD
 export OPENCRVS_METABASE_ADMIN_PASSWORD_HASH=$(java -cp $METABASE_JAR clojure.main -e "(require 'metabase.util.password) (println (metabase.util.password/hash-bcrypt \"$SALT_AND_PASSWORD\"))" 2>/dev/null | tail -n 1)
 

--- a/packages/countryconfig-template/assets/metabase/update-database.sh
+++ b/packages/countryconfig-template/assets/metabase/update-database.sh
@@ -28,13 +28,13 @@ environment_configuration_sql_file=${OPENCRVS_ENVIRONMENT_CONFIGURATION_SQL_FILE
 # as environment variables
 #########
 
-if ! which envsubst >/dev/null; then
-  echo "envsubst could not be found. Please install envsubst before continuing."
-  echo "MacOS: brew install gettext && brew link --force gettext"
-  exit 1
-fi
 echo "Applying environment configuration from $environment_configuration_sql_file"
-envsubst < $environment_configuration_sql_file > $environment_configuration_sql_file.tmp
+
+# Expand $VAR / ${VAR} using bash's own heredoc expansion instead of envsubst,
+# because envsubst is not installed in the Metabase image
+eval "cat <<OPENCRVS_ENV_EOF
+$(cat "$environment_configuration_sql_file")
+OPENCRVS_ENV_EOF" > "$environment_configuration_sql_file.tmp"
 
 java -cp "$metabase_jar" org.h2.tools.RunScript -url jdbc:h2:"$metabase_db_path_for_metabase" -script "$environment_configuration_sql_file.tmp"
 rm $environment_configuration_sql_file.tmp

--- a/packages/testland/assets/metabase/run.sh
+++ b/packages/testland/assets/metabase/run.sh
@@ -97,14 +97,10 @@ if [ -z "${OPENCRVS_METABASE_ADMIN_PASSWORD}" ]; then
   exit 1
 fi
 
-apk update
-apk upgrade
-apk add --no-cache gettext
-apk add --no-cache util-linux
-
 export MB_JETTY_PORT=${MB_JETTY_PORT:-4444}
 export MB_DB_FILE=${MB_DB_FILE:-'/data/metabase/metabase.mv.db'}
-export OPENCRVS_METABASE_ADMIN_PASSWORD_SALT=$(uuidgen)
+export OPENCRVS_METABASE_ADMIN_PASSWORD_SALT=$(cat /proc/sys/kernel/random/uuid 2>/dev/null || uuidgen)
+
 SALT_AND_PASSWORD=$OPENCRVS_METABASE_ADMIN_PASSWORD_SALT$OPENCRVS_METABASE_ADMIN_PASSWORD
 export OPENCRVS_METABASE_ADMIN_PASSWORD_HASH=$(java -cp $METABASE_JAR clojure.main -e "(require 'metabase.util.password) (println (metabase.util.password/hash-bcrypt \"$SALT_AND_PASSWORD\"))" 2>/dev/null | tail -n 1)
 

--- a/packages/testland/assets/metabase/update-database.sh
+++ b/packages/testland/assets/metabase/update-database.sh
@@ -28,13 +28,13 @@ environment_configuration_sql_file=${OPENCRVS_ENVIRONMENT_CONFIGURATION_SQL_FILE
 # as environment variables
 #########
 
-if ! which envsubst >/dev/null; then
-  echo "envsubst could not be found. Please install envsubst before continuing."
-  echo "MacOS: brew install gettext && brew link --force gettext"
-  exit 1
-fi
 echo "Applying environment configuration from $environment_configuration_sql_file"
-envsubst < $environment_configuration_sql_file > $environment_configuration_sql_file.tmp
+
+# Expand $VAR / ${VAR} using bash's own heredoc expansion instead of envsubst,
+# because envsubst is not installed in the Metabase image
+eval "cat <<OPENCRVS_ENV_EOF
+$(cat "$environment_configuration_sql_file")
+OPENCRVS_ENV_EOF" > "$environment_configuration_sql_file.tmp"
 
 java -cp "$metabase_jar" org.h2.tools.RunScript -url jdbc:h2:"$metabase_db_path_for_metabase" -script "$environment_configuration_sql_file.tmp"
 rm $environment_configuration_sql_file.tmp


### PR DESCRIPTION
## Description

Design note: https://github.com/opencrvs/opencrvs-core/pull/13783#issuecomment-5662489952

- **Root cause:** the banner read a local cache that a separate call only filled after assignment, so an empty cache looked the same as "not allowed" — and it flashed on records that were fine.
- The hook now fetches itself and reports a status (`UNDETERMINED` / `CHECKING` / `AVAILABLE` / `UNAVAILABLE`) instead of a boolean doubling as "don't know yet".
- No banner shows while a check is outstanding.
- It asks only once the record is assigned to you, since the server refuses otherwise.
- Only a `403` gives the jurisdiction banner; other failures leave the plain warning.
- The banner is limited to users with `record.review-duplicates`, as the issue asked.
- **Removed `prefetchPotentialDuplicates`:** it only filled that cache, and the hook now does its own fetching.

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly