### PR TITLE
fix: Replace minio/mc image with quay.io/minio/mc

### DIFF
--- a/charts/opencrvs-services/values.yaml
+++ b/charts/opencrvs-services/values.yaml
@@ -62,8 +62,8 @@ minio:
   users_secret: minio-opencrvs-users
   # Image used as client to run OpenCRVS configuration scripts
   image:
-    repository: minio/mc
-    tag: 'latest'
+    repository: quay.io/minio/mc
+    tag: 'RELEASE.2025-08-13T08-35-41Z'
 
 redis:
   host: redis-0.redis.opencrvs-deps-dev.svc.cluster.local


### PR DESCRIPTION
## Description

Problem

Docker Hub no longer hosts the minio/minio server or client images. This affects all our environments (Kubernetes and Docker Swarm) — the data cleanup job is currently broken as a result.

Affected releases: v1.9.x, v2.0.x, v2.1.x (develop)

Fix

Switch to quay.io/minio/minio, the current official MinIO image source.

Note: this repository is also outdated, so further action may be needed down the line to fully resolve image availability long-term.

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
